### PR TITLE
Accept tool_ops parameters and show validation failures in chat

### DIFF
--- a/apps/api/api/v1/design.py
+++ b/apps/api/api/v1/design.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import time
+from dataclasses import dataclass, field
 from typing import Any
 
 from fastapi import APIRouter, Header, HTTPException, Request
@@ -27,6 +28,25 @@ _log = logging.getLogger("design.run_api")
 # Also drives user-visible Thought-row heartbeats while the model is silent.
 _SSE_HEARTBEAT_SEC = 8.0
 
+_DESIGN_ARM_STAGES = frozenset(
+    {
+        "lookup",
+        "validate",
+        "ops",
+        "scene_check",
+        "critic",
+        "refine",
+        "scene",
+        "failed",
+    }
+)
+_EARLY_EXPLORE_STAGES = frozenset(
+    {"prompt", "prepare", "model_wait", "model_stream"}
+)
+_PAINT_EVENT_TYPES = frozenset({"tool_ops", "svg_delta", "drawing"})
+_PAINT_ACTIVITY_KINDS = frozenset({"tool", "added", "updated", "deleted"})
+_TERMINAL_STAGES = frozenset({"done", "failed"})
+
 
 def _bearer(authorization: str | None) -> str | None:
     if not authorization:
@@ -42,6 +62,188 @@ def _require_user(authorization: str | None):
     if not user:
         raise HTTPException(status_code=401, detail="Unauthorized")
     return user
+
+
+def _sse_data(obj: dict[str, Any]) -> str:
+    return f"data: {json.dumps(obj, ensure_ascii=False)}\n\n"
+
+
+@dataclass
+class _PipelineSseState:
+    """Mutable Explored-pipeline bookkeeping for one /run SSE stream."""
+
+    current_stage: str | None = None
+    pipeline_armed: bool = False
+    saw_paint: bool = False
+    chat_divert: bool = False
+    result_failed: bool = False
+    out_n: int = 0
+    t0: float = field(default_factory=time.time)
+
+    def arm(self, stage: str | None = "prepare") -> None:
+        if self.chat_divert or self.pipeline_armed:
+            return
+        self.pipeline_armed = True
+        self.current_stage = stage or "prepare"
+
+    def mark_chat_divert(self) -> None:
+        self.chat_divert = True
+        self.current_stage = "done"
+
+    def terminal_stage_event(self) -> dict[str, Any] | None:
+        from services.design.runtime.progress_stages import thought_stage_event
+
+        if not self.pipeline_armed or self.chat_divert:
+            return None
+        if self.current_stage in _TERMINAL_STAGES:
+            return None
+        if self.result_failed:
+            return thought_stage_event("failed", status="error")
+        return thought_stage_event("done", status="done")
+
+    def heartbeat_stage_event(self) -> dict[str, Any] | None:
+        from services.design.runtime.progress_stages import thought_stage_event
+
+        if not self.pipeline_armed or self.chat_divert or self.saw_paint:
+            return None
+        if not self.current_stage or self.current_stage in _TERMINAL_STAGES:
+            return None
+        elapsed = int(time.time() - self.t0)
+        return thought_stage_event(self.current_stage, elapsed_s=elapsed)
+
+
+def _should_chat_divert(payload: dict[str, Any]) -> bool:
+    et = str(payload.get("type") or "")
+    if et == "chat_done":
+        return True
+    if et == "result":
+        if str(payload.get("status") or "") == "error":
+            return False
+        return str(payload.get("intent") or "") == "chat"
+    if et != "decision":
+        return False
+    return (
+        payload.get("is_chitchat") is True
+        or str(payload.get("route") or "") == "chitchat"
+        or str(payload.get("intent") or "") == "chat"
+    )
+
+
+def _arm_stage_from_activity(payload: dict[str, Any]) -> str | None:
+    kind = str(payload.get("kind") or "")
+    stage = str(payload.get("stage") or "").strip()
+    if kind in _PAINT_ACTIVITY_KINDS:
+        return "ops"
+    if stage in _DESIGN_ARM_STAGES:
+        return stage
+    if kind == "explored" and stage and stage not in _EARLY_EXPLORE_STAGES:
+        return stage
+    return None
+
+
+def _maybe_arm_pipeline(state: _PipelineSseState, payload: dict[str, Any]) -> None:
+    if state.chat_divert:
+        return
+    et = str(payload.get("type") or "")
+    if et in _PAINT_EVENT_TYPES:
+        state.arm("ops")
+        return
+    if et != "activity":
+        return
+    stage = _arm_stage_from_activity(payload)
+    if stage:
+        state.arm(stage)
+
+
+def _is_paint_signal(payload: dict[str, Any]) -> bool:
+    et = str(payload.get("type") or "")
+    if et in _PAINT_EVENT_TYPES or et == "result":
+        return True
+    if et != "activity":
+        return False
+    return str(payload.get("kind") or "") in _PAINT_ACTIVITY_KINDS
+
+
+def _stage_advance_events(
+    state: _PipelineSseState, payload: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Advance Explored stage and return any stage SSE frames to emit."""
+    from services.design.runtime.progress_stages import (
+        maybe_advance_stage,
+        stage_for_event,
+        thought_stage_event,
+    )
+
+    if not state.pipeline_armed or state.chat_divert:
+        return []
+    nxt = stage_for_event(payload)
+    advanced = maybe_advance_stage(state.current_stage, nxt)
+    if not advanced or advanced == state.current_stage:
+        return []
+    state.current_stage = advanced
+    elapsed = int(time.time() - state.t0)
+    if advanced == "done":
+        if state.result_failed:
+            state.current_stage = "failed"
+            return [thought_stage_event("failed", status="error")]
+        return [thought_stage_event("done", status="done")]
+    if not state.saw_paint or advanced in ("ops", "refine"):
+        return [thought_stage_event(advanced, elapsed_s=elapsed)]
+    return []
+
+
+def _result_terminal_event(
+    state: _PipelineSseState,
+) -> dict[str, Any] | None:
+    from services.design.runtime.progress_stages import thought_stage_event
+
+    if not state.pipeline_armed or state.current_stage in _TERMINAL_STAGES:
+        return None
+    if state.result_failed:
+        state.current_stage = "failed"
+        return thought_stage_event("failed", status="error")
+    state.current_stage = "done"
+    return None
+
+
+def _pipeline_side_effects(
+    state: _PipelineSseState, payload: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Update pipeline state for one agent event; return extra stage frames."""
+    extra: list[dict[str, Any]] = []
+    if _should_chat_divert(payload):
+        state.mark_chat_divert()
+    if str(payload.get("type") or "") == "result" and str(
+        payload.get("status") or ""
+    ) == "error":
+        state.result_failed = True
+    _maybe_arm_pipeline(state, payload)
+    extra.extend(_stage_advance_events(state, payload))
+    if _is_paint_signal(payload):
+        state.saw_paint = True
+    if str(payload.get("type") or "") == "result":
+        term = _result_terminal_event(state)
+        if term:
+            extra.append(term)
+    return extra
+
+
+def _should_log_sse(et: str | None, out_n: int) -> bool:
+    return out_n <= 12 or et in (
+        "thinking",
+        "analysis_delta",
+        "skill_start",
+        "error",
+    )
+
+
+def _sse_log_line(
+    *, t0: float, out_n: int, et: str | None, payload: Any
+) -> str:
+    preview = ""
+    if isinstance(payload, dict) and et in ("thinking", "analysis_delta"):
+        preview = repr(str(payload.get("text") or "")[:60])
+    return f"[sse_out] +{time.time() - t0:6.2f}s  n={out_n} type={et} {preview}"
 
 
 class DesignRunIn(BaseModel):
@@ -129,23 +331,11 @@ async def design_run(
     client_country = resolve_client_country(request)
 
     async def gen():
-        from services.design.runtime.progress_stages import (
-            maybe_advance_stage,
-            stage_for_event,
-            thought_stage_event,
-        )
-
         # Flush headers / proxy buffers immediately so FE can leave "Thinking…".
         yield ": connected\n\n"
 
         queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
-        t0 = time.time()
-        out_n = 0
-        # Explored pipeline only after model return codes show design (lookups/ops).
-        current_stage: str | None = None
-        pipeline_armed = False
-        saw_paint = False
-        chat_divert = False
+        state = _PipelineSseState()
 
         async def produce() -> None:
             try:
@@ -185,136 +375,52 @@ async def design_run(
             finally:
                 await queue.put(("done", None))
 
-        def _emit(obj: dict[str, Any]) -> str:
-            return f"data: {json.dumps(obj, ensure_ascii=False)}\n\n"
-
-        def _arm_pipeline(stage: str | None = "prepare") -> None:
-            nonlocal pipeline_armed, current_stage
-            if chat_divert:
-                return
-            if not pipeline_armed:
-                pipeline_armed = True
-                current_stage = stage or "prepare"
-
         task = asyncio.create_task(produce())
         try:
-            # Do NOT seed Explored here — wait for lookups/ops (design return codes).
-
             while True:
                 try:
                     kind, payload = await asyncio.wait_for(
                         queue.get(), timeout=_SSE_HEARTBEAT_SEC
                     )
                 except asyncio.TimeoutError:
-                    elapsed = int(time.time() - t0)
-                    if (
-                        pipeline_armed
-                        and not chat_divert
-                        and not saw_paint
-                        and current_stage
-                        and current_stage != "done"
-                    ):
-                        yield _emit(
-                            thought_stage_event(current_stage, elapsed_s=elapsed)
-                        )
+                    hb = state.heartbeat_stage_event()
+                    if hb:
+                        yield _sse_data(hb)
                     yield ": ping\n\n"
                     continue
+
                 if kind == "done":
-                    if (
-                        pipeline_armed
-                        and not chat_divert
-                        and current_stage != "done"
-                    ):
-                        yield _emit(thought_stage_event("done", status="done"))
+                    term = state.terminal_stage_event()
+                    if term:
+                        yield _sse_data(term)
                     break
+
                 if kind == "err":
                     msg = str(payload)[:800] or "design_run_failed"
-                    yield _emit({"type": "error", "message": msg})
+                    yield _sse_data({"type": "error", "message": msg})
                     break
 
-                out_n += 1
+                state.out_n += 1
                 et = payload.get("type") if isinstance(payload, dict) else None
                 if isinstance(payload, dict):
-                    if et == "chat_done" or (
-                        et == "result"
-                        and str(payload.get("intent") or "") == "chat"
-                    ):
-                        chat_divert = True
-                        current_stage = "done"
-                    elif et == "decision" and (
-                        payload.get("is_chitchat") is True
-                        or str(payload.get("route") or "") == "chitchat"
-                        or str(payload.get("intent") or "") == "chat"
-                    ):
-                        chat_divert = True
-                        current_stage = "done"
+                    for frame in _pipeline_side_effects(state, payload):
+                        yield _sse_data(frame)
 
-                    # Arm Explored only on design signals — never on early
-                    # prompt/model_wait alone (those used to fire for 「你好」).
-                    if not chat_divert:
-                        if et in ("tool_ops", "svg_delta", "drawing"):
-                            _arm_pipeline("ops")
-                        elif et == "activity":
-                            kind_a = str(payload.get("kind") or "")
-                            stage_a = str(payload.get("stage") or "")
-                            if kind_a in ("tool", "added", "updated", "deleted"):
-                                _arm_pipeline("ops")
-                            elif stage_a in (
-                                "lookup",
-                                "validate",
-                                "ops",
-                                "scene_check",
-                                "critic",
-                                "refine",
-                                "scene",
-                            ):
-                                _arm_pipeline(stage_a)
-                            elif (
-                                kind_a == "explored"
-                                and stage_a
-                                and stage_a
-                                not in (
-                                    "prompt",
-                                    "prepare",
-                                    "model_wait",
-                                    "model_stream",
-                                )
-                            ):
-                                _arm_pipeline(stage_a)
+                if _should_log_sse(et if isinstance(et, str) else None, state.out_n):
+                    line = _sse_log_line(
+                        t0=state.t0,
+                        out_n=state.out_n,
+                        et=et if isinstance(et, str) else None,
+                        payload=payload,
+                    )
+                    _log.info(line)
+                    _safe_print(line)
 
-                    if pipeline_armed and not chat_divert:
-                        nxt = stage_for_event(payload)
-                        advanced = maybe_advance_stage(current_stage, nxt)
-                        if advanced and advanced != current_stage:
-                            current_stage = advanced
-                            elapsed = int(time.time() - t0)
-                            if advanced == "done":
-                                yield _emit(thought_stage_event("done", status="done"))
-                            elif not saw_paint or advanced in ("ops", "refine"):
-                                yield _emit(
-                                    thought_stage_event(advanced, elapsed_s=elapsed)
-                                )
-                    if et in ("tool_ops", "svg_delta", "drawing") or (
-                        et == "activity"
-                        and str(payload.get("kind") or "")
-                        in ("tool", "added", "updated", "deleted")
-                    ):
-                        saw_paint = True
-                    elif et == "result":
-                        saw_paint = True
-                        if pipeline_armed:
-                            current_stage = "done"
+                if isinstance(payload, dict):
+                    yield _sse_data(payload)
+                else:
+                    yield f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
 
-                if out_n <= 12 or et in ("thinking", "analysis_delta", "skill_start", "error"):
-                    preview = ""
-                    if isinstance(payload, dict) and et in ("thinking", "analysis_delta"):
-                        preview = repr(str(payload.get("text") or "")[:60])
-                    msg = f"[sse_out] +{time.time()-t0:6.2f}s  n={out_n} type={et} {preview}"
-                    _log.info(msg)
-                    _safe_print(msg)
-                yield _emit(payload) if isinstance(payload, dict) else (
-                    f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
-                )
             yield "data: [DONE]\n\n"
         finally:
             if not task.done():
@@ -323,6 +429,7 @@ async def design_run(
                     await task
                 except (asyncio.CancelledError, Exception):
                     pass
+
     return StreamingResponse(
         gen(),
         media_type="text/event-stream",

--- a/apps/api/data/public/progress_stages.json
+++ b/apps/api/data/public/progress_stages.json
@@ -11,7 +11,8 @@
     "scene_check": "回读画布状态",
     "critic": "目标检查",
     "refine": "根据检查结果调整",
-    "done": "完成"
+    "done": "完成",
+    "failed": "未完成"
   },
   "eventStage": {
     "decision": "prepare",

--- a/apps/api/services/design/ops/tool_ops_contract.py
+++ b/apps/api/services/design/ops/tool_ops_contract.py
@@ -304,6 +304,68 @@ def _max_ops_per_step(rules: dict[str, str] | None) -> int:
     return n
 
 
+_OP_META_KEYS = frozenset(
+    {
+        "name",
+        "tool",
+        "type",
+        "op",
+        "args",
+        "parameters",
+        "arguments",
+        "properties",
+        "props",
+        "updates",
+        "params",
+        "op_id",
+        "opId",
+    }
+)
+# Nested bags accepted as args payload (models often use parameters from FC habit).
+_OP_NEST_ARG_KEYS = (
+    "args",
+    "parameters",
+    "arguments",
+    "properties",
+    "props",
+    "updates",
+    "params",
+)
+
+
+def _coerce_op_args(item: dict[str, Any]) -> dict[str, Any]:
+    """Normalize op payload to ``args``; accept ``parameters`` / ``arguments`` too."""
+    args: dict[str, Any] = {}
+    # Prefer explicit args, then parameters/arguments, then other legacy nests.
+    for nest_key in _OP_NEST_ARG_KEYS:
+        nested = item.get(nest_key)
+        if not isinstance(nested, dict):
+            continue
+        for nk, nv in nested.items():
+            args.setdefault(nk, nv)
+    if not args:
+        args = {k: v for k, v in item.items() if k not in _OP_META_KEYS}
+    else:
+        # Flat sibling fields fill gaps (e.g. name + top-level x).
+        for k, v in item.items():
+            if k not in _OP_META_KEYS:
+                args.setdefault(k, v)
+    op_id = item.get("op_id") or item.get("opId")
+    if op_id is not None and str(op_id).strip():
+        args["op_id"] = str(op_id).strip()[:64]
+    if not args.get("nodeId"):
+        nid = (
+            args.get("id")
+            or item.get("id")
+            or item.get("nodeId")
+            or item.get("node_id")
+        )
+        if nid is not None and str(nid).strip():
+            args["nodeId"] = str(nid).strip()
+    args.pop("id", None)
+    return args
+
+
 def _parse_raw_ops(content: str | dict[str, Any] | list[Any] | None) -> list[dict[str, Any]]:
     """Parse model JSON into raw op dicts (before allowlist / validation)."""
     if isinstance(content, (dict, list)):
@@ -334,46 +396,7 @@ def _parse_raw_ops(content: str | dict[str, Any] | list[Any] | None) -> list[dic
         )
         if not name:
             continue
-        args = item.get("args")
-        if not isinstance(args, dict):
-            args = {
-                k: v
-                for k, v in item.items()
-                if k
-                not in (
-                    "name",
-                    "tool",
-                    "type",
-                    "op",
-                    "args",
-                    "properties",
-                    "props",
-                    "updates",
-                    "params",
-                    "op_id",
-                )
-            }
-        else:
-            args = dict(args)
-        for nest_key in ("properties", "props", "updates", "params"):
-            nested = item.get(nest_key)
-            if isinstance(nested, dict):
-                for nk, nv in nested.items():
-                    args.setdefault(nk, nv)
-        op_id = item.get("op_id") or item.get("opId")
-        if op_id is not None and str(op_id).strip():
-            args["op_id"] = str(op_id).strip()[:64]
-        if not args.get("nodeId"):
-            nid = (
-                args.get("id")
-                or item.get("id")
-                or item.get("nodeId")
-                or item.get("node_id")
-            )
-            if nid is not None and str(nid).strip():
-                args["nodeId"] = str(nid).strip()
-        args.pop("id", None)
-        out.append({"name": name, "args": args})
+        out.append({"name": name, "args": _coerce_op_args(item)})
     return out
 
 
@@ -717,8 +740,8 @@ def normalize_agent_tool_ops(
             )
             continue
         name = str(item.get("name") or "").strip()
-        args = item.get("args") if isinstance(item.get("args"), dict) else {}
-        args = dict(args)
+        # Accept args / parameters / arguments; normalize to args for FE.
+        args = _coerce_op_args(item)
         if not name:
             errors.append(
                 format_op_error(

--- a/apps/api/services/design/runtime/agent_controller.py
+++ b/apps/api/services/design/runtime/agent_controller.py
@@ -100,6 +100,8 @@ _PAINT_OP_META_KEYS = frozenset(
         "op_key",
         "opKey",
         "args",
+        "parameters",
+        "arguments",
         "properties",
         "props",
         "updates",
@@ -108,61 +110,92 @@ _PAINT_OP_META_KEYS = frozenset(
         "opId",
     }
 )
+# Prefer args; also accept parameters/arguments (function-calling habit) + legacy nests.
+_PAINT_OP_NEST_ARG_KEYS = (
+    "args",
+    "parameters",
+    "arguments",
+    "properties",
+    "props",
+    "updates",
+    "params",
+)
+
+_PAINT_OP_NAME_ALIASES = ("name", "tool", "op", "op_key", "opKey")
+_PAINT_CREATE_SHAPE_NAMES = frozenset(
+    {
+        "create_shape",
+        "create_text",
+        "create_image",
+        "create_frame",
+        "update_node",
+        "delete_nodes",
+        "delete_frame",
+        "create_svg",
+        "create_icon",
+    }
+)
+
+
+def _paint_op_name(d: dict[str, Any]) -> str:
+    for key in _PAINT_OP_NAME_ALIASES:
+        raw = d.get(key)
+        if raw is not None and str(raw).strip():
+            return str(raw).strip()
+    type_as_name = str(d.get("type") or "").strip()
+    if type_as_name in _PAINT_CREATE_SHAPE_NAMES:
+        return type_as_name
+    return ""
+
+
+def _merge_nested_op_args(d: dict[str, Any]) -> dict[str, Any]:
+    args: dict[str, Any] = {}
+    for nest_key in _PAINT_OP_NEST_ARG_KEYS:
+        nested = d.get(nest_key)
+        if not isinstance(nested, dict):
+            continue
+        for nk, nv in nested.items():
+            args.setdefault(nk, nv)
+    if not args:
+        return {k: v for k, v in d.items() if k not in _PAINT_OP_META_KEYS}
+    for k, v in d.items():
+        if k not in _PAINT_OP_META_KEYS:
+            args.setdefault(k, v)
+    return args
+
+
+def _coalesce_paint_tool_op(data: Any) -> Any:
+    """Normalize one tool_op envelope to ``{name, args}`` (accepts parameters)."""
+    if not isinstance(data, dict):
+        return data
+    d = dict(data)
+    name = _paint_op_name(d)
+    args = _merge_nested_op_args(d)
+    if (
+        name == "create_shape"
+        and args.get("shapeType") is None
+        and d.get("type") is not None
+        and str(d.get("type")) not in {"create_shape"}
+    ):
+        args.setdefault("shapeType", d.get("type"))
+    return {"name": name, "args": args}
 
 
 class PaintToolOp(BaseModel):
-    """LangChain envelope for one canvas op — name + args only (not canvas semantics)."""
+    """LangChain envelope for one canvas op — normalized to ``{name, args}``."""
 
     name: str = Field(..., min_length=1)
-    args: dict[str, Any] = Field(default_factory=dict)
+    args: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Canvas op arguments. Prefer key 'args'; 'parameters' also accepted.",
+    )
 
     model_config = {"extra": "allow"}
 
     @model_validator(mode="before")
     @classmethod
     def _coalesce_flat_op(cls, data: Any) -> Any:
-        if not isinstance(data, dict):
-            return data
-        d = dict(data)
-        name = (
-            d.get("name")
-            or d.get("tool")
-            or d.get("op")
-            or d.get("op_key")
-            or d.get("opKey")
-            or ""
-        )
-        type_as_name = str(d.get("type") or "").strip()
-        if not str(name or "").strip() and type_as_name in {
-            "create_shape",
-            "create_text",
-            "create_image",
-            "create_frame",
-            "update_node",
-            "delete_nodes",
-            "delete_frame",
-            "create_svg",
-            "create_icon",
-        }:
-            name = type_as_name
-        args = d.get("args")
-        if not isinstance(args, dict):
-            args = {k: v for k, v in d.items() if k not in _PAINT_OP_META_KEYS}
-        else:
-            args = dict(args)
-        for nest_key in ("properties", "props", "updates", "params"):
-            nested = d.get(nest_key)
-            if isinstance(nested, dict):
-                for nk, nv in nested.items():
-                    args.setdefault(nk, nv)
-        if (
-            str(name or "").strip() == "create_shape"
-            and args.get("shapeType") is None
-            and d.get("type") is not None
-            and str(d.get("type")) not in {"create_shape"}
-        ):
-            args.setdefault("shapeType", d.get("type"))
-        return {"name": str(name or "").strip(), "args": args}
+        return _coalesce_paint_tool_op(data)
 
 
 class AgentTurnSchema(BaseModel):
@@ -959,6 +992,7 @@ def _paint_ops_system(rt: Any) -> str:
         "Your ONLY job: emit non-empty tool_ops that change the canvas.\n"
         "Rules:\n"
         "- tool_ops must be a non-empty array; use TOOL_DETAILS `name`/`op_key` exactly.\n"
+        "- Each op: {\"name\":\"create_shape\",\"args\":{...}} (args preferred; parameters ok).\n"
         "- New poster/page/artboard → create_frame first (with width/height), then children.\n"
         "- Infinite canvas: add shape/text → create_shape/create_text in world "
         "space; do NOT create_frame unless the user asked for a new artboard/page/poster.\n"
@@ -1697,6 +1731,53 @@ def _op_errors_for_log(errors: list[Any] | None, *, limit: int = 20) -> list[str
         if s:
             out.append(s[:400])
     return out or None
+
+
+def _op_error_codes(errors: list[Any] | None, *, limit: int = 4) -> list[str]:
+    codes: list[str] = []
+    for e in list(errors or []):
+        s = str(e or "").strip()
+        if not s:
+            continue
+        code = s
+        if "code=" in s:
+            code = s.split("code=", 1)[1].split(";", 1)[0].strip()
+        if code and code not in codes:
+            codes.append(code)
+        if len(codes) >= limit:
+            break
+    return codes
+
+
+def _emit_tool_ops_validation_ui(
+    rt: Any,
+    errors: list[Any] | None,
+    *,
+    kept: int = 0,
+) -> None:
+    """Surface tool_ops validation failures in chat (not Admin-only)."""
+    errs = [str(e).strip() for e in list(errors or []) if str(e or "").strip()]
+    if not errs:
+        return
+    codes = _op_error_codes(errs)
+    code_hint = "、".join(codes[:3]) if codes else "invalid_op"
+    if kept > 0:
+        detail = f"{len(errs)} 条操作校验失败（已应用 {kept}）：{code_hint}"
+    else:
+        detail = f"{len(errs)} 条操作校验失败：{code_hint}"
+    st = rt.run
+    _emit(
+        {
+            "type": "activity",
+            "id": f"validate-ops-{st.task_id[:8]}",
+            "kind": "skipped",
+            "status": "error",
+            "stage": "validate",
+            "count": len(errs),
+            "detail": detail[:240],
+            "summary": "; ".join(errs[:6])[:800],
+        }
+    )
 
 
 def _hydrate_srcs_for_log(ops: list[dict[str, Any]] | None) -> list[str] | None:
@@ -4413,11 +4494,13 @@ async def _node_settle(state: GraphState) -> Command:
             )
         ),
     )
+    failed_attempt = bool(st.errors) and not st.painted and not has_proposal
+    settle_status = "error" if failed_attempt else "success"
     await asyncio.to_thread(_persist_task_meta, st.task_id, decision=rt.decision, state=st)
     await asyncio.to_thread(
         _update_task,
         st.task_id,
-        status="success",
+        status=settle_status,
         charged_credits=spend,
         total_tokens=st.total_tokens,
         result_svg="",
@@ -4425,14 +4508,17 @@ async def _node_settle(state: GraphState) -> Command:
     exec_payload = st.to_execution_log()
     balance = await asyncio.to_thread(get_user_tokens, rt.user_id)
     _emit({"type": "execution_log", **exec_payload})
+    fail_summary = ""
+    if failed_attempt and st.errors:
+        fail_summary = str(st.errors[-1])[:240]
     _emit(
         {
             "type": "result",
             "task_id": st.task_id,
             "trace_id": st.trace_id,
-            "status": "success",
+            "status": settle_status,
             "svg": "",
-            "summary": st.reply[:500] if st.reply else "",
+            "summary": (st.reply[:500] if st.reply else "") or fail_summary,
             "charged_credits": spend,
             "total_tokens": st.total_tokens,
             "tool_ops_applied": st.painted,
@@ -4442,6 +4528,7 @@ async def _node_settle(state: GraphState) -> Command:
             **({"proposed_ops": st.proposed_ops} if st.proposed_ops else {}),
             **({"apply_choice": st.apply_choice} if st.apply_choice else {}),
             **({"choice_ui": st.choice_ui} if st.choice_ui else {}),
+            **({"errors": list(st.errors)[-5:]} if failed_attempt else {}),
             "balance": balance,
             "decision_log": rt.decision.to_log(),
             "execution_log": exec_payload
@@ -5184,6 +5271,12 @@ async def _node_paint_ops(state: GraphState) -> Command:
                 "tokens": used_hint
             }
         )
+        # Show validation failures in chat when leaving paint (keep or exhaust).
+        # Mid-retry: keep Admin/LAST_ERROR only so the model can fix quietly.
+        will_keep = bool(step_ops)
+        will_exhaust = (not will_keep) and (attempt >= max_attempts - 1)
+        if op_errors and (will_keep or will_exhaust):
+            _emit_tool_ops_validation_ui(rt, op_errors, kept=len(step_ops))
 
         if step_ops:
             ask_mode = str(rt.flags.get("mode") or "") == "ask"

--- a/apps/api/services/design/runtime/progress_stages.py
+++ b/apps/api/services/design/runtime/progress_stages.py
@@ -120,26 +120,35 @@ def explored_stage_event(
 
     FE upserts the parent and merges `item` into `items[]`.
     """
+    failed = status == "error"
     done = status == "done"
-    key = "done" if done else stage
+    if failed:
+        key = "failed"
+        ui_status = "error"
+    elif done:
+        key = "done"
+        ui_status = "done"
+    else:
+        key = stage
+        ui_status = "running"
     label = _item_label(
         key,
-        elapsed_s=None if done else elapsed_s,
-        extra=None if done else extra,
+        elapsed_s=None if (done or failed) else elapsed_s,
+        extra=None if (done or failed) else extra,
     )
     count = item_count
-    if count is None and not done:
+    if count is None and not done and not failed:
         count = max(1, stage_index(stage) + 1)
     return {
         "type": "activity",
         "id": EXPLORE_ID,
         "kind": "explored",
-        "status": "done" if done else "running",
+        "status": ui_status,
         "count": count,
         "detail": "design pipeline",
         "stage": key,
         "item": {
-            "id": item_id or f"stage-{stage}",
+            "id": item_id or f"stage-{key}",
             "name": label,
         },
         "skill_name": "agent",

--- a/apps/api/tests/unit_tests/test_tool_ops_contract.py
+++ b/apps/api/tests/unit_tests/test_tool_ops_contract.py
@@ -150,6 +150,37 @@ def test_update_node_accepts_shape_type():
     assert ops[0]["args"]["shapeType"] == "circle"
 
 
+def test_accepts_parameters_envelope_as_args():
+    """Models often emit OpenAI-style parameters; normalize to args."""
+    raw_ops = [
+        {
+            "name": "create_shape",
+            "parameters": {
+                "shapeType": "rect",
+                "x": 0,
+                "y": 0,
+                "width": 100,
+                "height": 80,
+                "fill": "#fff",
+            },
+        },
+        {
+            "name": "create_text",
+            "arguments": {"text": "Hi", "x": 10, "y": 20, "fontSize": 16},
+        },
+        {
+            "name": "create_image",
+            "parameters": {"genPrompt": "avatar", "x": 0, "y": 0, "width": 64, "height": 64},
+        },
+    ]
+    ops, errs = normalize_agent_tool_ops(raw_ops)
+    assert not errs
+    assert len(ops) == 3
+    assert ops[0]["args"]["shapeType"] == "rect"
+    assert ops[1]["args"]["text"] == "Hi"
+    assert ops[2]["args"]["genPrompt"] == "avatar"
+
+
 def test_create_shape_next_to_images_is_not_rewritten_to_update():
     """Large create_shape must not rewrite onto image nodes (looks like no-op)."""
     raw_ops = [

--- a/apps/web/src/apis/design.ts
+++ b/apps/web/src/apis/design.ts
@@ -134,7 +134,7 @@ export type DesignJobEvent =
       type: 'activity';
       id?: string;
       kind?: 'thought' | 'added' | 'updated' | 'explored' | 'skipped' | 'tool';
-      status?: 'running' | 'done';
+      status?: 'running' | 'done' | 'error';
       count?: number;
       detail?: string;
       skillName?: string;

--- a/apps/web/src/components/editor/panels/AgentDock.tsx
+++ b/apps/web/src/components/editor/panels/AgentDock.tsx
@@ -103,6 +103,7 @@ import {
   buildChatProcessSteps,
   formatActivityLabel,
   localizeExploreItem,
+  normalizeActivityStatus,
 } from '@/components/editor/panels/agent/ChatTurnList';
 import type { VirtualListHandle } from '@/components/base/VirtualList';
 import AgentComposerShell, {
@@ -309,6 +310,52 @@ function humanizeDesignError(
 }
 
 type TFn = (key: string, opts?: Record<string, unknown>) => string;
+
+const DETAIL_SUMMARY_KINDS = new Set([
+  'tool',
+  'skipped',
+  'added',
+  'updated',
+  'deleted',
+]);
+const SUCCESS_VARIANT_KINDS = new Set(['added', 'updated', 'deleted']);
+const CONFIRM_VARIANT_KINDS = new Set(['thought', 'explored', 'tool']);
+
+function activityRowSummary(opts: {
+  kind: string;
+  label: string;
+  detailText: string;
+  summaryText: string;
+}): string | undefined {
+  const { kind, label, detailText, summaryText } = opts;
+  if (summaryText && summaryText !== label) return summaryText;
+  if (!DETAIL_SUMMARY_KINDS.has(kind)) return undefined;
+  if (detailText && detailText !== label) return detailText;
+  return undefined;
+}
+
+function activityRowVariant(
+  status: 'running' | 'done' | 'error',
+  kind: string
+): 'success' | 'confirm' | undefined {
+  if (status === 'error') return undefined;
+  if (SUCCESS_VARIANT_KINDS.has(kind)) return 'success';
+  if (CONFIRM_VARIANT_KINDS.has(kind)) return 'confirm';
+  return undefined;
+}
+
+function activityNestItem(
+  t: TFn,
+  item: { id?: string; name?: string; summary?: string } | undefined
+) {
+  if (!item || !(item.name || item.id)) return null;
+  return localizeExploreItem(t, {
+    id: String(item.id || `item-${Date.now()}`),
+    name: String(item.name || '').trim() || '…',
+    summary: item.summary ? String(item.summary) : undefined,
+  });
+}
+
 type FinishAssistant = (
   m: ChatUiMessage,
   patch?: Partial<ChatUiMessage>
@@ -1679,9 +1726,10 @@ function createDesignAgentEventRouter(opts: {
     }
     // Intent confirm / "understanding request" rows — keep off the chat timeline.
     if (ev.kind === 'thought') return;
+    const actStatus = normalizeActivityStatus(ev.status);
     const label = formatActivityLabel(opts.t, {
       kind: ev.kind,
-      status: ev.status === 'running' ? 'running' : 'done',
+      status: actStatus,
       durationSec: ev.durationSec,
       count: ev.count,
       skillName: ev.skillName,
@@ -1691,38 +1739,21 @@ function createDesignAgentEventRouter(opts: {
     if (!label) return;
     const detailText = (ev.detail || '').trim();
     const summaryText = String(ev.summary || '').trim();
-    const summary =
-      (summaryText && summaryText !== label ? summaryText : undefined) ||
-      (ev.kind === 'tool' ||
-      ev.kind === 'skipped' ||
-      ev.kind === 'added' ||
-      ev.kind === 'updated' ||
-      ev.kind === 'deleted'
-        ? detailText && detailText !== label
-          ? detailText
-          : undefined
-        : undefined);
-    const variant =
-      ev.kind === 'added' || ev.kind === 'updated' || ev.kind === 'deleted'
-        ? ('success' as const)
-        : ev.kind === 'thought' || ev.kind === 'explored' || ev.kind === 'tool'
-          ? ('confirm' as const)
-          : undefined;
-    const nestItem =
-      ev.item && (ev.item.name || ev.item.id)
-        ? localizeExploreItem(opts.t, {
-            id: String(ev.item.id || `item-${Date.now()}`),
-            name: String(ev.item.name || '').trim() || '…',
-            summary: ev.item.summary ? String(ev.item.summary) : undefined,
-          })
-        : null;
+    const summary = activityRowSummary({
+      kind: ev.kind,
+      label,
+      detailText,
+      summaryText,
+    });
+    const variant = activityRowVariant(actStatus, ev.kind);
+    const nestItem = activityNestItem(opts.t, ev.item);
     opts.setMessages((prev) =>
       prev.map((m) => {
         if (m.id !== opts.assistantId) return m;
         const next = applyActivityEventToSteps(m.steps || [], {
           kind: ev.kind,
           eventId: ev.id,
-          status: ev.status === 'running' ? 'running' : 'done',
+          status: actStatus,
           label,
           summary,
           variant,

--- a/apps/web/src/components/editor/panels/agent/ChatTurnList.tsx
+++ b/apps/web/src/components/editor/panels/agent/ChatTurnList.tsx
@@ -101,7 +101,7 @@ export type AssistantStep = NonNullable<ChatUiMessage['steps']>[number];
 
 export type ActivityStepEvent = {
   kind: 'thought' | 'added' | 'updated' | 'explored' | 'skipped' | 'deleted' | 'tool';
-  status: 'running' | 'done';
+  status: 'running' | 'done' | 'error';
   durationSec?: number;
   count?: number;
   skillName?: string;
@@ -110,6 +110,171 @@ export type ActivityStepEvent = {
 };
 
 type ProcessTFn = (key: string, opts?: Record<string, unknown>) => string;
+
+export function normalizeActivityStatus(
+  status: string | undefined | null
+): 'running' | 'done' | 'error' {
+  if (status === 'running') return 'running';
+  if (status === 'error') return 'error';
+  return 'done';
+}
+
+function countLabel(
+  t: ProcessTFn,
+  count: number | undefined,
+  withCount: string,
+  bare: string
+): string {
+  if (count != null && count > 0) return t(withCount, { count });
+  return t(bare);
+}
+
+function formatThoughtLabel(
+  t: ProcessTFn,
+  ev: ActivityStepEvent,
+  detail: string,
+  preferDetail: boolean
+): string | null {
+  if (ev.status === 'running') {
+    return preferDetail ? detail : t('agent.activityThoughtRunning');
+  }
+  if (preferDetail) return detail;
+  if (ev.status === 'done' && ev.durationSec != null) {
+    return t('agent.activityThought', { seconds: ev.durationSec });
+  }
+  if (ev.status === 'done') return t('agent.activityThoughtBrief');
+  return null;
+}
+
+function formatPreloadExploredLabel(
+  t: ProcessTFn,
+  detail: string,
+  stage: string | undefined
+): string | null {
+  const preloadTag = detail.toLowerCase();
+  const isPreload =
+    stage === 'skill_preload' ||
+    preloadTag === 'skills' ||
+    preloadTag === 'tools' ||
+    preloadTag === 'knowledge' ||
+    preloadTag === 'aesthetics';
+  if (!isPreload) return null;
+  if (preloadTag === 'tools') return t('agent.lookupKindRule');
+  if (preloadTag === 'knowledge') return t('agent.lookupKindKnowledge');
+  if (preloadTag === 'aesthetics') return t('agent.lookupKindAesthetics');
+  return t('agent.lookupKindSkill');
+}
+
+function formatCanvasSizeExploredLabel(
+  t: ProcessTFn,
+  ev: ActivityStepEvent,
+  detail: string
+): string | null {
+  if (ev.stage !== 'scene' && !detail.startsWith('canvas_size:')) return null;
+  const raw = detail.replace(/^canvas_size:/i, '').trim();
+  const size =
+    raw && /^\d+x\d+$/i.test(raw) ? raw.replace(/x/i, '×') : detail;
+  if (ev.status === 'running') {
+    return size
+      ? t('agent.activityCanvasSizeRunning', { size })
+      : t('agent.stageScene');
+  }
+  return size
+    ? t('agent.activityCanvasSizeDone', { size })
+    : t('agent.stageScene');
+}
+
+function formatLookupExploredLabel(
+  t: ProcessTFn,
+  ev: ActivityStepEvent,
+  detail: string
+): string | null {
+  if (ev.stage !== 'lookup' && !detail.includes('lookup')) return null;
+  if (ev.status === 'running') return t('agent.activityLookupRunning');
+  const n = ev.count != null && ev.count > 0 ? ev.count : 0;
+  return countLabel(
+    t,
+    n || undefined,
+    'agent.activityLookupDoneCount',
+    'agent.activityLookupDone'
+  );
+}
+
+function formatExploredLabel(
+  t: ProcessTFn,
+  ev: ActivityStepEvent,
+  detail: string,
+  preferDetail: boolean
+): string {
+  const preload = formatPreloadExploredLabel(t, detail, ev.stage);
+  if (preload) return preload;
+  if (preferDetail && !detail.startsWith('canvas_size:')) return detail;
+  const canvas = formatCanvasSizeExploredLabel(t, ev, detail);
+  if (canvas) return canvas;
+  const lookup = formatLookupExploredLabel(t, ev, detail);
+  if (lookup) return lookup;
+  if (ev.status === 'running') return t('agent.activityExploredRunning');
+  const fromCount = ev.count != null && ev.count > 0 ? ev.count : 0;
+  const fromDetail = detail
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean).length;
+  return countLabel(
+    t,
+    fromCount || fromDetail || undefined,
+    'agent.activityExploredCount',
+    'agent.activityExplored'
+  );
+}
+
+export function formatActivityLabel(
+  t: ProcessTFn,
+  ev: ActivityStepEvent
+): string | null {
+  const detail = (ev.detail || '').trim();
+  const preferDetail = detail.length > 0;
+
+  if (ev.kind === 'thought') {
+    return formatThoughtLabel(t, ev, detail, preferDetail);
+  }
+  if (ev.kind === 'added') {
+    if (preferDetail) return detail;
+    return countLabel(
+      t,
+      ev.count,
+      'agent.activityAddedCount',
+      'agent.activityAdded'
+    );
+  }
+  if (ev.kind === 'updated') {
+    if (preferDetail) return detail;
+    return countLabel(
+      t,
+      ev.count,
+      'agent.activityUpdatedCount',
+      'agent.activityUpdated'
+    );
+  }
+  if (ev.kind === 'explored') {
+    return formatExploredLabel(t, ev, detail, preferDetail);
+  }
+  if (ev.kind === 'skipped') {
+    if (preferDetail) return detail;
+    return t('agent.activitySkipped');
+  }
+  if (ev.kind === 'deleted') {
+    if (preferDetail) return detail;
+    return countLabel(
+      t,
+      ev.count,
+      'agent.activityDeletedCount',
+      'agent.activityDeleted'
+    );
+  }
+  if (preferDetail) return detail;
+  if (ev.status === 'running') return t('agent.activityToolRunning');
+  return t('agent.activityTool');
+}
 
 function exploreItemKindKey(id: string): string {
   if (id === 'lookup-skill' || id.startsWith('lookup-skill')) {
@@ -139,8 +304,8 @@ function mergeExploreStepStatus(
   a: 'running' | 'done' | 'error' | 'pending' | undefined,
   b: 'running' | 'done' | 'error' | 'pending' | undefined
 ): 'running' | 'done' | 'error' {
-  if (a === 'running' || b === 'running') return 'running';
   if (a === 'error' || b === 'error') return 'error';
+  if (a === 'running' || b === 'running') return 'running';
   return 'done';
 }
 
@@ -164,94 +329,6 @@ export function localizeExploreItem(
     ...item,
     name: host ? t('agent.lookupHostPrefix', { name: label }) : label,
   };
-}
-
-export function formatActivityLabel(
-  t: ProcessTFn,
-  ev: ActivityStepEvent
-): string | null {
-  const detail = (ev.detail || '').trim();
-  const preferDetail = detail.length > 0;
-
-  if (ev.kind === 'thought') {
-    if (ev.status === 'running') {
-      return preferDetail ? detail : t('agent.activityThoughtRunning');
-    }
-    if (preferDetail) return detail;
-    if (ev.status === 'done' && ev.durationSec != null) {
-      return t('agent.activityThought', { seconds: ev.durationSec });
-    }
-    if (ev.status === 'done') return t('agent.activityThoughtBrief');
-    return null;
-  }
-  if (ev.kind === 'added') {
-    if (preferDetail) return detail;
-    return ev.count != null && ev.count > 0
-      ? t('agent.activityAddedCount', { count: ev.count })
-      : t('agent.activityAdded');
-  }
-  if (ev.kind === 'updated') {
-    if (preferDetail) return detail;
-    return ev.count != null && ev.count > 0
-      ? t('agent.activityUpdatedCount', { count: ev.count })
-      : t('agent.activityUpdated');
-  }
-  if (ev.kind === 'explored') {
-    // skill-preload emits short tags (skills|tools|…) — never show raw English as the row title.
-    const preloadTag = detail.toLowerCase();
-    if (
-      ev.stage === 'skill_preload' ||
-      preloadTag === 'skills' ||
-      preloadTag === 'tools' ||
-      preloadTag === 'knowledge' ||
-      preloadTag === 'aesthetics'
-    ) {
-      if (preloadTag === 'tools') return t('agent.lookupKindRule');
-      if (preloadTag === 'knowledge') return t('agent.lookupKindKnowledge');
-      if (preloadTag === 'aesthetics') return t('agent.lookupKindAesthetics');
-      return t('agent.lookupKindSkill');
-    }
-    if (preferDetail && !detail.startsWith('canvas_size:')) return detail;
-    if (ev.stage === 'scene' || detail.startsWith('canvas_size:')) {
-      const raw = detail.replace(/^canvas_size:/i, '').trim();
-      const size =
-        raw && /^\d+x\d+$/i.test(raw) ? raw.replace(/x/i, '×') : detail;
-      if (ev.status === 'running') {
-        return size
-          ? t('agent.activityCanvasSizeRunning', { size })
-          : t('agent.stageScene');
-      }
-      return size
-        ? t('agent.activityCanvasSizeDone', { size })
-        : t('agent.stageScene');
-    }
-    if (ev.stage === 'lookup' || detail.includes('lookup')) {
-      if (ev.status === 'running') return t('agent.activityLookupRunning');
-      const n = ev.count != null && ev.count > 0 ? ev.count : 0;
-      return n > 0
-        ? t('agent.activityLookupDoneCount', { count: n })
-        : t('agent.activityLookupDone');
-    }
-    if (ev.status === 'running') return t('agent.activityExploredRunning');
-    const fromCount = ev.count != null && ev.count > 0 ? ev.count : 0;
-    const fromDetail = detail
-      .split(',')
-      .map((s) => s.trim())
-      .filter(Boolean).length;
-    const n = fromCount || fromDetail;
-    return n > 0
-      ? t('agent.activityExploredCount', { count: n })
-      : t('agent.activityExplored');
-  }
-  if (ev.kind === 'skipped') return preferDetail ? detail : t('agent.activitySkipped');
-  if (ev.kind === 'deleted') {
-    if (preferDetail) return detail;
-    return ev.count != null && ev.count > 0
-      ? t('agent.activityDeletedCount', { count: ev.count })
-      : t('agent.activityDeleted');
-  }
-  if (preferDetail) return detail;
-  return ev.status === 'running' ? t('agent.activityToolRunning') : t('agent.activityTool');
 }
 
 function collapseExplorePipelineSteps(steps: AssistantStep[]): AssistantStep[] {
@@ -431,7 +508,7 @@ export function applyActivityEventToSteps(
   opts: {
     kind: NonNullable<AssistantStep['kind']>;
     eventId?: string;
-    status: 'running' | 'done';
+    status: 'running' | 'done' | 'error';
     label: string;
     summary?: string;
     variant?: NonNullable<AssistantStep['variant']>;

--- a/apps/web/src/components/editor/panels/agent/runDesignAgent.ts
+++ b/apps/web/src/components/editor/panels/agent/runDesignAgent.ts
@@ -2044,7 +2044,7 @@ export type AgentStepEvent =
       type: 'activity';
       id: string;
       kind: 'thought' | 'added' | 'updated' | 'explored' | 'skipped' | 'deleted' | 'tool';
-      status: 'running' | 'done';
+      status: 'running' | 'done' | 'error';
       durationSec?: number;
       count?: number;
       skillName?: string;
@@ -2180,6 +2180,135 @@ type LiveDrawState = {
   frameId: string | null;
   fingerprintById: Record<string, string>;
 };
+
+type ActivityKind =
+  | 'thought'
+  | 'added'
+  | 'updated'
+  | 'explored'
+  | 'skipped'
+  | 'deleted'
+  | 'tool';
+
+function parseActivityKind(raw: unknown): ActivityKind {
+  const k = String(raw || '').trim();
+  if (
+    k === 'thought' ||
+    k === 'added' ||
+    k === 'updated' ||
+    k === 'explored' ||
+    k === 'skipped' ||
+    k === 'deleted' ||
+    k === 'tool'
+  ) {
+    return k;
+  }
+  return 'tool';
+}
+
+function activityDetailParts(ev: {
+  detail?: unknown;
+  summary?: unknown;
+  body?: unknown;
+}): { detail: string; summaryRaw: string; body: string } {
+  const detailRaw = String(ev.detail || '').trim();
+  const summaryRaw = String(ev.summary || '').trim();
+  const detail =
+    detailRaw ||
+    (summaryRaw.length > 0 && summaryRaw.length <= 48 ? summaryRaw : '');
+  const bodyFromSummary =
+    !detailRaw && summaryRaw.length > 48 ? summaryRaw : '';
+  return {
+    detail,
+    summaryRaw,
+    body: String(ev.body || bodyFromSummary || '').trim(),
+  };
+}
+
+function activityItemPayload(item: {
+  id?: unknown;
+  name?: unknown;
+  summary?: unknown;
+} | null | undefined) {
+  if (!item) return undefined;
+  return {
+    id: item.id ? String(item.id) : undefined,
+    name: item.name ? String(item.name) : undefined,
+    summary: item.summary ? String(item.summary) : undefined,
+  };
+}
+
+function normalizeActivityStatusLocal(
+  status: unknown
+): 'running' | 'done' | 'error' {
+  if (status === 'running') return 'running';
+  if (status === 'error') return 'error';
+  return 'done';
+}
+
+function bindExploredSceneActivity(opts: {
+  chatDiverted: boolean;
+  kind: unknown;
+  stage: string;
+  detail: string;
+  pinnedFrameId?: string | null;
+  live: LiveDrawState;
+  getDocument: RunDesignAgentParams['getDocument'];
+  shimmerFrameId: string | null;
+  setProcessPill: (frameId: string, label: string) => void;
+  exploringLabel: string;
+  setLiveCanvasSize: (size: string) => void;
+}): void {
+  if (opts.chatDiverted || opts.kind !== 'explored') return;
+  if (opts.stage !== 'scene' && !opts.detail.startsWith('canvas_size:')) return;
+  if (opts.detail.startsWith('canvas_size:')) {
+    const raw = opts.detail.replace(/^canvas_size:/i, '').trim().toLowerCase();
+    if (/^\d+x\d+$/.test(raw)) opts.setLiveCanvasSize(raw);
+  }
+  const pinned = explicitPinnedFrameId({
+    pinnedFrameId: opts.pinnedFrameId,
+  });
+  const focus = pinned || opts.live.frameId || null;
+  if (!focus) return;
+  const boardSize = frameSizeFromDoc(opts.getDocument, focus);
+  if (boardSize) {
+    opts.setLiveCanvasSize(`${boardSize.width}x${boardSize.height}`);
+  }
+  opts.live.frameId = focus;
+  if (!opts.shimmerFrameId && !pinned) return;
+  opts.setProcessPill(focus, opts.exploringLabel);
+}
+
+function refreshActivityProcessPill(opts: {
+  pillFrame: string | null;
+  status: unknown;
+  kind: ActivityKind;
+  setProcessPill: (frameId: string, label: string) => void;
+  processLabels: {
+    exploring?: string;
+    thinking?: string;
+    editing?: string;
+  };
+}): void {
+  const { pillFrame, status, kind, setProcessPill, processLabels } = opts;
+  if (!pillFrame || status === 'done') return;
+  if (kind === 'explored') {
+    setProcessPill(pillFrame, processLabels.exploring || 'Exploring…');
+    return;
+  }
+  if (kind === 'thought') {
+    setProcessPill(pillFrame, processLabels.thinking || 'Thinking…');
+    return;
+  }
+  if (
+    kind === 'tool' ||
+    kind === 'added' ||
+    kind === 'updated' ||
+    kind === 'deleted'
+  ) {
+    setProcessPill(pillFrame, processLabels.editing || 'Editing elements…');
+  }
+}
 
 export async function runDesignAgent(params: RunDesignAgentParams): Promise<void> {
   const runMode = params.runMode || 'agent';
@@ -2668,96 +2797,51 @@ export async function runDesignAgent(params: RunDesignAgentParams): Promise<void
   };
 
   const handleStreamActivity = (ev: any) => {
-
     // Backend-authored progress (counts / detail) — do not invent on the client.
     if (chatDiverted && (ev.kind === 'explored' || ev.kind === 'thought')) {
       return;
     }
     const stage = ev.stage ? String(ev.stage) : '';
-    const detailRaw = String(ev.detail || '').trim();
-    const summaryRaw = String(ev.summary || '').trim();
-    // Product capsule/row label from `detail`; long `summary` becomes expandable body.
-    const detail =
-      detailRaw ||
-      (summaryRaw.length > 0 && summaryRaw.length <= 48 ? summaryRaw : '');
-    const bodyFromSummary =
-      !detailRaw && summaryRaw.length > 48 ? summaryRaw : '';
-    const activityBody = String(ev.body || bodyFromSummary || '').trim();
+    const { detail, summaryRaw, body: activityBody } = activityDetailParts(ev);
     // Bind an existing @ / focus board for shimmer — never spawn an empty artboard.
-    // Free-canvas create/edit does not need a frame; only model create_frame opens one.
-    if (
-      !chatDiverted &&
-      ev.kind === 'explored' &&
-      (stage === 'scene' || detail.startsWith('canvas_size:'))
-    ) {
-      if (detail.startsWith('canvas_size:')) {
-        const raw = detail.replace(/^canvas_size:/i, '').trim().toLowerCase();
-        if (/^\d+x\d+$/.test(raw)) liveCanvasSize = raw;
-      }
-      // Only @-pin or a plate already opened this run — not ambient FOCUS.
-      const pinned = explicitPinnedFrameId({
-        pinnedFrameId: params.pinnedFrameId,
-      });
-      const focus = pinned || live.frameId || null;
-      if (focus) {
-        const boardSize = frameSizeFromDoc(params.getDocument, focus);
-        if (boardSize) {
-          liveCanvasSize = `${boardSize.width}x${boardSize.height}`;
-        }
-        live.frameId = focus;
-        if (shimmerFrameId || pinned) {
-          setProcessPill(focus, processLabels.exploring || 'Exploring…');
-        }
-      }
-    }
-    const kind =
-      (ev.kind as
-        | 'thought'
-        | 'added'
-        | 'updated'
-        | 'explored'
-        | 'skipped'
-        | 'deleted'
-        | 'tool') || 'tool';
+    bindExploredSceneActivity({
+      chatDiverted,
+      kind: ev.kind,
+      stage,
+      detail,
+      pinnedFrameId: params.pinnedFrameId,
+      live,
+      getDocument: params.getDocument,
+      shimmerFrameId,
+      setProcessPill,
+      exploringLabel: processLabels.exploring || 'Exploring…',
+      setLiveCanvasSize: (size) => {
+        liveCanvasSize = size;
+      },
+    });
+    const kind = parseActivityKind(ev.kind);
+    const actStatus = normalizeActivityStatusLocal(ev.status);
     params.onEvent({
       type: 'activity',
       id: String(ev.id || `activity-${activitySeq++}`),
       kind,
-      status: ev.status === 'running' ? 'running' : 'done',
+      status: actStatus,
       count: typeof ev.count === 'number' ? ev.count : undefined,
       detail: detail || undefined,
       summary: summaryRaw && summaryRaw !== detail ? summaryRaw : undefined,
       skillName: ev.skillName || ev.skill_name || undefined,
       durationSec: typeof ev.durationSec === 'number' ? ev.durationSec : undefined,
       stage: stage || undefined,
-      item: ev.item
-        ? {
-            id: ev.item.id ? String(ev.item.id) : undefined,
-            name: ev.item.name ? String(ev.item.name) : undefined,
-            summary: ev.item.summary ? String(ev.item.summary) : undefined,
-          }
-        : undefined,
+      item: activityItemPayload(ev.item),
       body: activityBody || undefined,
     });
-    // Only refresh an already-active plate shimmer — never start scan-light from
-    // ambient focus / free-canvas create_shape.
-    const pillFrame = shimmerFrameId;
-    if (pillFrame && ev.status !== 'done') {
-      if (kind === 'explored') {
-        setProcessPill(pillFrame, processLabels.exploring || 'Exploring…');
-      } else if (kind === 'thought') {
-        setProcessPill(pillFrame, processLabels.thinking || 'Thinking…');
-      } else if (
-        kind === 'tool' ||
-        kind === 'added' ||
-        kind === 'updated' ||
-        kind === 'deleted'
-      ) {
-        setProcessPill(pillFrame, processLabels.editing || 'Editing elements…');
-      }
-    }
-    return;
-    
+    refreshActivityProcessPill({
+      pillFrame: shimmerFrameId,
+      status: ev.status,
+      kind,
+      setProcessPill,
+      processLabels,
+    });
   };
 
   const handleStreamToolOps = (ev: any) => {


### PR DESCRIPTION
## Summary
- Normalize tool_ops envelopes so `parameters` / `arguments` are accepted alongside `args` (Doubao FC habit).
- Emit chat activity when paint validation drops ops; mark settle/result as error and pipeline stage as `未完成` when nothing painted.
- Flatten SSE pipeline and activity helpers in-file for readability.

## Test plan
- [ ] Attach a ref image and ask for a login page: ops with `parameters` should apply (not only create_frame).
- [ ] Force invalid ops: chat shows validation failure row (error status), not silent green 完成.
- [ ] Full paint failure: pipeline ends with `未完成` / result status error.
- [ ] `pytest apps/api/tests/unit_tests/test_tool_ops_contract.py -q`

Made with [Cursor](https://cursor.com)