### PR TITLE
Fix LangGraph checkpointer async bridge for MySQL 5.7

### DIFF
--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -65,7 +65,15 @@ Skill 命名空间、ACL、版本 pin、热加载说明见 [data/design_skills/R
 
 Admin HTTP 前缀：`/api/v1/admin/...`（需管理员会话）。
 
-Postgres / 读写分离 / 备份：见仓库 [docs/postgres-switch.md](../../docs/postgres-switch.md)。
+Postgres / 读写分离 / 备份 / LangGraph checkpointer：见仓库 [docs/postgres-switch.md](../../docs/postgres-switch.md)。
+
+### LangGraph checkpointer
+
+`get_agent_checkpointer()`（`services/llm/agent.py`）供 Design 外层图与 `create_agent` 共用：
+
+1. **MySQL ≥ 8.0.19**（`LANGGRAPH_CHECKPOINT_URL` 或 `DATABASE_URL`）
+2. 否则 **SQLite**（`LANGGRAPH_CHECKPOINT_SQLITE_PATH`，默认 `storage/langgraph_checkpoints.db`）+ async bridge（供 `graph.astream`）
+3. 再否则内存
 
 ## 安装
 

--- a/apps/api/services/design/runtime/agent_controller.py
+++ b/apps/api/services/design/runtime/agent_controller.py
@@ -5343,10 +5343,9 @@ def _design_graph_node_timeout() -> TimeoutPolicy | None:
 
 
 def _get_design_graph_checkpointer() -> Any:
-    """Durable LangGraph checkpointer (MySQL → Sqlite → memory).
+    """Shared durable checkpointer (MySQL 8+ → Sqlite+async-bridge → memory).
 
-    Wallet settle/refund callables are bound via ``_bind_design_hold_fns`` and
-    must never sit on ``AgentRuntime`` in checkpointed state.
+    Wallet settle/refund stay on ``_bind_design_hold_fns``, not in graph state.
     """
     from services.llm.agent import checkpointer_backend, get_agent_checkpointer
 

--- a/apps/api/services/llm/agent.py
+++ b/apps/api/services/llm/agent.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import logging
+import re
 import threading
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator, Sequence
 from pathlib import Path
 from typing import Any, Literal
 
@@ -636,6 +637,124 @@ def _checkpoint_serde() -> Any:
     )
 
 
+def _mysql_version_ok_for_langgraph(version: str) -> bool:
+    """langgraph-checkpoint-mysql needs MySQL >= 8.0.19 or MariaDB >= 10.7.1."""
+    raw = (version or "").strip().lower()
+    if not raw:
+        return False
+    if "mariadb" in raw:
+        m = re.search(r"(\d+)\.(\d+)\.(\d+)", raw)
+        return bool(m) and tuple(int(x) for x in m.groups()) >= (10, 7, 1)
+    m = re.match(r"(\d+)\.(\d+)\.(\d+)", raw)
+    return bool(m) and tuple(int(x) for x in m.groups()) >= (8, 0, 19)
+
+
+def _checkpointer_async_is_stub(saver: Any) -> bool:
+    """True when ``aget_tuple`` is NotImplemented / SqliteSaver's raise stub."""
+    import inspect
+
+    try:
+        src = inspect.getsource(type(saver).aget_tuple)
+    except (OSError, TypeError):
+        return False
+    return "NotImplementedError" in src
+
+
+def _wrap_sync_checkpointer_for_async(inner: Any) -> Any:
+    """
+    Make sync savers usable with ``graph.astream``.
+
+    SqliteSaver / PyMySQLSaver only implement sync APIs; LangGraph async paths
+    call ``aget_*`` / ``aput_*``. Mirror InMemorySaver: async methods delegate
+    to the sync implementations (conn is ``check_same_thread=False`` / autocommit).
+    """
+    from langgraph.checkpoint.base import BaseCheckpointSaver
+
+    if isinstance(inner, BaseCheckpointSaver) and not _checkpointer_async_is_stub(inner):
+        return inner
+
+    class _AsyncBridge(BaseCheckpointSaver):
+        def __init__(self, wrapped: Any) -> None:
+            super().__init__(serde=getattr(wrapped, "serde", None))
+            self._inner = wrapped
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._inner, name)
+
+        def get_tuple(self, config: Any) -> Any:
+            return self._inner.get_tuple(config)
+
+        def list(
+            self,
+            config: Any | None,
+            *,
+            filter: dict[str, Any] | None = None,
+            before: Any | None = None,
+            limit: int | None = None,
+        ) -> Iterator[Any]:
+            return self._inner.list(config, filter=filter, before=before, limit=limit)
+
+        def put(
+            self,
+            config: Any,
+            checkpoint: Any,
+            metadata: Any,
+            new_versions: Any,
+        ) -> Any:
+            return self._inner.put(config, checkpoint, metadata, new_versions)
+
+        def put_writes(
+            self,
+            config: Any,
+            writes: Sequence[tuple[str, Any]],
+            task_id: str,
+            task_path: str = "",
+        ) -> Any:
+            return self._inner.put_writes(config, writes, task_id, task_path)
+
+        def delete_thread(self, thread_id: str) -> Any:
+            return self._inner.delete_thread(thread_id)
+
+        async def aget_tuple(self, config: Any) -> Any:
+            return self._inner.get_tuple(config)
+
+        async def alist(
+            self,
+            config: Any | None,
+            *,
+            filter: dict[str, Any] | None = None,
+            before: Any | None = None,
+            limit: int | None = None,
+        ) -> AsyncIterator[Any]:
+            for item in self._inner.list(
+                config, filter=filter, before=before, limit=limit
+            ):
+                yield item
+
+        async def aput(
+            self,
+            config: Any,
+            checkpoint: Any,
+            metadata: Any,
+            new_versions: Any,
+        ) -> Any:
+            return self._inner.put(config, checkpoint, metadata, new_versions)
+
+        async def aput_writes(
+            self,
+            config: Any,
+            writes: Sequence[tuple[str, Any]],
+            task_id: str,
+            task_path: str = "",
+        ) -> Any:
+            return self._inner.put_writes(config, writes, task_id, task_path)
+
+        async def adelete_thread(self, thread_id: str) -> Any:
+            return self._inner.delete_thread(thread_id)
+
+    return _AsyncBridge(inner)
+
+
 def _build_mysql_checkpointer() -> Any | None:
     url = _checkpoint_mysql_url()
     if not url:
@@ -643,13 +762,45 @@ def _build_mysql_checkpointer() -> Any | None:
     import pymysql
     from langgraph.checkpoint.mysql.pymysql import PyMySQLSaver
 
+    from services.db import _parse_mysql_url
+
     global _CHECKPOINTER_CONN
-    params = PyMySQLSaver.parse_conn_string(url)
-    conn = pymysql.connect(**params, autocommit=True)
-    saver = PyMySQLSaver(conn, serde=_checkpoint_serde())
-    saver.setup()
+    # App parser unquotes password; PyMySQLSaver.parse_conn_string does not
+    # (``!`` / ``&`` in DATABASE_URL → Access denied → false sqlite fallback).
+    cfg = _parse_mysql_url(url)
+    conn = pymysql.connect(
+        host=cfg["host"],
+        port=int(cfg["port"]),
+        user=cfg["user"],
+        password=cfg["password"],
+        database=cfg["database"],
+        charset=cfg.get("charset") or "utf8mb4",
+        autocommit=True,
+        connect_timeout=10,
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT VERSION()")
+            row = cur.fetchone()
+        ver = str(row[0] if row else "")
+        if not _mysql_version_ok_for_langgraph(ver):
+            _log.warning(
+                "MySQL %s below langgraph-checkpoint-mysql requirement "
+                "(MySQL >= 8.0.19 / MariaDB >= 10.7.1); using sqlite",
+                ver,
+            )
+            conn.close()
+            return None
+        saver = PyMySQLSaver(conn, serde=_checkpoint_serde())
+        saver.setup()
+    except Exception:
+        try:
+            conn.close()
+        except Exception:
+            pass
+        raise
     _CHECKPOINTER_CONN = conn
-    return saver
+    return _wrap_sync_checkpointer_for_async(saver)
 
 
 def _build_sqlite_checkpointer() -> Any:
@@ -673,16 +824,15 @@ def _build_sqlite_checkpointer() -> Any:
     saver = SqliteSaver(conn, serde=_checkpoint_serde())
     saver.setup()
     _CHECKPOINTER_CONN = conn
-    return saver
+    return _wrap_sync_checkpointer_for_async(saver)
 
 
 def get_agent_checkpointer() -> Any:
     """
-    Production short-term memory checkpointer (docs: In production → DB saver).
+    Durable short-term memory checkpointer for ``create_agent`` + design graph.
 
-    Shared by ``create_agent`` threads and the design outer ``StateGraph``.
-    Priority: MySQL (``langgraph-checkpoint-mysql``, same DB as app) →
-    SqliteSaver → InMemorySaver.
+    Priority: MySQL 8.0.19+ (same DB as app) → Sqlite (async-bridged) → memory.
+    Sync Sqlite/MySQL savers are wrapped so ``graph.astream`` can call ``aget_*``.
     """
     global _CHECKPOINTER, _CHECKPOINTER_BACKEND
     if _CHECKPOINTER is not None:
@@ -703,7 +853,7 @@ def get_agent_checkpointer() -> Any:
             _CHECKPOINTER = _build_sqlite_checkpointer()
             _CHECKPOINTER_BACKEND = "sqlite"
             _log.info(
-                "LangGraph checkpointer: SqliteSaver (%s)",
+                "LangGraph checkpointer: Sqlite+async-bridge (%s)",
                 _checkpoint_sqlite_path(),
             )
             return _CHECKPOINTER

--- a/apps/api/tests/unit_tests/test_langchain_stack.py
+++ b/apps/api/tests/unit_tests/test_langchain_stack.py
@@ -172,6 +172,9 @@ def test_build_official_agent_accepts_response_format():
 
 
 def test_sqlite_checkpointer_setup_and_thread_config(tmp_path, monkeypatch):
+    import asyncio
+
+    from langgraph.checkpoint.base import BaseCheckpointSaver
     from config import settings as settings_mod
     from services.llm import agent as agent_mod
 
@@ -189,8 +192,21 @@ def test_sqlite_checkpointer_setup_and_thread_config(tmp_path, monkeypatch):
     cp = agent_mod.get_agent_checkpointer()
     assert agent_mod.checkpointer_backend() in ("sqlite", "memory")
     assert cp is not None
+    assert isinstance(cp, BaseCheckpointSaver)
     cfg = agent_mod.agent_thread_config("unit-thread")
     assert cfg and cfg["configurable"]["thread_id"] == "unit-thread"
+    # graph.astream needs aget_tuple; bare SqliteSaver raises NotImplementedError.
+    assert asyncio.run(cp.aget_tuple(cfg)) is None
+
+
+def test_mysql_version_ok_for_langgraph():
+    from services.llm.agent import _mysql_version_ok_for_langgraph
+
+    assert _mysql_version_ok_for_langgraph("8.0.19")
+    assert _mysql_version_ok_for_langgraph("8.4.0")
+    assert not _mysql_version_ok_for_langgraph("5.7.18-cynos-2.1.14-log")
+    assert _mysql_version_ok_for_langgraph("10.7.1-MariaDB")
+    assert not _mysql_version_ok_for_langgraph("10.6.0-MariaDB")
 
 
 def test_summarization_middleware_matches_docs(monkeypatch):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,6 +29,8 @@ Design Agent 的可配置内容（默认图、节点模板、动作契约、字�
 
 数据库：SQLite / MySQL / PostgreSQL（见 [postgres-switch.md](./postgres-switch.md)）；SQLite 默认 WAL，可选周期备份。
 
+LangGraph 短时 checkpoint：见 [postgres-switch.md · LangGraph checkpointer](./postgres-switch.md#langgraph-checkpointer-design-agent--create_agent)。
+
 ## 导入数据流
 
 ```

--- a/docs/postgres-switch.md
+++ b/docs/postgres-switch.md
@@ -54,7 +54,25 @@ with connect(immediate=True) as conn:  # wallet / critical writes
 - MySQL/Postgres: scheduler writes a `.hint.txt` with `mysqldump` / `pg_dump`; prefer cloud automated backups in production
 - Celery beat task: `worker.tasks.run_db_backup_job`
 
+## LangGraph checkpointer (Design Agent / create_agent)
+
+App data (`DATABASE_URL`) and LangGraph **short-term checkpoints** share the same priority chain in `services/llm/agent.py` → `get_agent_checkpointer()`:
+
+| Priority | Backend | When |
+|----------|---------|------|
+| 1 | MySQL via `langgraph-checkpoint-mysql` | `DATABASE_URL` / `LANGGRAPH_CHECKPOINT_URL` is MySQL **≥ 8.0.19** (or MariaDB ≥ 10.7.1) |
+| 2 | SQLite file | Below that version, or MySQL connect/setup fails → `LANGGRAPH_CHECKPOINT_SQLITE_PATH` (default `storage/langgraph_checkpoints.db`) |
+| 3 | In-memory | SQLite unavailable |
+
+Password in `DATABASE_URL` must be URL-encoded (`!` → `%21`, `&` → `%26`); the app unquotes before connecting. Sync savers are wrapped so `graph.astream` can call `aget_*` / `aput_*`.
+
+| Env | Role |
+|-----|------|
+| `LANGGRAPH_CHECKPOINT_URL` | Optional override (empty → reuse `DATABASE_URL`) |
+| `LANGGRAPH_CHECKPOINT_SQLITE_PATH` | SQLite fallback path |
+| `DESIGN_GRAPH_CHECKPOINT` | Compile outer design graph with checkpointer (default on) |
+
 ## Not in scope yet
 
 - Full dual DDL for every `CREATE TABLE` in Postgres (use migration tools)
-- LangGraph checkpointer/store Postgres backends (still MySQL/SQLite paths)
+- LangGraph checkpointer/store **Postgres** backends (still MySQL 8+ / SQLite paths)

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -31,6 +31,8 @@ Default config (skills, flows, dicts, …) loads from seed JSON under `apps/api/
 
 Periodic backups (default on): SQLite online copy under `DB_BACKUP_DIR` (`storage/backups/`); MySQL/Postgres write a dump hint. Celery beat: `run_db_backup_job`.
 
+LangGraph checkpoints: [postgres-switch.md](./postgres-switch.md#langgraph-checkpointer-design-agent--create_agent).
+
 ## Design skills (Agent)
 
 - **core** — seed skills in `design_skills_seed.json`


### PR DESCRIPTION
﻿## Summary
- Make LangGraph durable checkpointer work with `graph.astream`: unquote MySQL passwords, skip MySQL &lt; 8.0.19, wrap sync Sqlite/MySQL savers with an async bridge.
- Keep design graph on the shared checkpointer; document the MySQL → SQLite → memory fallback in postgres-switch / architecture / API README / self-hosting.

## Test plan
- [x] `pytest tests/unit_tests/test_langchain_stack.py::test_sqlite_checkpointer_setup_and_thread_config tests/unit_tests/test_langchain_stack.py::test_mysql_version_ok_for_langgraph tests/unit_tests/test_flow_conditional_edges.py::test_design_graph_uses_shared_durable_checkpointer`
- [ ] Restart API and send a short chat turn (no Errno 22 / SqliteSaver async error)
