### PR TITLE
Wait for remote image decode before swapping upload preview

### DIFF
--- a/apps/web/src/components/editor/canvas/svg/SvgCanvas.tsx
+++ b/apps/web/src/components/editor/canvas/svg/SvgCanvas.tsx
@@ -88,6 +88,7 @@ import {
   uploadImageFile,
   uploadImageFromSrc,
   readFileAsDataUrl,
+  waitForImageReady,
 } from '@/utils/uploadImage';
 import store from '@/store';
 import {
@@ -2549,10 +2550,13 @@ function SvgCanvas({
           try {
             const uploaded = await uploadImageFromSrc(url, 'chat-image.png', { signal });
             if (signal?.aborted) return;
+            const remoteReady = await waitForImageReady(uploaded.url, { signal });
+            if (signal?.aborted) return;
             dispatch(
               finishImageProcess({
                 nodeId: spawnedId || undefined,
-                src: uploaded.url,
+                // Keep local preview until the remote URL is fully decoded.
+                ...(remoteReady ? { src: uploaded.url } : {}),
                 attrs: uploaded.key ? { uploadKey: uploaded.key } : undefined,
               })
             );
@@ -2994,10 +2998,13 @@ function SvgCanvas({
         try {
           const uploaded = await uploadImageFile(file, { signal });
           if (signal?.aborted) return;
+          const remoteReady = await waitForImageReady(uploaded.url, { signal });
+          if (signal?.aborted) return;
           dispatch(
             finishImageProcess({
               nodeId: spawnedId || undefined,
-              src: uploaded.url,
+              // Keep local preview until the remote URL is fully decoded.
+              ...(remoteReady ? { src: uploaded.url } : {}),
               attrs: uploaded.key ? { uploadKey: uploaded.key } : undefined,
             })
           );

--- a/apps/web/src/components/editor/chrome/EditorToolStrip.tsx
+++ b/apps/web/src/components/editor/chrome/EditorToolStrip.tsx
@@ -24,7 +24,14 @@ import { RiVideoAiLine } from 'react-icons/ri';
 import { Dropdown, Tooltip, message } from '@/components/base';
 import type { MenuItemType } from '@/components/base/dropdown/MenuItem';
 import { FloatingToolbar } from '@/components/editor/chrome/FloatingToolbar';
-import { uploadImageFile, readFileAsDataUrl, beginNodeUpload, finishNodeUpload, isUploadAbortError } from '@/utils/uploadImage';
+import {
+  uploadImageFile,
+  readFileAsDataUrl,
+  beginNodeUpload,
+  finishNodeUpload,
+  isUploadAbortError,
+  waitForImageReady,
+} from '@/utils/uploadImage';
 import store from '@/store';
 import {
   setActiveTool,
@@ -491,10 +498,12 @@ function EditorToolStrip({
       try {
         const uploaded = await uploadImageFile(file, { signal });
         if (signal?.aborted) return;
+        const remoteReady = await waitForImageReady(uploaded.url, { signal });
+        if (signal?.aborted) return;
         dispatch(
           finishImageProcess({
             nodeId: spawnedId || undefined,
-            src: uploaded.url,
+            ...(remoteReady ? { src: uploaded.url } : {}),
             attrs: uploaded.key ? { uploadKey: uploaded.key } : undefined,
           })
         );

--- a/apps/web/src/components/editor/nodes/ImageNode/ImageReplaceUploadControl.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageReplaceUploadControl.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { HiOutlineArrowUpTray } from 'react-icons/hi2';
 import { message } from '@/components/base';
 import Tooltip from '@/components/base/tooltip';
-import { uploadImageFile, readFileAsDataUrl } from '@/utils/uploadImage';
+import { uploadImageFile, readFileAsDataUrl, waitForImageReady } from '@/utils/uploadImage';
 import { measureImageNaturalSize } from '@/components/rcb/scene/document/sceneDocument';
 import { finishImageProcess, patchDocumentNode } from '@/store/modules/editor';
 
@@ -83,10 +83,14 @@ function ImageReplaceUploadControl({
         const src = uploaded.url;
         if (!aliveRef.current || nodeIdRef.current !== targetId) return;
 
+        const remoteReady = await waitForImageReady(src);
+        if (!aliveRef.current || nodeIdRef.current !== targetId) return;
+
         let naturalW = Number(uploaded.width) || 0;
         let naturalH = Number(uploaded.height) || 0;
         if (!(naturalW > 0 && naturalH > 0)) {
-          const natural = await measureImageNaturalSize(src);
+          // Prefer already-decoded remote; fall back to local preview size.
+          const natural = await measureImageNaturalSize(remoteReady ? src : preview);
           naturalW = natural.width;
           naturalH = natural.height;
         }
@@ -102,7 +106,7 @@ function ImageReplaceUploadControl({
         dispatch(
           finishImageProcess({
             nodeId: targetId,
-            src,
+            ...(remoteReady ? { src } : {}),
             attrs: {
               assetKind,
               ...(uploaded.key ? { uploadKey: uploaded.key } : {}),

--- a/apps/web/src/utils/uploadImage.ts
+++ b/apps/web/src/utils/uploadImage.ts
@@ -127,6 +127,52 @@ export function readFileAsDataUrl(file: File): Promise<string> {
   });
 }
 
+/**
+ * Wait until a remote/local URL is fully loaded + decoded before swapping off a
+ * local data:/blob: preview (avoids blank flash right after upload succeeds).
+ * Returns false if load failed or aborted — caller should keep the local preview.
+ */
+export function waitForImageReady(
+  src: string,
+  opts?: { signal?: AbortSignal }
+): Promise<boolean> {
+  const url = String(src || '').trim();
+  if (!url) return Promise.resolve(false);
+  // Already local — nothing to wait for.
+  if (url.startsWith('data:') || url.startsWith('blob:')) return Promise.resolve(true);
+
+  return new Promise((resolve) => {
+    if (opts?.signal?.aborted) {
+      resolve(false);
+      return;
+    }
+    const img = new Image();
+    let settled = false;
+    const finish = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      opts?.signal?.removeEventListener('abort', onAbort);
+      img.onload = null;
+      img.onerror = null;
+      resolve(ok);
+    };
+    const onAbort = () => finish(false);
+    opts?.signal?.addEventListener('abort', onAbort, { once: true });
+    img.onload = () => {
+      if (typeof img.decode === 'function') {
+        void img
+          .decode()
+          .then(() => finish(true))
+          .catch(() => finish(true));
+        return;
+      }
+      finish(true);
+    };
+    img.onerror = () => finish(false);
+    img.src = url;
+  });
+}
+
 export function isOurStoredImageUrl(src: string): boolean {
   const s = (src || '').trim();
   if (!s || s.startsWith('data:')) return false;


### PR DESCRIPTION
## Summary
- After image upload succeeds, preload/decode the remote URL before replacing the local data URL preview.
- If remote load fails, keep the local preview and still persist `uploadKey`.
- Covers canvas drop/file pick, toolstrip image pick, and image replace control.

## Test plan
- [ ] Upload a large image to canvas: no blank flash when upload finishes
- [ ] Replace image via corner control: same smooth handoff
- [ ] Abort/delete placeholder mid-upload: still no resurrect

Made with [Cursor](https://cursor.com)