### PR TITLE
Validate agent ops and gate OpenRouter for CN

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -78,6 +78,12 @@ LLM_DEFAULT_MODEL=doubao-seed-2-0-mini
 # OPENROUTER_API_KEY=sk-or-v1-...   # chat/agent via https://openrouter.ai/api/v1
 # OPENROUTER_HTTP_REFERER=https://your-site.example
 # OPENROUTER_APP_TITLE=recombyn
+# Region gate — OpenRouter is unreachable on many CN networks. Block by country:
+# OPENROUTER_BLOCK_COUNTRIES=CN
+# GeoLite2-Country.mmdb (MaxMind). Optional if CDN sets CF-IPCountry / similar.
+# GEOLITE2_COUNTRY_DB=storage/GeoLite2-Country.mmdb
+# Force country for local tests (empty = detect from headers / GeoLite2):
+# CLIENT_COUNTRY_OVERRIDE=CN
 # QWEN_API_KEY=
 # MOONSHOT_API_KEY=
 # Optional: extra Ark inference endpoints (ep-xxxx) appended to the picker

--- a/apps/api/api/v1/chat.py
+++ b/apps/api/api/v1/chat.py
@@ -6,7 +6,7 @@ import json
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -157,10 +157,24 @@ def _charge_image(
 
 
 @router.get("/models")
-def get_models() -> dict[str, Any]:
+def get_models(request: Request) -> dict[str, Any]:
     # Keep text/chat and image catalogs separate — FE merges with dedupe.
     # Do not use list_all_models() here or image ids appear twice under models + imageModels.
-    items = list_llm_models()
+    from services.geoip import (
+        filter_catalog_models_for_region,
+        openrouter_allowed_for_country,
+        resolve_client_country,
+    )
+
+    country = resolve_client_country(request)
+    or_ok = openrouter_allowed_for_country(country)
+    items = filter_catalog_models_for_region(list_llm_models(), country=country)
+    image_models = filter_catalog_models_for_region(
+        list_image_models(), country=country
+    )
+    video_models = filter_catalog_models_for_region(
+        list_video_models(), country=country
+    )
     available = True
     try:
         get_llm_endpoint()
@@ -169,8 +183,10 @@ def get_models() -> dict[str, Any]:
     return {
         "models": items,
         "available": available,
-        "imageModels": list_image_models(),
-        "videoModels": list_video_models(),
+        "imageModels": image_models,
+        "videoModels": video_models,
+        "clientRegion": country,
+        "openrouterAvailable": or_ok,
     }
 
 

--- a/apps/api/api/v1/design.py
+++ b/apps/api/api/v1/design.py
@@ -8,7 +8,7 @@ import logging
 import time
 from typing import Any
 
-from fastapi import APIRouter, Header, HTTPException
+from fastapi import APIRouter, Header, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -120,9 +120,13 @@ def design_canvas_tools() -> dict[str, Any]:
 @router.post("/run")
 async def design_run(
     body: DesignRunIn,
+    request: Request,
     authorization: str | None = Header(default=None),
 ) -> StreamingResponse:
     user = _require_user(authorization)
+    from services.geoip import resolve_client_country
+
+    client_country = resolve_client_country(request)
 
     async def gen():
         from services.design.progress_stages import (
@@ -173,6 +177,7 @@ async def design_run(
                     route_overrides=body.route_overrides,
                     apply_ops=body.apply_ops,
                     interaction_mode=body.interaction_mode,
+                    client_country=client_country,
                 ):
                     await queue.put(("ev", ev))
             except Exception as err:  # noqa: BLE001

--- a/apps/api/config/settings.py
+++ b/apps/api/config/settings.py
@@ -140,6 +140,12 @@ class Settings(BaseSettings):
     # Optional OpenRouter attribution headers (https://openrouter.ai/docs)
     openrouter_http_referer: str = ""
     openrouter_app_title: str = "recombyn"
+    # Region gate: hide/block OpenRouter when client country is listed (ISO-3166-1 alpha-2).
+    # GeoLite2-Country.mmdb path (optional). Edge headers CF-IPCountry etc. also work.
+    openrouter_block_countries: str = "CN"
+    geolite2_country_db: str = ""
+    # Force country for local tests (e.g. CLIENT_COUNTRY_OVERRIDE=CN). Empty = detect.
+    client_country_override: str = ""
     # Doubao Ark chat: model name or inference endpoint id (ep-xxxx).
     # Leave empty to hide that Doubao entry from the catalog.
     doubao_seed_model: str = ""

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "langchain-text-splitters>=0.3.0",
   "langfuse>=3.0.0",
   "cryptography>=42.0.0",
+  "geoip2>=4.8.0",
 ]
 
 [project.optional-dependencies]

--- a/apps/api/services/design/agent_controller.py
+++ b/apps/api/services/design/agent_controller.py
@@ -825,11 +825,12 @@ def _box_num(d: dict[str, Any], *keys: str, default: float = 0.0) -> float:
 
 
 def _derive_suggested_place_world(
-    spatial: dict[str, Any],
+    spatial: dict[str, Any] | None,
     *,
     focus_frame: dict[str, Any] | None = None,
 ) -> dict[str, float] | None:
-    """Host derives free-canvas place from FE viewport / frame-local slot."""
+    """Host derives free-canvas place from FE viewport / frame-local slot / focus frame."""
+    spatial = spatial if isinstance(spatial, dict) else {}
     vp = spatial.get("viewport")
     if isinstance(vp, dict):
         vx = _box_num(vp, "x")
@@ -849,12 +850,31 @@ def _derive_suggested_place_world(
     if isinstance(sp, dict) and isinstance(focus_frame, dict):
         fox = _box_num(focus_frame, "x")
         foy = _box_num(focus_frame, "y")
-        return {
-            "x": round(fox + _box_num(sp, "x")),
-            "y": round(foy + _box_num(sp, "y")),
-            "w": round(_box_num(sp, "w", "width", default=320)),
-            "h": round(_box_num(sp, "h", "height", default=200)),
-        }
+        fw = _box_num(focus_frame, "w", "width")
+        fh = _box_num(focus_frame, "h", "height")
+        # Only promote frame-local slots when the focus frame has a world origin.
+        if fw > 8 and fh > 8:
+            return {
+                "x": round(fox + _box_num(sp, "x")),
+                "y": round(foy + _box_num(sp, "y")),
+                "w": round(_box_num(sp, "w", "width", default=320)),
+                "h": round(_box_num(sp, "h", "height", default=200)),
+            }
+    # Last resort: center of the focused artboard in world coords.
+    if isinstance(focus_frame, dict):
+        fox = _box_num(focus_frame, "x")
+        foy = _box_num(focus_frame, "y")
+        fw = _box_num(focus_frame, "w", "width")
+        fh = _box_num(focus_frame, "h", "height")
+        if fw > 8 and fh > 8:
+            cw = min(320.0, max(80.0, fw * 0.25))
+            ch = min(200.0, max(80.0, fh * 0.25))
+            return {
+                "x": round(fox + max(24.0, (fw - cw) / 2)),
+                "y": round(foy + max(24.0, (fh - ch) / 2)),
+                "w": round(cw),
+                "h": round(ch),
+            }
     return None
 
 
@@ -863,17 +883,23 @@ def _format_spatial_placement(
     *,
     focus_frame: dict[str, Any] | None = None,
 ) -> str:
-    """Host placement brief — FE supplies viewport + scene facts only."""
-    if not isinstance(spatial, dict) or not spatial:
-        return ""
+    """Host placement brief — concrete numbers the paint model must use."""
+    spatial = spatial if isinstance(spatial, dict) else {}
     spw = _derive_suggested_place_world(spatial, focus_frame=focus_frame)
+    vp = spatial.get("viewport")
+    sp = spatial.get("suggested_place")
+    empties = spatial.get("empty_rects")
+    has_vp = isinstance(vp, dict) and _box_num(vp, "w", "width") > 0
+    has_sp = isinstance(sp, dict) and _box_num(sp, "w", "width") > 0
+    if not spw and not has_vp and not has_sp:
+        return ""
     lines: list[str] = [
         "PLACEMENT (no user position → pick a visible empty slot; stay in viewport):",
-        "- free-canvas create_shape/create_text (omit frameId): use suggested_place_world x/y.",
-        "- inside FOCUS_FRAME_ID: suggested_place / empty_rects are frame-local.",
+        "- free-canvas create_shape/create_text (omit frameId): use suggested_place_world x/y as WORLD coords.",
+        "- inside FOCUS_FRAME_ID: pass frameId + suggested_place / empty_rects (frame-local).",
+        "- Never invent near-origin x/y when suggested_place_world is far from (0,0).",
     ]
-    vp = spatial.get("viewport")
-    if isinstance(vp, dict) and _box_num(vp, "w", "width") > 0:
+    if has_vp:
         lines.append(
             f"- viewport_world: x={vp.get('x')} y={vp.get('y')} "
             f"w={vp.get('w') or vp.get('width')} h={vp.get('h') or vp.get('height')}"
@@ -883,13 +909,11 @@ def _format_spatial_placement(
             f"- suggested_place_world: x={spw['x']} y={spw['y']} "
             f"w={spw['w']} h={spw['h']}"
         )
-    sp = spatial.get("suggested_place")
-    if isinstance(sp, dict) and _box_num(sp, "w", "width") > 0:
+    if has_sp:
         lines.append(
             f"- suggested_place (frame-local): x={sp.get('x')} y={sp.get('y')} "
             f"w={sp.get('w')} h={sp.get('h')}"
         )
-    empties = spatial.get("empty_rects")
     if isinstance(empties, list):
         for i, box in enumerate(empties[:3]):
             if not isinstance(box, dict):
@@ -898,7 +922,102 @@ def _format_spatial_placement(
                 f"- empty_rect[{i}] (frame-local): x={box.get('x')} y={box.get('y')} "
                 f"w={box.get('w')} h={box.get('h')}"
             )
-    return "\n".join(lines) if len(lines) > 3 else ""
+    return "\n".join(lines)
+
+
+def _focus_frame_from_rt(rt: Any) -> dict[str, Any] | None:
+    focus_id = str(getattr(rt, "focus_id", "") or "").strip()
+    if not focus_id:
+        return None
+    for f in getattr(rt, "scene_frames", None) or []:
+        if isinstance(f, dict) and str(f.get("id") or "") == focus_id:
+            return f
+    return None
+
+
+def _point_outside_world_box(
+    x: float,
+    y: float,
+    box: dict[str, Any],
+    *,
+    pad: float = 0.0,
+) -> bool:
+    bx = _box_num(box, "x")
+    by = _box_num(box, "y")
+    bw = _box_num(box, "w", "width")
+    bh = _box_num(box, "h", "height")
+    if bw <= 0 or bh <= 0:
+        return False
+    return (
+        x < bx - pad
+        or y < by - pad
+        or x > bx + bw + pad
+        or y > by + bh + pad
+    )
+
+
+def _create_op_placement_fields(op: dict[str, Any]) -> tuple[Any, Any, str]:
+    """Return (x, y, frameId) from normalized {args} or flat model shape."""
+    args = op.get("args") if isinstance(op.get("args"), dict) else None
+    src = args if args is not None else op
+    return src.get("x"), src.get("y"), str(src.get("frameId") or src.get("frame_id") or "").strip()
+
+
+def _placement_errors_for_free_creates(rt: Any, ops: list[dict[str, Any]]) -> list[str]:
+    """Reject free-canvas creates outside the camera; model must re-emit with suggested_place_world.
+
+    Does not mutate ops. Frame-scoped creates (frameId set) are skipped — those use frame-local coords.
+    """
+    if not ops:
+        return []
+    spatial = (
+        getattr(rt, "spatial_summary", None)
+        if isinstance(getattr(rt, "spatial_summary", None), dict)
+        else {}
+    )
+    focus_frame = _focus_frame_from_rt(rt)
+    spw = _derive_suggested_place_world(spatial, focus_frame=focus_frame)
+    vp = spatial.get("viewport") if isinstance(spatial, dict) else None
+    view_box = vp if isinstance(vp, dict) and _box_num(vp, "w", "width") > 0 else None
+    if view_box is None and isinstance(focus_frame, dict):
+        view_box = focus_frame
+    if view_box is None:
+        return []
+    pad = max(
+        64.0,
+        0.25 * min(_box_num(view_box, "w", "width"), _box_num(view_box, "h", "height")),
+    )
+    errors: list[str] = []
+    for op in ops:
+        if not isinstance(op, dict):
+            continue
+        name = str(op.get("name") or op.get("op_key") or "").strip()
+        if name not in ("create_shape", "create_text", "create_image"):
+            continue
+        ox_raw, oy_raw, frame_id = _create_op_placement_fields(op)
+        if frame_id:
+            continue
+        if ox_raw is None and oy_raw is None:
+            continue
+        try:
+            ox = float(ox_raw if ox_raw is not None else (spw["x"] if spw else 0))
+            oy = float(oy_raw if oy_raw is not None else (spw["y"] if spw else 0))
+        except (TypeError, ValueError):
+            continue
+        if not _point_outside_world_box(ox, oy, view_box, pad=pad):
+            continue
+        if spw is not None:
+            errors.append(
+                f"{name} at world ({int(round(ox))},{int(round(oy))}) is outside viewport_world; "
+                f"re-emit with x={spw['x']} y={spw['y']} from suggested_place_world "
+                f"(omit frameId for free-canvas)."
+            )
+        else:
+            errors.append(
+                f"{name} at world ({int(round(ox))},{int(round(oy))}) is outside viewport_world; "
+                f"re-emit create_* with x/y inside the visible camera (omit frameId for free-canvas)."
+            )
+    return errors[:8]
 
 
 def _paint_ops_user(rt: Any) -> str:
@@ -906,15 +1025,9 @@ def _paint_ops_user(rt: Any) -> str:
     spatial = (
         getattr(rt, "spatial_summary", None)
         if isinstance(getattr(rt, "spatial_summary", None), dict)
-        else None
+        else {}
     )
-    focus_frame = None
-    focus_id = str(getattr(rt, "focus_id", "") or "").strip()
-    if focus_id:
-        for f in getattr(rt, "scene_frames", None) or []:
-            if isinstance(f, dict) and str(f.get("id") or "") == focus_id:
-                focus_frame = f
-                break
+    focus_frame = _focus_frame_from_rt(rt)
     spatial_hint = _format_spatial_placement(spatial, focus_frame=focus_frame)
     lean = _is_lean_paint_turn(rt)
     # Lean: tools + scene only — drop skill/knowledge/aesthetics essays for short adds.
@@ -2080,10 +2193,11 @@ def _scene_digest(
     if focus_id:
         lines.append(f"FOCUS_FRAME_ID: {focus_id}")
     if frames:
-        lines.append("SCENE_FRAMES:")
+        lines.append("SCENE_FRAMES (world x/y):")
         for f in frames[:16]:
             lines.append(
                 f"- id={f.get('id')} name={f.get('name') or ''} "
+                f"x={f.get('x')} y={f.get('y')} "
                 f"w={f.get('w')} h={f.get('h')} empty={f.get('is_empty')}"
             )
     if nodes:
@@ -4430,6 +4544,8 @@ async def _node_paint_ops(state: GraphState) -> Command:
         if attempt > 0:
             user_msg += (
                 "\n\nCRITICAL RETRY: previous tool_ops were empty or invalid. "
+                "If LAST_ERROR mentions viewport_world / suggested_place_world, "
+                "re-emit create_* with those world x/y (omit frameId for free-canvas). "
                 "Output a non-empty tool_ops array now."
             )
         try:
@@ -4519,6 +4635,12 @@ async def _node_paint_ops(state: GraphState) -> Command:
                 skill_keys=list(st.skills_loaded or []),
                 scene=rt.scene_key or "website",
             )
+        if step_ops:
+            place_errs = _placement_errors_for_free_creates(rt, step_ops)
+            if place_errs:
+                # Do not silently rewrite coords — reject and teach via LAST_ERROR / paint retry.
+                op_errors = list(op_errors or []) + place_errs
+                step_ops = []
         rt.step_ops = step_ops
         rt.op_errors = list(op_errors or [])
         st.push_log(

--- a/apps/api/services/design/models_route.py
+++ b/apps/api/services/design/models_route.py
@@ -415,6 +415,86 @@ def apply_user_route_overrides(
     return out
 
 
+def _serialize_lanes(lanes: dict[str, str]) -> str:
+    return ";".join(
+        f"{k}->{v}"
+        for k, v in lanes.items()
+        if k and v and k in ("fast", "standard", "reasoning", "else", "vision", "image")
+    )
+
+
+def sanitize_rules_for_openrouter_region(
+    rules: dict[str, str] | None,
+    *,
+    platform_rules: dict[str, str] | None,
+    country: str | None,
+) -> dict[str, str]:
+    """Replace OpenRouter lane models with Standard (platform) map when region blocks OR."""
+    from services.geoip import is_openrouter_model_ref, openrouter_allowed_for_country
+
+    out = dict(rules or {})
+    if openrouter_allowed_for_country(country):
+        return out
+    plat = parse_model_lanes(platform_rules)
+    lanes = parse_model_lanes(out)
+    changed = False
+    for key in ("fast", "standard", "reasoning", "else", "vision", "image"):
+        mid = str(lanes.get(key) or "").strip()
+        if not is_openrouter_model_ref(mid):
+            continue
+        fallback = (
+            str(plat.get(key) or "").strip()
+            or str(plat.get("standard") or "").strip()
+            or str(plat.get("else") or "").strip()
+            or mid
+        )
+        if fallback and fallback != mid:
+            lanes[key] = fallback
+            changed = True
+    if changed:
+        serialized = _serialize_lanes(lanes)
+        out["precheck.model_threshold"] = serialized
+        out["precheck.model_lanes"] = serialized
+    vision = str(out.get("precheck.vision_model") or "").strip()
+    if is_openrouter_model_ref(vision):
+        out["precheck.vision_model"] = (
+            str(plat.get("vision") or "").strip()
+            or str(platform_rules or {}).get("precheck.vision_model")
+            or str(plat.get("standard") or "").strip()
+            or vision
+        )
+    image = str(out.get("assets.image_default_model") or "").strip()
+    if is_openrouter_model_ref(image):
+        out["assets.image_default_model"] = (
+            str(plat.get("image") or "").strip()
+            or str(platform_rules or {}).get("assets.image_default_model")
+            or image
+        )
+    return out
+
+
+def sanitize_model_ref_for_openrouter_region(
+    model_ref: str | None,
+    *,
+    platform_rules: dict[str, str] | None,
+    country: str | None,
+) -> str:
+    """Locked/BYOK OpenRouter picks fall back to platform standard lane when blocked."""
+    from services.geoip import is_openrouter_model_ref, openrouter_allowed_for_country
+
+    mid = str(model_ref or "").strip()
+    if not mid or mid.lower() in ("auto", "platform", "default"):
+        return mid or "auto"
+    if openrouter_allowed_for_country(country) or not is_openrouter_model_ref(mid):
+        return mid
+    plat = parse_model_lanes(platform_rules)
+    return (
+        str(plat.get("standard") or "").strip()
+        or str(plat.get("else") or "").strip()
+        or "auto"
+    )
+
+
 def heuristic_route_lane(
     prompt: str,
     *,

--- a/apps/api/services/design/orchestrator.py
+++ b/apps/api/services/design/orchestrator.py
@@ -31,6 +31,8 @@ from services.design.models_route import (
     apply_user_route_overrides,
     pin_user_locked_model_routes,
     resolve_model_for_skill,
+    sanitize_model_ref_for_openrouter_region,
+    sanitize_rules_for_openrouter_region,
 )
 from services.design.pipeline_support import (
     _normalize_ref_images,
@@ -174,6 +176,7 @@ async def run_design_job(
     route_overrides: dict[str, Any] | None = None,
     apply_ops: list[dict[str, Any]] | None = None,
     interaction_mode: str | None = None,
+    client_country: str | None = None,
 ) -> AsyncIterator[dict[str, Any]]:
     """LangGraph agent loop. Chat vs design from model intent / ops."""
     del is_premium  # reserved
@@ -233,8 +236,18 @@ async def run_design_job(
             exec_trace(t0, "DONE", mode="permission", can_call_llm=False, balance=bal)
             return
 
+        platform_rules = get_global_rules()
+        user_selected_model = sanitize_model_ref_for_openrouter_region(
+            user_selected_model,
+            platform_rules=platform_rules,
+            country=client_country,
+        )
         rules = pin_user_locked_model_routes(
-            apply_user_route_overrides(get_global_rules(), route_overrides),
+            sanitize_rules_for_openrouter_region(
+                apply_user_route_overrides(platform_rules, route_overrides),
+                platform_rules=platform_rules,
+                country=client_country,
+            ),
             user_selected_model,
         )
         free_daily = False
@@ -308,8 +321,18 @@ async def run_design_job(
             reset_byok_user_id(byok_token)
         return
 
+    platform_rules = get_global_rules()
+    user_selected_model = sanitize_model_ref_for_openrouter_region(
+        user_selected_model,
+        platform_rules=platform_rules,
+        country=client_country,
+    )
     rules = pin_user_locked_model_routes(
-        apply_user_route_overrides(get_global_rules(), route_overrides),
+        sanitize_rules_for_openrouter_region(
+            apply_user_route_overrides(platform_rules, route_overrides),
+            platform_rules=platform_rules,
+            country=client_country,
+        ),
         user_selected_model,
     )
 

--- a/apps/api/services/design/tool_ops_contract.py
+++ b/apps/api/services/design/tool_ops_contract.py
@@ -489,77 +489,6 @@ def _collect_delete_node_ids(args: dict[str, Any]) -> list[str]:
     return [str(x).strip() for x in ids if str(x).strip()]
 
 
-def _rewrite_shape_morph_ops(ops: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """delete one node + create_shape → update_node(shapeType) to keep z-order.
-
-    Models often morph via delete+create because older schemas lacked shapeType
-    on update_node; that bumps the new shape to the top of the stack.
-    """
-    if len(ops) < 2:
-        return ops
-    delete_idxs: list[int] = []
-    create_idxs: list[int] = []
-    deleted: list[str] = []
-    for i, raw in enumerate(ops):
-        name = str(raw.get("name") or "").strip()
-        args = raw.get("args") if isinstance(raw.get("args"), dict) else {}
-        if name == "delete_nodes":
-            ids = _collect_delete_node_ids(args)
-            if ids:
-                delete_idxs.append(i)
-                deleted.extend(ids)
-        elif name == "create_shape":
-            create_idxs.append(i)
-    if len(deleted) != 1 or len(create_idxs) != 1 or len(delete_idxs) != 1:
-        return ops
-    create = ops[create_idxs[0]]
-    cargs = dict(create.get("args") or {})
-    shape_type = cargs.get("shapeType")
-    if shape_type is None:
-        shape_type = cargs.get("type")
-    if shape_type is None or not str(shape_type).strip():
-        return ops
-    update_args: dict[str, Any] = {
-        "nodeId": deleted[0],
-        "shapeType": shape_type,
-    }
-    for k in (
-        "x",
-        "y",
-        "width",
-        "height",
-        "w",
-        "h",
-        "fill",
-        "fillColor",
-        "stroke",
-        "borderWidth",
-        "opacity",
-        "rotation",
-        "cornerRadius",
-        "sides",
-        "name",
-    ):
-        if cargs.get(k) is not None:
-            update_args[k] = cargs.get(k)
-    drop = {delete_idxs[0], create_idxs[0]}
-    out: list[dict[str, Any]] = []
-    inserted = False
-    for i, raw in enumerate(ops):
-        if i in drop:
-            if not inserted:
-                out.append(
-                    {
-                        "name": "update_node",
-                        "args": _normalize_update_node_args(update_args),
-                    }
-                )
-                inserted = True
-            continue
-        out.append(raw)
-    return out
-
-
 def _normalize_inventory_text(s: str) -> str:
     return re.sub(r"\s+", "", str(s or "")).lower()
 
@@ -597,25 +526,49 @@ def _find_matching_text_node(
     return None
 
 
-def _hygiene_edit_ops(
+def _reject_shape_morph_ops(
+    ops: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Detect delete+create_shape morphs — do not rewrite; tell the model to use update_node."""
+    if len(ops) < 2:
+        return ops, []
+    delete_idxs: list[int] = []
+    create_idxs: list[int] = []
+    deleted: list[str] = []
+    for i, raw in enumerate(ops):
+        name = str(raw.get("name") or "").strip()
+        args = raw.get("args") if isinstance(raw.get("args"), dict) else {}
+        if name == "delete_nodes":
+            ids = _collect_delete_node_ids(args)
+            if ids:
+                delete_idxs.append(i)
+                deleted.extend(ids)
+        elif name == "create_shape":
+            create_idxs.append(i)
+    if len(deleted) != 1 or len(create_idxs) != 1 or len(delete_idxs) != 1:
+        return ops, []
+    create = ops[create_idxs[0]]
+    cargs = create.get("args") if isinstance(create.get("args"), dict) else {}
+    shape_type = cargs.get("shapeType")
+    if shape_type is None:
+        shape_type = cargs.get("type")
+    if shape_type is None or not str(shape_type).strip():
+        return ops, []
+    drop = {delete_idxs[0], create_idxs[0]}
+    kept = [raw for i, raw in enumerate(ops) if i not in drop]
+    err = (
+        f"prefer_update_node_shapeType: delete_nodes+create_shape morphs z-order; "
+        f"re-emit update_node nodeId={deleted[0]} shapeType={shape_type} "
+        f"(include fill/x/y/width/height as needed)."
+    )
+    return kept, [err]
+
+
+def _reject_create_text_as_edit(
     ops: list[dict[str, Any]],
     scene_nodes: list[dict[str, Any]] | None,
-) -> list[dict[str, Any]]:
-    """Edit-run hygiene (formerly FE sanitizeEditToolOps). Backend owns this.
-
-    - create_shape always stays create (add ≠ update an existing rect)
-    - create_text matching SCENE_NODES → update_node
-    - unmatched create_text on populated UI (no deletes) → drop
-    - update_node missing nodeId + fill → bind largest plate
-    """
-    _non_plate = frozenset({"text", "image", "svg"})
-    plates = [
-        n
-        for n in (scene_nodes or [])
-        if isinstance(n, dict)
-        and n.get("id")
-        and str(n.get("type") or "").lower() not in _non_plate
-    ]
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Detect create_text that matches SCENE_NODES — do not rewrite to update_node."""
     existing_texts = [
         n
         for n in (scene_nodes or [])
@@ -623,63 +576,29 @@ def _hygiene_edit_ops(
         and n.get("id")
         and str(n.get("type") or "").lower() == "text"
     ]
-    bg = None
-    if plates:
-        bg = max(
-            plates,
-            key=lambda n: float(n.get("w") or n.get("width") or 0)
-            * float(n.get("h") or n.get("height") or 0),
-        )
-    bg_id = str((bg or {}).get("id") or "")
-    has_delete = any(
-        str(o.get("name") or "").strip() in ("delete_nodes", "delete_frame") for o in ops
-    )
+    if not existing_texts:
+        return ops, []
     used_text_ids: set[str] = set()
-    out: list[dict[str, Any]] = []
+    kept: list[dict[str, Any]] = []
+    errors: list[str] = []
     for raw in ops:
         name = str(raw.get("name") or "").strip()
-        if not name:
+        args = raw.get("args") if isinstance(raw.get("args"), dict) else {}
+        if name != "create_text":
+            kept.append(raw)
             continue
-        args = dict(raw.get("args") or {})
-        if name == "create_text" and existing_texts:
-            match = _find_matching_text_node(
-                scene_nodes, str(args.get("text") or ""), used_text_ids
-            )
-            if match:
-                mid = str(match.get("id") or "")
-                used_text_ids.add(mid)
-                update_args: dict[str, Any] = {"nodeId": mid}
-                for k in (
-                    "text",
-                    "fontSize",
-                    "color",
-                    "fontWeight",
-                    "fontFamily",
-                    "textAlign",
-                ):
-                    if args.get(k) is not None:
-                        update_args[k] = args.get(k)
-                out.append(
-                    {
-                        "name": "update_node",
-                        "args": _normalize_update_node_args(update_args),
-                    }
-                )
-                continue
-            if not has_delete and len(existing_texts) >= 2:
-                continue
-        if (
-            name == "update_node"
-            and not args.get("nodeId")
-            and not args.get("id")
-            and bg_id
-            and args.get("fill") is not None
-        ):
-            args["nodeId"] = bg_id
-        if name == "update_node":
-            args = _normalize_update_node_args(args)
-        out.append({"name": name, "args": args})
-    return out
+        text = str(args.get("text") or args.get("content") or "")
+        match = _find_matching_text_node(scene_nodes, text, used_text_ids)
+        if not match:
+            kept.append(raw)
+            continue
+        mid = str(match.get("id") or "")
+        used_text_ids.add(mid)
+        errors.append(
+            f"prefer_update_node: create_text matches SCENE_NODES id={mid}; "
+            f"re-emit update_node nodeId={mid} with text/fontSize/color (do not create_text)."
+        )
+    return kept, errors
 
 
 def normalize_agent_tool_ops(
@@ -690,7 +609,10 @@ def normalize_agent_tool_ops(
     rules: dict[str, str] | None = None,
 ) -> tuple[list[dict[str, Any]], list[str]]:
     """
-    Allowlist + edit hygiene + per-op validation + op_id + dedupe.
+    Allowlist + alias normalize + per-op validation + op_id + dedupe.
+
+    Semantic mistakes are rejected with errors for the model to re-emit — never
+    silently rewritten (no create→update morph, no inventing nodeId).
     Returns (ops, errors). ops empty with errors → orchestrator should retry/fail.
     FE must execute these ops as-is (no client rewrite).
     """
@@ -719,6 +641,9 @@ def normalize_agent_tool_ops(
         if name == "create_shape":
             if args.get("shapeType") is None and args.get("type") is not None:
                 args["shapeType"] = args.get("type")
+        if name == "create_text":
+            if args.get("text") is None and args.get("content") is not None:
+                args["text"] = args.get("content")
         if name in (
             "delete_nodes",
             "align_nodes",
@@ -735,8 +660,11 @@ def normalize_agent_tool_ops(
             args = _normalize_update_node_args(args)
         working.append({"name": name, "args": args})
 
-    working = _rewrite_shape_morph_ops(working)
-    working = _hygiene_edit_ops(working, scene_nodes)
+    # Validate intent — reject, do not rewrite into a "fixed" op.
+    working, morph_errs = _reject_shape_morph_ops(working)
+    errors.extend(morph_errs)
+    working, text_errs = _reject_create_text_as_edit(working, scene_nodes)
+    errors.extend(text_errs)
 
     normalized: list[dict[str, Any]] = []
     for idx, item in enumerate(working):

--- a/apps/api/services/geoip.py
+++ b/apps/api/services/geoip.py
@@ -1,0 +1,161 @@
+"""Client country lookup for region-gated providers (e.g. OpenRouter on CN networks).
+
+Resolution order:
+1. ``CLIENT_COUNTRY_OVERRIDE`` (tests / forced region)
+2. Edge headers: ``CF-IPCountry``, ``CloudFront-Viewer-Country``, ``X-Appengine-Country``
+3. GeoLite2-Country.mmdb via ``GEOLITE2_COUNTRY_DB`` (optional ``geoip2`` package)
+
+Fail-open: missing DB / lookup errors → country unknown → OpenRouter allowed
+(unless override forces a blocked country).
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_HEADER_COUNTRY_KEYS = (
+    "cf-ipcountry",
+    "cloudfront-viewer-country",
+    "x-appengine-country",
+    "x-country-code",
+)
+
+
+def _settings() -> Any:
+    from config.settings import settings
+
+    return settings
+
+
+def is_openrouter_model_ref(model_ref: str | None) -> bool:
+    mid = str(model_ref or "").strip().lower()
+    if not mid:
+        return False
+    if mid.startswith("or-") or mid.startswith("openrouter/"):
+        return True
+    try:
+        from services.llm.catalog_store import get_model
+
+        row = get_model(str(model_ref or "").strip())
+        if isinstance(row, dict) and str(row.get("provider") or "").lower() == "openrouter":
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def openrouter_block_countries() -> set[str]:
+    raw = str(getattr(_settings(), "openrouter_block_countries", "CN") or "CN")
+    return {p.strip().upper() for p in raw.split(",") if p.strip()}
+
+
+def openrouter_allowed_for_country(country: str | None) -> bool:
+    """False when country is in the block list (typically mainland CN)."""
+    code = str(country or "").strip().upper()
+    if not code or code in ("XX", "T1", "UNKNOWN"):
+        return True
+    return code not in openrouter_block_countries()
+
+
+def client_ip_from_request(request: Any) -> str:
+    if request is None:
+        return ""
+    headers = getattr(request, "headers", None)
+    if headers is not None:
+        forwarded = str(headers.get("x-forwarded-for") or "").strip()
+        if forwarded:
+            return forwarded.split(",")[0].strip()
+        real_ip = str(headers.get("x-real-ip") or "").strip()
+        if real_ip:
+            return real_ip
+    client = getattr(request, "client", None)
+    host = getattr(client, "host", None) if client is not None else None
+    return str(host or "").strip()
+
+
+def country_from_headers(request: Any) -> str | None:
+    if request is None:
+        return None
+    headers = getattr(request, "headers", None)
+    if headers is None:
+        return None
+    for key in _HEADER_COUNTRY_KEYS:
+        raw = str(headers.get(key) or "").strip().upper()
+        if raw and raw not in ("XX", "T1"):
+            return raw[:8]
+    return None
+
+
+@lru_cache(maxsize=1)
+def _geoip_reader() -> Any | None:
+    path = str(getattr(_settings(), "geolite2_country_db", "") or "").strip()
+    if not path:
+        return None
+    try:
+        from pathlib import Path
+
+        p = Path(path)
+        if not p.is_file():
+            logger.warning("geolite2_country_db missing: %s", path)
+            return None
+        import geoip2.database
+
+        return geoip2.database.Reader(str(p))
+    except ImportError:
+        logger.warning("geoip2 not installed — GeoLite2 lookup disabled")
+        return None
+    except Exception as err:  # noqa: BLE001
+        logger.warning("geolite2 open failed: %s", err)
+        return None
+
+
+def lookup_country_for_ip(ip: str) -> str | None:
+    addr = str(ip or "").strip()
+    if not addr or addr in ("127.0.0.1", "::1", "localhost"):
+        return None
+    reader = _geoip_reader()
+    if reader is None:
+        return None
+    try:
+        resp = reader.country(addr)
+        code = str(getattr(getattr(resp, "country", None), "iso_code", None) or "").strip().upper()
+        return code or None
+    except Exception:
+        return None
+
+
+def resolve_client_country(request: Any = None) -> str | None:
+    override = str(getattr(_settings(), "client_country_override", "") or "").strip().upper()
+    if override:
+        return override
+    from_hdr = country_from_headers(request)
+    if from_hdr:
+        return from_hdr
+    return lookup_country_for_ip(client_ip_from_request(request))
+
+
+def openrouter_allowed_for_request(request: Any = None) -> bool:
+    return openrouter_allowed_for_country(resolve_client_country(request))
+
+
+def filter_catalog_models_for_region(
+    models: list[dict[str, Any]],
+    *,
+    country: str | None,
+) -> list[dict[str, Any]]:
+    if openrouter_allowed_for_country(country):
+        return models
+    out: list[dict[str, Any]] = []
+    for m in models:
+        if not isinstance(m, dict):
+            continue
+        provider = str(m.get("provider") or "").strip().lower()
+        mid = str(m.get("id") or "").strip()
+        if provider == "openrouter" or is_openrouter_model_ref(mid):
+            continue
+        out.append(m)
+    return out

--- a/apps/api/tests/unit_tests/test_agent_controller_parse.py
+++ b/apps/api/tests/unit_tests/test_agent_controller_parse.py
@@ -337,3 +337,102 @@ def test_paint_tool_keys_with_images_includes_create_image():
     assert _is_lean_paint_turn(rt) is False
     keys = _paint_tool_keys_for_turn(rt)
     assert "create_image" in keys
+
+
+def test_derive_suggested_place_world_prefers_viewport():
+    from services.design.agent_controller import _derive_suggested_place_world
+
+    spw = _derive_suggested_place_world(
+        {"viewport": {"x": 5000, "y": 2000, "w": 1200, "h": 800}},
+        focus_frame={"id": "f1", "x": 0, "y": 0, "w": 410, "h": 729},
+    )
+    assert spw is not None
+    assert 5000 <= spw["x"] <= 6200
+    assert 2000 <= spw["y"] <= 2800
+
+
+def test_format_spatial_placement_from_focus_frame_alone():
+    from services.design.agent_controller import _format_spatial_placement
+
+    text = _format_spatial_placement(
+        None,
+        focus_frame={"id": "f1", "x": 4800, "y": 1200, "w": 410, "h": 729},
+    )
+    assert "PLACEMENT" in text
+    assert "suggested_place_world" in text
+    # Centered inside focus frame world box (4800 + inset).
+    assert "x=4954" in text
+    assert "y=1473" in text
+
+
+def test_placement_errors_for_offscreen_free_creates():
+    from types import SimpleNamespace
+
+    from services.design.agent_controller import (
+        _derive_suggested_place_world,
+        _placement_errors_for_free_creates,
+    )
+
+    spatial = {"viewport": {"x": 4800, "y": 1200, "w": 1400, "h": 900}}
+    focus = {"id": "f1", "x": 5000, "y": 1400, "w": 410, "h": 729}
+    rt = SimpleNamespace(
+        spatial_summary=spatial,
+        focus_id="f1",
+        scene_frames=[focus],
+    )
+    # Normalized post-validate shape ({name, args}).
+    ops = [
+        {
+            "name": "create_shape",
+            "args": {
+                "shapeType": "rect",
+                "x": 120,
+                "y": 440,
+                "width": 170,
+                "height": 120,
+            },
+            "op_id": "t1",
+        }
+    ]
+    errs = _placement_errors_for_free_creates(rt, ops)
+    spw = _derive_suggested_place_world(spatial, focus_frame=focus)
+    assert errs
+    assert "outside viewport_world" in errs[0]
+    assert "suggested_place_world" in errs[0]
+    assert spw is not None
+    assert f"x={spw['x']}" in errs[0]
+    assert f"y={spw['y']}" in errs[0]
+    # Ops must not be mutated — teach via error, model re-emits.
+    assert ops[0]["args"]["x"] == 120
+
+
+def test_placement_errors_skip_framed_creates():
+    from types import SimpleNamespace
+
+    from services.design.agent_controller import _placement_errors_for_free_creates
+
+    rt = SimpleNamespace(
+        spatial_summary={"viewport": {"x": 4800, "y": 1200, "w": 1400, "h": 900}},
+        focus_id="f1",
+        scene_frames=[{"id": "f1", "x": 5000, "y": 1400, "w": 410, "h": 729}],
+    )
+    ops = [
+        {
+            "name": "create_shape",
+            "args": {"shapeType": "rect", "x": 120, "y": 440, "frameId": "f1"},
+            "op_id": "t1",
+        }
+    ]
+    assert _placement_errors_for_free_creates(rt, ops) == []
+
+
+def test_scene_digest_includes_frame_world_xy():
+    from services.design.agent_controller import _scene_digest
+
+    text = _scene_digest(
+        [],
+        [{"id": "f1", "name": "Design", "x": 5120, "y": 880, "w": 410, "h": 729, "is_empty": False}],
+        focus_id="f1",
+    )
+    assert "x=5120" in text
+    assert "y=880" in text

--- a/apps/api/tests/unit_tests/test_geoip_openrouter.py
+++ b/apps/api/tests/unit_tests/test_geoip_openrouter.py
@@ -1,0 +1,73 @@
+"""Region gate for OpenRouter (CN networks)."""
+
+from __future__ import annotations
+
+
+def test_openrouter_blocked_for_cn(monkeypatch):
+    from services import geoip
+
+    monkeypatch.setattr(geoip, "openrouter_block_countries", lambda: {"CN"})
+    assert geoip.openrouter_allowed_for_country("CN") is False
+    assert geoip.openrouter_allowed_for_country("US") is True
+    assert geoip.openrouter_allowed_for_country(None) is True
+
+
+def test_filter_catalog_drops_openrouter_in_cn(monkeypatch):
+    from services import geoip
+
+    monkeypatch.setattr(geoip, "openrouter_block_countries", lambda: {"CN"})
+    models = [
+        {"id": "doubao-seed-2-1-turbo", "provider": "doubao"},
+        {"id": "or-gpt-5-6-luna", "provider": "openrouter"},
+        {"id": "or-gpt-image-2", "provider": "openrouter"},
+    ]
+    kept = geoip.filter_catalog_models_for_region(models, country="CN")
+    assert [m["id"] for m in kept] == ["doubao-seed-2-1-turbo"]
+
+
+def test_sanitize_rules_replaces_openrouter_lanes(monkeypatch):
+    from services.design.models_route import sanitize_rules_for_openrouter_region
+
+    monkeypatch.setenv("CLIENT_COUNTRY_OVERRIDE", "")
+    platform = {
+        "precheck.model_threshold": (
+            "fast->doubao-seed-2-1-turbo;standard->deepseek-v4-flash;"
+            "reasoning->deepseek-v4-pro;vision->doubao-seed-2-1-turbo;"
+            "image->doubao-seedream-5-0-lite"
+        ),
+        "precheck.vision_model": "doubao-seed-2-1-turbo",
+        "assets.image_default_model": "doubao-seedream-5-0-lite",
+    }
+    merged = {
+        **platform,
+        "precheck.model_threshold": (
+            "fast->doubao-seed-2-1-turbo;standard->or-gpt-5-6-luna;"
+            "reasoning->or-gemini-3-flash-preview;vision->or-gemini-3-flash-preview;"
+            "image->or-gpt-image-2"
+        ),
+        "precheck.vision_model": "or-gemini-3-flash-preview",
+        "assets.image_default_model": "or-gpt-image-2",
+    }
+    out = sanitize_rules_for_openrouter_region(
+        merged, platform_rules=platform, country="CN"
+    )
+    assert "or-" not in out["precheck.model_threshold"]
+    assert out["precheck.vision_model"] == "doubao-seed-2-1-turbo"
+    assert out["assets.image_default_model"] == "doubao-seedream-5-0-lite"
+
+
+def test_sanitize_rules_keeps_openrouter_outside_cn():
+    from services.design.models_route import sanitize_rules_for_openrouter_region
+
+    platform = {
+        "precheck.model_threshold": "fast->doubao-seed-2-1-turbo;standard->deepseek-v4-flash",
+    }
+    merged = {
+        "precheck.model_threshold": "fast->doubao-seed-2-1-turbo;standard->or-gpt-5-6-luna",
+        "precheck.vision_model": "or-gemini-3-flash-preview",
+    }
+    out = sanitize_rules_for_openrouter_region(
+        merged, platform_rules=platform, country="US"
+    )
+    assert "or-gpt-5-6-luna" in out["precheck.model_threshold"]
+    assert out["precheck.vision_model"] == "or-gemini-3-flash-preview"

--- a/apps/api/tests/unit_tests/test_tool_ops_contract.py
+++ b/apps/api/tests/unit_tests/test_tool_ops_contract.py
@@ -71,8 +71,8 @@ def test_delete_accepts_node_ids_alias():
     assert ops[0]["args"]["nodeIds"] == ["n1"]
 
 
-def test_delete_plus_create_rewrites_to_update_shape():
-    """Rect→circle morph must keep id / z-order (not delete+create)."""
+def test_delete_plus_create_rejected_prefer_update_shape():
+    """Morph via delete+create is invalid — tell model to use update_node (no silent rewrite)."""
     raw_ops = [
         {"name": "delete_nodes", "args": {"node_ids": ["green1"]}},
         {
@@ -91,12 +91,39 @@ def test_delete_plus_create_rewrites_to_update_shape():
         raw_ops,
         scene_nodes=[{"id": "green1", "type": "rect", "w": 120, "h": 100}],
     )
-    assert not errs
-    assert len(ops) == 1
-    assert ops[0]["name"] == "update_node"
-    assert ops[0]["args"]["nodeId"] == "green1"
-    assert ops[0]["args"]["shapeType"] == "ellipse"
-    assert ops[0]["args"]["fill"] == "#00FF00"
+    assert not ops
+    assert any("prefer_update_node_shapeType" in e for e in errs)
+    assert any("green1" in e for e in errs)
+    assert any("ellipse" in e for e in errs)
+
+
+def test_create_text_matching_scene_rejected_prefer_update():
+    raw_ops = [
+        {
+            "name": "create_text",
+            "args": {"text": "Hello", "x": 10, "y": 20, "fontSize": 24},
+        },
+    ]
+    ops, errs = normalize_agent_tool_ops(
+        raw_ops,
+        scene_nodes=[{"id": "t1", "type": "text", "text": "Hello"}],
+    )
+    assert not ops
+    assert any("prefer_update_node" in e for e in errs)
+    assert any("t1" in e for e in errs)
+
+
+def test_update_node_missing_nodeId_not_invented():
+    """Do not bind fill-only update_node onto the largest plate."""
+    raw_ops = [
+        {"name": "update_node", "args": {"fill": "#ff0000"}},
+    ]
+    ops, errs = normalize_agent_tool_ops(
+        raw_ops,
+        scene_nodes=[{"id": "bg", "type": "rect", "w": 400, "h": 400}],
+    )
+    assert not ops
+    assert any("update_node_missing_nodeId" in e for e in errs)
 
 
 def test_update_node_accepts_shape_type():

--- a/apps/web/src/apis/chat.ts
+++ b/apps/web/src/apis/chat.ts
@@ -64,6 +64,10 @@ export type ChatModelsResponse = {
   available: boolean;
   imageModels?: LlmModel[];
   videoModels?: LlmModel[];
+  /** ISO country from GeoLite2 / edge headers when known. */
+  clientRegion?: string | null;
+  /** False on CN (and other blocked) networks — OpenRouter catalog hidden. */
+  openrouterAvailable?: boolean;
 };
 
 export type GenerateImageInput = {

--- a/apps/web/src/components/editor/panels/AgentDock.tsx
+++ b/apps/web/src/components/editor/panels/AgentDock.tsx
@@ -115,7 +115,13 @@ import { normalizeCanvasSizeChip } from '@/components/editor/chrome/SizePresetPa
 import {
   customProvidersAsModels,
 } from '@/components/editor/panels/agent/customLlmProviders';
-import { routeOverridesForApi, warmAgentRoutePresetRules, loadAgentRoutePrefs, AgentRoutePrefsEditor } from '@/components/editor/panels/agent/AgentModelsPanel';
+import {
+  routeOverridesForApi,
+  warmAgentRoutePresetRules,
+  warmOpenrouterAvailability,
+  loadAgentRoutePrefs,
+  AgentRoutePrefsEditor,
+} from '@/components/editor/panels/agent/AgentModelsPanel';
 import {
   fetchDesignCatalog,
   type DesignCatalog,
@@ -2106,6 +2112,7 @@ function AgentDock({
     listModels()
       .then((res) => {
         if (cancelled) return;
+        warmOpenrouterAvailability(res?.openrouterAvailable);
         const list = normalizeModelList(res?.models, res?.imageModels, res?.videoModels);
         setModels(list);
         setModelsStatus('ready');

--- a/apps/web/src/components/editor/panels/agent/AgentModelsPanel.tsx
+++ b/apps/web/src/components/editor/panels/agent/AgentModelsPanel.tsx
@@ -105,6 +105,35 @@ const ROUTE_PRESETS_FALLBACK: Record<
 };
 
 let cachedPresetRules: Record<string, string> | null = null;
+/** From GET /chat/models — null until first fetch. */
+let cachedOpenrouterAvailable: boolean | null = null;
+
+function isOpenRouterModelId(id: string | undefined): boolean {
+  const s = String(id || '').trim().toLowerCase();
+  return s.startsWith('or-') || s.startsWith('openrouter/');
+}
+
+function remapPrefsWithoutOpenRouter(prefs: AgentRoutePrefs): AgentRoutePrefs {
+  const domestic = resolveNamedPreset('economy');
+  const out: AgentRoutePrefs = { ...prefs };
+  for (const key of ['fast', 'standard', 'reasoning', 'vision', 'image'] as const) {
+    if (isOpenRouterModelId(out[key])) {
+      out[key] = domestic[key];
+    }
+  }
+  return out;
+}
+
+function resolvePresetForRegion(
+  name: Exclude<AgentRoutePreset, 'platform' | 'custom'>,
+  rules?: Record<string, string> | null
+): AgentRoutePrefs {
+  const base = resolveNamedPreset(name, rules);
+  if (cachedOpenrouterAvailable === false) {
+    return { ...remapPrefsWithoutOpenRouter(base), preset: name };
+  }
+  return base;
+}
 
 function migrateLegacyRouteKeys(
   raw: Record<string, unknown>
@@ -189,7 +218,7 @@ export function loadAgentRoutePrefs(
     }
     if (preset === 'platform') return { preset: 'platform' };
     if (preset === 'balanced' || preset === 'quality') {
-      return resolveNamedPreset(preset, rules);
+      return resolvePresetForRegion(preset, rules);
     }
     if (preset === 'custom') {
       const migrated = migrateLegacyRouteKeys(parsed);
@@ -221,12 +250,23 @@ export function routeOverridesForApi(
   prefs: AgentRoutePrefs = loadAgentRoutePrefs()
 ): Record<string, string> | null {
   if (!prefs || prefs.preset === 'platform') return null;
-  const base =
+  let base: AgentRoutePrefs =
     prefs.preset === 'economy' ||
     prefs.preset === 'balanced' ||
     prefs.preset === 'quality'
-      ? resolveNamedPreset(prefs.preset)
-      : prefs;
+      ? resolvePresetForRegion(prefs.preset)
+      : { ...prefs };
+  if (cachedOpenrouterAvailable === false) {
+    base = remapPrefsWithoutOpenRouter(base);
+  }
+  // When every lane fell back to domestic Standard, omit overrides (same as platform).
+  if (prefs.preset === 'balanced' || prefs.preset === 'quality') {
+    const platformish = resolveNamedPreset('economy');
+    const sameAsDomestic = (
+      ['fast', 'standard', 'reasoning', 'vision', 'image'] as const
+    ).every((k) => String(base[k] || '') === String(platformish[k] || ''));
+    if (sameAsDomestic) return null;
+  }
   const out: Record<string, string> = {};
   for (const key of ['fast', 'standard', 'reasoning', 'vision', 'image'] as const) {
     const v = String(base[key] || '').trim();
@@ -235,19 +275,33 @@ export function routeOverridesForApi(
   return Object.keys(out).length ? out : null;
 }
 
+/** Cache OpenRouter availability from GET /chat/models (region gate). */
+export function warmOpenrouterAvailability(available: boolean | null | undefined) {
+  if (available == null) return;
+  cachedOpenrouterAvailable = Boolean(available);
+}
+
 /** Warm Admin preset cache (call before send if panel not opened). */
 export async function warmAgentRoutePresetRules(
   rules?: Record<string, string> | null,
 ): Promise<void> {
   if (rules && typeof rules === 'object') {
     cachedPresetRules = rules;
-    return;
+  } else {
+    try {
+      const cat = await fetchDesignCatalog();
+      cachedPresetRules = cat.global_rules || {};
+    } catch {
+      /* keep fallback */
+    }
   }
-  try {
-    const cat = await fetchDesignCatalog();
-    cachedPresetRules = cat.global_rules || {};
-  } catch {
-    /* keep fallback */
+  if (cachedOpenrouterAvailable == null) {
+    try {
+      const res = await listModels();
+      warmOpenrouterAvailability(res?.openrouterAvailable);
+    } catch {
+      /* keep null */
+    }
   }
 }
 
@@ -327,6 +381,9 @@ function AgentRoutePrefsEditor({
   const [textModels, setTextModels] = useState<LlmModel[]>([]);
   const [imageModels, setImageModels] = useState<LlmModel[]>([]);
   const [submenu, setSubmenu] = useState<CompactSubmenu>(null);
+  const [openrouterAvailable, setOpenrouterAvailable] = useState<boolean | null>(
+    cachedOpenrouterAvailable
+  );
   const narrow = useNarrowViewport();
 
   useEffect(() => {
@@ -350,8 +407,12 @@ function AgentRoutePrefsEditor({
     void listModels()
       .then((res) => {
         if (cancelled) return;
+        const orOk = res?.openrouterAvailable !== false;
+        cachedOpenrouterAvailable = orOk;
+        setOpenrouterAvailable(orOk);
         setTextModels(res?.models || []);
         setImageModels(res?.imageModels || []);
+        setRoutePrefs(loadAgentRoutePrefs(cachedPresetRules));
       })
       .catch(() => undefined);
     return () => {
@@ -402,7 +463,7 @@ function AgentRoutePrefsEditor({
       return;
     }
     if (preset === 'balanced' || preset === 'quality') {
-      commit(resolveNamedPreset(preset));
+      commit(resolvePresetForRegion(preset));
       return;
     }
     commit({ preset: 'platform' });
@@ -557,7 +618,10 @@ function AgentRoutePrefsEditor({
                 const title = t(`account.agentRouteCard.${id}.title`);
                 const mult = t(`account.agentRouteCard.${id}.mult`);
                 const badge = t(`account.agentRouteCard.${id}.badge`);
-                const desc = t(`account.agentRouteCard.${id}.desc`);
+                const desc =
+                  openrouterAvailable === false && (id === 'balanced' || id === 'quality')
+                    ? t('account.agentRouteOpenrouterBlocked')
+                    : t(`account.agentRouteCard.${id}.desc`);
                 return (
                   <button
                     key={id}
@@ -836,15 +900,21 @@ function AgentRoutePrefsEditor({
         />
       </div>
 
-      <p className="text-[12px] leading-relaxed text-[var(--muted)]">
-        {routePrefs.preset === 'balanced'
-          ? t('account.agentRouteBalancedNote')
-          : routePrefs.preset === 'quality'
-            ? t('account.agentRouteQualityNote')
-            : routePrefs.preset === 'custom'
-              ? t('account.agentRouteCard.custom.desc')
-              : t('account.agentRoutePlatformNote')}
-      </p>
+      {openrouterAvailable === false ? (
+        <p className="text-[12px] leading-relaxed text-[var(--muted)]">
+          {t('account.agentRouteOpenrouterBlocked')}
+        </p>
+      ) : (
+        <p className="text-[12px] leading-relaxed text-[var(--muted)]">
+          {routePrefs.preset === 'balanced'
+            ? t('account.agentRouteBalancedNote')
+            : routePrefs.preset === 'quality'
+              ? t('account.agentRouteQualityNote')
+              : routePrefs.preset === 'custom'
+                ? t('account.agentRouteCard.custom.desc')
+                : t('account.agentRoutePlatformNote')}
+        </p>
+      )}
 
       {routePrefs.preset === 'custom' ? (
         <div className="space-y-3 rounded-lg bg-[var(--account-main)] p-3 ring-1 ring-[var(--line)]">

--- a/apps/web/src/components/editor/panels/agent/designTools.ts
+++ b/apps/web/src/components/editor/panels/agent/designTools.ts
@@ -95,16 +95,9 @@ function resolveFrameOpId(
 ): string {
   const focus = String(ctx.targetFrameId || '').trim();
   const fromArgs = String(args.frameId ?? args.id ?? '').trim();
-  if (focus) {
-    if (fromArgs && fromArgs !== focus) {
-      console.warn(
-        '[designTools] frame op retarget blocked',
-        { fromArgs, focus }
-      );
-    }
-    return focus;
-  }
-  return fromArgs;
+  // Honor model frameId when present — do not silently retarget to focus.
+  if (fromArgs) return fromArgs;
+  return focus;
 }
 
 /** Visible scene AABB in world coords (from camera + stage size). */
@@ -1071,6 +1064,58 @@ function resolveCreateXY(
   };
 }
 
+/** Reject creates that would require host geometry rewrite — tell the model via op error. */
+function placementRewriteError(
+  tool: string,
+  args: Record<string, unknown>,
+  placed: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    clamped: boolean;
+    scale: number;
+  }
+): AgentToolResult | null {
+  const hasGeom =
+    args.x != null ||
+    args.y != null ||
+    args.width != null ||
+    args.height != null ||
+    args.w != null ||
+    args.h != null;
+  if (!hasGeom) return null;
+  if (!placed.clamped && !(placed.scale > 0 && placed.scale < 0.999)) return null;
+  return {
+    status: 'error',
+    summary:
+      `${tool}_placement_invalid: host will not clamp/scale; ` +
+      `re-emit x/y/width/height inside the target frame ` +
+      `(refused rewrite → ${Math.round(placed.x)},${Math.round(placed.y)} ` +
+      `${Math.round(placed.width)}×${Math.round(placed.height)}).`,
+    next_actions: [
+      'Use frame-local coords inside FOCUS_FRAME',
+      'Or free-canvas world x/y from suggested_place_world',
+    ],
+  };
+}
+
+function requireCreateXY(
+  tool: string,
+  args: Record<string, unknown>
+): AgentToolResult | null {
+  const hasX = args.x != null && Number.isFinite(Number(args.x));
+  const hasY = args.y != null && Number.isFinite(Number(args.y));
+  if (hasX && hasY) return null;
+  return {
+    status: 'error',
+    summary:
+      `${tool}_missing_xy: provide numeric x and y ` +
+      `(frame-local with frameId, or world coords from suggested_place_world).`,
+    next_actions: ['Re-emit create_* with explicit x and y'],
+  };
+}
+
 const FRAME_GAP = 80;
 const NODE_GAP = 12;
 
@@ -1297,6 +1342,8 @@ function execCreateShape(
   const width = Math.max(1, num(args.width, 120));
   const height = Math.max(1, num(args.height, 80));
   const target = ctx.targetFrameId ? frameById(doc, ctx.targetFrameId) : null;
+  const missXY = requireCreateXY('create_shape', args);
+  if (missXY) return missXY;
   const svgRaw = args.svg != null ? String(args.svg) : args.iconSvg != null ? String(args.iconSvg) : '';
   // Icon SVG → native svg node (not image, not path conversion).
   if (svgRaw.trim() || mapped === 'svg') {
@@ -1309,6 +1356,8 @@ function execCreateShape(
     }
     const origin = resolveCreateXY(args, target, width, height);
     const placed = fitIntoFrame(target, origin.x, origin.y, width, height);
+    const placeErr = placementRewriteError('create_shape', args, placed);
+    if (placeErr) return placeErr;
     const fill = args.fill != null ? String(args.fill) : undefined;
     const { id, node } = createSvgNode({
       x: placed.x,
@@ -1328,7 +1377,7 @@ function execCreateShape(
     pushHistory();
     ctx.dispatch(setDocument(addNodeToDocument(ctx.getDocument(), id, node)));
     return {
-      status: placed.clamped ? 'warning' : 'success',
+      status: 'success',
       summary: `Created svg ${id}`,
       artifacts: { nodeId: id, shapeType: 'svg' },
       next_actions: ['Continue layout or create_text'],
@@ -1338,6 +1387,8 @@ function execCreateShape(
   // Honor model x/y when provided; otherwise center in the target frame.
   const origin = resolveCreateXY(args, target, width, height);
   const placed = fitIntoFrame(target, origin.x, origin.y, width, height);
+  const placeErr = placementRewriteError('create_shape', args, placed);
+  if (placeErr) return placeErr;
   if (mapped === 'path' || path) {
     console.info('[create_shape path diag]', {
       source: 'model tool_ops path (pass-through)',
@@ -1428,10 +1479,8 @@ function execCreateShape(
   pushHistory();
   ctx.dispatch(setDocument(addNodeToDocument(ctx.getDocument(), id, node)));
   return {
-    status: placed.clamped ? 'warning' : 'success',
-    summary: placed.clamped
-      ? `Created ${mapped} ${id} (clamped into frame at ${Math.round(placed.x)},${Math.round(placed.y)} ${Math.round(placed.width)}×${Math.round(placed.height)})`
-      : `Created ${mapped} ${id}${path ? ' (path)' : ''}`,
+    status: 'success',
+    summary: `Created ${mapped} ${id}${path ? ' (path)' : ''}`,
     artifacts: { nodeId: id, shapeType: mapped },
     next_actions: ['Continue layout or create_text'],
   };
@@ -1444,7 +1493,9 @@ function execCreateText(
   pushHistory: () => void
 ): AgentToolResult {
 
-  const text = String(args.text ?? '');
+  const text = String(args.text ?? args.content ?? '');
+  const missXY = requireCreateXY('create_text', args);
+  if (missXY) return missXY;
   const target = ctx.targetFrameId ? frameById(doc, ctx.targetFrameId) : null;
   // Fixed width+height = label-in-box (button/chip); do not hug content.
   const boxMode = args.width != null && args.height != null;
@@ -1500,12 +1551,8 @@ function execCreateText(
   // Labels must sit on top of buttons — never nudge away from overlapping shapes.
   const textOrigin = resolveCreateXY(args, target, boxW, boxH);
   const placed = fitIntoFrame(target, textOrigin.x, textOrigin.y, boxW, boxH);
-  if (placed.scale > 0 && placed.scale < 0.999 && nextStyle.fontSize != null) {
-    nextStyle.fontSize = Math.max(
-      10,
-      Math.round(Number(nextStyle.fontSize) * placed.scale)
-    );
-  }
+  const placeErr = placementRewriteError('create_text', args, placed);
+  if (placeErr) return placeErr;
   const { id, node } = createTextNode({
     x: placed.x,
     y: placed.y,
@@ -1534,10 +1581,8 @@ function execCreateText(
   pushHistory();
   ctx.dispatch(setDocument(addNodeToDocument(ctx.getDocument(), id, node)));
   return {
-    status: placed.clamped ? 'warning' : 'success',
-    summary: placed.clamped
-      ? `Created text ${id} (clamped ${Math.round(placed.width)}×${Math.round(placed.height)} at ${Math.round(placed.x)},${Math.round(placed.y)})`
-      : `Created text ${id} (${Math.round(placed.width)}×${Math.round(placed.height)})`,
+    status: 'success',
+    summary: `Created text ${id} (${Math.round(placed.width)}×${Math.round(placed.height)})`,
     artifacts: { nodeId: id },
   };
 }
@@ -2183,6 +2228,8 @@ function execCreateSvg(
     const width = Math.max(1, num(args.width, 48));
     const height = Math.max(1, num(args.height, 48));
     const target = ctx.targetFrameId ? frameById(doc, ctx.targetFrameId) : null;
+    const missXY = requireCreateXY('create_svg', args);
+    if (missXY) return missXY;
     const svgRaw = String(args.svg || args.iconSvg || args.content || '').trim();
     if (!svgRaw) {
       return {
@@ -2193,6 +2240,8 @@ function execCreateSvg(
     }
     const origin = resolveCreateXY(args, target, width, height);
     const placed = fitIntoFrame(target, origin.x, origin.y, width, height);
+    const placeErr = placementRewriteError('create_svg', args, placed);
+    if (placeErr) return placeErr;
     const fill = args.fill != null ? String(args.fill) : undefined;
     const { id, node } = createSvgNode({
       x: placed.x,
@@ -2213,7 +2262,7 @@ function execCreateSvg(
     pushHistory();
     ctx.dispatch(setDocument(addNodeToDocument(ctx.getDocument(), id, node)));
     return {
-      status: placed.clamped ? 'warning' : 'success',
+      status: 'success',
       summary: `Created svg ${id}`,
       artifacts: { nodeId: id, shapeType: 'svg' },
       next_actions: ['Continue layout'],
@@ -2229,9 +2278,13 @@ function execCreateImage(
 ): AgentToolResult {
   const width = Math.max(8, num(args.width, 240));
   const height = Math.max(8, num(args.height, 180));
+  const missXY = requireCreateXY('create_image', args);
+  if (missXY) return missXY;
   const target = ctx.targetFrameId ? frameById(doc, ctx.targetFrameId) : null;
   const origin = resolveCreateXY(args, target, width, height);
   const placed = fitIntoFrame(target, origin.x, origin.y, width, height);
+  const placeErr = placementRewriteError('create_image', args, placed);
+  if (placeErr) return placeErr;
   const userImages = Array.isArray(ctx.userImages) ? ctx.userImages : [];
   const genPrompt = String(args.genPrompt || args.prompt || '').trim();
   let src = '';
@@ -2284,10 +2337,7 @@ function execCreateImage(
   pushHistory();
   ctx.dispatch(setDocument(addNodeToDocument(ctx.getDocument(), id, node)));
   return {
-    status:
-      placed.clamped || (sourceKind === 'placeholder' && Boolean(genPrompt))
-        ? 'warning'
-        : 'success',
+    status: sourceKind === 'placeholder' && Boolean(genPrompt) ? 'warning' : 'success',
     summary: summarizeCreateImage({
       id,
       sourceKind,

--- a/apps/web/src/components/editor/panels/agent/runDesignAgent.ts
+++ b/apps/web/src/components/editor/panels/agent/runDesignAgent.ts
@@ -399,20 +399,35 @@ const FREE_CANVAS_CREATE_OPS = new Set([
   'create_icon',
 ]);
 
-/** Drop model frameId on free-canvas creates so they do not inject into an existing page. */
-function stripFrameIdFromFreeCreates(
+/** Free-canvas creates must omit frameId — reject (do not silently strip). */
+function rejectFramedFreeCreates(
   ops: Array<{ name?: string; args?: Record<string, unknown>; op_id?: string }>
-): Array<{ name?: string; args?: Record<string, unknown>; op_id?: string }> {
-  return ops.map((op) => {
+): {
+  kept: Array<{ name?: string; args?: Record<string, unknown>; op_id?: string }>;
+  rejected: ToolOpResult[];
+} {
+  const kept: Array<{ name?: string; args?: Record<string, unknown>; op_id?: string }> = [];
+  const rejected: ToolOpResult[] = [];
+  for (const op of ops) {
     const name = String(op?.name || '').trim();
-    if (!FREE_CANVAS_CREATE_OPS.has(name)) return op;
     const args =
-      op?.args && typeof op.args === 'object' ? { ...op.args } : {};
-    if (args.frameId == null && args.parentId == null) return op;
-    delete args.frameId;
-    delete args.parentId;
-    return { ...op, args };
-  });
+      op?.args && typeof op.args === 'object' ? op.args : {};
+    const hasFrame =
+      FREE_CANVAS_CREATE_OPS.has(name) &&
+      (args.frameId != null || args.parentId != null);
+    if (!hasFrame) {
+      kept.push(op);
+      continue;
+    }
+    rejected.push({
+      op_id: String(op?.op_id || ''),
+      name,
+      ok: false,
+      error:
+        'free_canvas: omit frameId/parentId; re-emit create_* with world x/y from suggested_place_world',
+    });
+  }
+  return { kept, rejected };
 }
 
 /** Pull WxH from a create_frame op when Host size is still unknown. */
@@ -997,8 +1012,16 @@ async function applyAgentToolOps(opts: {
     const op = allowed[i];
     const name = String(op?.name || '').trim();
     if (!name) continue;
-    // Host auto-groups once at the end of the run — ignore mid-stream group ops.
-    if (name === 'group_nodes' || name === 'ungroup_nodes') continue;
+    // Host auto-groups once at the end of the run — report skip, do not silently drop.
+    if (name === 'group_nodes' || name === 'ungroup_nodes') {
+      opResults.push({
+        op_id: String((op as { op_id?: string })?.op_id || ''),
+        name,
+        ok: false,
+        error: `${name}_deferred: host auto-groups at end of run; omit mid-stream group/ungroup`,
+      });
+      continue;
+    }
     const opId = String((op as { op_id?: string })?.op_id || '');
     const args = op?.args && typeof op.args === 'object' ? op.args : {};
     if (name === 'create_shape' && (args.path != null || String(args.type || args.shapeType || '') === 'path')) {
@@ -2786,8 +2809,11 @@ export async function runDesignAgent(params: RunDesignAgentParams): Promise<void
         live.frameId || pinned
           ? ops.filter((o) => String(o?.name || '').trim() !== 'create_frame')
           : ops;
+      let freeCanvasRejects: ToolOpResult[] = [];
       if (!bindToBoard) {
-        paintOps = stripFrameIdFromFreeCreates(paintOps);
+        const screened = rejectFramedFreeCreates(paintOps);
+        paintOps = screened.kept;
+        freeCanvasRejects = screened.rejected;
       }
 
       const frameId = bindToBoard
@@ -2821,8 +2847,10 @@ export async function runDesignAgent(params: RunDesignAgentParams): Promise<void
           appliedOpIds: appliedOpIdsRef.current,
           canvasUi: params.canvasUi,
         });
-        pendingOpResults.push(...applied.opResults);
-        const failures = applied.opResults.filter((r) => !r.ok);
+        pendingOpResults.push(...freeCanvasRejects, ...applied.opResults);
+        const failures = [...freeCanvasRejects, ...applied.opResults].filter(
+          (r) => !r.ok
+        );
         if (failures.length) {
           // Correct the backend's pre-emitted counts — user must see the truth.
           activitySeq += 1;

--- a/apps/web/src/components/home/HomeAgentComposer.tsx
+++ b/apps/web/src/components/home/HomeAgentComposer.tsx
@@ -48,6 +48,7 @@ import ModelPickerPanel, {
 import {
   AgentRoutePrefsEditor,
   loadAgentRoutePrefs,
+  warmOpenrouterAvailability,
   routeOverridesForApi,
 } from '@/components/editor/panels/agent/AgentModelsPanel';
 import { cn } from '@/utils/classnames';
@@ -391,6 +392,7 @@ function HomeAgentComposer({
     listModels()
       .then((res) => {
         if (cancelled) return;
+        warmOpenrouterAvailability(res?.openrouterAvailable);
         const list = normalizeModelList(res?.models, res?.imageModels, res?.videoModels);
         setModels(list);
         setModelsStatus('ready');

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -662,6 +662,8 @@ const en = {
     agentRoutePlatformNote: 'Using Standard routes (domestic Seed / DeepSeek / Seedream preferred).',
     agentRouteBalancedNote: 'Using Pro routing — stronger models by lane.',
     agentRouteQualityNote: 'Using Max routing — highest quality reasoning and instruction following.',
+    agentRouteOpenrouterBlocked:
+      'OpenRouter is unavailable on this network. Pro / Max fall back to domestic models (same as Standard lanes).',
     agentRouteSave: 'Save routing prefs',
     agentRouteSaved: 'Saved',
     notices: {

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -641,6 +641,8 @@ const ja = {
     agentRoutePlatformNote: 'スタンダード（プラットフォーム既定）ルートを使用中です。',
     agentRouteBalancedNote: 'Pro ルートを使用中。車線に応じてより強いモデルを選びます。',
     agentRouteQualityNote: 'Max ルートを使用中。最高品質の推論と指示追従を優先します。',
+    agentRouteOpenrouterBlocked:
+      'このネットワークでは OpenRouter を利用できません。Pro / Max は国内モデル（Standard 相当）にフォールバックします。',
     agentRouteSave: 'ルーティングを保存',
     agentRouteSaved: '保存済み',
     notices: {

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -656,6 +656,8 @@ const zhCN = {
     agentRoutePlatformNote: '当前使用标准版路由（优先国内 Seed / DeepSeek / Seedream）。',
     agentRouteBalancedNote: '当前使用 Pro 路由偏好，按车道自动选用更强模型。',
     agentRouteQualityNote: '当前使用 Max 路由偏好，优先高质量推理与指令跟随。',
+    agentRouteOpenrouterBlocked:
+      '当前网络无法使用 OpenRouter。Pro / Max 已回退为国内模型（与标准版车道一致）。',
     agentRouteSave: '保存路由偏好',
     agentRouteSaved: '已保存',
     notices: {

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -635,6 +635,8 @@ const zhTW = {
     agentRoutePlatformNote: '目前使用標準版（平台預設）路由，無需額外設定。',
     agentRouteBalancedNote: '目前使用 Pro 路由偏好，依車道自動選用更強模型。',
     agentRouteQualityNote: '目前使用 Max 路由偏好，優先高質量推理與指令跟隨。',
+    agentRouteOpenrouterBlocked:
+      '目前網路無法使用 OpenRouter。Pro / Max 已回退為國內模型（與標準版車道一致）。',
     agentRouteSave: '儲存路由偏好',
     agentRouteSaved: '已儲存',
     notices: {


### PR DESCRIPTION
## Summary
- Stop silently rewriting design-agent tool ops (placement, morph, create_text hygiene, FE clamp/frameId); reject with errors so paint/observe can teach the model via LAST_ERROR.
- Add GeoIP region gate (edge headers + optional GeoLite2) to hide OpenRouter models on CN networks and rewrite Pro/Max route overrides to domestic Standard lanes.
- Surface `openrouterAvailable` to the Agent route UI so Standard/Pro/Max copy reflects the fallback.

## Test plan
- [ ] Unit: `pytest apps/api/tests/unit_tests/test_geoip_openrouter.py test_tool_ops_contract.py test_agent_controller_parse.py -q`
- [ ] With `CLIENT_COUNTRY_OVERRIDE=CN`, confirm `/api/v1/chat/models` omits `or-*` and returns `openrouterAvailable: false`
- [ ] Pro/Max Auto send still works on CN (domestic lane models) and on non-CN (OpenRouter lanes unchanged)
- [ ] Off-viewport free-canvas create is rejected and paint retries with LAST_ERROR mentioning `suggested_place_world`
- [ ] delete+create shape morph returns `prefer_update_node_shapeType` instead of rewriting