### PR TITLE
Fix TOOL_OPS_SCHEMA_VERSION NameError on paint action

### DIFF
--- a/apps/api/services/design/runtime/graph/nodes/apply.py
+++ b/apps/api/services/design/runtime/graph/nodes/apply.py
@@ -9,6 +9,7 @@ from typing import Any
 from langgraph.types import Command
 
 from services.design.ops.tool_ops_contract import (
+    TOOL_OPS_SCHEMA_VERSION,
     tool_ops_activity_events as _tool_ops_activity_events,
     tool_ops_for_sse,
     validation_failure_reason,


### PR DESCRIPTION
## Summary
- Import TOOL_OPS_SCHEMA_VERSION in apply node so tool_ops SSE can emit after paint.

## Test plan
- [ ] Ask agent: 添加一个矩形到画布
- [ ] Confirm tool_ops SSE and rectangle appears (no generic designExecFailed)


Made with [Cursor](https://cursor.com)