### PR TITLE
Remove Breatic references from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ e2e/               Playwright
 
 [Recombyn Open Source License v1.0](./LICENSE) © Recombyn contributors · [NOTICE](./NOTICE)
 
-Apache License 2.0 with additional conditions (same shape as [Breatic](https://github.com/orime-org/breatic)):
+Apache License 2.0 with additional conditions:
 
 - **Personal / private self-host** — free
 - **Internal org use** — permitted

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,7 +88,7 @@ e2e/               Playwright
 
 [Recombyn Open Source License v1.0](./LICENSE) © Recombyn contributors · [NOTICE](./NOTICE)
 
-基于 Apache License 2.0 的附加条件协议（参考 [Breatic](https://github.com/orime-org/breatic)）：
+基于 Apache License 2.0 的附加条件协议：
 
 - **个人 / 私有自托管** — 免费
 - **单一组织内部使用** — 允许


### PR DESCRIPTION
## Summary
- Drop Breatic / orime-org links from English and Chinese README license sections.
- License terms themselves are unchanged.

## Test plan
- [ ] Confirm README.md and README.zh-CN.md have no Breatic / orime-org mentions
- [ ] Confirm LICENSE / NOTICE text is unchanged

Made with [Cursor](https://cursor.com)