### PR TITLE
Polish home rail/hero and clear plaza seed cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,18 +69,6 @@ npm run dev:api              # empty DATABASE_URL → SQLite
 npm run dev:web
 ```
 
-## Architecture (high level)
-
-```mermaid
-flowchart LR
-  User[Browser] --> Web[apps/web]
-  Web --> API[apps/api]
-  API --> DB[(MySQL / SQLite / Postgres)]
-  API --> Redis[(Redis)]
-  API --> LLM[LLM providers]
-```
-
-Compose defaults to **MySQL**. Dev often uses **SQLite**. **Postgres** is optional (driver + migrate first).
 ## Repository layout
 
 ```

--- a/apps/api/data/official_cases/index.json
+++ b/apps/api/data/official_cases/index.json
@@ -6,42 +6,5 @@
     "poster",
     "video"
   ],
-  "cases": [
-    {
-      "id": "case-resume-fresh",
-      "file": "resume-fresh.json",
-      "category": "website",
-      "nameKey": "resumeFresh"
-    },
-    {
-      "id": "case-resume-classic",
-      "file": "resume-classic.json",
-      "category": "website",
-      "nameKey": "resumeClassic"
-    },
-    {
-      "id": "case-poster-event",
-      "file": "poster-event.json",
-      "category": "poster",
-      "nameKey": "posterEvent"
-    },
-    {
-      "id": "case-poster-promo",
-      "file": "poster-promo.json",
-      "category": "poster",
-      "nameKey": "posterPromo"
-    },
-    {
-      "id": "case-ui-dashboard",
-      "file": "ui-dashboard.json",
-      "category": "website",
-      "nameKey": "uiDashboard"
-    },
-    {
-      "id": "case-ui-mobile",
-      "file": "ui-mobile.json",
-      "category": "mobile",
-      "nameKey": "uiMobile"
-    }
-  ]
+  "cases": []
 }

--- a/apps/api/services/seed.py
+++ b/apps/api/services/seed.py
@@ -113,6 +113,7 @@ def seed_official_plaza_cases() -> int:
     data_dir = _api_data() / "official_cases"
     index_path = data_dir / "index.json"
     cases: list[Any] = []
+    index_loaded = False
     if index_path.is_file():
         try:
             index = json.loads(index_path.read_text(encoding="utf-8"))
@@ -121,14 +122,16 @@ def seed_official_plaza_cases() -> int:
             index = None
         if isinstance(index, dict) and isinstance(index.get("cases"), list):
             cases = index["cases"]
+            index_loaded = True
     else:
         logger.warning("plaza cases seed: missing %s — using file fallback", index_path)
 
-    if not cases:
+    # Empty cases in a valid index means "do not seed" (not file fallback).
+    if not cases and not index_loaded:
         cases = _default_official_case_entries(data_dir)
         if cases:
             logger.warning(
-                "plaza cases seed: index cases empty — seeding %s file(s) from titles map",
+                "plaza cases seed: index missing — seeding %s file(s) from titles map",
                 len(cases),
             )
     if not cases:

--- a/apps/web/src/components/home/HomeHero.tsx
+++ b/apps/web/src/components/home/HomeHero.tsx
@@ -4,9 +4,10 @@ import { useTranslation } from 'react-i18next';
 import {
   HiOutlineDevicePhoneMobile,
   HiOutlineFilm,
-  HiOutlineNewspaper,
   HiOutlinePhoto,
+  HiOutlineRectangleStack,
 } from 'react-icons/hi2';
+import type { IconType } from 'react-icons';
 import AppLogo from '@/components/base/AppLogo';
 import { SegmentedControl } from '@/components/base/segmented';
 import HomeAgentComposer, {
@@ -19,12 +20,13 @@ type Props = {
   onSubmit: (payload: HomeAgentSubmitPayload) => void;
 };
 
+/** Same hi2 outline family as AgentComposerShell (strokeWidth 1.75). */
 const CATEGORIES: Array<{
   id: HomeAgentCategory;
-  icon: typeof HiOutlinePhoto;
+  icon: IconType;
   labelKey: string;
 }> = [
-  { id: 'poster', icon: HiOutlineNewspaper, labelKey: 'homeCategories.poster' },
+  { id: 'poster', icon: HiOutlineRectangleStack, labelKey: 'homeCategories.poster' },
   { id: 'mobile', icon: HiOutlineDevicePhoneMobile, labelKey: 'homeCategories.mobile' },
   { id: 'image', icon: HiOutlinePhoto, labelKey: 'homeCategories.image' },
   { id: 'video', icon: HiOutlineFilm, labelKey: 'homeCategories.video' },
@@ -37,11 +39,11 @@ function resolveHeroLang(langRaw: string) {
   return { isZh, isJa };
 }
 
-/** Logo + brand name — same line weight as tagline (Lovart-style). */
+/** Logo mark + brand word — matched to the 30px hero line. */
 function HeroBrandMark({ size }: { size: number }) {
   const { t } = useTranslation();
   return (
-    <span className="inline-flex items-center gap-[0.22em] align-middle">
+    <span className="inline-flex items-center gap-[0.28em] align-middle text-[30px] font-medium leading-none tracking-tight">
       {/* Decorative; brand name follows for screen readers. */}
       <span aria-hidden className="inline-flex">
         <AppLogo size={size} className="translate-y-[0.02em]" />
@@ -95,7 +97,7 @@ function HomeHero({ onSubmit }: Props): ReactNode {
     [t, category]
   );
 
-  const logoPx = 24;
+  const logoPx = 30;
   const prefix = t('app.heroLinePrefix');
   const suffix = t('app.heroLineSuffix');
 
@@ -105,7 +107,7 @@ function HomeHero({ onSubmit }: Props): ReactNode {
         <h1
           className={cn(
             'inline-flex flex-wrap items-center justify-center gap-x-[0.35em] gap-y-1 font-medium text-[var(--ink)]',
-            'text-[26px] leading-[1.3] tracking-[-0.01em] sm:text-[28px] sm:leading-[1.25]',
+            'text-[30px] leading-[1.25] tracking-[-0.01em]',
             (isZh || isJa) && 'tracking-[0.01em]'
           )}
           style={{ fontFamily: 'var(--font-hero)' }}
@@ -116,7 +118,7 @@ function HomeHero({ onSubmit }: Props): ReactNode {
         </h1>
         <p
           className={cn(
-            'mt-5 max-w-[min(100%,36rem)] text-[14px] font-normal leading-[1.6] text-[var(--muted)] sm:text-[15px]',
+            'mt-5 max-w-[min(100%,36rem)] text-[16px] font-normal leading-[1.6] text-[var(--muted)]',
             (isZh || isJa) && 'tracking-[0.02em]'
           )}
         >

--- a/apps/web/src/components/layout/HomeBody.tsx
+++ b/apps/web/src/components/layout/HomeBody.tsx
@@ -2,17 +2,15 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode, memo
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { GoHome, GoHomeFill } from 'react-icons/go';
+import { GoHome } from 'react-icons/go';
 import {
-  HiFolder,
   HiOutlineBell,
   HiOutlineBookOpen,
   HiOutlineChatBubbleLeftRight,
   HiOutlineFolder,
   HiOutlineUser,
-  HiUser,
 } from 'react-icons/hi2';
-import { Dropdown } from '@/components/base';
+import { Dropdown, Tooltip } from '@/components/base';
 import AppLogo from '@/components/base/AppLogo';
 import { fetchProjects } from '@/apis/projects';
 import HomeHero from '@/components/home/HomeHero';
@@ -52,7 +50,7 @@ const RAIL_STROKE = 1.5;
 const RAIL_HELP_WIKI =
   'https://my.feishu.cn/wiki/EuoxwPk4OighdZkmAVMc7Gisn8b?from=from_copylink';
 
-/** Circled + — matches home rail add reference. */
+/** Circled + — rail create action. */
 function RailPlusIcon({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden>
@@ -79,42 +77,45 @@ function RailItem({
   disabled,
   onClick,
   icon,
-  activeIcon,
 }: {
   label: string;
   active?: boolean;
   disabled?: boolean;
   onClick?: () => void;
   icon: ReactNode;
-  activeIcon?: ReactNode;
 }) {
   return (
-    <button
-      type="button"
-      aria-label={label}
-      aria-current={active ? 'page' : undefined}
-      disabled={disabled}
-      onClick={onClick}
-      className={cn(
-        'flex w-full flex-col items-center gap-1 rounded-xl px-1 py-2 transition-colors disabled:opacity-50',
-        active
-          ? 'text-[var(--ink)]'
-          : 'text-[var(--ink)]/55 hover:text-[var(--ink)]'
-      )}
-    >
-      <span className="flex h-10 w-10 items-center justify-center">
-        {active && activeIcon ? activeIcon : icon}
-      </span>
-      <span className="text-[11px] font-medium leading-none tracking-tight">{label}</span>
-    </button>
+    <Tooltip tip={label} placement="right" offset={10}>
+      <button
+        type="button"
+        aria-label={label}
+        aria-current={active ? 'page' : undefined}
+        disabled={disabled}
+        onClick={onClick}
+        className={cn(
+          'mx-auto flex h-10 w-10 items-center justify-center rounded-full transition-colors disabled:opacity-50',
+          active
+            ? 'bg-[color-mix(in_srgb,var(--ink)_4%,var(--rail))] text-[var(--ink)]'
+            : 'text-[var(--ink)]/55 hover:bg-[color-mix(in_srgb,var(--ink)_2%,var(--rail))] hover:text-[var(--ink)]'
+        )}
+      >
+        {icon}
+      </button>
+    </Tooltip>
   );
 }
 
 function RailLogo() {
   return (
-    <div className="mx-auto flex h-10 w-10 shrink-0 items-center justify-center" aria-hidden>
-      <AppLogo size={22} />
+    <div className="mx-auto flex h-8 w-8 shrink-0 items-center justify-center" aria-hidden>
+      <AppLogo size={26} />
     </div>
+  );
+}
+
+function RailDivider() {
+  return (
+    <div className="mx-auto my-1 h-px w-6 bg-[var(--line)]" aria-hidden />
   );
 }
 
@@ -193,7 +194,7 @@ function RailHelpMenu() {
   );
 }
 
-/** Left rail — logo top, nav vertically centered, help bottom. */
+/** Side rail — logo, Add, nav icons; help (?) stays at the bottom. */
 function HomeSidebar({
   nav,
   setNav,
@@ -233,17 +234,17 @@ function HomeSidebar({
         </div>
       </div>
 
-      {/* Desktop rail — logo top, nav centered, help bottom. */}
+      {/* Desktop rail — top-packed icons; ? help pinned to bottom. */}
       <aside
-        className="pointer-events-none fixed inset-y-0 left-0 z-30 hidden w-[76px] flex-col overflow-visible md:flex"
+        className="pointer-events-none fixed inset-y-0 left-0 z-30 hidden w-[64px] flex-col overflow-visible border-r border-[var(--line)] md:flex"
         aria-label={t('app.name')}
       >
-        <div className="pointer-events-auto flex h-full flex-col items-stretch overflow-visible bg-transparent px-1.5 pb-5 pt-4">
-          <div className="flex shrink-0 justify-center overflow-visible pb-3">
+        <div className="pointer-events-auto flex h-full flex-col items-stretch overflow-visible bg-[var(--rail)] px-2 pb-5 pt-4">
+          <div className="flex shrink-0 justify-center pb-4">
             <RailLogo />
           </div>
           <nav
-            className="flex min-h-0 flex-1 flex-col items-stretch justify-center gap-1"
+            className="flex min-h-0 flex-1 flex-col items-stretch gap-1.5"
             aria-label={t('app.name')}
           >
             <RailItem
@@ -257,21 +258,19 @@ function HomeSidebar({
               active={nav === 'home'}
               onClick={() => goNav('home')}
               icon={<GoHome className="h-[22px] w-[22px]" aria-hidden />}
-              activeIcon={<GoHomeFill className="h-[22px] w-[22px]" aria-hidden />}
-            />
-            <RailItem
-              label={t('home.mine')}
-              active={nav === 'mine'}
-              onClick={() => goNav('mine')}
-              icon={<HiOutlineFolder className="h-5 w-5" strokeWidth={RAIL_STROKE} aria-hidden />}
-              activeIcon={<HiFolder className="h-5 w-5" aria-hidden />}
             />
             <RailItem
               label={t('home.account')}
               active={nav === 'account'}
               onClick={() => goNav('account')}
               icon={<HiOutlineUser className="h-[22px] w-[22px]" strokeWidth={RAIL_STROKE} aria-hidden />}
-              activeIcon={<HiUser className="h-[22px] w-[22px]" aria-hidden />}
+            />
+            <RailDivider />
+            <RailItem
+              label={t('home.mine')}
+              active={nav === 'mine'}
+              onClick={() => goNav('mine')}
+              icon={<HiOutlineFolder className="h-[18px] w-[18px]" strokeWidth={RAIL_STROKE} aria-hidden />}
             />
           </nav>
           <div className="mt-auto flex shrink-0 justify-center pt-3">

--- a/apps/web/src/components/layout/HomeTopBar.tsx
+++ b/apps/web/src/components/layout/HomeTopBar.tsx
@@ -16,25 +16,10 @@ import { getToken } from '@/utils/token';
 
 type Props = {
   setNav: (id: string) => void;
-  onCreate?: () => void;
 };
 
-function MobilePlusIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden>
-      <circle cx="12" cy="12" r="8.25" stroke="currentColor" strokeWidth={1.5} />
-      <path
-        d="M12 8.5v7M8.5 12h7"
-        stroke="currentColor"
-        strokeWidth={1.5}
-        strokeLinecap="round"
-      />
-    </svg>
-  );
-}
-
 /** Floating top-right — account chip; mobile also has nav menu after avatar. */
-function HomeTopBar({ setNav, onCreate }: Props) {
+function HomeTopBar({ setNav }: Props) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const userId = useSelector((state: any) => state.auth?.user?.id) as string | undefined;
@@ -51,15 +36,6 @@ function HomeTopBar({ setNav, onCreate }: Props) {
   const mobileNavItems: MenuItemType[] = useMemo(
     () => [
       {
-        key: 'generate',
-        label: (
-          <span className="inline-flex items-center gap-2">
-            <MobilePlusIcon className="h-4 w-4 shrink-0 opacity-80" />
-            {t('home.railAdd')}
-          </span>
-        ),
-      },
-      {
         key: 'home',
         label: (
           <span className="inline-flex items-center gap-2">
@@ -69,20 +45,20 @@ function HomeTopBar({ setNav, onCreate }: Props) {
         ),
       },
       {
-        key: 'mine',
-        label: (
-          <span className="inline-flex items-center gap-2">
-            <HiOutlineFolder className="h-4 w-4 shrink-0 opacity-80" strokeWidth={1.5} />
-            {t('home.mine')}
-          </span>
-        ),
-      },
-      {
         key: 'account',
         label: (
           <span className="inline-flex items-center gap-2">
             <HiOutlineUser className="h-4 w-4 shrink-0 opacity-80" strokeWidth={1.5} />
             {t('home.account')}
+          </span>
+        ),
+      },
+      {
+        key: 'mine',
+        label: (
+          <span className="inline-flex items-center gap-2">
+            <HiOutlineFolder className="h-4 w-4 shrink-0 opacity-80" strokeWidth={1.5} />
+            {t('home.mine')}
           </span>
         ),
       },
@@ -101,10 +77,6 @@ function HomeTopBar({ setNav, onCreate }: Props) {
           offset={8}
           items={mobileNavItems}
           onClick={(key) => {
-            if (key === 'generate') {
-              onCreate?.();
-              return;
-            }
             if (key === 'home' || key === 'mine' || key === 'account') {
               goNav(key);
             }

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -401,9 +401,9 @@ function HomePage() {
         importing={importing}
         onCreate={handleCreate}
       />
-      {/* Full-bleed column — left rail is position:fixed and must not reserve flow space. */}
+      {/* Full-bleed column — side rail is position:fixed and must not reserve flow space. */}
       <div className="relative flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden">
-        <HomeTopBar setNav={setNav} onCreate={handleCreate} />
+        <HomeTopBar setNav={setNav} />
         <HomeTemplateList
           nav={nav}
           setNav={setNav}

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,7 +14,7 @@ Base URL: `http://localhost:8000/api/v1`
 | `/uploads` · `/fonts` | 上传与字体 |
 | `/image-tools` | 抠图等视觉工具 |
 | `/shares` · `/notices` · `/users` | 分享、公告、用户目录 |
-| `/import/*` | 图片 → Scene（同步或异步 job；PDF/DOCX 为遗留接口） |
+| `/import/*` | 图片 → Scene（同步或异步 job） |
 | `/admin/*` | 管理端（流程、字典、模型、广场审核等；需管理员） |
 
 ## Health
@@ -23,19 +23,10 @@ Base URL: `http://localhost:8000/api/v1`
 
 ## Import（摘要）
 
-产品支持：
-
 | 方法 | 路径 | 说明 |
 |------|------|------|
 | POST | `/import/image` | 上传图片 |
 | POST | `/import/jobs` | 异步导入任务（`source_type=image`） |
 | GET | `/import/jobs/{id}` | 查询任务状态 |
-
-遗留（不作为正式产品能力）：
-
-| 方法 | 路径 | 说明 |
-|------|------|------|
-| POST | `/import/pdf` | 上传 PDF |
-| POST | `/import/docx` | 上传 DOCX |
 
 导入管线细节见 [import-pipeline.md](./import-pipeline.md)。

--- a/docs/import-pipeline.md
+++ b/docs/import-pipeline.md
@@ -1,6 +1,6 @@
 # 导入管线
 
-> **产品现状**：对外仅支持**图片导入**。PDF / DOCX 相关步骤为仓库内遗留实现，**不作为正式产品能力**。
+> **产品现状**：对外仅支持**图片导入**。
 
 ## 阶段一：预处理 + 任务队列（图片）
 
@@ -8,8 +8,6 @@
 2. Celery 异步任务（可选）+ Redis 存 job 状态
 3. 图片：归一化为单页图
 4. 页图写入 `storage/results/{job_id}/pages/`
-
-遗留（非产品路径）：PDF 经 `pdf2image` + poppler；DOCX 经 LibreOffice → PDF → 页图。
 
 ## 阶段二：图像算法（页图 → 布局/文字）
 
@@ -23,8 +21,6 @@
 | KMeans | 主色板 `meta.palette` | OpenCV |
 | 轻量 SAM | 区域提案（默认关，需模型） | 可选 |
 | LaMa | 修复/去字（默认关） | 可选 |
-
-数字 PDF 遗留链路：若视觉链路无结果，仍可能回退 `pdfplumber` 文字层（非产品保证）。
 
 坐标会缩放到 `SCENE_TARGET_WIDTH`（默认 794）再写入 Scene。
 
@@ -66,7 +62,6 @@ pip install -e ".[storage]"
 1. OCR/版面结果中的碎文本按行高聚类合并为更少的 textbox（`merge_text_blocks`）
 2. PPStructure 检出的 figure/table：从页图裁剪为 PNG data URL，落入 Scene `image` 节点；裁剪失败的 table 用浅色 `rect` 占位
 3. 多页时按页高垂直拼接到同一画布
-4. `pdfplumber` 回退路径同样经过行合并
 
 `meta.engines` 可能出现：`merge`、`crop`。
 
@@ -90,7 +85,7 @@ LAMA_USE_SAM_MASK=true
 ## 阶段六：联调就绪
 
 - `GET /api/v1/health` 返回 `redis` / `worker` / `ocr` 状态
-- Docker API 镜像含 poppler；`INSTALL_OCR=true docker compose build` 可打入 OCR
+- `INSTALL_OCR=true docker compose build` 可打入 OCR
 - 前端异步 Job 失败或排队过久时自动回退同步导入
 - `make health` / `python scripts/smoke_health.py`
 
@@ -102,8 +97,8 @@ make dev-redis && make dev-api && make dev-worker
 
 ## API
 
-- 同步：`POST /api/v1/import/{pdf,docx,image}`
-- 异步：`POST /api/v1/import/jobs` → `GET /api/v1/import/jobs/{id}`
+- 同步：`POST /api/v1/import/image`
+- 异步：`POST /api/v1/import/jobs` → `GET /api/v1/import/jobs/{id}`（`source_type=image`）
 
 `meta` 字段：`page_images`、`object_keys`、`object_urls`、`palette`、`engines`、`warnings`。
 


### PR DESCRIPTION
## Summary
- Restyle the home side rail: icon-only, `--rail` background, light circular selected state, tooltips, and clearer nav order
- Bump hero title/brand/logo to 30px and keep category icons on the hi2 outline family
- Clear official plaza seed cases from the index and avoid reseeding when `cases` is intentionally empty; tighten import docs to image-only

## Test plan
- [ ] Home rail: Home / Me / Account selection shows a light circular chip; hover tooltips work
- [ ] Hero line renders at 30px with matching logo; category tabs look consistent
- [ ] Inspiration feed stays empty after API restart (no official cases reseed)
- [ ] Mobile top-bar nav still switches Home / Account / Projects

Made with [Cursor](https://cursor.com)