### PR TITLE
Prefer local artboard snaps for center align

### DIFF
--- a/apps/web/src/components/editor/canvas/svg/SvgCanvas.tsx
+++ b/apps/web/src/components/editor/canvas/svg/SvgCanvas.tsx
@@ -933,14 +933,15 @@ function SvgCanvas({
   const queryNodeIdsInRect = useCallback(
     (box: { left: number; top: number; width: number; height: number }) => {
       const all = listNodeIds();
-      if (all.length < 48) return all;
+      // Always prefer spatial hits — returning every node on small docs made distant
+      // posters steal center-align guides; keep snaps to nearby / same-artboard targets.
       const hits = nodeSpatialIndex.search(
         box.left,
         box.top,
         box.left + box.width,
         box.top + box.height
       );
-      if (!hits.length) return all;
+      if (!hits.length) return [];
       const allow = new Set(hits.map((h) => h.id));
       // Keep document z-order.
       return all.filter((id) => allow.has(id));

--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -15,7 +15,9 @@ import AlignGuidesOverlay, { type AlignGuide } from './AlignGuidesOverlay';
 import {
   chromeBandGuideBoxes,
   frameGuideBoxes,
+  framesContainingBox,
   getDocumentGridSize,
+  getSnapNeighborPad,
   getSnapThreshold,
   nodeGuideBoxes,
   nodeGuideBoxesForIds,
@@ -49,6 +51,7 @@ import {
   isNodeHidden,
   isNodeLocked,
   listImageVariantUrls,
+  nodeIdsInsideFrames,
   supportsFill,
 } from '@/components/rcb/scene/document/sceneDocument';
 import { TEXT_SELECTION_PAD } from '@/components/rcb/scene/document/sceneEffects';
@@ -715,7 +718,7 @@ function computeMovedUnion(ctx: MoveSnapContext): {
         .map((id) => ctx.getNodeBox(id))
         .filter(Boolean) as SceneBox[]
   );
-  const frames = frameGuideBoxes(ctx.document);
+  const frames = snapContainerFrames(ctx.document, nextUnion, ctx.snapThreshold);
   const snapped = snapBoxToGuides(nextUnion, others, frames, ctx.snapThreshold, {
     edgeBoxes: movingGuideBoxes(nextUnion, ctx.document, ctx.originIds),
   });
@@ -786,7 +789,7 @@ function computeResizedUnion(ctx: ResizeSnapContext): {
         .map((id) => ctx.getNodeBox(id))
         .filter(Boolean) as SceneBox[]
   );
-  const frames = frameGuideBoxes(ctx.document);
+  const frames = snapContainerFrames(ctx.document, next, ctx.snapThreshold);
   const snapped = snapResizeToGuides(next, handle, others, frames, ctx.snapThreshold, 8, {
     edgeBoxes: movingGuideBoxes(next, ctx.document, originIds),
     lockAspect,
@@ -862,8 +865,10 @@ function siblingGuideBoxes(
 }
 
 /**
- * Prefer spatial neighbors around `probe` (move / resize / nudge).
- * Pad covers snap threshold + nearby gap partners without scanning the whole doc.
+ * Prefer local snap targets:
+ * - siblings inside the containing artboard(s)
+ * - plus spatial neighbors within ~192 screen px
+ * Avoid scanning distant posters that steal center-align guides.
  */
 function siblingGuideBoxesNear(
   document: any,
@@ -873,23 +878,58 @@ function siblingGuideBoxesNear(
   queryNodeIdsInRect: ((box: SceneBox) => string[]) | undefined,
   fallback: () => SceneBox[]
 ): SceneBox[] {
-  if (queryNodeIdsInRect) {
-    const pad = Math.max(
-      snapThreshold * 8,
-      probe.width || 0,
-      probe.height || 0,
-      256
-    );
-    const ids = queryNodeIdsInRect({
-      left: probe.left - pad,
-      top: probe.top - pad,
-      width: probe.width + pad * 2,
-      height: probe.height + pad * 2,
-    });
-    const fromDoc = nodeGuideBoxesForIds(document, ids, { excludeIds });
+  const containing = framesContainingBox(document, probe);
+  const insideIds = containing.length
+    ? nodeIdsInsideFrames(
+        document,
+        containing.map((f) => f.id)
+      )
+    : [];
+  const pad = getSnapNeighborPad(snapThreshold);
+  const nearIds = queryNodeIdsInRect
+    ? queryNodeIdsInRect({
+        left: probe.left - pad,
+        top: probe.top - pad,
+        width: probe.width + pad * 2,
+        height: probe.height + pad * 2,
+      })
+    : [];
+  const idSet = new Set<string>([...insideIds, ...nearIds]);
+  if (idSet.size) {
+    const fromDoc = nodeGuideBoxesForIds(document, [...idSet], { excludeIds });
     if (fromDoc.length) return fromDoc;
   }
+  // Inside a frame with no siblings yet — empty is OK (still snap to the frame).
+  if (containing.length) return [];
   return siblingGuideBoxes(document, excludeIds, fallback);
+}
+
+/** Containers for snap: containing artboard(s), else nearby frames only. */
+function snapContainerFrames(
+  document: any,
+  probe: SceneBox,
+  snapThreshold: number
+): SceneBox[] {
+  const containing = framesContainingBox(document, probe);
+  if (containing.length) {
+    return containing.map(({ left, top, width, height }) => ({
+      left,
+      top,
+      width,
+      height,
+    }));
+  }
+  const pad = getSnapNeighborPad(snapThreshold);
+  const all = frameGuideBoxes(document);
+  return all.filter((f) => {
+    const ol =
+      Math.min(probe.left + probe.width + pad, f.left + f.width) -
+      Math.max(probe.left - pad, f.left);
+    const ot =
+      Math.min(probe.top + probe.height + pad, f.top + f.height) -
+      Math.max(probe.top - pad, f.top);
+    return ol > 0 && ot > 0;
+  });
 }
 
 /** Moving selection's stroke-band faces (single node) or chrome union (multi). */
@@ -2106,7 +2146,7 @@ function SelectionFeature({
             .map((id) => getNodeBox(id))
             .filter(Boolean) as SceneBox[]
       );
-      const frames = frameGuideBoxes(document);
+      const frames = snapContainerFrames(document, nextUnion, snapThreshold);
       setLiveUnion(nextUnion);
       setLiveOrigins(nextOrigins);
       // Arrow-key nudge: show nearest gaps as measure guides (orange + arrows).

--- a/apps/web/src/components/rcb/selection/alignGuides.ts
+++ b/apps/web/src/components/rcb/selection/alignGuides.ts
@@ -180,6 +180,21 @@ function rangesOverlap(a0: number, a1: number, b0: number, b1: number) {
   return Math.min(a1, b1) - Math.max(a0, b0) > 0.5;
 }
 
+/** Gap between two 1D ranges (0 when they overlap). Used as a locality tie-break. */
+function spanGap(a0: number, a1: number, b0: number, b1: number) {
+  if (rangesOverlap(a0, a1, b0, b1)) return 0;
+  if (a1 <= b0) return b0 - a1;
+  return a0 - b1;
+}
+
+/**
+ * Scene pad for neighbor collection (~24× snap threshold ≈ 192 screen px).
+ * Keeps snaps local (nearby / same artboard) instead of scanning the whole canvas.
+ */
+export function getSnapNeighborPad(snapThreshold: number) {
+  return Math.max(snapThreshold * 24, 64);
+}
+
 type Gap = {
   orient: 'h' | 'v';
   /** Distance between the two faces. */
@@ -565,12 +580,16 @@ export function snapBoxToGuides(
   let dy = 0;
   let bestX = threshold;
   let bestY = threshold;
+  /** Secondary score: prefer overlapping / nearby targets over distant ones. */
+  let bestCrossX = Number.POSITIVE_INFINITY;
+  let bestCrossY = Number.POSITIVE_INFINITY;
   let snapsX: SnapPair[] = [];
   let snapsY: SnapPair[] = [];
   let useGapX = false;
   let useGapY = false;
 
-  // Keep all ties at the nearest distance; wipe on closer.
+  // Keep ties at the nearest snap distance; among ties prefer smaller cross-axis gap
+  // so a local artboard center beats a distant sibling with the same mid line.
   const tryX = (
     sourceX: number,
     sourceY: number,
@@ -582,10 +601,19 @@ export function snapBoxToGuides(
     if (!facesCompatible(sourceFace, target.face)) return;
     const d = target.pos - sourceX;
     const ad = Math.abs(d);
-    if (roundSnap(ad) > roundSnap(bestX)) return;
-    if (roundSnap(ad) < roundSnap(bestX)) {
+    const cross = spanGap(sourceSpan[0], sourceSpan[1], target.span0, target.span1);
+    const rad = roundSnap(ad);
+    const rBest = roundSnap(bestX);
+    if (rad > rBest) return;
+    if (rad < rBest) {
       snapsX = [];
       bestX = ad;
+      bestCrossX = cross;
+    } else if (roundSnap(cross) > roundSnap(bestCrossX)) {
+      return;
+    } else if (roundSnap(cross) < roundSnap(bestCrossX)) {
+      snapsX = [];
+      bestCrossX = cross;
     }
     dx = d;
     snapsX.push({
@@ -609,10 +637,19 @@ export function snapBoxToGuides(
     if (!facesCompatible(sourceFace, target.face)) return;
     const d = target.pos - sourceY;
     const ad = Math.abs(d);
-    if (roundSnap(ad) > roundSnap(bestY)) return;
-    if (roundSnap(ad) < roundSnap(bestY)) {
+    const cross = spanGap(sourceSpan[0], sourceSpan[1], target.span0, target.span1);
+    const rad = roundSnap(ad);
+    const rBest = roundSnap(bestY);
+    if (rad > rBest) return;
+    if (rad < rBest) {
       snapsY = [];
       bestY = ad;
+      bestCrossY = cross;
+    } else if (roundSnap(cross) > roundSnap(bestCrossY)) {
+      return;
+    } else if (roundSnap(cross) < roundSnap(bestCrossY)) {
+      snapsY = [];
+      bestCrossY = cross;
     }
     dy = d;
     snapsY.push({
@@ -752,6 +789,7 @@ export function snapResizeToGuides(
     axis: 'x' | 'y'
   ) => {
     let best = threshold + 1;
+    let bestCross = Number.POSITIVE_INFINITY;
     let delta = 0;
     const pairs: SnapPair[] = [];
     for (const source of sources) {
@@ -759,10 +797,20 @@ export function snapResizeToGuides(
         if (!facesCompatible(source.face, t.face)) continue;
         const d = t.pos - source.pos;
         const ad = Math.abs(d);
-        if (roundSnap(ad) > roundSnap(best)) continue;
-        if (roundSnap(ad) < roundSnap(best)) {
+        const cross = spanGap(source.span0, source.span1, t.span0, t.span1);
+        const rad = roundSnap(ad);
+        const rBest = roundSnap(best);
+        if (rad > rBest) continue;
+        if (rad < rBest) {
           pairs.length = 0;
           best = ad;
+          bestCross = cross;
+          delta = d;
+        } else if (roundSnap(cross) > roundSnap(bestCross)) {
+          continue;
+        } else if (roundSnap(cross) < roundSnap(bestCross)) {
+          pairs.length = 0;
+          bestCross = cross;
           delta = d;
         }
         const center = !!source.isMid && !!t.isMid;
@@ -1135,6 +1183,40 @@ export function frameGuideBoxes(document: { frames?: ArtboardFrame[] } | null | 
       width: Math.max(1, Number(f.width) || 1),
       height: Math.max(1, Number(f.height) || 1),
     }));
+}
+
+type FrameGuideEntry = SceneBox & { id: string };
+
+/** Artboard frames with ids (for containing-frame snap scoping). */
+export function frameGuideEntries(
+  document: { frames?: ArtboardFrame[] } | null | undefined
+): FrameGuideEntry[] {
+  const frames = Array.isArray(document?.frames) ? document.frames : [];
+  return frames
+    .filter((f) => f?.id && Number(f.width) > 0 && Number(f.height) > 0)
+    .map((f) => ({
+      id: String(f.id),
+      left: Number(f.x) || 0,
+      top: Number(f.y) || 0,
+      width: Math.max(1, Number(f.width) || 1),
+      height: Math.max(1, Number(f.height) || 1),
+    }));
+}
+
+/** Frames whose bounds contain the box center (same-artboard snap scope). */
+export function framesContainingBox(
+  document: { frames?: ArtboardFrame[] } | null | undefined,
+  box: SceneBox
+): FrameGuideEntry[] {
+  const cx = box.left + box.width / 2;
+  const cy = box.top + box.height / 2;
+  return frameGuideEntries(document).filter(
+    (f) =>
+      cx >= f.left &&
+      cx <= f.left + f.width &&
+      cy >= f.top &&
+      cy <= f.top + f.height
+  );
 }
 
 function pushNodeGuideBoxes(


### PR DESCRIPTION
## Summary
- Scope snap targets to the containing artboard and nearby neighbors so distant posters no longer steal center-align guides.
- When snap distances tie, prefer overlapping / nearer targets on the cross axis.
- Always use the spatial index for neighbor queries (no whole-canvas fallback on small docs).

## Test plan
- [ ] Drag a shape inside a white artboard toward vertical/horizontal center — parent frame mid guides appear first
- [ ] Distant content on another poster should not draw long mid-align lines across the canvas
- [ ] Edge / gap snaps between nearby siblings in the same artboard still work
- [ ] Free-canvas shapes (outside any artboard) still snap to nearby neighbors
