### PR TITLE
Prefer English docs defaults and fix rail plus icon weight

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,46 +1,46 @@
-# recombyn 文档站
+# recombyn docs site
 
-Vite + React 文档站。
+Vite + React documentation site.
 
-- **帮助文档**：白底文档壳（顶栏 / 侧栏 / 面包屑），入口如 `/guide/getting-started`
-- **法律页**：独立深色阅读页，入口如 `/legal/terms`（不嵌套帮助文档框架）
-- **国际化**：顶栏语言切换，支持 `en` / `zh-CN` / `zh-TW` / `ja`；与主站共用 localStorage 键 `language`
+- **Help docs**: light shell (top bar / sidebar / breadcrumbs), e.g. `/guide/getting-started`
+- **Legal pages**: standalone dark reading pages, e.g. `/legal/terms` (not nested in the help chrome)
+- **i18n**: top-bar language switch for `en` / `zh-CN` / `zh-TW` / `ja`; shares the main app localStorage key `language`. Default / fallback locale is **English**.
 
-## 本地预览
+## Local preview
 
 ```bash
-# 仓库根目录
+# repo root
 npm install
 npm run dev:docs
 ```
 
-默认 [http://localhost:5175](http://localhost:5175)。主站开发时在 `apps/web` 设置：
+Default [http://localhost:5175](http://localhost:5175). For main-app local linking, set in `apps/web`:
 
 ```bash
 VITE_DOCS_URL=http://localhost:5175
 ```
 
-## 构建
+## Build
 
 ```bash
 npm run build:docs
 ```
 
-产物在 `apps/docs/dist`。
+Output: `apps/docs/dist`.
 
-## 内容
+## Content
 
-Markdown 按语言分目录，在 `content/{locale}/`：
+Markdown is split by locale under `content/{locale}/`:
 
-| 路径 | 内容 |
-|------|------|
-| `content/zh-CN/` | 简体中文（默认） |
-| `content/zh-TW/` | 繁體中文 |
-| `content/en/` | English |
-| `content/ja/` | 日本語 |
+| Path | Content |
+|------|---------|
+| `content/en/` | English (default) |
+| `content/zh-CN/` | Simplified Chinese |
+| `content/zh-TW/` | Traditional Chinese |
+| `content/ja/` | Japanese |
 
-各语言下结构相同：`guide/`、`features/`、`faq/`、`legal/`。
+Each locale mirrors the same structure: `guide/`, `features/`, `faq/`, `legal/`.
 
-顶栏 / 侧栏文案在 `src/i18n/locales/`。缺某语言正文时会按 `zh-CN → en → zh-TW → ja` 回退。
+Chrome copy lives in `src/i18n/locales/`. Missing body for a locale falls back `en → zh-CN → zh-TW → ja`.
 
-「开始创作 / 首页」指向 `VITE_APP_URL`（默认 `https://recombyn.com`）。
+“Start creating / Home” links use `VITE_APP_URL` (default `https://recombyn.com`).

--- a/apps/docs/src/data/nav.ts
+++ b/apps/docs/src/data/nav.ts
@@ -111,7 +111,7 @@ export function normalizePath(pathname: string): string {
   return p
 }
 
-const FALLBACK_ORDER: DocsLang[] = ['zh-CN', 'en', 'zh-TW', 'ja']
+const FALLBACK_ORDER: DocsLang[] = ['en', 'zh-CN', 'zh-TW', 'ja']
 
 export function getDocMarkdown(pathname: string, locale: DocsLang): string | undefined {
   const path = normalizePath(pathname)

--- a/apps/docs/src/i18n/index.ts
+++ b/apps/docs/src/i18n/index.ts
@@ -15,7 +15,7 @@ export const SUPPORTED_LANGS = [
 
 export type DocsLang = (typeof SUPPORTED_LANGS)[number]['code']
 
-export const DEFAULT_LANG: DocsLang = 'zh-CN'
+export const DEFAULT_LANG: DocsLang = 'en'
 
 const resources = {
   en: { common: en },

--- a/apps/web/src/components/layout/HomeBody.tsx
+++ b/apps/web/src/components/layout/HomeBody.tsx
@@ -50,19 +50,19 @@ const RAIL_STROKE = 1.5;
 const RAIL_HELP_WIKI =
   'https://my.feishu.cn/wiki/EuoxwPk4OighdZkmAVMc7Gisn8b?from=from_copylink';
 
-/** Circled + — rail create action. */
+/** Circled + — rail create action (glyph fills viewBox like Home/User). */
 function RailPlusIcon({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" aria-hidden>
       <circle
         cx="12"
         cy="12"
-        r="8.25"
+        r="10"
         stroke="currentColor"
         strokeWidth={RAIL_STROKE}
       />
       <path
-        d="M12 8.5v7M8.5 12h7"
+        d="M12 7.25v9.5M7.25 12h9.5"
         stroke="currentColor"
         strokeWidth={RAIL_STROKE}
         strokeLinecap="round"

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,44 +1,44 @@
 # API
 
 Base URL: `http://localhost:8000/api/v1`  
-完整契约以 Swagger 为准：http://127.0.0.1:8000/docs
+Full contract: Swagger at http://127.0.0.1:8000/docs
 
-## 路由概览
+## Route overview
 
-| 前缀 | 说明 |
-|------|------|
-| `/auth` | 登录 / OAuth / 会话 |
-| `/projects` | 项目 CRUD |
-| `/plaza` | 广场 feed / 投稿 / 点赞 |
-| `/chat` · `/chat-sessions` | Agent 对话与会话 |
-| `/uploads` · `/fonts` | 上传与字体 |
-| `/image-tools` | 抠图等视觉工具 |
-| `/shares` · `/notices` · `/users` | 分享、公告、用户目录 |
-| `/design/*` | Design Agent 跑图（SSE）、catalog、canvas-tools、scene 回传 |
-| `/import/*` | 图片 → Scene（同步或异步 job） |
-| `/admin/*` | 管理端（流程、字典、模型、广场审核等；需管理员） |
+| Prefix | Notes |
+|--------|-------|
+| `/auth` | Login / OAuth / session |
+| `/projects` | Project CRUD |
+| `/plaza` | Plaza feed / submissions / likes |
+| `/chat` · `/chat-sessions` | Agent chat and sessions |
+| `/uploads` · `/fonts` | Uploads and fonts |
+| `/image-tools` | Cutout and other vision tools |
+| `/shares` · `/notices` · `/users` | Shares, notices, user directory |
+| `/design/*` | Design Agent run (SSE), catalog, canvas-tools, scene feedback |
+| `/import/*` | Image → Scene (sync or async job) |
+| `/admin/*` | Admin (flows, dictionaries, models, plaza review, etc.; admin only) |
 
 ## Health
 
 `GET /api/v1/health` → `{ "status": "ok" }`
 
-## Design Agent（摘要）
+## Design Agent (summary)
 
-| 方法 | 路径 | 说明 |
-|------|------|------|
-| POST | `/design/run` | SSE：权限 → LangGraph agent（事件流） |
-| POST | `/design/run/{taskId}/scene` | 前端回传真实画布 inventory |
-| GET | `/design/catalog` | 公开 catalog |
-| GET | `/design/canvas-tools` | 画布 op 能力表 |
+| Method | Path | Notes |
+|--------|------|-------|
+| POST | `/design/run` | SSE: auth → LangGraph agent (event stream) |
+| POST | `/design/run/{taskId}/scene` | FE returns live canvas inventory |
+| GET | `/design/catalog` | Public catalog |
+| GET | `/design/canvas-tools` | Canvas op capability table |
 
-后端调用链与包结构见 [design-agent-runtime.md](./design-agent-runtime.md)。
+Backend call chain and package layout: [design-agent-runtime.md](./design-agent-runtime.md).
 
-## Import（摘要）
+## Import (summary)
 
-| 方法 | 路径 | 说明 |
-|------|------|------|
-| POST | `/import/image` | 上传图片 |
-| POST | `/import/jobs` | 异步导入任务（`source_type=image`） |
-| GET | `/import/jobs/{id}` | 查询任务状态 |
+| Method | Path | Notes |
+|--------|------|-------|
+| POST | `/import/image` | Upload image |
+| POST | `/import/jobs` | Async import job (`source_type=image`) |
+| GET | `/import/jobs/{id}` | Job status |
 
-导入管线细节见 [import-pipeline.md](./import-pipeline.md)。
+Import pipeline details: [import-pipeline.md](./import-pipeline.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,60 +1,61 @@
-# 架构
+# Architecture
 
-## 仓库结构
+## Repository layout
 
-| 目录 | 职责 |
+| Path | Role |
 |------|------|
-| `apps/web` | React 编辑器、首页、Agent 对话 |
-| `apps/api` | FastAPI：导入、项目/广场、Design Agent 等 |
-| `apps/docs` | 用户帮助与法律文档站 |
-| `packages/scene-schema` | Scene JSON 协议 |
-| `packages/scene-builder-py` | 解析块 → Scene JSON |
+| `apps/web` | React editor, home, Agent chat |
+| `apps/api` | FastAPI: import, projects/plaza, Design Agent, etc. |
+| `apps/docs` | User help and legal docs site |
+| `packages/scene-schema` | Scene JSON protocol |
+| `packages/scene-builder-py` | Parse blocks → Scene JSON |
 
-后端细节见 [apps/api/README.md](../apps/api/README.md)。
+Backend details: [apps/api/README.md](../apps/api/README.md).
 
-## Web 画布
+## Web canvas
 
-混排约 **5k** 节点日常编辑流畅（Chromium 平移中位约 **17ms**）；矩形向可到约 **10k**；超重 path 建议单场景约 **1k–2k**。靠视口裁剪 + LOD、空间索引命中、写时复制历史实现。复测：`npm run test:stress --workspace=apps/web`。
+Mixed scenes of about **5k** nodes stay smooth for daily editing (Chromium pan median ~**17ms**); rectangle-heavy scenes can reach ~**10k**; for very heavy paths, keep roughly **1k–2k** per scene. Implemented with viewport culling + LOD, spatial-index hits, and copy-on-write history. Retest: `npm run test:stress --workspace=apps/web`.
 
-## 后端分层
+## Backend layers
 
 ```
-HTTP     api/v1/*                 薄路由
-业务     services/*               按域分包（design / plaza / wallet / …）
-种子     data/*.json              流程、字典、字体、官方案例 → DB（INSERT 缺失，不覆盖已有）
+HTTP     api/v1/*                 thin routes
+Domain   services/*               by domain (design / plaza / wallet / …)
+Seeds    data/*.json              flows, dictionaries, fonts, official cases → DB
+                                  (INSERT missing; do not overwrite existing)
 Design   design.runtime           orchestrator → design_stream → graph
          design.prompts           Skill / prompt pack / knowledge / token
-         design.ops               tool_ops 契约
+         design.ops               tool_ops contract
 ```
 
-Design Agent 主路径：
+Design Agent main path:
 
 ```text
 POST /api/v1/design/run
-  → run_design_job → design_stream → run_agent_graph（LangGraph nodes）
+  → run_design_job → design_stream → run_agent_graph (LangGraph nodes)
 ```
 
-- `runtime/host/`：产品原语（prompt 组装、放置、ops 校验、资源加载）
-- `runtime/graph/`：图编译、节点、SSE / turn / paint 辅助
-- `agent_controller`：兼容 re-export，不是外层入口
+- `runtime/host/` — product primitives (prompt assembly, placement, ops validation, resource loading)
+- `runtime/graph/` — graph compile, nodes, SSE / turn / paint helpers
+- `agent_controller` — compatibility re-exports; not the outer entry
 
-可配置内容（prompt packs、Skill、字典、全局规则等）以 `apps/api/data/public/`（及可选 `private/` 覆盖）为种子；Admin / DB 为准。Skill 命名空间见 [design_skills/README.md](../apps/api/data/public/design_skills/README.md)。
+Configurable content (prompt packs, Skills, dictionaries, global rules, etc.) is seeded from `apps/api/data/public/` (and optional `private/` overrides); Admin / DB is authoritative. Skill namespaces: [design_skills/README.md](../apps/api/data/public/design_skills/README.md).
 
-包结构、调用约定与 SSE 相关接口见 **[design-agent-runtime.md](./design-agent-runtime.md)**。
+Package layout, call conventions, and SSE-related interfaces: **[design-agent-runtime.md](./design-agent-runtime.md)**.
 
-数据库：SQLite / MySQL / PostgreSQL（见 [postgres-switch.md](./postgres-switch.md)）；SQLite 默认 WAL，可选周期备份。
+Database: SQLite / MySQL / PostgreSQL (see [postgres-switch.md](./postgres-switch.md)); SQLite defaults to WAL with optional periodic backups.
 
-LangGraph 短时 checkpoint：见 [postgres-switch.md · LangGraph checkpointer](./postgres-switch.md#langgraph-checkpointer-design-agent--create_agent)。
+LangGraph short-lived checkpoints: [postgres-switch.md · LangGraph checkpointer](./postgres-switch.md#langgraph-checkpointer-design-agent--create_agent).
 
-## 导入数据流
+## Import data flow
 
 ```
-Image -> OpenCV + OCR/布局 ──> scene_builder ──> Scene JSON ──> Web
+Image -> OpenCV + OCR/layout ──> scene_builder ──> Scene JSON ──> Web
 ```
 
-异步任务：Redis + Celery（`POST /api/v1/import/jobs`，`source_type=image`）。
+Async jobs: Redis + Celery (`POST /api/v1/import/jobs`, `source_type=image`).
 
-## 部署
+## Deploy
 
-开发：`npm run dev:web` + `npm run dev:api`（+ Redis / Worker 按需）  
-生产：Docker Compose（web + api + worker + redis）
+Dev: `npm run dev:web` + `npm run dev:api` (+ Redis / Worker as needed)  
+Prod: Docker Compose (web + api + worker + redis)

--- a/docs/design-agent-runtime.md
+++ b/docs/design-agent-runtime.md
@@ -1,97 +1,97 @@
 # Design Agent Runtime
 
-后端 Design Agent 的调用链、包划分与内容边界。实现以代码为准；本页描述稳定约定。
+Call chain, package split, and content boundaries for the backend Design Agent. Implementation is source of truth; this page describes stable conventions.
 
-## 调用链
+## Call chain
 
 ```text
 POST /api/v1/design/run  (api/v1/design.py)
   → orchestrator.run_design_job
-      # 权限、hold、rules / region、BYOK
-      → design_run.design_stream          # runtime 公开 facade
+      # auth, hold, rules / region, BYOK
+      → design_run.design_stream          # public runtime facade
           → graph.build.run_agent_graph  # LangGraph
               → nodes: bootstrap → memory → intent → decide
                        → paint / apply / observe → settle
 ```
 
-| 调用方 | 应使用 |
-|--------|--------|
-| HTTP / harness / 集成测试 | `services.design.runtime.orchestrator.run_design_job` |
-| 编排内部（已过权限） | `services.design.runtime.design_run.design_stream` |
-| Host 能力（拼 prompt / 校验 ops） | `services.design.runtime.host` 或 `design_run` 再导出 |
-| 旧测试 / checkpoint serde | `agent_controller`（薄 re-export，非主路径） |
+| Caller | Use |
+|--------|-----|
+| HTTP / harness / integration tests | `services.design.runtime.orchestrator.run_design_job` |
+| Orchestration internals (after auth) | `services.design.runtime.design_run.design_stream` |
+| Host capabilities (assemble prompts / validate ops) | `services.design.runtime.host` or re-exports from `design_run` |
+| Legacy tests / checkpoint serde | `agent_controller` (thin re-export; not the main path) |
 
-业务代码不要直接调用 `run_agent_graph`。
+Business code should not call `run_agent_graph` directly.
 
-相关 HTTP：
+Related HTTP:
 
-| 方法 | 路径 | 说明 |
-|------|------|------|
-| POST | `/design/run` | SSE 主跑（`status` / `decision` / `tool_ops` / `token` …） |
-| POST | `/design/run/{taskId}/scene` | FE 回传画布快照 → `scene_feedback` |
-| GET | `/design/catalog` | 公开 catalog |
-| GET | `/design/canvas-tools` | 画布 op 能力表 |
+| Method | Path | Notes |
+|--------|------|-------|
+| POST | `/design/run` | SSE main run (`status` / `decision` / `tool_ops` / `token` …) |
+| POST | `/design/run/{taskId}/scene` | FE canvas snapshot → `scene_feedback` |
+| GET | `/design/catalog` | Public catalog |
+| GET | `/design/canvas-tools` | Canvas op capability table |
 
-## `services/design/runtime/` 包结构
+## `services/design/runtime/` package layout
 
 ```text
 runtime/
-  design_run.py           # 公开 facade：design_stream + host 再导出
-  orchestrator.py         # 门禁 + 调 design_stream；partial 旁路
-  agent_controller.py     # 兼容 shim（serde / 旧 import）
-  models_route.py         # lane 选模（fast / standard / reasoning / vision / image）
-  llm_step.py             # 单步 LLM stream / collect
-  scene_feedback.py       # FE→BE 场景闩锁
-  progress_stages.py      # Cursor 风格进度阶段
-  decision_log.py         # 单次 run decision trace
-  pipeline_support.py     # ref 图、用户可见错误等
-  flow_runtime.py         # Admin 流程图 walker（非主 LangGraph 路径）
-  host/                   # 产品侧原语（非 LC/LG 内置）
+  design_run.py           # public facade: design_stream + host re-exports
+  orchestrator.py         # gate + call design_stream; partial bypass
+  agent_controller.py     # compat shim (serde / old imports)
+  models_route.py         # lane model pick (fast / standard / reasoning / vision / image)
+  llm_step.py             # single-step LLM stream / collect
+  scene_feedback.py       # FE→BE scene latch
+  progress_stages.py      # Cursor-style progress stages
+  decision_log.py         # per-run decision trace
+  pipeline_support.py     # ref images, user-visible errors, etc.
+  flow_runtime.py         # Admin flow-graph walker (not main LangGraph path)
+  host/                   # product primitives (not LC/LG builtins)
     prompts.py            # assemble_stage_system / require_prompt_pack …
-    placement.py          # 放置块与 free-create 校验
-    ops_gate.py           # paint ops 契约校验
-    resources.py          # 延迟加载 need_* 资源
+    placement.py          # placement blocks + free-create checks
+    ops_gate.py           # paint ops contract validation
+    resources.py          # lazy-load need_* resources
   graph/
-    build.py              # StateGraph 编译 + run_agent_graph
-    state.py              # AgentRuntime / schemas / 常量
-    nodes/                # 图节点
+    build.py              # StateGraph compile + run_agent_graph
+    state.py              # AgentRuntime / schemas / constants
+    nodes/                # graph nodes
     emit_sse.py           # SSE / canvas chrome
-    llm_io.py             # stream LLM、persona、prompt text
-    turns.py              # turn parse、Ask choice UI、decide→paint
+    llm_io.py             # stream LLM, persona, prompt text
+    turns.py              # turn parse, Ask choice UI, decide→paint
     paint_kit.py          # paint tool kit / create_frame
-    scene_log.py          # scene digest、admin-step、bump/goto
-    support.py            # 薄 barrel（兼容旧 import）
+    scene_log.py          # scene digest, admin-step, bump/goto
+    support.py            # thin barrel (compat old imports)
 ```
 
-约定：
+Conventions:
 
-- **LC/LG** 管图与流；**host** 管产品逻辑（prompt pack、放置、资源、ops 校验）。
-- Agent 模式由模型决策并执行，不追问；Ask 模式可澄清。
-- 放置跟用户意图，不单靠 ambient FOCUS。
-- Stage system / paint / ask 等文案来自 **Admin prompt packs**；缺 pack 应失败，不在代码里硬编码兜底。
-- Validation = 契约检查，不改写模型意图。
+- **LC/LG** own the graph and stream; **host** owns product logic (prompt packs, placement, resources, ops validation).
+- Agent mode: the model decides and executes — no follow-up questions. Ask mode may clarify.
+- Placement follows user intent, not ambient FOCUS alone.
+- Stage system / paint / ask copy comes from **Admin prompt packs**; missing packs should fail hard — no hardcoded fallbacks in code.
+- Validation = contract checks; do not rewrite model intent.
 
-## `services/design/prompts/`（内容库）
+## `services/design/prompts/` (content library)
 
-与 runtime 分工：prompts = 存取与组装；runtime = 执行与 SSE。
+Split vs runtime: prompts = store and assemble; runtime = execute and SSE.
 
-| 模块 | 职责 |
-|------|------|
-| `prompt_pack_store.py` | Prompt packs（`paint_system` / `ask_system` / …），seed + DB；字段 `usedBy` 标注阶段（decide/paint/…） |
-| `system_prompt_store.py` | 系统提示（agent / aesthetics / persona） |
-| `skill_store.py` | Skills：触发、ACL、`need_skills`、文件包 |
-| `knowledge_store.py` | 场景/技能知识注入 |
+| Module | Role |
+|--------|------|
+| `prompt_pack_store.py` | Prompt packs (`paint_system` / `ask_system` / …), seed + DB; `usedBy` marks stages (decide/paint/…) |
+| `system_prompt_store.py` | System prompts (agent / aesthetics / persona) |
+| `skill_store.py` | Skills: triggers, ACL, `need_skills`, file packs |
+| `knowledge_store.py` | Scene/skill knowledge injection |
 | `token_store.py` | Design token packs |
-| `content_pack.py` | Content pack 版本戳 |
-| `prompt_build.py` / `rules_text.py` | 拼装与规则文本工具 |
+| `content_pack.py` | Content pack version stamp |
+| `prompt_build.py` / `rules_text.py` | Assembly and rules-text helpers |
 
-种子：`apps/api/data/public/design_prompt_packs_seed.json`、`design_skills_seed.json`、`design_skills/` 等。Skill 命名空间见 [design_skills/README.md](../apps/api/data/public/design_skills/README.md)。
+Seeds: `apps/api/data/public/design_prompt_packs_seed.json`, `design_skills_seed.json`, `design_skills/`, etc. Skill namespaces: [design_skills/README.md](../apps/api/data/public/design_skills/README.md).
 
-Prompt pack 的 `usedBy`（阶段）：`intent` / `decide` / `paint` / `apply` / `observe` / `resources` / `aesthetics` / `persona` / `precheck` / `orchestrator` / `legacy` 等。Admin 可筛；ensure 时从 seed 同步到 DB。
+Prompt pack `usedBy` stages: `intent` / `decide` / `paint` / `apply` / `observe` / `resources` / `aesthetics` / `persona` / `precheck` / `orchestrator` / `legacy`, etc. Admin can filter; ensure syncs from seed to DB.
 
-## 相关文档
+## Related docs
 
-- API 概览：[api.md](./api.md)
-- 后端目录与种子：[apps/api/README.md](../apps/api/README.md)
-- LangGraph checkpointer：[postgres-switch.md](./postgres-switch.md#langgraph-checkpointer-design-agent--create_agent)
-- 总架构：[architecture.md](./architecture.md)
+- API overview: [api.md](./api.md)
+- Backend layout and seeds: [apps/api/README.md](../apps/api/README.md)
+- LangGraph checkpointer: [postgres-switch.md](./postgres-switch.md#langgraph-checkpointer-design-agent--create_agent)
+- Architecture: [architecture.md](./architecture.md)

--- a/docs/import-pipeline.md
+++ b/docs/import-pipeline.md
@@ -1,75 +1,75 @@
-# 导入管线
+# Import pipeline
 
-> **产品现状**：对外仅支持**图片导入**。
+> **Product status**: externally, only **image import** is supported.
 
-## 阶段一：预处理 + 任务队列（图片）
+## Stage 1: preprocess + job queue (images)
 
-1. 上传图片
-2. Celery 异步任务（可选）+ Redis 存 job 状态
-3. 图片：归一化为单页图
-4. 页图写入 `storage/results/{job_id}/pages/`
+1. Upload image
+2. Optional Celery async job + Redis job status
+3. Normalize image to a single page bitmap
+4. Write page images under `storage/results/{job_id}/pages/`
 
-## 阶段二：图像算法（页图 → 布局/文字）
+## Stage 2: vision algorithms (page image → layout/text)
 
-在页图上运行（`USE_VISION=true`，默认开启）：
+Run on the page image (`USE_VISION=true`, on by default):
 
-| 模块 | 作用 | 依赖 |
-|------|------|------|
-| OpenCV | 降噪 / CLAHE 增强 | `opencv-python-headless` |
-| PaddleOCR | 文字框 + 文本 | `paddleocr` + PaddlePaddle |
-| PPStructure | 版面（标题/图/表），失败则回退 OCR | 随 `paddleocr` |
-| KMeans | 主色板 `meta.palette` | OpenCV |
-| 轻量 SAM | 区域提案（默认关，需模型） | 可选 |
-| LaMa | 修复/去字（默认关） | 可选 |
+| Module | Role | Dependency |
+|--------|------|------------|
+| OpenCV | Denoise / CLAHE | `opencv-python-headless` |
+| PaddleOCR | Text boxes + text | `paddleocr` + PaddlePaddle |
+| PPStructure | Layout (title/figure/table); falls back to OCR on failure | with `paddleocr` |
+| KMeans | Primary palette `meta.palette` | OpenCV |
+| Lightweight SAM | Region proposals (off by default; needs weights) | optional |
+| LaMa | Inpaint / remove text (off by default) | optional |
 
-坐标会缩放到 `SCENE_TARGET_WIDTH`（默认 794）再写入 Scene。
+Coordinates are scaled to `SCENE_TARGET_WIDTH` (default 794) before writing Scene.
 
-## 阶段三：对象存储 + 前端异步导入
+## Stage 3: object storage + frontend async import
 
-### S3 兼容存储
+### S3-compatible storage
 
-默认本地磁盘。开启后通过 boto3 上传页图（兼容阿里云 OSS、腾讯云 COS、MinIO、AWS S3）：
+Local disk by default. When enabled, page images upload via boto3 (Aliyun OSS, Tencent COS, MinIO, AWS S3):
 
 ```env
 S3_ENABLED=true
-S3_ENDPOINT_URL=https://oss-cn-hangzhou.aliyuncs.com   # 或 COS/MinIO endpoint
+S3_ENDPOINT_URL=https://oss-cn-hangzhou.aliyuncs.com   # or COS/MinIO endpoint
 S3_ACCESS_KEY=...
 S3_SECRET_KEY=...
 S3_BUCKET=resume-scene
 S3_REGION=us-east-1
-S3_PUBLIC_BASE_URL=https://cdn.example.com             # 可选，拼公开 URL
-S3_ADDRESSING_STYLE=virtual                            # 部分网关用 path
+S3_PUBLIC_BASE_URL=https://cdn.example.com             # optional public URL base
+S3_ADDRESSING_STYLE=virtual                            # some gateways need path
 ```
 
 ```bash
 pip install -e ".[storage]"
 ```
 
-任务结果 `meta`：`object_keys`、`object_urls`（本地模式与 `page_images` 同源）。
+Job result `meta`: `object_keys`, `object_urls` (same source as `page_images` in local mode).
 
-### 前端
+### Frontend
 
-首页「导入文件」走异步 Job：
+Home “Import file” uses an async job:
 
 1. `POST /api/v1/import/jobs`
-2. 轮询 `GET /api/v1/import/jobs/{id}`
-3. `done` 后打开编辑器
+2. Poll `GET /api/v1/import/jobs/{id}`
+3. On `done`, open the editor
 
-需同时运行 API + Redis + Celery worker。
+Requires API + Redis + Celery worker running together.
 
-## 阶段四：文本合并 + 图/表图层
+## Stage 4: text merge + figure/table layers
 
-1. OCR/版面结果中的碎文本按行高聚类合并为更少的 textbox（`merge_text_blocks`）
-2. PPStructure 检出的 figure/table：从页图裁剪为 PNG data URL，落入 Scene `image` 节点；裁剪失败的 table 用浅色 `rect` 占位
-3. 多页时按页高垂直拼接到同一画布
+1. Fragment OCR/layout text is clustered by line height into fewer textboxes (`merge_text_blocks`)
+2. PPStructure figures/tables: crop from the page image to PNG data URLs as Scene `image` nodes; failed table crops use a light `rect` placeholder
+3. Multi-page: stack pages vertically on one canvas by page height
 
-`meta.engines` 可能出现：`merge`、`crop`。
+`meta.engines` may include: `merge`, `crop`.
 
-## 阶段五：表格单元格 + SAM/LaMa 接入
+## Stage 5: table cells + SAM/LaMa hooks
 
-1. **表格**：版面检出的 table 默认再 OCR，拆成背景 `rect` + 可编辑 text 单元格（`EXPAND_TABLE_CELLS=true`，`engines` 含 `table-cells`）
-2. **SAM**：`ENABLE_SAM=true` 且配置 `SAM_CHECKPOINT` 权重时运行 MobileSAM / segment_anything；大区域裁成 image 层
-3. **LaMa**：`ENABLE_LAMA=true` 时，可用 `simple-lama-inpainting` 或 OpenCV Telea；默认用 SAM 框作 mask（`LAMA_USE_SAM_MASK=true`）
+1. **Tables**: layout tables are OCR’d again by default into background `rect` + editable text cells (`EXPAND_TABLE_CELLS=true`, `engines` includes `table-cells`)
+2. **SAM**: when `ENABLE_SAM=true` and `SAM_CHECKPOINT` is set, run MobileSAM / segment_anything; large regions become image layers
+3. **LaMa**: when `ENABLE_LAMA=true`, use `simple-lama-inpainting` or OpenCV Telea; default mask from SAM boxes (`LAMA_USE_SAM_MASK=true`)
 
 ```env
 EXPAND_TABLE_CELLS=true
@@ -80,41 +80,41 @@ ENABLE_LAMA=false
 LAMA_USE_SAM_MASK=true
 ```
 
-前端导入时会提示「正在导入…」。
+The frontend shows “Importing…” during import.
 
-## 阶段六：联调就绪
+## Stage 6: integration readiness
 
-- `GET /api/v1/health` 返回 `redis` / `worker` / `ocr` 状态
-- `INSTALL_OCR=true docker compose build` 可打入 OCR
-- 前端异步 Job 失败或排队过久时自动回退同步导入
+- `GET /api/v1/health` reports `redis` / `worker` / `ocr` status
+- `INSTALL_OCR=true docker compose build` can bake OCR in
+- Frontend auto-falls back to sync import if the async job fails or queues too long
 - `make health` / `python scripts/smoke_health.py`
 
 ```bash
 make dev-stack          # redis + api + worker
-# 或本地：
+# or locally:
 make dev-redis && make dev-api && make dev-worker
 ```
 
 ## API
 
-- 同步：`POST /api/v1/import/image`
-- 异步：`POST /api/v1/import/jobs` → `GET /api/v1/import/jobs/{id}`（`source_type=image`）
+- Sync: `POST /api/v1/import/image`
+- Async: `POST /api/v1/import/jobs` → `GET /api/v1/import/jobs/{id}` (`source_type=image`)
 
-`meta` 字段：`page_images`、`object_keys`、`object_urls`、`palette`、`engines`、`warnings`。
+`meta` fields: `page_images`, `object_keys`, `object_urls`, `palette`, `engines`, `warnings`.
 
-## 安装 OCR
+## Install OCR
 
 ```bash
 pip install -e ".[ocr]"
-# CPU Paddle（示例）
+# CPU Paddle (example)
 pip install paddlepaddle -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
 ```
 
-## 待完善
+## Checklist
 
-- [x] 异步 OCR 任务队列
-- [x] S3 对象存储（阶段三）
-- [x] 行合并为更稳的 textbox
-- [x] figure/table 落盘为可编辑图层
-- [x] table 结构识别为可编辑单元格（OCR 单元格，非完美表格重建）
-- [x] 接入手动 SAM/LaMa 权重路径（可选开启）
+- [x] Async OCR job queue
+- [x] S3 object storage (stage 3)
+- [x] Line merge into stabler textboxes
+- [x] Figures/tables as editable layers
+- [x] Table structure → editable cells (OCR cells, not perfect table rebuild)
+- [x] Manual SAM/LaMa weight paths (optional)

--- a/docs/scene-json-spec.md
+++ b/docs/scene-json-spec.md
@@ -1,6 +1,6 @@
-# Scene JSON 规范
+# Scene JSON spec
 
-与 Web 编辑器运行时文档及 `packages/scene-schema` 保持一致。
+Aligned with the Web editor runtime docs and `packages/scene-schema`.
 
 ```json
 {
@@ -15,7 +15,7 @@
       "width": 240,
       "height": 24,
       "attrs": {
-        "ORIGIN_DATA": "示例文本",
+        "ORIGIN_DATA": "Sample text",
         "DATA": { "chars": [] }
       }
     }
@@ -23,4 +23,4 @@
 }
 ```
 
-完整 Schema 见 `packages/scene-schema/schema/scene-document.schema.json`。
+Full schema: `packages/scene-schema/schema/scene-document.schema.json`.


### PR DESCRIPTION
## Summary
- Translate root engineering docs (`architecture`, `api`, runtime, import pipeline, scene JSON) to English.
- Set docs-site default/fallback locale to `en`.
- Enlarge the home rail circled-plus glyph so it matches other nav icons optically.

## Test plan
- [ ] Open `docs/architecture.md` — headings/body are English
- [ ] Docs site with cleared `language` localStorage defaults to English chrome/content
- [ ] Home sidebar Add icon visual weight matches Home/User icons