### PR TITLE
Ignore entire data/private seed overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,9 +92,8 @@ apps/web/public/ffmpeg/
 # Local infra not published with OSS (keep on disk only)
 infra/langfuse/
 
-# SaaS / private design seeds (overlay on apps/api/data/)
-apps/api/data/private/**
-!apps/api/data/private/README.md
+# SaaS / private design seeds — whole dir local-only (create yourself)
+apps/api/data/private/
 
 # local sqlite sidecars
 apps/api/storage/*.db-shm

--- a/apps/api/data/README.md
+++ b/apps/api/data/README.md
@@ -3,15 +3,15 @@
 ```
 apps/api/data/
   public/     # tracked — OSS-safe / infra seeds
-  private/    # gitignored — SaaS / local product content
+  private/    # local only (gitignored) — create for SaaS / full product content
   README.md
 ```
 
 | Location | Git | Role |
 |----------|-----|------|
 | `data/public/` | Tracked | Public stubs + infra (`canvas_actions`, fonts, stages, …) |
-| `data/private/` | Ignored (except README) | Full prompts / skills / knowledge / tokens / models / cases |
+| `data/private/` | Not in git | Full prompts / skills / knowledge / tokens / models / cases |
 
 Loaders use `resolve_data_file` / `resolve_data_dir`: **private wins** when the path exists.
 
-Optional: `DESIGN_DATA_PRIVATE_DIR` (absolute, or relative to `apps/api`).
+Create `data/private/` locally (or on the SaaS host) and drop seed JSON there — same filenames as under `public/`. Optional: `DESIGN_DATA_PRIVATE_DIR` (absolute, or relative to `apps/api`).

--- a/apps/api/services/seed.py
+++ b/apps/api/services/seed.py
@@ -122,7 +122,7 @@ def _default_official_case_entries(data_dir: Path) -> list[dict[str, str]]:
 
 
 def seed_official_plaza_cases() -> int:
-    """Seed approved plaza_submissions from api/data/official_cases. Skip existing ids."""
+    """Seed approved plaza_submissions from data/public|private/official_cases."""
     init_schema()
     data_dir = _resolve_seed_dir("official_cases")
     index_path = data_dir / "index.json"


### PR DESCRIPTION
## Summary
- `.gitignore` ignores `apps/api/data/private/` entirely (no tracked README).
- `data/README.md` documents public vs private overlay.
- Tiny docstring path sync in `seed.py`.

## Test plan
- [ ] GitHub no longer shows `apps/api/data/private`
- [ ] Local private JSON still resolves first

Made with [Cursor](https://cursor.com)