### PR TITLE
Fix canvas pointer coords and context menu on small viewports

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,53 +10,8 @@ import type { LedgerEntry } from '@/utils/wallet';
 import { syncFromServer } from '@/store/modules/wallet';
 import { getToken } from '@/utils/token';
 
-/** Block browser page zoom (Ctrl/⌘±/0, Ctrl+wheel, Safari pinch). Canvas camera zoom stays. */
-function installBlockBrowserZoom() {
-  const onWheel = (e: WheelEvent) => {
-    if (e.ctrlKey || e.metaKey) e.preventDefault();
-  };
-  const onKeyDown = (e: KeyboardEvent) => {
-    if (!(e.ctrlKey || e.metaKey)) return;
-    const k = e.key;
-    const code = e.code;
-    if (
-      k === '+' ||
-      k === '-' ||
-      k === '=' ||
-      k === '_' ||
-      k === '0' ||
-      code === 'Equal' ||
-      code === 'Minus' ||
-      code === 'Digit0' ||
-      code === 'NumpadAdd' ||
-      code === 'NumpadSubtract' ||
-      code === 'Numpad0'
-    ) {
-      e.preventDefault();
-    }
-  };
-  const onGesture = (e: Event) => e.preventDefault();
-
-  window.addEventListener('wheel', onWheel, { passive: false, capture: true });
-  window.addEventListener('keydown', onKeyDown, { capture: true });
-  // Safari pinch-to-zoom
-  document.addEventListener('gesturestart', onGesture, { passive: false } as AddEventListenerOptions);
-  document.addEventListener('gesturechange', onGesture, { passive: false } as AddEventListenerOptions);
-  document.addEventListener('gestureend', onGesture, { passive: false } as AddEventListenerOptions);
-
-  return () => {
-    window.removeEventListener('wheel', onWheel, true);
-    window.removeEventListener('keydown', onKeyDown, true);
-    document.removeEventListener('gesturestart', onGesture);
-    document.removeEventListener('gesturechange', onGesture);
-    document.removeEventListener('gestureend', onGesture);
-  };
-}
-
 function App() {
   const dispatch = useDispatch();
-
-  useEffect(() => installBlockBrowserZoom(), []);
 
   useEffect(() => {
     const onUnauthorized = () => {

--- a/apps/web/src/components/base/colorPanel/pickScreenColor.ts
+++ b/apps/web/src/components/base/colorPanel/pickScreenColor.ts
@@ -245,7 +245,7 @@ function pickColorWithLoupe(): Promise<string | null> {
       overlay.remove();
     }
 
-    void (async () => {
+    async function initLoupe() {
       bitmap = await captureStageBitmap();
       if (!bitmap) {
         finish(null);
@@ -261,7 +261,8 @@ function pickColorWithLoupe(): Promise<string | null> {
       window.addEventListener('keydown', onKey, true);
       // Seed loupe at current pointer if possible.
       paintLoupe(window.innerWidth / 2, window.innerHeight / 2);
-    })();
+    }
+    initLoupe();
   });
 }
 

--- a/apps/web/src/components/editor/canvas/svg/SvgCanvas.tsx
+++ b/apps/web/src/components/editor/canvas/svg/SvgCanvas.tsx
@@ -76,6 +76,7 @@ import {
   getShapeHost,
   listShapeHosts,
   rcbFitImageIntoViewport,
+  rcbResolveViewportEl,
   rcbScreenToScene,
   type RcbCamera,
   type SvgBoardHandle,
@@ -167,18 +168,24 @@ import CanvasContextMenu, {
 import {
   useRcbCamera,
   useRcbOverlayRoot,
+  useRcbViewportEl,
 } from '@/components/rcb';
-
-
 type ArtboardRect = { x?: number; y?: number; width: number; height: number };
 
 function pointerToWorld(
   camera: RcbCamera,
-  opts: { stageEl?: HTMLElement | null; paperEl?: HTMLElement | null; artboard?: ArtboardRect },
+  opts: {
+    stageEl?: HTMLElement | null;
+    paperEl?: HTMLElement | null;
+    viewportEl?: HTMLElement | null;
+    artboard?: ArtboardRect;
+  },
   clientX: number,
   clientY: number
 ): { x: number; y: number } {
-  if (opts.stageEl) return rcbScreenToScene(camera, opts.stageEl, clientX, clientY);
+  // Prefer a connected stage — EditorPage stageEl can go stale after resize remounts.
+  const stage = rcbResolveViewportEl(opts.viewportEl, opts.stageEl);
+  if (stage) return rcbScreenToScene(camera, stage, clientX, clientY);
   if (opts.paperEl && opts.artboard) {
     const rect = opts.paperEl.getBoundingClientRect();
     if (!rect.width || !rect.height) return { x: 0, y: 0 };
@@ -370,11 +377,9 @@ async function readSystemPasteFromNavigator(): Promise<SystemPastePayload | null
         const videoType = types.find((t) => t.startsWith('video/'));
         if (videoType) {
           const blob = await item.getType(videoType);
-          const ext = videoType.includes('webm')
-            ? 'webm'
-            : videoType.includes('quicktime')
-              ? 'mov'
-              : 'mp4';
+          let ext = 'mp4';
+          if (videoType.includes('webm')) ext = 'webm';
+          else if (videoType.includes('quicktime')) ext = 'mov';
           return {
             kind: 'video',
             file: new File([blob], `paste.${ext}`, { type: videoType }),
@@ -619,6 +624,7 @@ function SvgCanvas({
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const camera = useRcbCamera();
+  const viewportEl = useRcbViewportEl();
   const activeTool = useSelector((s: any) => s.editor.activeTool);
   const shapeKind = useSelector((s: any) => s.editor.shapeKind);
   const pendingImageSrc = useSelector((s: any) => s.editor.pendingImageSrc);
@@ -755,8 +761,7 @@ function SvgCanvas({
     }
   }, []);
   documentRef.current = document;
-  selectedIdsRef.current =
-    selectedNodeIds?.length > 0 ? selectedNodeIds : selectedNodeId ? [selectedNodeId] : [];
+  selectedIdsRef.current = ctxMenuSeedNodeIds(selectedNodeIds || [], selectedNodeId);
   activeFrameIdRef.current = activeFrameId;
   selectedFrameIdsRef.current = selectedFrameIds;
 
@@ -1865,32 +1870,30 @@ function SvgCanvas({
   );
 
   const placeImageAt = useCallback(
-    (src: string, x: number, y: number) => {
+    async (src: string, x: number, y: number) => {
       if (readOnly) return;
-      void (async () => {
-        try {
-          const natural = await measureImageNaturalSize(src);
-          const { width, height } = imageSizeForViewport(natural);
-          const latest = documentRef.current;
-          if (!latest) return;
-          const placed = rcbCenterOnPoint({ x, y }, { width, height });
-          const origin = sceneToDocumentCoords(latest, placed.left, placed.top);
-          const { id, node } = createImageNode({
-            x: origin.x,
-            y: origin.y,
-            width: placed.width,
-            height: placed.height,
-            src,
-          });
-          dispatch(setDocument(addNodeToDocument(latest, id, node)));
-          dispatch(setSelectedNodeId(id));
-          dispatch(setPendingImageSrc(null));
-          finishToSelect();
-        } catch {
-          dispatch(setPendingImageSrc(null));
-          finishToSelect();
-        }
-      })();
+      try {
+        const natural = await measureImageNaturalSize(src);
+        const { width, height } = imageSizeForViewport(natural);
+        const latest = documentRef.current;
+        if (!latest) return;
+        const placed = rcbCenterOnPoint({ x, y }, { width, height });
+        const origin = sceneToDocumentCoords(latest, placed.left, placed.top);
+        const { id, node } = createImageNode({
+          x: origin.x,
+          y: origin.y,
+          width: placed.width,
+          height: placed.height,
+          src,
+        });
+        dispatch(setDocument(addNodeToDocument(latest, id, node)));
+        dispatch(setSelectedNodeId(id));
+        dispatch(setPendingImageSrc(null));
+        finishToSelect();
+      } catch {
+        dispatch(setPendingImageSrc(null));
+        finishToSelect();
+      }
     },
     [dispatch, imageSizeForViewport, readOnly]
   );
@@ -1912,7 +1915,7 @@ function SvgCanvas({
     const center = view && (stageEl || paperEl)
       ? pointerToWorld(
           camera,
-          { stageEl, paperEl, artboard },
+          { viewportEl, stageEl, paperEl, artboard },
           view.left + view.width / 2,
           view.top + view.height / 2
         )
@@ -1924,6 +1927,7 @@ function SvgCanvas({
     paperH,
     paperEl,
     stageEl,
+    viewportEl,
     camera,
     overlayRoot,
     artboard,
@@ -2435,25 +2439,48 @@ function SvgCanvas({
     [dispatch, readOnly]
   );
 
-  // Context menu: infinite paper is 0×0 — listen on stage (same as SelectionFeature).
+  // Context menu: prefer right-button pointer/mouse down (real client coords).
+  // DevTools / some browsers fire only `contextmenu` at (1,1) with no button-2 down.
   useEffect(() => {
-    const hitEl = stageEl || paperEl;
+    const hitEl = rcbResolveViewportEl(viewportEl, stageEl, paperEl);
     if (readOnly || !hitEl) return undefined;
 
     const skipSel =
       '[data-sel-toolbar],[data-frame-toolbar],[data-ctx-menu],[data-export-panel],[data-image-label],[data-frame-label],[data-crop-expand-overlay],[data-crop-expand-toolbar],[data-image-tool-panel],[data-text-inline-editor],[data-video-trim-toolbar],[data-video-playback-bar]';
 
-    const onCtx = (e: MouseEvent) => {
-      const target = e.target as HTMLElement | null;
-      if (target?.closest?.(skipSel)) return;
-      // Ignore right-clicks outside the canvas stage (e.g. side panels).
-      if (stageEl && target && !stageEl.contains(target) && target !== stageEl) return;
+    let lastClientX = Number.NaN;
+    let lastClientY = Number.NaN;
+    let suppressCtxUntil = 0;
 
-      e.preventDefault();
-      e.stopPropagation();
+    const clientInStage = (clientX: number, clientY: number) => {
+      const r = hitEl.getBoundingClientRect();
+      return (
+        clientX >= r.left &&
+        clientX <= r.right &&
+        clientY >= r.top &&
+        clientY <= r.bottom
+      );
+    };
 
-      const p = pointerToWorld(camera, { stageEl, paperEl, artboard }, e.clientX, e.clientY);
-      const id = hitTest(p.x, p.y, { clientX: e.clientX, clientY: e.clientY });
+    /** Synthetic contextmenu often reports (0,0) or (1,1) — not a real click. */
+    const isBogusClient = (clientX: number, clientY: number) =>
+      !Number.isFinite(clientX) ||
+      !Number.isFinite(clientY) ||
+      (clientX <= 2 && clientY <= 2);
+
+    const isChromeTarget = (target: EventTarget | null) => {
+      const el = target as HTMLElement | null;
+      return Boolean(el?.closest?.(skipSel));
+    };
+
+    const openMenuAt = (clientX: number, clientY: number) => {
+      const p = pointerToWorld(
+        camera,
+        { viewportEl, stageEl, paperEl, artboard },
+        clientX,
+        clientY
+      );
+      const id = hitTest(p.x, p.y, { clientX, clientY });
       const selected = selectedIdsRef.current;
       if (id && !selected.includes(id)) {
         dispatch(setSelectedNodeIds([id]));
@@ -2485,21 +2512,105 @@ function SvgCanvas({
           }
         }
       }
-      const menuNodeId =
-        id || (selected.length === 1 ? selected[0] : null);
       setCtxMenu({
-        clientX: e.clientX,
-        clientY: e.clientY,
+        clientX,
+        clientY,
         sceneX: p.x,
         sceneY: p.y,
-        nodeId: menuNodeId,
+        nodeId: id || (selected.length === 1 ? selected[0] : null),
         frameId,
       });
     };
 
-    hitEl.addEventListener('contextmenu', onCtx);
-    return () => hitEl.removeEventListener('contextmenu', onCtx);
-  }, [paperEl, stageEl, camera, readOnly, artboard, hitTest, dispatch]);
+    const noteClient = (clientX: number, clientY: number) => {
+      if (!clientInStage(clientX, clientY) || isBogusClient(clientX, clientY)) return;
+      lastClientX = clientX;
+      lastClientY = clientY;
+    };
+
+    const openFromRightButton = (
+      clientX: number,
+      clientY: number,
+      target: EventTarget | null
+    ) => {
+      if (performance.now() < suppressCtxUntil) return false;
+      if (isBogusClient(clientX, clientY)) return false;
+      if (!clientInStage(clientX, clientY)) return false;
+      if (isChromeTarget(target)) return false;
+      noteClient(clientX, clientY);
+      suppressCtxUntil = performance.now() + 500;
+      openMenuAt(clientX, clientY);
+      return true;
+    };
+
+    // Track hover by geometry (target may be outside roots when portals / overlays move).
+    const onPointerMove = (e: PointerEvent) => {
+      noteClient(e.clientX, e.clientY);
+    };
+
+    const onPointerDown = (e: PointerEvent) => {
+      noteClient(e.clientX, e.clientY);
+      if (e.button !== 2) return;
+      if (openFromRightButton(e.clientX, e.clientY, e.target)) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+
+    // Some environments deliver right-click via mouse events without pointerdown button=2.
+    const onMouseDown = (e: MouseEvent) => {
+      noteClient(e.clientX, e.clientY);
+      if (e.button !== 2) return;
+      if (openFromRightButton(e.clientX, e.clientY, e.target)) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+
+    const onCtx = (e: MouseEvent) => {
+      if (isChromeTarget(e.target)) return;
+      // Accept when click is on-stage, or when event coords are bogus but we have a last hover.
+      const eventOnStage = clientInStage(e.clientX, e.clientY);
+      const hasLast = !isBogusClient(lastClientX, lastClientY);
+      if (!eventOnStage && !hasLast) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+      if (performance.now() < suppressCtxUntil) return;
+
+      const bogus = isBogusClient(e.clientX, e.clientY);
+      let clientX = bogus ? lastClientX : e.clientX;
+      let clientY = bogus ? lastClientY : e.clientY;
+      if (isBogusClient(clientX, clientY)) {
+        // Last resort: stage center (better than pinning to 1,1).
+        const r = hitEl.getBoundingClientRect();
+        clientX = r.left + r.width / 2;
+        clientY = r.top + r.height / 2;
+      }
+      openMenuAt(clientX, clientY);
+    };
+
+    // Window capture: right-click coords survive even when target path is odd.
+    window.addEventListener('pointermove', onPointerMove, { capture: true });
+    window.addEventListener('pointerdown', onPointerDown, { capture: true });
+    window.addEventListener('mousedown', onMouseDown, { capture: true });
+    hitEl.addEventListener('contextmenu', onCtx, { capture: true });
+    return () => {
+      window.removeEventListener('pointermove', onPointerMove, true);
+      window.removeEventListener('pointerdown', onPointerDown, true);
+      window.removeEventListener('mousedown', onMouseDown, true);
+      hitEl.removeEventListener('contextmenu', onCtx, true);
+    };
+  }, [
+    paperEl,
+    stageEl,
+    viewportEl,
+    camera,
+    readOnly,
+    artboard,
+    hitTest,
+    dispatch,
+  ]);
 
   // Drag chat gallery images onto the canvas → placeholder + upload.
   useEffect(() => {
@@ -2512,64 +2623,62 @@ function SvgCanvas({
       if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
     };
 
-    const onDrop = (e: DragEvent) => {
+    const onDrop = async (e: DragEvent) => {
       const url = readChatImageDragUrl(e.dataTransfer);
       if (!url) return;
       e.preventDefault();
       e.stopPropagation();
-      void (async () => {
+      try {
+        const natural = await measureImageNaturalSize(url);
+        const { width, height } = imageSizeForViewport(natural);
+        const world = pointerToWorld(
+          camera,
+          { viewportEl, stageEl, paperEl, artboard },
+          e.clientX,
+          e.clientY
+        );
+        const placed = rcbCenterOnPoint(world, { width, height });
+        const latest = documentRef.current;
+        if (!latest) return;
+        const origin = sceneToDocumentCoords(latest, placed.left, placed.top);
+        dispatch(
+          startImageUploadPlaceholder({
+            src: url,
+            width,
+            height,
+            x: origin.x,
+            y: origin.y,
+            label: '上传中',
+            name: 'Image',
+          })
+        );
+        finishToSelect();
+        const spawnedId = String(
+          (store.getState() as any).editor?.pendingImageProcessId || ''
+        );
+        const signal = spawnedId ? beginNodeUpload(spawnedId) : undefined;
         try {
-          const natural = await measureImageNaturalSize(url);
-          const { width, height } = imageSizeForViewport(natural);
-          const world = pointerToWorld(
-            camera,
-            { stageEl, paperEl, artboard },
-            e.clientX,
-            e.clientY
-          );
-          const placed = rcbCenterOnPoint(world, { width, height });
-          const latest = documentRef.current;
-          if (!latest) return;
-          const origin = sceneToDocumentCoords(latest, placed.left, placed.top);
+          const uploaded = await uploadImageFromSrc(url, 'chat-image.png', { signal });
+          if (signal?.aborted) return;
+          const remoteReady = await waitForImageReady(uploaded.url, { signal });
+          if (signal?.aborted) return;
           dispatch(
-            startImageUploadPlaceholder({
-              src: url,
-              width,
-              height,
-              x: origin.x,
-              y: origin.y,
-              label: '上传中',
-              name: 'Image',
+            finishImageProcess({
+              nodeId: spawnedId || undefined,
+              // Keep local preview until the remote URL is fully decoded.
+              ...(remoteReady ? { src: uploaded.url } : {}),
+              attrs: uploaded.key ? { uploadKey: uploaded.key } : undefined,
             })
           );
-          finishToSelect();
-          const spawnedId = String(
-            (store.getState() as any).editor?.pendingImageProcessId || ''
-          );
-          const signal = spawnedId ? beginNodeUpload(spawnedId) : undefined;
-          try {
-            const uploaded = await uploadImageFromSrc(url, 'chat-image.png', { signal });
-            if (signal?.aborted) return;
-            const remoteReady = await waitForImageReady(uploaded.url, { signal });
-            if (signal?.aborted) return;
-            dispatch(
-              finishImageProcess({
-                nodeId: spawnedId || undefined,
-                // Keep local preview until the remote URL is fully decoded.
-                ...(remoteReady ? { src: uploaded.url } : {}),
-                attrs: uploaded.key ? { uploadKey: uploaded.key } : undefined,
-              })
-            );
-          } finally {
-            finishNodeUpload(spawnedId);
-          }
-        } catch (err: any) {
-          if (isUploadAbortError(err)) return;
-          dispatch(failImageProcess({}));
-          const detail = err?.response?.data?.detail || err?.message || '图片上传失败';
-          message.error(typeof detail === 'string' ? detail : '图片上传失败');
+        } finally {
+          finishNodeUpload(spawnedId);
         }
-      })();
+      } catch (err: any) {
+        if (isUploadAbortError(err)) return;
+        dispatch(failImageProcess({}));
+        const detail = err?.response?.data?.detail || err?.message || '图片上传失败';
+        message.error(typeof detail === 'string' ? detail : '图片上传失败');
+      }
     };
 
     hitEl.addEventListener('dragover', onDragOver);
@@ -2589,26 +2698,23 @@ function SvgCanvas({
   ]);
 
   const runCtxAction = (action: CtxAction) => {
-    const ids =
-      selectedIdsRef.current.length > 0
-        ? selectedIdsRef.current
-        : ctxMenu?.nodeId
-          ? [ctxMenu.nodeId]
-          : [];
-    const placeAt =
-      ctxMenu && Number.isFinite(ctxMenu.sceneX)
-        ? { x: ctxMenu.sceneX, y: ctxMenu.sceneY }
-        : null;
+    let ids = selectedIdsRef.current;
+    if (!ids.length && ctxMenu?.nodeId) ids = [ctxMenu.nodeId];
+
+    let placeAt: { x: number; y: number } | null = null;
+    if (ctxMenu && Number.isFinite(ctxMenu.sceneX) && Number.isFinite(ctxMenu.sceneY)) {
+      placeAt = { x: ctxMenu.sceneX, y: ctxMenu.sceneY };
+    }
+
     const hitNodeId = ctxMenu?.nodeId ?? null;
     const menuFrameId = ctxMenu?.frameId || activeFrameIdRef.current;
     // Only expand via artboards that are actually in the selection (or the
     // frame under the context-menu cursor). Do not use activeFrameId alone —
     // that would pull unrelated board content into group / lock / export.
-    const frameIdsForAction = selectedFrameIdsRef.current.length
-      ? selectedFrameIdsRef.current
-      : ctxMenu?.frameId
-        ? [String(ctxMenu.frameId)]
-        : [];
+    let frameIdsForAction = selectedFrameIdsRef.current;
+    if (!frameIdsForAction.length && ctxMenu?.frameId) {
+      frameIdsForAction = [String(ctxMenu.frameId)];
+    }
     setCtxMenu(null);
 
     if (action === 'upload') {
@@ -2625,7 +2731,7 @@ function SvgCanvas({
         dispatch(setSelectedFrameIds([]));
         dispatch(setActiveFrameId(null));
       };
-      const seedNodes = ids.length > 0 ? ids : hitNodeId ? [hitNodeId] : [];
+      const seedNodes = ctxMenuSeedNodeIds(ids, hitNodeId);
       const expanded = resolveSelectionNodeIds(
         documentRef.current,
         seedNodes,
@@ -2700,11 +2806,11 @@ function SvgCanvas({
       return;
     }
     if (action === 'delete') {
-      const frameIds = selectedFrameIdsRef.current.length
-        ? selectedFrameIdsRef.current
-        : !ids.length && (menuFrameId || activeFrameIdRef.current)
-          ? [String(menuFrameId || activeFrameIdRef.current)]
-          : [];
+      let frameIds = selectedFrameIdsRef.current;
+      if (!frameIds.length && !ids.length) {
+        const fid = menuFrameId || activeFrameIdRef.current;
+        if (fid) frameIds = [String(fid)];
+      }
       deleteCanvasSelection({ nodeIds: ids, frameIds });
       return;
     }
@@ -2714,7 +2820,7 @@ function SvgCanvas({
       return;
     }
     if (action === 'toggleHidden') {
-      const seedNodes = ids.length > 0 ? ids : hitNodeId ? [hitNodeId] : [];
+      const seedNodes = ctxMenuSeedNodeIds(ids, hitNodeId);
       // Frame-only selection has no hide target (artboards are not scene nodes).
       if (!seedNodes.length) return;
       const targetIds = resolveSelectionNodeIds(
@@ -2744,7 +2850,7 @@ function SvgCanvas({
       return;
     }
     if (action === 'toggleLocked') {
-      const seedNodes = ids.length > 0 ? ids : hitNodeId ? [hitNodeId] : [];
+      const seedNodes = ctxMenuSeedNodeIds(ids, hitNodeId);
       const targetIds = seedNodes.length
         ? resolveSelectionNodeIds(documentRef.current, seedNodes, frameIdsForAction).filter(
             (id) => !isGeneratorNode(documentRef.current?.deltaSetLike?.[id])
@@ -2801,7 +2907,7 @@ function SvgCanvas({
     }
     if (action === 'exportMp4' || action === 'exportMp3') {
       const doc = documentRef.current;
-      const seedNodes = ids.length > 0 ? ids : hitNodeId ? [hitNodeId] : [];
+      const seedNodes = ctxMenuSeedNodeIds(ids, hitNodeId);
       const targetIds = resolveSelectionNodeIds(
         doc,
         seedNodes,
@@ -2826,7 +2932,7 @@ function SvgCanvas({
         ),
         0
       );
-      void (async () => {
+      const exportSelectedVideos = async () => {
         try {
           for (const node of videoNodes) {
             const attrs = node?.attrs || {};
@@ -2865,14 +2971,16 @@ function SvgCanvas({
             )
           );
         }
-      })();
+      };
+      exportSelectedVideos();
       return;
     }
     if (action === 'exportPng' || action === 'exportJpg' || action === 'exportSvg') {
-      const format: ExportImageFormat =
-        action === 'exportJpg' ? 'jpeg' : action === 'exportSvg' ? 'svg' : 'png';
+      let format: ExportImageFormat = 'png';
+      if (action === 'exportJpg') format = 'jpeg';
+      else if (action === 'exportSvg') format = 'svg';
       const doc = documentRef.current;
-      const seedNodes = ids.length > 0 ? ids : hitNodeId ? [hitNodeId] : [];
+      const seedNodes = ctxMenuSeedNodeIds(ids, hitNodeId);
       // Mixed / node selection: export expanded nodes. Frame-only keeps crop export
       // so artboard background is preserved.
       if (seedNodes.length) {
@@ -2938,175 +3046,6 @@ function SvgCanvas({
   const runCtxActionRef = useRef(runCtxAction);
   runCtxActionRef.current = runCtxAction;
 
-  const onImageFile = (file: File | null) => {
-    if (!file) return;
-    void (async () => {
-      const at = imagePlaceAtRef.current;
-      imagePlaceAtRef.current = null;
-      try {
-        const preview = await readFileAsDataUrl(file);
-        const natural = await measureImageNaturalSize(preview);
-        const { width, height } = imageSizeForViewport(natural);
-        let x: number | undefined;
-        let y: number | undefined;
-        if (at) {
-          const placed = rcbCenterOnPoint({ x: at.x, y: at.y }, { width, height });
-          const latest = documentRef.current;
-          if (latest) {
-            const origin = sceneToDocumentCoords(latest, placed.left, placed.top);
-            x = origin.x;
-            y = origin.y;
-          }
-        } else {
-          // Viewport center (same as pendingImageSrc auto-place).
-          const view =
-            overlayRoot?.getBoundingClientRect() ||
-            paperEl?.parentElement?.getBoundingClientRect() ||
-            null;
-          if (view && (stageEl || paperEl)) {
-            const center = pointerToWorld(
-              camera,
-              { stageEl, paperEl, artboard },
-              view.left + view.width / 2,
-              view.top + view.height / 2
-            );
-            const placed = rcbCenterOnPoint(center, { width, height });
-            const latest = documentRef.current;
-            if (latest) {
-              const origin = sceneToDocumentCoords(latest, placed.left, placed.top);
-              x = origin.x;
-              y = origin.y;
-            }
-          }
-        }
-        dispatch(
-          startImageUploadPlaceholder({
-            src: preview,
-            width,
-            height,
-            x,
-            y,
-            label: '上传中',
-            name: file.name?.replace(/\.[^.]+$/, '') || 'Image',
-          })
-        );
-        finishToSelect();
-        const spawnedId = String(
-          (store.getState() as any).editor?.pendingImageProcessId || ''
-        );
-        const signal = spawnedId ? beginNodeUpload(spawnedId) : undefined;
-        try {
-          const uploaded = await uploadImageFile(file, { signal });
-          if (signal?.aborted) return;
-          const remoteReady = await waitForImageReady(uploaded.url, { signal });
-          if (signal?.aborted) return;
-          dispatch(
-            finishImageProcess({
-              nodeId: spawnedId || undefined,
-              // Keep local preview until the remote URL is fully decoded.
-              ...(remoteReady ? { src: uploaded.url } : {}),
-              attrs: uploaded.key ? { uploadKey: uploaded.key } : undefined,
-            })
-          );
-        } finally {
-          finishNodeUpload(spawnedId);
-        }
-      } catch (err: any) {
-        if (isUploadAbortError(err)) return;
-        dispatch(failImageProcess({}));
-        const detail = err?.response?.data?.detail || err?.message || '图片上传失败';
-        message.error(typeof detail === 'string' ? detail : '图片上传失败');
-      }
-    })();
-  };
-
-  const onVideoFile = (file: File | null) => {
-    if (!file) return;
-    void (async () => {
-      const at = imagePlaceAtRef.current;
-      imagePlaceAtRef.current = null;
-      try {
-        const prepared = await prepareVideoUploadPreview(file);
-        const { width, height } = imageSizeForViewport({
-          width: prepared.width,
-          height: prepared.height,
-        });
-        let x: number | undefined;
-        let y: number | undefined;
-        if (at) {
-          const placed = rcbCenterOnPoint({ x: at.x, y: at.y }, { width, height });
-          const latest = documentRef.current;
-          if (latest) {
-            const origin = sceneToDocumentCoords(latest, placed.left, placed.top);
-            x = origin.x;
-            y = origin.y;
-          }
-        } else {
-          const view =
-            overlayRoot?.getBoundingClientRect() ||
-            paperEl?.parentElement?.getBoundingClientRect() ||
-            null;
-          if (view && (stageEl || paperEl)) {
-            const center = pointerToWorld(
-              camera,
-              { stageEl, paperEl, artboard },
-              view.left + view.width / 2,
-              view.top + view.height / 2
-            );
-            const placed = rcbCenterOnPoint(center, { width, height });
-            const latest = documentRef.current;
-            if (latest) {
-              const origin = sceneToDocumentCoords(latest, placed.left, placed.top);
-              x = origin.x;
-              y = origin.y;
-            }
-          }
-        }
-        dispatch(
-          startVideoUploadPlaceholder({
-            src: prepared.preview,
-            poster: prepared.poster,
-            width,
-            height,
-            x,
-            y,
-            label: '上传中',
-            name: prepared.name,
-            duration: prepared.duration,
-          })
-        );
-        finishToSelect();
-        const uploaded = await uploadImageFile(file);
-        dispatch(
-          finishImageProcess({
-            src: uploaded.url,
-            attrs: {
-              ...(uploaded.key ? { uploadKey: uploaded.key } : {}),
-              ...(prepared.poster ? { poster: prepared.poster } : {}),
-              ...(Number.isFinite(prepared.duration) && prepared.duration > 0
-                ? { duration: prepared.duration }
-                : {}),
-              assetKind: 'video',
-            },
-          })
-        );
-      } catch (err: any) {
-        dispatch(failImageProcess({}));
-        const detail = err?.response?.data?.detail || err?.message || '视频上传失败';
-        message.error(typeof detail === 'string' ? detail : '视频上传失败');
-      }
-    })();
-  };
-
-  const onMediaFile = (file: File | null) => {
-    if (!file) return;
-    if (file.type.startsWith('video/')) {
-      onVideoFile(file);
-      return;
-    }
-    onImageFile(file);
-  };
-
   /** Document x/y so a box of given size is centered on anchor or viewport. */
   const placeOriginForSize = useCallback(
     (
@@ -3126,7 +3065,7 @@ function SvgCanvas({
       if (view && (stageEl || paperEl)) {
         const center = pointerToWorld(
           camera,
-          { stageEl, paperEl, artboard },
+          { viewportEl, stageEl, paperEl, artboard },
           view.left + view.width / 2,
           view.top + view.height / 2
         );
@@ -3135,8 +3074,112 @@ function SvgCanvas({
       }
       return { x: 40, y: 40 };
     },
-    [artboard, camera, overlayRoot, paperEl, stageEl]
+    [artboard, camera, overlayRoot, paperEl, stageEl, viewportEl]
   );
+
+  const onImageFile = async (file: File | null) => {
+    if (!file) return;
+    const at = imagePlaceAtRef.current;
+    imagePlaceAtRef.current = null;
+    try {
+      const preview = await readFileAsDataUrl(file);
+      const natural = await measureImageNaturalSize(preview);
+      const { width, height } = imageSizeForViewport(natural);
+      const origin = placeOriginForSize({ width, height }, at);
+      dispatch(
+        startImageUploadPlaceholder({
+          src: preview,
+          width,
+          height,
+          x: origin?.x,
+          y: origin?.y,
+          label: '上传中',
+          name: file.name?.replace(/\.[^.]+$/, '') || 'Image',
+        })
+      );
+      finishToSelect();
+      const spawnedId = String(
+        (store.getState() as any).editor?.pendingImageProcessId || ''
+      );
+      const signal = spawnedId ? beginNodeUpload(spawnedId) : undefined;
+      try {
+        const uploaded = await uploadImageFile(file, { signal });
+        if (signal?.aborted) return;
+        const remoteReady = await waitForImageReady(uploaded.url, { signal });
+        if (signal?.aborted) return;
+        dispatch(
+          finishImageProcess({
+            nodeId: spawnedId || undefined,
+            // Keep local preview until the remote URL is fully decoded.
+            ...(remoteReady ? { src: uploaded.url } : {}),
+            attrs: uploaded.key ? { uploadKey: uploaded.key } : undefined,
+          })
+        );
+      } finally {
+        finishNodeUpload(spawnedId);
+      }
+    } catch (err: any) {
+      if (isUploadAbortError(err)) return;
+      dispatch(failImageProcess({}));
+      const detail = err?.response?.data?.detail || err?.message || '图片上传失败';
+      message.error(typeof detail === 'string' ? detail : '图片上传失败');
+    }
+  };
+
+  const onVideoFile = async (file: File | null) => {
+    if (!file) return;
+    const at = imagePlaceAtRef.current;
+    imagePlaceAtRef.current = null;
+    try {
+      const prepared = await prepareVideoUploadPreview(file);
+      const { width, height } = imageSizeForViewport({
+        width: prepared.width,
+        height: prepared.height,
+      });
+      const origin = placeOriginForSize({ width, height }, at);
+      dispatch(
+        startVideoUploadPlaceholder({
+          src: prepared.preview,
+          poster: prepared.poster,
+          width,
+          height,
+          x: origin?.x,
+          y: origin?.y,
+          label: '上传中',
+          name: prepared.name,
+          duration: prepared.duration,
+        })
+      );
+      finishToSelect();
+      const uploaded = await uploadImageFile(file);
+      dispatch(
+        finishImageProcess({
+          src: uploaded.url,
+          attrs: {
+            ...(uploaded.key ? { uploadKey: uploaded.key } : {}),
+            ...(prepared.poster ? { poster: prepared.poster } : {}),
+            ...(Number.isFinite(prepared.duration) && prepared.duration > 0
+              ? { duration: prepared.duration }
+              : {}),
+            assetKind: 'video',
+          },
+        })
+      );
+    } catch (err: any) {
+      dispatch(failImageProcess({}));
+      const detail = err?.response?.data?.detail || err?.message || '视频上传失败';
+      message.error(typeof detail === 'string' ? detail : '视频上传失败');
+    }
+  };
+
+  const onMediaFile = (file: File | null) => {
+    if (!file) return;
+    if (file.type.startsWith('video/')) {
+      onVideoFile(file);
+      return;
+    }
+    onImageFile(file);
+  };
 
   const insertPastedText = useCallback(
     (text: string, anchor?: { x: number; y: number } | null) => {
@@ -3517,16 +3560,17 @@ function SvgCanvas({
   useEffect(() => {
     if (readOnly) return undefined;
 
-    const isTypingTarget = (t: HTMLElement | null) =>
-      Boolean(
-        t &&
-          (t.tagName === 'INPUT' ||
-            t.tagName === 'TEXTAREA' ||
-            t.isContentEditable ||
-            t.closest?.(
-              '[data-fill-panel], [data-color-panel], [data-select-dropdown], [data-frame-label], [data-text-inline-editor], [data-agent-composer]'
-            ))
+    const isTypingTarget = (t: HTMLElement | null) => {
+      if (!t) return false;
+      if (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable) {
+        return true;
+      }
+      return Boolean(
+        t.closest?.(
+          '[data-fill-panel], [data-color-panel], [data-select-dropdown], [data-frame-label], [data-text-inline-editor], [data-agent-composer]'
+        )
       );
+    };
 
     const onPaste = (e: ClipboardEvent) => {
       const target = e.target as HTMLElement | null;
@@ -3675,10 +3719,9 @@ function SvgCanvas({
   // Select / inspect: Dev+readOnly (share preview) still needs hit-test + spacing overlays.
   // Path-edit owns the pointer (anchors / draft pen) — do not let SelectionFeature
   // clear selection on empty click (that unmounts path-edit and looks like “auto exit”).
-  const selectMode =
-    (activeTool === 'select' || activeTool === 'scale') &&
-    (!readOnly || workspaceMode === 'dev') &&
-    !editingPenId;
+  const selectToolActive = activeTool === 'select' || activeTool === 'scale';
+  const selectAllowed = !readOnly || workspaceMode === 'dev';
+  const selectMode = selectToolActive && selectAllowed && !editingPenId;
   const shapeMode = !readOnly && activeTool === 'shape';
   const textMode = !readOnly && activeTool === 'text';
   const imageMode = !readOnly && activeTool === 'image';

--- a/apps/web/src/components/editor/nodes/ImageGeneratorNode/ImageGeneratorCard.tsx
+++ b/apps/web/src/components/editor/nodes/ImageGeneratorNode/ImageGeneratorCard.tsx
@@ -19,7 +19,10 @@ import {
   useRcbCamera,
   useRcbScreenToolbarStyle,
 } from '@/components/rcb';
-import { SELECTION_TOOLBAR_BELOW_BOX_GAP_PX } from '@/components/rcb/selection/chrome/SelectionToolbarShell';
+import {
+  SELECTION_TOOLBAR_BELOW_BOX_GAP_PX,
+  useChromePointerActivate,
+} from '@/components/rcb/selection/chrome/SelectionToolbarShell';
 import AgentComposerInput, {
   chipBaseKey,
   parseAtMentionQuery,
@@ -418,6 +421,7 @@ function ImageGeneratorCard({
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const { zoom } = useRcbCamera();
+  const chromePointer = useChromePointerActivate();
   const inputRef = useRef<AgentComposerHandle | null>(null);
   const fileRef = useRef<HTMLInputElement | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -835,10 +839,7 @@ function ImageGeneratorCard({
             'shadow-[0_8px_28px_rgba(15,23,42,0.12)]'
           )}
           style={composerStyle}
-          onPointerDown={(e) => {
-            e.stopPropagation();
-            e.nativeEvent.stopImmediatePropagation?.();
-          }}
+          {...chromePointer}
         >
           {/* Reference images occupy their own row, using the chat attachment chip. */}
           <div className="flex flex-wrap items-center gap-1.5 px-3 pt-2.5">

--- a/apps/web/src/components/editor/nodes/ImageNode/ImageQuickEditComposer.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageQuickEditComposer.tsx
@@ -210,32 +210,30 @@ function ImageQuickEditComposer({
     setContexts((prev) => prev.filter((c) => c.key !== key));
   };
 
-  const onPickRef = (e: ChangeEvent<HTMLInputElement>) => {
+  const onPickRef = async (e: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files || []).filter((f) => f.type.startsWith('image/'));
     e.target.value = '';
     if (!files.length) return;
-    void (async () => {
-      const results = await Promise.all(
-        files.map(async (file, i) => {
-          try {
-            const dataUrl = await readFileAsDataUrl(file);
-            return {
-              key: `att-${Date.now()}-${Math.random().toString(36).slice(2, 7)}-${i}`,
-              kind: 'attachment' as const,
-              label: file.name || 'image',
-              payload: dataUrl,
-              dataUrl,
-              thumbUrl: dataUrl,
-            } satisfies ComposerContext;
-          } catch {
-            return null;
-          }
-        })
-      );
-      const next = results.filter(Boolean) as ComposerContext[];
-      if (!next.length) return;
-      setContexts((prev) => [...prev, ...next]);
-    })();
+    const results = await Promise.all(
+      files.map(async (file, i) => {
+        try {
+          const dataUrl = await readFileAsDataUrl(file);
+          return {
+            key: `att-${Date.now()}-${Math.random().toString(36).slice(2, 7)}-${i}`,
+            kind: 'attachment' as const,
+            label: file.name || 'image',
+            payload: dataUrl,
+            dataUrl,
+            thumbUrl: dataUrl,
+          } satisfies ComposerContext;
+        } catch {
+          return null;
+        }
+      })
+    );
+    const next = results.filter(Boolean) as ComposerContext[];
+    if (!next.length) return;
+    setContexts((prev) => [...prev, ...next]);
   };
 
   const onGenerate = async () => {

--- a/apps/web/src/components/editor/nodes/ImageNode/ImageReplaceUploadControl.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageReplaceUploadControl.tsx
@@ -48,15 +48,14 @@ function ImageReplaceUploadControl({
     onLoadingChange?.(loading);
   }, [loading, onLoadingChange]);
 
-  const onFile = (file: File | null) => {
+  const onFile = async (file: File | null) => {
     if (!file || !file.type.startsWith('image/') || loading) return;
     const targetId = nodeId;
     const keepWidth = Math.max(1, Math.round(boxRef.current.width));
     setLoading(true);
 
-    void (async () => {
-      try {
-        const preview = await readFileAsDataUrl(file);
+    try {
+      const preview = await readFileAsDataUrl(file);
         const naturalPreview = await measureImageNaturalSize(preview);
         const previewH = Math.max(
           1,
@@ -129,7 +128,6 @@ function ImageReplaceUploadControl({
       } finally {
         if (aliveRef.current && nodeIdRef.current === targetId) setLoading(false);
       }
-    })();
   };
 
   return (

--- a/apps/web/src/components/editor/nodes/ImageNode/cropExpand/CropExpandSessionHost.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/cropExpand/CropExpandSessionHost.tsx
@@ -379,7 +379,7 @@ function CropExpandSessionHost({ document }: { document: any }): ReactNode {
     }
 
     setBusy(true);
-    void (async () => {
+    async function applyCrop() {
       try {
         const uploadKey = String(node?.attrs?.uploadKey || node?.attrs?.key || '').trim() || null;
         const nextSrc = await cropImageToDataUrl(
@@ -402,7 +402,8 @@ function CropExpandSessionHost({ document }: { document: any }): ReactNode {
         message.error(detail ? `裁剪失败：${detail}` : '裁剪失败');
         setBusy(false);
       }
-    })();
+    }
+    applyCrop();
   };
 
   return (

--- a/apps/web/src/components/editor/nodes/ImageNode/toolPanels/ImageToolPanelHost.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/toolPanels/ImageToolPanelHost.tsx
@@ -263,7 +263,7 @@ function ImageToolPanelHost({ document }: { document: any }): ReactNode {
           setHasStrokes(false);
         }}
         onCancel={close}
-        onConfirm={() => {
+        onConfirm={async () => {
           if (!hasStrokes || eraseBusy) return;
           const sourceId = panel.nodeId;
           const node = document?.deltaSetLike?.[sourceId];
@@ -275,27 +275,25 @@ function ImageToolPanelHost({ document }: { document: any }): ReactNode {
           const applyErase = maskRef.current?.applyErase;
           if (!applyErase) return;
           setEraseBusy(true);
-          void (async () => {
-            try {
-              await confirmEraserAsNewNode({
-                applyErase,
-                src,
-                uploadKey: String(node?.attrs?.uploadKey || node?.attrs?.key || '') || null,
-                sourceId,
-                label: t('editor.imageToolbar.processingEraser'),
-                dispatch,
-                getPendingProcessId: () =>
-                  (store.getState() as any).editor?.pendingImageProcessId || null,
-                onSpawned: close,
-              });
-              message.success('擦除完成（透明 PNG）');
-            } catch (err: unknown) {
-              const msg = err instanceof Error ? err.message : '';
-              message.error(msg && msg !== '橡皮失败' ? msg : '橡皮失败');
-            } finally {
-              setEraseBusy(false);
-            }
-          })();
+          try {
+            await confirmEraserAsNewNode({
+              applyErase,
+              src,
+              uploadKey: String(node?.attrs?.uploadKey || node?.attrs?.key || '') || null,
+              sourceId,
+              label: t('editor.imageToolbar.processingEraser'),
+              dispatch,
+              getPendingProcessId: () =>
+                (store.getState() as any).editor?.pendingImageProcessId || null,
+              onSpawned: close,
+            });
+            message.success('擦除完成（透明 PNG）');
+          } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : '';
+            message.error(msg && msg !== '橡皮失败' ? msg : '橡皮失败');
+          } finally {
+            setEraseBusy(false);
+          }
         }}
       />
     );

--- a/apps/web/src/components/editor/nodes/ShapeNode/GradientHandlesOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/ShapeNode/GradientHandlesOverlay.tsx
@@ -116,8 +116,11 @@ function GradientHandlesOverlay({
 
   const toLocal = (clientX: number, clientY: number, el: HTMLElement) => {
     const rect = el.getBoundingClientRect();
-    const sx = (clientX - rect.left) / z;
-    const sy = (clientY - rect.top) / z;
+    if (!(rect.width > 0) || !(rect.height > 0)) return { x: 0, y: 0 };
+    // Normalize by the painted box — more stable than /zoom when CSS width
+    // rounds differently from `box * z` on small / fractional viewports.
+    const sx = ((clientX - rect.left) / rect.width) * w;
+    const sy = ((clientY - rect.top) / rect.height) * h;
     return unrotateLocal(sx, sy, w, h, angle);
   };
 

--- a/apps/web/src/components/editor/nodes/ShapeNode/MeshHandlesOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/ShapeNode/MeshHandlesOverlay.tsx
@@ -89,8 +89,11 @@ function MeshHandlesOverlay({
 
   const toLocal = (clientX: number, clientY: number, el: HTMLElement) => {
     const rect = el.getBoundingClientRect();
-    const sx = (clientX - rect.left) / z;
-    const sy = (clientY - rect.top) / z;
+    if (!(rect.width > 0) || !(rect.height > 0)) return { x: 0, y: 0 };
+    // Normalize by the painted box — more stable than /zoom when CSS width
+    // rounds differently from `box * z` on small / fractional viewports.
+    const sx = ((clientX - rect.left) / rect.width) * w;
+    const sy = ((clientY - rect.top) / rect.height) * h;
     return unrotateLocal(sx, sy, w, h, angle);
   };
 

--- a/apps/web/src/components/editor/nodes/ShapeNode/ShapeSelectionToolbar.tsx
+++ b/apps/web/src/components/editor/nodes/ShapeNode/ShapeSelectionToolbar.tsx
@@ -198,35 +198,33 @@ function ShapeSelectionToolbar({
     );
   };
 
-  const applyOutline = () => {
-    void (async () => {
-      const hide = message.loading('轮廓化中…', 0);
-      try {
-        const outline = await buildOutlinePathAsync(node);
-        if (!outline?.pathD) {
-          message.error('轮廓化失败');
-          return;
-        }
-        const patch = outlineNodePatch(node, outline);
-        dispatch(
-          patchDocumentNode({
-            nodeId,
-            patch: {
-              key: 'shape',
-              x: patch.x,
-              y: patch.y,
-              width: patch.width,
-              height: patch.height,
-              attrs: patch.attrs,
-            },
-          })
-        );
-        requestEnterPathEdit(nodeId, outline.pathD);
-        message.success('已轮廓化');
-      } finally {
-        hide();
+  const applyOutline = async () => {
+    const hide = message.loading('轮廓化中…', 0);
+    try {
+      const outline = await buildOutlinePathAsync(node);
+      if (!outline?.pathD) {
+        message.error('轮廓化失败');
+        return;
       }
-    })();
+      const patch = outlineNodePatch(node, outline);
+      dispatch(
+        patchDocumentNode({
+          nodeId,
+          patch: {
+            key: 'shape',
+            x: patch.x,
+            y: patch.y,
+            width: patch.width,
+            height: patch.height,
+            attrs: patch.attrs,
+          },
+        })
+      );
+      requestEnterPathEdit(nodeId, outline.pathD);
+      message.success('已轮廓化');
+    } finally {
+      hide();
+    }
   };
 
   const openStyle = (kind: 'fill' | 'stroke' | 'radius') => {

--- a/apps/web/src/components/editor/nodes/VideoGeneratorNode/VideoGeneratorCard.tsx
+++ b/apps/web/src/components/editor/nodes/VideoGeneratorNode/VideoGeneratorCard.tsx
@@ -19,7 +19,10 @@ import {
   useRcbCamera,
   useRcbScreenToolbarStyle,
 } from '@/components/rcb';
-import { SELECTION_TOOLBAR_BELOW_BOX_GAP_PX } from '@/components/rcb/selection/chrome/SelectionToolbarShell';
+import {
+  SELECTION_TOOLBAR_BELOW_BOX_GAP_PX,
+  useChromePointerActivate,
+} from '@/components/rcb/selection/chrome/SelectionToolbarShell';
 import AgentComposerInput, {
   chipBaseKey,
   parseAtMentionQuery,
@@ -382,6 +385,7 @@ function VideoGeneratorCard({
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const { zoom } = useRcbCamera();
+  const chromePointer = useChromePointerActivate();
   const inputRef = useRef<AgentComposerHandle | null>(null);
   const fileRef = useRef<HTMLInputElement | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -870,10 +874,7 @@ function VideoGeneratorCard({
             'shadow-[0_8px_28px_rgba(15,23,42,0.12)]'
           )}
           style={composerStyle}
-          onPointerDown={(e) => {
-            e.stopPropagation();
-            e.nativeEvent.stopImmediatePropagation?.();
-          }}
+          {...chromePointer}
         >
           {/* Reference images occupy their own row, using the chat attachment chip. */}
           <div className="flex flex-wrap items-center gap-1.5 px-3 pt-2.5">

--- a/apps/web/src/components/editor/nodes/VideoNode/VideoReplaceCornerButton.tsx
+++ b/apps/web/src/components/editor/nodes/VideoNode/VideoReplaceCornerButton.tsx
@@ -69,15 +69,14 @@ function VideoReplaceUploadControl({
     onLoadingChange?.(loading);
   }, [loading, onLoadingChange]);
 
-  const onFile = (file: File | null) => {
+  const onFile = async (file: File | null) => {
     if (!file || !file.type.startsWith('video/') || loading) return;
     const targetId = nodeId;
     const keepWidth = Math.max(1, Math.round(boxRef.current.width));
     setLoading(true);
 
-    void (async () => {
-      try {
-        const preview = await readFileAsDataUrl(file);
+    try {
+      const preview = await readFileAsDataUrl(file);
         const naturalPreview = await measureVideoNaturalSize(preview);
         const previewH = Math.max(
           1,
@@ -174,7 +173,6 @@ function VideoReplaceUploadControl({
       } finally {
         if (aliveRef.current && nodeIdRef.current === targetId) setLoading(false);
       }
-    })();
   };
 
   return (

--- a/apps/web/src/components/editor/panels/AgentDock.tsx
+++ b/apps/web/src/components/editor/panels/AgentDock.tsx
@@ -3027,7 +3027,7 @@ function AgentDock({
             queueMicrotask(() => inputRef.current?.focusEnd());
           };
           if (attachable.length || frameId) {
-            void (async () => {
+            async function attachSelection() {
               if (attachable.length) {
                 await applyCanvasAttachPayload({
                   document: doc,
@@ -3050,7 +3050,8 @@ function AgentDock({
                   imagesOnly,
                 });
               }
-            })();
+            }
+            attachSelection();
           } else {
             dispatch(
               startCanvasAttachPick({

--- a/apps/web/src/components/home/InspirationSection.tsx
+++ b/apps/web/src/components/home/InspirationSection.tsx
@@ -208,34 +208,32 @@ function InspirationCaseCard({
     },
   ];
 
-  const onUseMenu = (key: string) => {
-    void (async () => {
-      if (key === 'prompt') {
-        const prompt = resolveCasePrompt(meta, t);
-        const ok = await copyTextToClipboard(prompt);
-        if (ok) {
-          message.success(t('home.cases.promptCopied'));
-          void recordPlazaUse(meta.id).catch(() => undefined);
-        } else {
-          message.error(t('home.cases.copyFailed'));
-        }
+  const onUseMenu = async (key: string) => {
+    if (key === 'prompt') {
+      const prompt = resolveCasePrompt(meta, t);
+      const ok = await copyTextToClipboard(prompt);
+      if (ok) {
+        message.success(t('home.cases.promptCopied'));
+        recordPlazaUse(meta.id).catch(() => undefined);
+      } else {
+        message.error(t('home.cases.copyFailed'));
+      }
+      return;
+    }
+    if (key === 'image') {
+      const url = coverImageUrl(meta);
+      if (!url) {
+        message.error(t('home.cases.copyFailed'));
         return;
       }
-      if (key === 'image') {
-        const url = coverImageUrl(meta);
-        if (!url) {
-          message.error(t('home.cases.copyFailed'));
-          return;
-        }
-        const ok = await copyImageToClipboard(url);
-        if (ok) {
-          message.success(t('home.cases.imageCopied'));
-          void recordPlazaUse(meta.id).catch(() => undefined);
-        } else {
-          message.error(t('home.cases.copyFailed'));
-        }
+      const ok = await copyImageToClipboard(url);
+      if (ok) {
+        message.success(t('home.cases.imageCopied'));
+        recordPlazaUse(meta.id).catch(() => undefined);
+      } else {
+        message.error(t('home.cases.copyFailed'));
       }
-    })();
+    }
   };
 
   return (

--- a/apps/web/src/components/home/MePage.tsx
+++ b/apps/web/src/components/home/MePage.tsx
@@ -254,7 +254,7 @@ function MePage({ onOpenCase }: Props): ReactNode {
     const gen = ++likedFetchGen.current;
     setLikedLoading(true);
     setLikedLoadingMore(false);
-    void (async () => {
+    async function loadLiked() {
       try {
         if (!likedMigratedRef.current) {
           const localIds = loadLocalLikedIds(userId);
@@ -288,7 +288,8 @@ function MePage({ onOpenCase }: Props): ReactNode {
           setLikedReady(true);
         }
       }
-    })();
+    }
+    loadLiked();
     return () => {
       cancelled = true;
     };

--- a/apps/web/src/components/home/SkillsLibraryPanel.tsx
+++ b/apps/web/src/components/home/SkillsLibraryPanel.tsx
@@ -285,7 +285,7 @@ function SkillsLibraryPanel(): ReactNode {
     let cancelled = false;
     setLoadingMine(true);
     setLoadingOfficial(true);
-    void (async () => {
+    async function loadSkills() {
       try {
         const res = await fetchDesignSkills({ manage: true });
         if (cancelled) return;
@@ -300,7 +300,8 @@ function SkillsLibraryPanel(): ReactNode {
           setLoadingOfficial(false);
         }
       }
-    })();
+    }
+    loadSkills();
     return () => {
       cancelled = true;
     };

--- a/apps/web/src/components/layout/HomeBody.tsx
+++ b/apps/web/src/components/layout/HomeBody.tsx
@@ -355,7 +355,7 @@ function HomeTemplateList({
     const gen = ++projectsFetchGen.current;
     setProjectsReady(false);
     setProjectsLoadingMore(false);
-    void (async () => {
+    async function loadProjects() {
       // Wait for editor leave-flush (doc + cover) so list thumbs are not one revision behind.
       try {
         await flushCurrentProjectNow({ force: true });
@@ -379,7 +379,8 @@ function HomeTemplateList({
       } finally {
         if (!cancelled && gen === projectsFetchGen.current) setProjectsReady(true);
       }
-    })();
+    }
+    loadProjects();
     return () => {
       cancelled = true;
     };
@@ -390,7 +391,7 @@ function HomeTemplateList({
     const nextPage = projectsPage + 1;
     const gen = projectsFetchGen.current;
     setProjectsLoadingMore(true);
-    void (async () => {
+    async function loadNextPage() {
       try {
         const res = await fetchProjects({ page: nextPage, pageSize: PROJECT_PAGE_SIZE });
         if (gen !== projectsFetchGen.current) return;
@@ -403,7 +404,8 @@ function HomeTemplateList({
       } finally {
         if (gen === projectsFetchGen.current) setProjectsLoadingMore(false);
       }
-    })();
+    }
+    loadNextPage();
   }, [
     authed,
     dispatch,

--- a/apps/web/src/components/rcb/camera/context.tsx
+++ b/apps/web/src/components/rcb/camera/context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useMemo, type CSSProperties, type ReactNode, memo } from 'react';
 import { createPortal } from 'react-dom';
-import { rcbSceneToScreen } from '../core/math';
+import { rcbSceneToScreen, rcbScreenToScene } from '../core/math';
 import { RCB_DEFAULT_CAMERA, type RcbCamera, type RcbVec } from '../core/types';
 
 export const RcbCameraContext = createContext<RcbCamera>(RCB_DEFAULT_CAMERA);
@@ -46,17 +46,13 @@ export function useRcbDevicePixelRatio(): number {
 export function useRcbScreenToScene(): (clientX: number, clientY: number) => RcbVec {
   const camera = useRcbCamera();
   const viewportEl = useRcbViewportEl();
+  const dpr = useRcbDevicePixelRatio();
   return useCallback(
     (clientX: number, clientY: number) => {
       if (!viewportEl) return { x: 0, y: 0 };
-      const rect = viewportEl.getBoundingClientRect();
-      const z = Math.max(0.05, camera.zoom || 1);
-      return {
-        x: (clientX - rect.left - camera.x) / z,
-        y: (clientY - rect.top - camera.y) / z,
-      };
+      return rcbScreenToScene(camera, viewportEl, clientX, clientY, dpr);
     },
-    [camera.x, camera.y, camera.zoom, viewportEl]
+    [camera, viewportEl, dpr]
   );
 }
 
@@ -67,7 +63,8 @@ export function useRcbScreenToolbarStyle(opts: {
   anchor?: 'bottom' | 'top';
 }): CSSProperties {
   const camera = useRcbCamera();
-  const { x, y } = rcbSceneToScreen(camera, opts.left, opts.top);
+  const dpr = useRcbDevicePixelRatio();
+  const { x, y } = rcbSceneToScreen(camera, opts.left, opts.top, dpr);
   const anchor = opts.anchor ?? 'bottom';
   return useMemo(
     () => ({

--- a/apps/web/src/components/rcb/canvas/RcbCanvas.tsx
+++ b/apps/web/src/components/rcb/canvas/RcbCanvas.tsx
@@ -7,12 +7,18 @@ import {
   RcbOverlayRootContext,
   RcbViewportElContext,
 } from '../camera/context';
-import { readDevicePixelRatio, snapCssToDevicePixel, subscribeDevicePixelRatio, toDomPrecision } from '../core/dpr';
+import { readDevicePixelRatio, subscribeDevicePixelRatio, toDomPrecision } from '../core/dpr';
 import {
   installDprDebugHelpers,
   logDprCameraState,
 } from '../core/dprDebug';
-import { rcbFitCamera, rcbStepZoom, rcbZoomAtPoint } from '../core/math';
+import {
+  rcbCameraScreenOffset,
+  rcbClientToStageLocal,
+  rcbFitCamera,
+  rcbStepZoom,
+  rcbZoomAtPoint,
+} from '../core/math';
 import { RCB_DEFAULT_CAMERA, type RcbCamera } from '../core/types';
 
 export type { RcbCamera };
@@ -55,6 +61,12 @@ export type RcbCanvasProps = {
   showGrid?: boolean;
   gridSize?: number;
   stageRef?: RefObject<HTMLDivElement | null>;
+  /**
+   * Fires whenever the live viewport node mounts/unmounts.
+   * Hosts must use this (not a one-shot effect) so stageEl stays connected
+   * after resize / mobile breakpoint remounts.
+   */
+  onViewportEl?: (el: HTMLElement | null) => void;
   cursor?: string;
   background?: string;
   /** Stable id for one-time autofit (e.g. document id). */
@@ -90,14 +102,17 @@ function RcbCanvas({
   showGrid = false,
   gridSize = 10,
   stageRef: stageRefProp,
+  onViewportEl,
   cursor,
   background,
   fitKey,
 }: RcbCanvasProps) {
   const localRef = useRef<HTMLDivElement | null>(null);
   const stageRef = stageRefProp || localRef;
+  const onViewportElRef = useRef(onViewportEl);
+  onViewportElRef.current = onViewportEl;
   const cameraRef = useRef(camera);
-  const panRef = useRef<{ x: number; y: number } | null>(null);
+  const panRef = useRef<{ x: number; y: number; scaleX: number; scaleY: number } | null>(null);
   const pendingPanRef = useRef<{ x: number; y: number; pointerId: number } | null>(null);
   const spaceDown = useRef(false);
   const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -147,8 +162,7 @@ function RcbCanvas({
       dpr: devicePixelRatio,
       camera,
       camCss: {
-        x: toDomPrecision(snapCssToDevicePixel(camera.x, devicePixelRatio)),
-        y: toDomPrecision(snapCssToDevicePixel(camera.y, devicePixelRatio)),
+        ...rcbCameraScreenOffset(camera, devicePixelRatio),
         z: toDomPrecision(camera.zoom),
       },
     });
@@ -200,6 +214,7 @@ function RcbCanvas({
       localRef.current = node;
     }
     setViewportEl(node);
+    onViewportElRef.current?.(node);
   };
 
   useEffect(() => {
@@ -284,23 +299,30 @@ function RcbCanvas({
       pendingPanRef.current = null;
       e.preventDefault();
       e.stopPropagation();
-      panRef.current = { x: e.clientX, y: e.clientY };
+      const local = rcbClientToStageLocal(el, e.clientX, e.clientY);
+      panRef.current = { x: local.x, y: local.y, scaleX: local.scaleX, scaleY: local.scaleY };
       el.setPointerCapture?.(e.pointerId);
     };
 
     const onWheel = (e: WheelEvent) => {
       e.preventDefault();
-      const rect = el.getBoundingClientRect();
-      const localX = e.clientX - rect.left;
-      const localY = e.clientY - rect.top;
+      const local = rcbClientToStageLocal(el, e.clientX, e.clientY);
       const cam = cameraRef.current;
       markCameraMoving();
 
       if (e.ctrlKey || e.metaKey) {
-        onCameraChange(rcbZoomAtPoint(cam, cam.zoom * (e.deltaY > 0 ? 0.92 : 1.08), localX, localY));
+        onCameraChange(
+          rcbZoomAtPoint(cam, cam.zoom * (e.deltaY > 0 ? 0.92 : 1.08), local.x, local.y)
+        );
         return;
       }
-      onCameraChange({ ...cam, x: cam.x - e.deltaX, y: cam.y - e.deltaY });
+      const sx = local.scaleX > 0 ? local.scaleX : 1;
+      const sy = local.scaleY > 0 ? local.scaleY : 1;
+      onCameraChange({
+        ...cam,
+        x: cam.x - e.deltaX / sx,
+        y: cam.y - e.deltaY / sy,
+      });
     };
 
     const onDown = (e: PointerEvent) => {
@@ -317,9 +339,15 @@ function RcbCanvas({
     };
     const onMove = (e: PointerEvent) => {
       if (panRef.current) {
-        const dx = e.clientX - panRef.current.x;
-        const dy = e.clientY - panRef.current.y;
-        panRef.current = { x: e.clientX, y: e.clientY };
+        const local = rcbClientToStageLocal(el, e.clientX, e.clientY);
+        const dx = local.x - panRef.current.x;
+        const dy = local.y - panRef.current.y;
+        panRef.current = {
+          x: local.x,
+          y: local.y,
+          scaleX: local.scaleX,
+          scaleY: local.scaleY,
+        };
         const cam = cameraRef.current;
         markCameraMoving();
         onCameraChange({ ...cam, x: cam.x + dx, y: cam.y + dy });
@@ -364,8 +392,8 @@ function RcbCanvas({
 
   // Snap pan to the device-pixel grid so translate doesn't add extra frac error
   // on top of scene*dpr (critical at browser 90% → dpr≈0.9).
-  const camX = toDomPrecision(snapCssToDevicePixel(camera.x, devicePixelRatio));
-  const camY = toDomPrecision(snapCssToDevicePixel(camera.y, devicePixelRatio));
+  // Must stay in sync with rcbScreenToScene / rcbSceneToScreen.
+  const { x: camX, y: camY } = rcbCameraScreenOffset(camera, devicePixelRatio);
   const camZ = toDomPrecision(camera.zoom);
 
   return (
@@ -380,14 +408,14 @@ function RcbCanvas({
               data-canvas-stage="1"
               data-rcb-dpr={String(devicePixelRatio)}
               className={cn(
-                'relative h-full w-full overflow-hidden',
+                // Own pan/zoom/draw — block browser scroll/pinch so it cannot
+                // fire pointercancel mid-gesture (common on tablet / DevTools device).
+                'relative h-full w-full touch-none overflow-hidden select-none',
                 !background && 'bg-[var(--canvas)]',
-                panning
-                  ? 'cursor-grab active:cursor-grabbing'
-                    : cursor
-                    ? // Force nested shapes / chrome to inherit tool cursor (eraser / pencil / …).
-                      '[&_*]:!cursor-inherit'
-                    : 'cursor-default',
+                panning && 'cursor-grab active:cursor-grabbing',
+                // Force nested shapes / chrome to inherit tool cursor (eraser / pencil / …).
+                !panning && cursor && '[&_*]:!cursor-inherit',
+                !panning && !cursor && 'cursor-default',
                 className
               )}
               style={{

--- a/apps/web/src/components/rcb/core/__tests__/mathScreenScene.test.ts
+++ b/apps/web/src/components/rcb/core/__tests__/mathScreenScene.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  rcbCameraScreenOffset,
+  rcbClientDeltaToScene,
+  rcbClientToStageLocal,
+  rcbResolveViewportEl,
+  rcbSceneToScreen,
+  rcbScreenToScene,
+} from '../math';
+import { snapCssToDevicePixel, toDomPrecision } from '../dpr';
+
+function mockViewport(opts: {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  clientWidth?: number;
+  clientHeight?: number;
+  connected?: boolean;
+}) {
+  return {
+    getBoundingClientRect: () =>
+      ({
+        left: opts.left,
+        top: opts.top,
+        width: opts.width,
+        height: opts.height,
+        right: opts.left + opts.width,
+        bottom: opts.top + opts.height,
+        x: opts.left,
+        y: opts.top,
+        toJSON: () => ({}),
+      }) as DOMRect,
+    clientWidth: opts.clientWidth ?? opts.width,
+    clientHeight: opts.clientHeight ?? opts.height,
+    isConnected: opts.connected ?? true,
+  } as HTMLElement;
+}
+
+describe('rcb screen ↔ scene', () => {
+  it('uses DPR-snapped pan so scene→screen matches CSS translate', () => {
+    const camera = { zoom: 0.18, x: 100.4, y: -40.7 };
+    const dpr = 0.9;
+    const offset = rcbCameraScreenOffset(camera, dpr);
+    expect(offset.x).toBe(toDomPrecision(snapCssToDevicePixel(camera.x, dpr)));
+    expect(offset.y).toBe(toDomPrecision(snapCssToDevicePixel(camera.y, dpr)));
+
+    const screen = rcbSceneToScreen(camera, 50, 80, dpr);
+    expect(screen.x).toBeCloseTo(50 * 0.18 + offset.x, 5);
+    expect(screen.y).toBeCloseTo(80 * 0.18 + offset.y, 5);
+  });
+
+  it('round-trips through a mock viewport with snapped pan', () => {
+    const camera = { zoom: 0.18, x: 120.3, y: 44.8 };
+    const dpr = 1.25;
+    const viewportEl = mockViewport({ left: 10, top: 20, width: 400, height: 300 });
+
+    const scene = { x: 220, y: -30 };
+    const screen = rcbSceneToScreen(camera, scene.x, scene.y, dpr);
+    const back = rcbScreenToScene(
+      camera,
+      viewportEl,
+      10 + screen.x,
+      20 + screen.y,
+      dpr
+    );
+    expect(back.x).toBeCloseTo(scene.x, 5);
+    expect(back.y).toBeCloseTo(scene.y, 5);
+  });
+
+  it('corrects ancestor CSS scale via rect/clientWidth ratio', () => {
+    const camera = { zoom: 1, x: 0, y: 0 };
+    // Layout 800×600, visually scaled to 400×300 (scale 0.5).
+    const viewportEl = mockViewport({
+      left: 0,
+      top: 0,
+      width: 400,
+      height: 300,
+      clientWidth: 800,
+      clientHeight: 600,
+    });
+    const local = rcbClientToStageLocal(viewportEl, 200, 150);
+    expect(local.x).toBeCloseTo(400, 5);
+    expect(local.y).toBeCloseTo(300, 5);
+    const scene = rcbScreenToScene(camera, viewportEl, 200, 150);
+    expect(scene.x).toBeCloseTo(400, 5);
+    expect(scene.y).toBeCloseTo(300, 5);
+  });
+
+  it('maps client deltas with scale', () => {
+    expect(rcbClientDeltaToScene(0.18, 18, -9)).toEqual({ x: 100, y: -50 });
+    expect(rcbClientDeltaToScene(1, 10, 20, 0.5, 0.5)).toEqual({ x: 20, y: 40 });
+  });
+
+  it('prefers a connected viewport node', () => {
+    const dead = mockViewport({ left: 0, top: 0, width: 0, height: 0, connected: false });
+    const live = mockViewport({ left: 0, top: 0, width: 100, height: 100, connected: true });
+    expect(rcbResolveViewportEl(dead, live)).toBe(live);
+    expect(rcbResolveViewportEl(null, dead)).toBe(dead);
+  });
+});

--- a/apps/web/src/components/rcb/core/math.ts
+++ b/apps/web/src/components/rcb/core/math.ts
@@ -1,34 +1,121 @@
+import { readDevicePixelRatio, snapCssToDevicePixel, toDomPrecision } from './dpr';
 import type { RcbBox, RcbCamera, RcbVec } from './types';
 
 export function rcbClampZoom(z: number) {
   return Math.min(8, Math.max(0.05, Number(z.toFixed(4))));
 }
 
-/** Scene (page/world) -> screen/stage-local pixels. */
-export function rcbSceneToScreen(camera: RcbCamera, sceneX: number, sceneY: number): RcbVec {
-  const z = Math.max(0.05, camera.zoom || 1);
+/**
+ * CSS translate written on the camera world layer.
+ * Must match `RcbCanvas` so hit-testing and overlays stay locked to pixels.
+ */
+export function rcbCameraScreenOffset(
+  camera: RcbCamera,
+  dpr: number = readDevicePixelRatio()
+): RcbVec {
   return {
-    x: sceneX * z + camera.x,
-    y: sceneY * z + camera.y,
+    x: toDomPrecision(snapCssToDevicePixel(camera.x, dpr)),
+    y: toDomPrecision(snapCssToDevicePixel(camera.y, dpr)),
+  };
+}
+
+export type RcbViewportMetrics = {
+  rect: DOMRect;
+  /** Visual CSS px per layout px (≈1 unless an ancestor has CSS scale / zoom). */
+  scaleX: number;
+  scaleY: number;
+  clientWidth: number;
+  clientHeight: number;
+  connected: boolean;
+};
+
+/**
+ * Map a client point into the stage's *layout* coordinate space (same space as
+ * `camera.x/y` and CSS `translate` on the world layer).
+ *
+ * `getBoundingClientRect` is visual; `clientWidth` is layout. When they differ
+ * (ancestor `transform: scale`, browser zoom quirks, stale detached node),
+ * dividing by the ratio keeps the pointer on the ink.
+ */
+export function rcbViewportMetrics(viewportEl: HTMLElement): RcbViewportMetrics {
+  const rect = viewportEl.getBoundingClientRect();
+  const clientWidth = Math.max(0, viewportEl.clientWidth || 0);
+  const clientHeight = Math.max(0, viewportEl.clientHeight || 0);
+  const connected = typeof viewportEl.isConnected === 'boolean' ? viewportEl.isConnected : true;
+  const scaleX =
+    clientWidth > 0 && rect.width > 0 ? rect.width / clientWidth : 1;
+  const scaleY =
+    clientHeight > 0 && rect.height > 0 ? rect.height / clientHeight : 1;
+  return { rect, scaleX, scaleY, clientWidth, clientHeight, connected };
+}
+
+/** Client → stage-local layout px (pre-camera). */
+export function rcbClientToStageLocal(
+  viewportEl: HTMLElement,
+  clientX: number,
+  clientY: number
+): RcbVec & RcbViewportMetrics {
+  const m = rcbViewportMetrics(viewportEl);
+  const sx = m.scaleX > 0 ? m.scaleX : 1;
+  const sy = m.scaleY > 0 ? m.scaleY : 1;
+  return {
+    ...m,
+    x: (clientX - m.rect.left) / sx,
+    y: (clientY - m.rect.top) / sy,
+  };
+}
+
+/** Scene (page/world) -> screen/stage-local layout pixels. */
+export function rcbSceneToScreen(
+  camera: RcbCamera,
+  sceneX: number,
+  sceneY: number,
+  dpr?: number
+): RcbVec {
+  const z = Math.max(0.05, camera.zoom || 1);
+  const { x: camX, y: camY } = rcbCameraScreenOffset(camera, dpr);
+  return {
+    x: sceneX * z + camX,
+    y: sceneY * z + camY,
   };
 }
 
 /**
  * Screen/client -> scene (page/world).
- * iewportEl is the unscaled stage root (getBoundingClientRect origin).
+ * viewportEl is the unscaled stage root.
+ * Uses DPR-snapped pan + layout/visual scale correction.
  */
 export function rcbScreenToScene(
   camera: RcbCamera,
   viewportEl: HTMLElement,
   clientX: number,
-  clientY: number
+  clientY: number,
+  dpr?: number
 ): RcbVec {
-  const rect = viewportEl.getBoundingClientRect();
+  const local = rcbClientToStageLocal(viewportEl, clientX, clientY);
   const z = Math.max(0.05, camera.zoom || 1);
+  const { x: camX, y: camY } = rcbCameraScreenOffset(camera, dpr);
   return {
-    x: (clientX - rect.left - camera.x) / z,
-    y: (clientY - rect.top - camera.y) / z,
+    x: (local.x - camX) / z,
+    y: (local.y - camY) / z,
   };
+}
+
+/**
+ * Client-pixel gesture delta -> scene units.
+ * Pass the same scaleX/scaleY from `rcbViewportMetrics` at gesture start.
+ */
+export function rcbClientDeltaToScene(
+  zoom: number,
+  clientDx: number,
+  clientDy: number,
+  scaleX = 1,
+  scaleY = 1
+): RcbVec {
+  const z = Math.max(0.05, zoom || 1);
+  const sx = scaleX > 0 ? scaleX : 1;
+  const sy = scaleY > 0 ? scaleY : 1;
+  return { x: clientDx / sx / z, y: clientDy / sy / z };
 }
 
 /** On-screen pixel gap -> scene units. */
@@ -46,6 +133,7 @@ export function rcbZoomAtPoint(
   const z0 = camera.zoom;
   const z1 = rcbClampZoom(nextZoom);
   if (z0 === z1) return camera;
+  // Use raw camera pan (state space). CSS snap is display-only.
   const sceneX = (localX - camera.x) / z0;
   const sceneY = (localY - camera.y) / z0;
   return { zoom: z1, x: localX - sceneX * z1, y: localY - sceneY * z1 };
@@ -93,4 +181,17 @@ export function rcbStepZoom(zoom: number, step = 0.05): number {
   const z = Math.max(0.05, zoom || 1);
   const s = Math.max(0.01, step);
   return Math.round(Math.round(z / s) * s * 1e4) / 1e4;
+}
+
+/** Prefer a live, connected stage node (context beats a stale prop after resize). */
+export function rcbResolveViewportEl(
+  ...candidates: Array<HTMLElement | null | undefined>
+): HTMLElement | null {
+  for (const el of candidates) {
+    if (el && el.isConnected) return el;
+  }
+  for (const el of candidates) {
+    if (el) return el;
+  }
+  return null;
 }

--- a/apps/web/src/components/rcb/frames/FrameMoveFeature.tsx
+++ b/apps/web/src/components/rcb/frames/FrameMoveFeature.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, memo } from 'react';
 import type { RcbCamera } from '../core/types';
+import { rcbClientDeltaToScene, rcbResolveViewportEl, rcbScreenToScene, rcbViewportMetrics } from '../core/math';
 import type { ArtboardFrame } from '@/components/rcb/frames/types';
 import {
   resizeFromHandle,
@@ -45,11 +46,7 @@ function clientToWorld(
   clientX: number,
   clientY: number
 ) {
-  const r = stageEl.getBoundingClientRect();
-  return {
-    x: (clientX - r.left - camera.x) / camera.zoom,
-    y: (clientY - r.top - camera.y) / camera.zoom,
-  };
+  return rcbScreenToScene(camera, stageEl, clientX, clientY);
 }
 
 function hitFrame(frames: ArtboardFrame[], x: number, y: number): ArtboardFrame | null {
@@ -93,6 +90,10 @@ type DragState =
       originY: number;
       pointerX0: number;
       pointerY0: number;
+      clientX0: number;
+      clientY0: number;
+      scaleX: number;
+      scaleY: number;
       started: boolean;
     }
   | {
@@ -102,6 +103,10 @@ type DragState =
       union: SceneBox;
       pointerX0: number;
       pointerY0: number;
+      clientX0: number;
+      clientY0: number;
+      scaleX: number;
+      scaleY: number;
       aspectRatio: number;
       /** Persisted aspect lock at pointer-down (Shift OR's with lock while dragging). */
       aspectLocked: boolean;
@@ -149,7 +154,8 @@ function FrameMoveFeature({
   onClearSelectionRef.current = onClearSelection;
 
   useEffect(() => {
-    if (!enabled || !stageEl) return undefined;
+    const liveStage = rcbResolveViewportEl(stageEl);
+    if (!enabled || !liveStage) return undefined;
 
     const onDown = (e: PointerEvent) => {
       if (e.button !== 0) return;
@@ -164,7 +170,8 @@ function FrameMoveFeature({
         e.preventDefault();
         e.stopPropagation();
         onSelect(f.id);
-        const p = clientToWorld(stageEl, cameraRef.current, e.clientX, e.clientY);
+        const p = clientToWorld(liveStage, cameraRef.current, e.clientX, e.clientY);
+        const metrics = rcbViewportMetrics(liveStage);
         dragRef.current = {
           kind: 'resize',
           id: f.id,
@@ -177,6 +184,10 @@ function FrameMoveFeature({
           },
           pointerX0: p.x,
           pointerY0: p.y,
+          clientX0: e.clientX,
+          clientY0: e.clientY,
+          scaleX: metrics.scaleX,
+          scaleY: metrics.scaleY,
           aspectRatio: f.width / Math.max(1, f.height),
           aspectLocked: Boolean(f.lockAspect),
           started: false,
@@ -186,7 +197,7 @@ function FrameMoveFeature({
 
       if (target?.closest?.(SKIP_SELECTOR)) return;
 
-      const p = clientToWorld(stageEl, cameraRef.current, e.clientX, e.clientY);
+      const p = clientToWorld(liveStage, cameraRef.current, e.clientX, e.clientY);
       if (hitContent(p.x, p.y, { clientX: e.clientX, clientY: e.clientY })) return;
 
       const frame = hitFrame(framesRef.current, p.x, p.y);
@@ -222,9 +233,14 @@ function FrameMoveFeature({
         }
         return;
       }
-      const p = clientToWorld(stageEl, cameraRef.current, e.clientX, e.clientY);
-      const dx = p.x - drag.pointerX0;
-      const dy = p.y - drag.pointerY0;
+      // Client-delta — avoids drift when stage rect jitters mid-gesture.
+      const { x: dx, y: dy } = rcbClientDeltaToScene(
+        cameraRef.current.zoom,
+        e.clientX - drag.clientX0,
+        e.clientY - drag.clientY0,
+        drag.scaleX,
+        drag.scaleY
+      );
       const zoom = Math.max(0.05, cameraRef.current.zoom);
 
       if (drag.kind === 'move') {
@@ -267,27 +283,25 @@ function FrameMoveFeature({
       );
     };
 
+    // Soft-click deselect: move already drops the drag past threshold, so a
+    // surviving deselect drag is always a click. Ignore cancel (no clear).
     const onUp = (e: PointerEvent) => {
       const drag = dragRef.current;
       if (drag?.kind === 'deselect') {
         dragRef.current = null;
-        const distSq =
-          (e.clientX - drag.clientX0) ** 2 + (e.clientY - drag.clientY0) ** 2;
-        if (distSq <= DRAG_DISTANCE_SQUARED) {
-          onClearSelectionRef.current?.();
-        }
+        if (e.type === 'pointerup') onClearSelectionRef.current?.();
         return;
       }
       if (drag && 'started' in drag && drag.started) onDraggingChangeRef.current?.(null);
       dragRef.current = null;
     };
 
-    stageEl.addEventListener('pointerdown', onDown, true);
+    liveStage.addEventListener('pointerdown', onDown, true);
     window.addEventListener('pointermove', onMoveWin);
     window.addEventListener('pointerup', onUp);
     window.addEventListener('pointercancel', onUp);
     return () => {
-      stageEl.removeEventListener('pointerdown', onDown, true);
+      liveStage.removeEventListener('pointerdown', onDown, true);
       window.removeEventListener('pointermove', onMoveWin);
       window.removeEventListener('pointerup', onUp);
       window.removeEventListener('pointercancel', onUp);

--- a/apps/web/src/components/rcb/index.ts
+++ b/apps/web/src/components/rcb/index.ts
@@ -9,8 +9,13 @@ export type { RcbBox, RcbCamera, RcbVec } from './core/types';
 export { RCB_DEFAULT_CAMERA } from './core/types';
 export {
   rcbClampZoom,
+  rcbCameraScreenOffset,
+  rcbViewportMetrics,
+  rcbClientToStageLocal,
   rcbSceneToScreen,
   rcbScreenToScene,
+  rcbClientDeltaToScene,
+  rcbResolveViewportEl,
   rcbScreenPxToScene,
   rcbZoomAtPoint,
   rcbFitCamera,

--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -8,7 +8,13 @@ import {
   useRcbCamera,
   useRcbOverlayRoot,
   useRcbScreenToScene,
+  useRcbViewportEl,
 } from '@/components/rcb/camera/context';
+import {
+  rcbClientDeltaToScene,
+  rcbResolveViewportEl,
+  rcbViewportMetrics,
+} from '@/components/rcb/core/math';
 import { logEdgeSamples, sampleBoxEdges } from '@/components/rcb/core/dprDebug';
 import { cn } from '@/utils/classnames';
 import AlignGuidesOverlay, { type AlignGuide } from './AlignGuidesOverlay';
@@ -118,7 +124,7 @@ function ShapeIndicatorOverlay({
   );
 }
 
-/** World-layer rect outline — page stroke = screenPx / zoom. */
+/** World-layer rect outline ??page stroke = screenPx / zoom. */
 function WorldHairlineBox({
   box,
   color,
@@ -189,7 +195,7 @@ function readNodeAspectLocked(node: any): boolean {
   return nodeAspectLockDefault(node?.key);
 }
 
-/** Persist lock OR Shift — Shift adds constraint, does not toggle it off. */
+/** Persist lock OR Shift ??Shift adds constraint, does not toggle it off. */
 function combineAspectLock(locked: boolean, shiftKey: boolean) {
   return locked || shiftKey;
 }
@@ -262,7 +268,7 @@ function boxesIntersect(a: SceneBox, b: SceneBox) {
   );
 }
 
-/** Frame AABB ∩ marquee — same idea as selecting a rectangle. Locked frames are skipped. */
+/** Frame AABB ??marquee ??same idea as selecting a rectangle. Locked frames are skipped. */
 function framesHittingMarquee(doc: any, marquee: SceneBox): Array<{ id: string; area: number }> {
   const frames = Array.isArray(doc?.frames) ? doc.frames : [];
   const out: Array<{ id: string; area: number }> = [];
@@ -294,7 +300,7 @@ export function parseFrameSelId(selId: string): string | null {
   return selId.startsWith(FRAME_SEL_PREFIX) ? selId.slice(FRAME_SEL_PREFIX.length) : null;
 }
 
-/** Near-full-bleed artboard plate — must not block marquee (looks empty but hits as a shape). */
+/** Near-full-bleed artboard plate ??must not block marquee (looks empty but hits as a shape). */
 function frameForFullBleedPlate(doc: any, nodeId: string): string | null {
   const node = doc?.deltaSetLike?.[nodeId];
   if (!node || node.key !== 'shape') return null;
@@ -374,7 +380,7 @@ function pointInBox(x: number, y: number, box: SceneBox, pad = 0) {
 }
 
 /**
- * Marquee hit — match click semantics per type:
+ * Marquee hit ??match click semantics per type:
  * - rect / geo / text / image: AABB (same as click)
  * - pen / pencil / path: stroke/path sampling (click uses ink, not empty AABB gaps)
  * - line / arrow: shaft endpoints / mid
@@ -416,7 +422,7 @@ function nodeHitsMarquee(
     return boxesIntersect(marquee, box);
   }
 
-  // rect / ellipse / text / image / other geo — AABB like click.
+  // rect / ellipse / text / image / other geo ??AABB like click.
   return boxesIntersect(marquee, box);
 }
 
@@ -445,7 +451,7 @@ type GeometryPatch = {
 
 type SelectionFeatureProps = {
   enabled: boolean;
-  /** Share/preview: select + Dev annotations only — no move/resize/edit. */
+  /** Share/preview: select + Dev annotations only ??no move/resize/edit. */
   readOnly?: boolean;
   document: any;
   selectedNodeIds: string[];
@@ -504,14 +510,14 @@ type SelectionFeatureProps = {
   /** Fires when move / resize / rotate starts or ends (for hiding node titles). */
   onTransformingChange?: (transforming: boolean) => void;
   /**
-   * Composer "Add from canvas" pick mode — clicks attach via onSelect and must
+   * Composer "Add from canvas" pick mode ??clicks attach via onSelect and must
    * not start a move (already-selected hits would otherwise skip onSelect).
    */
   attachPickActive?: boolean;
 };
 
 /**
- * `dragDistanceSquared` default — screen px² before a
+ * `dragDistanceSquared` default ??screen px? before a
  * pointing_canvas gesture becomes brushing (marquee).
  */
 const DRAG_DISTANCE_SQUARED = 16;
@@ -535,6 +541,16 @@ type DragState = {
    * Skip pointerup onSelect so one-shot clearPick does not steal node selection.
    */
   skipSelectOnUp?: boolean;
+  /** Visual/layout scale at pointerdown (from rcbViewportMetrics). */
+  scaleX?: number;
+  scaleY?: number;
+  /**
+   * Continuously updated from pointerdown/move.
+   * End events (up/cancel) must not supply geometry ? their clientX/Y can be 0,0.
+   */
+  currentClientX: number;
+  currentClientY: number;
+  currentShift?: boolean;
 };
 
 /** Shared seed for blank / pointing_canvas / move / resize / rotate drags. */
@@ -542,18 +558,41 @@ function makeDragSeed(
   mode: DragState['mode'],
   e: { clientX: number; clientY: number },
   p: { x: number; y: number },
-  extras?: Partial<DragState>
+  extras?: Partial<DragState>,
+  viewport?: HTMLElement | null
 ): DragState {
+  const m = viewport ? rcbViewportMetrics(viewport) : null;
   return {
     mode,
     startX: e.clientX,
     startY: e.clientY,
     sceneX0: p.x,
     sceneY0: p.y,
+    scaleX: m?.scaleX ?? 1,
+    scaleY: m?.scaleY ?? 1,
+    currentClientX: e.clientX,
+    currentClientY: e.clientY,
     origins: [],
     union: { left: p.x, top: p.y, width: 1, height: 1 },
     ...extras,
   };
+}
+
+/** Scene point / delta from pointerdown ??stable if stage rect jitters mid-gesture. */
+function sceneFromClientGesture(
+  drag: Pick<DragState, 'sceneX0' | 'sceneY0' | 'startX' | 'startY' | 'scaleX' | 'scaleY'>,
+  zoom: number,
+  clientX: number,
+  clientY: number
+) {
+  const d = rcbClientDeltaToScene(
+    zoom,
+    clientX - drag.startX,
+    clientY - drag.startY,
+    drag.scaleX ?? 1,
+    drag.scaleY ?? 1
+  );
+  return { x: drag.sceneX0 + d.x, y: drag.sceneY0 + d.y, dx: d.x, dy: d.y };
 }
 
 function isSelectionOriginsLocked(
@@ -899,7 +938,7 @@ function siblingGuideBoxesNear(
     const fromDoc = nodeGuideBoxesForIds(document, [...idSet], { excludeIds });
     if (fromDoc.length) return fromDoc;
   }
-  // Inside a frame with no siblings yet — empty is OK (still snap to the frame).
+  // Inside a frame with no siblings yet ??empty is OK (still snap to the frame).
   if (containing.length) return [];
   return siblingGuideBoxes(document, excludeIds, fallback);
 }
@@ -976,6 +1015,7 @@ function SelectionFeature({
   attachPickActive = false,
 }: SelectionFeatureProps) {
   const overlayRoot = useRcbOverlayRoot();
+  const viewportEl = useRcbViewportEl();
   const toScene = useRcbScreenToScene();
   const camera = useRcbCamera();
   const zoom = Math.max(0.05, camera.zoom || 1);
@@ -986,8 +1026,8 @@ function SelectionFeature({
     (s: any) => (s.editor.workspaceMode || 'design') as 'design' | 'dev'
   );
   const gridSize = getDocumentGridSize(document);
-  /** Infinite paper is 0×0 — listen on the stage so empty artboard clicks select. */
-  const hitEl = stageEl || paperEl;
+  /** Prefer live context viewport ??prop stageEl can go stale after resize remounts. */
+  const hitEl = rcbResolveViewportEl(viewportEl, stageEl, paperEl);
   const dispatch = useDispatch();
   const shapeStylePanel = useSelector(
     (s: any) => s.editor.shapeStylePanel as null | { kind: string }
@@ -1006,7 +1046,7 @@ function SelectionFeature({
   const onTransformingChangeRef = useRef(onTransformingChange);
   onTransformingChangeRef.current = onTransformingChange;
 
-  // Keep pointer handlers stable — document identity churn must not tear down window listeners mid-marquee.
+  // Keep pointer handlers stable ??document identity churn must not tear down window listeners mid-marquee.
   const documentRef = useRef(document);
   const getNodeBoxRef = useRef(getNodeBox);
   const listNodeIdsRef = useRef(listNodeIds);
@@ -1047,14 +1087,14 @@ function SelectionFeature({
   const [guides, setGuides] = useState<AlignGuide[]>([]);
   /** Margin labels while moving / arrow-nudging (fig.1 pink). */
   const [moveMargins, setMoveMargins] = useState<SpacingMeasure[] | null>(null);
-  /** Neighbor boxes currently driving distance tips — orange outline like MasterGo. */
+  /** Neighbor boxes currently driving distance tips ??orange outline like MasterGo. */
   const [moveHighlights, setMoveHighlights] = useState<SceneBox[]>([]);
   /** Hide chrome/toolbars while move / resize / rotate is in progress. */
   const [transforming, setTransforming] = useState(false);
   /** Dev inspect: node under pointer (annotations follow mouse). */
   const [hoverNodeId, setHoverNodeId] = useState<string | null>(null);
   const hoverNodeIdRef = useRef<string | null>(null);
-  /** Preview / Dev: previous single selection — click A then B shows A↔B spacing. */
+  /** Preview / Dev: previous single selection ??click A then B shows A?B spacing. */
   const [inspectPairNodeId, setInspectPairNodeId] = useState<string | null>(null);
   const prevInspectSelRef = useRef<string | null>(null);
 
@@ -1251,7 +1291,7 @@ function SelectionFeature({
 
     /**
      * Second completed soft-click (pointerup, no drag) on the same text opens edit.
-     * Must not run on pointerdown — otherwise one click (down+up) looks like a double-tap.
+     * Must not run on pointerdown ??otherwise one click (down+up) looks like a double-tap.
      */
     const tryOpenTextEdit = (id: string) => {
       if (readOnly) return false;
@@ -1286,6 +1326,13 @@ function SelectionFeature({
       )
         return;
 
+      const seed = (
+        mode: DragState['mode'],
+        ev: { clientX: number; clientY: number },
+        pt: { x: number; y: number },
+        extras?: Partial<DragState>
+      ) => makeDragSeed(mode, ev, pt, extras, hitEl);
+
       const p = toScene(e.clientX, e.clientY);
       const liveUnionNow = liveUnionRef.current;
       const liveOriginsNow = liveOriginsRef.current;
@@ -1307,7 +1354,7 @@ function SelectionFeature({
             ? readNodeAngle(document, liveOriginsNow[0].nodeId)
             : 0);
         const pointerAngle0 = (Math.atan2(p.y - center.y, p.x - center.x) * 180) / Math.PI;
-        dragRef.current = makeDragSeed('rotate', e, p, {
+        dragRef.current = seed('rotate', e, p, {
           origins: liveOriginsNow.map((o) => ({
             nodeId: o.nodeId,
             box: { ...o.box },
@@ -1329,7 +1376,7 @@ function SelectionFeature({
         e.preventDefault();
         e.stopPropagation();
         const handle = (resizeEl.getAttribute('data-resize') || 'se') as ResizeHandle;
-        dragRef.current = makeDragSeed('resize', e, p, {
+        dragRef.current = seed('resize', e, p, {
           origins: liveOriginsNow.map((o) => ({ nodeId: o.nodeId, box: { ...o.box } })),
           union: { ...liveUnionNow },
           handle,
@@ -1351,7 +1398,7 @@ function SelectionFeature({
         e.preventDefault();
         e.stopPropagation();
         const origins = liveOriginsNow.map((o) => ({ nodeId: o.nodeId, box: { ...o.box } }));
-        dragRef.current = makeDragSeed('move', e, p, {
+        dragRef.current = seed('move', e, p, {
           origins,
           union: { ...liveUnionNow },
         });
@@ -1400,20 +1447,20 @@ function SelectionFeature({
                 .find((fid): fid is string => Boolean(fid))
             : null);
         if (hitId && !plateFrameId) {
-          // Do NOT call onSelectFrame(null) here — during pick that clears pick mode.
+          // Do NOT call onSelectFrame(null) here ??during pick that clears pick mode.
           onSelect(expandSelectionWithGroups(document, [hitId]));
         } else if (frameUnder) {
           onSelectFrame?.(frameUnder);
         } else {
-          // Truly empty canvas — exit pick mode.
+          // Truly empty canvas ??exit pick mode.
           onSelect([]);
         }
-        dragRef.current = makeDragSeed('blank', e, p, { skipSelectOnUp: true });
+        dragRef.current = seed('blank', e, p, { skipSelectOnUp: true });
         capture(e.pointerId);
         return;
       }
 
-      // Clicking a selected artboard (or its plate) moves the whole selection — like a rect.
+      // Clicking a selected artboard (or its plate) moves the whole selection ??like a rect.
       if (
         !readOnly &&
         selectionHasFrame &&
@@ -1431,20 +1478,20 @@ function SelectionFeature({
         if ((emptyOrSelectedPlate || selectedNodeHit) && beginMoveSelection()) return;
       }
 
-      // Full-bleed background plate looks empty — start marquee, don't drag the plate.
+      // Full-bleed background plate looks empty ??start marquee, don't drag the plate.
       if (hitId && plateFrameId) {
         e.preventDefault();
         if (!e.shiftKey && !readOnly) {
           onSelectFrame?.(null);
           onSelect([]);
         }
-        dragRef.current = makeDragSeed('pointing_canvas', e, p);
-        marqueeLog('treat plate as empty → pointing_canvas');
+        dragRef.current = seed('pointing_canvas', e, p);
+        marqueeLog('treat plate as empty ??pointing_canvas');
         capture(e.pointerId);
         return;
       }
 
-      // Shape under pointer — select (if needed) then move. Never start a marquee on a shape.
+      // Shape under pointer ??select (if needed) then move. Never start a marquee on a shape.
       if (hitId) {
         e.preventDefault();
         e.stopPropagation();
@@ -1455,14 +1502,14 @@ function SelectionFeature({
           // Preview / Dev inspect: select only (no move).
           onSelectFrame?.(null);
           onSelect(expandedHit, { additive });
-          dragRef.current = makeDragSeed('blank', e, p);
+          dragRef.current = seed('blank', e, p);
           capture(e.pointerId);
           return;
         }
 
-        // Expand on down so pointerdown→move uses full group origins before Redux catches up.
+        // Expand on down so pointerdown?move uses full group origins before Redux catches up.
         if (!selectedIds.includes(hitId)) {
-          // Do not open text edit on pointerdown — a single click's up would
+          // Do not open text edit on pointerdown ??a single click's up would
           // otherwise count as a second tap and enter edit immediately.
           lastTextClickRef.current = null;
           onSelectFrame?.(null);
@@ -1470,7 +1517,7 @@ function SelectionFeature({
         }
         // Shift-add only: wait for pointer-up; don't start a translate.
         if (additive && !selectedIds.includes(hitId)) {
-          dragRef.current = makeDragSeed('blank', e, p);
+          dragRef.current = seed('blank', e, p);
           capture(e.pointerId);
           return;
         }
@@ -1489,23 +1536,23 @@ function SelectionFeature({
         // Second click of a double-click: do not start a translate.
         if (isRecentNodeDoubleTap(lastNodeTapRef.current, hitId, e)) {
           lastNodeTapRef.current = null;
-          dragRef.current = makeDragSeed('blank', e, p);
+          dragRef.current = seed('blank', e, p);
           capture(e.pointerId);
           return;
         }
         lastNodeTapRef.current = { id: hitId, t: Date.now(), x: e.clientX, y: e.clientY };
 
-        // Keep chrome rotation in sync — transforming flips chromeAngle onto liveAngle.
+        // Keep chrome rotation in sync ??transforming flips chromeAngle onto liveAngle.
         if (origins.length === 1 && !parseFrameSelId(origins[0].nodeId)) {
           setLiveAngle(readNodeAngle(document, origins[0].nodeId));
         }
         // Locked layers stay selectable but cannot start a drag.
         if (isSelectionOriginsLocked(document, origins)) {
-          dragRef.current = makeDragSeed('blank', e, p);
+          dragRef.current = seed('blank', e, p);
           capture(e.pointerId);
           return;
         }
-        dragRef.current = makeDragSeed('move', e, p, { origins, union });
+        dragRef.current = seed('move', e, p, { origins, union });
         setLiveOrigins(origins);
         setLiveUnion(union);
         setTransformingNotify(true);
@@ -1513,7 +1560,7 @@ function SelectionFeature({
         return;
       }
 
-      // Empty canvas / artboard interior → PointingCanvas → marquee after drag threshold.
+      // Empty canvas / artboard interior ??PointingCanvas ??marquee after drag threshold.
       // Soft-click on artboard selects the frame (on pointerup). Frame move is via title label
       // or by dragging inside an existing selection union (handled above).
       e.preventDefault();
@@ -1524,14 +1571,17 @@ function SelectionFeature({
         onSelectFrame?.(null);
         onSelect([]);
       }
-      dragRef.current = makeDragSeed('pointing_canvas', e, p);
-      marqueeLog('empty → pointing_canvas');
+      dragRef.current = seed('pointing_canvas', e, p);
+      marqueeLog('empty ??pointing_canvas');
       capture(e.pointerId);
     };
 
     const onMove = (e: PointerEvent) => {
       const drag = dragRef.current;
       if (!drag) return;
+      drag.currentClientX = e.clientX;
+      drag.currentClientY = e.clientY;
+      drag.currentShift = e.shiftKey;
       const clientDistSq =
         (e.clientX - drag.startX) ** 2 + (e.clientY - drag.startY) ** 2;
       if (drag.mode === 'blank') {
@@ -1541,18 +1591,24 @@ function SelectionFeature({
         }
         return;
       }
-      // PointingCanvas → Brushing only after dragDistanceSquared.
+      // PointingCanvas ??Brushing only after dragDistanceSquared.
       if (drag.mode === 'pointing_canvas') {
         if (readOnly || clientDistSq < DRAG_DISTANCE_SQUARED) return;
         drag.mode = 'marquee';
-        const p0 = toScene(e.clientX, e.clientY);
+        const p0 = sceneFromClientGesture(drag, zoom, e.clientX, e.clientY);
         setMarquee(normalizeBox(drag.sceneX0, drag.sceneY0, p0.x, p0.y));
         marqueeLog('enter marquee', { clientDistSq });
         return;
       }
-      const p = toScene(e.clientX, e.clientY);
-      const dx = p.x - drag.sceneX0;
-      const dy = p.y - drag.sceneY0;
+      // Client-delta keeps the selection under the pointer when the stage rect
+      // shifts (mobile chrome / small-viewport reflow). Rotate still needs an
+      // absolute scene point for atan2 around the pivot.
+      const gesture = sceneFromClientGesture(drag, zoom, e.clientX, e.clientY);
+      const dx = gesture.dx;
+      const dy = gesture.dy;
+      const abs = toScene(e.clientX, e.clientY);
+      const p =
+        drag.mode === 'rotate' ? abs : { x: gesture.x, y: gesture.y };
 
       if (drag.mode === 'marquee') {
         setMarquee(normalizeBox(drag.sceneX0, drag.sceneY0, p.x, p.y));
@@ -1560,7 +1616,7 @@ function SelectionFeature({
       }
 
       if (drag.mode === 'rotate' && drag.center && drag.pointerAngle0 != null) {
-        // Soft-click on rotate knob — ignore OS pointer jitter.
+        // Soft-click on rotate knob ??ignore OS pointer jitter.
         if (clientDistSq <= DRAG_DISTANCE_SQUARED) return;
         const { next, delta } = computeRotateDelta(drag, p, e.shiftKey);
         setLiveAngle(next);
@@ -1615,7 +1671,7 @@ function SelectionFeature({
           getNodeBox,
           skipHiddenInFallback: true,
         });
-        // Keep exact snapped visual edges — integer rounding in geometry commits
+        // Keep exact snapped visual edges ??integer rounding in geometry commits
         // breaks flush align when stroke outset is *.5 (odd border-width).
         setGuides(guides);
         if (guides.length) {
@@ -1646,7 +1702,7 @@ function SelectionFeature({
       }
 
       if (drag.mode === 'resize' && drag.handle) {
-        // Soft-click on a handle must not resize: at 3% zoom, 2px jitter ≈ 60+
+        // Soft-click on a handle must not resize: at 3% zoom, 2px jitter ??60+
         // scene units and snap threshold is huge (8/zoom), so the box jumps.
         if (clientDistSq <= DRAG_DISTANCE_SQUARED) return;
         const stroke = strokeEndpointBox(drag, document, p.x, p.y);
@@ -1745,11 +1801,19 @@ function SelectionFeature({
         /* ignore */
       }
 
-      const p = toScene(e.clientX, e.clientY);
-      const dx = p.x - drag.sceneX0;
-      const dy = p.y - drag.sceneY0;
+      // End events are lifecycle-only; geometry uses last down/move client point.
+      const clientX = drag.currentClientX;
+      const clientY = drag.currentClientY;
+      const shiftKey = drag.currentShift ?? e.shiftKey;
+      const gesture = sceneFromClientGesture(drag, zoom, clientX, clientY);
+      const dx = gesture.dx;
+      const dy = gesture.dy;
+      const p =
+        drag.mode === 'move' || drag.mode === 'resize' || drag.mode === 'marquee'
+          ? { x: gesture.x, y: gesture.y }
+          : toScene(clientX, clientY);
       const clientDistSq =
-        (e.clientX - drag.startX) ** 2 + (e.clientY - drag.startY) ** 2;
+        (clientX - drag.startX) ** 2 + (clientY - drag.startY) ** 2;
 
       const endTransform = () => setTransformingNotify(false);
 
@@ -1758,9 +1822,10 @@ function SelectionFeature({
         setMarquee(null);
         lastTextClickRef.current = null;
         // Selection already cleared on pointerdown.
-        // Soft-click inside an artboard → select that frame.
+        // Soft-click inside an artboard ??select that frame.
         if (!readOnly) {
-          const frameId = hitTestFrame?.(p.x, p.y);
+          const abs = toScene(clientX, clientY);
+          const frameId = hitTestFrame?.(abs.x, abs.y);
           if (frameId) onSelectFrame?.(frameId);
         }
         endTransform();
@@ -1771,7 +1836,7 @@ function SelectionFeature({
         const box = normalizeBox(drag.sceneX0, drag.sceneY0, p.x, p.y);
         setMarquee(null);
         lastTextClickRef.current = null;
-        // Still under threshold somehow — treat as click, not brush.
+        // Still under threshold somehow ??treat as click, not brush.
         if (clientDistSq < DRAG_DISTANCE_SQUARED) {
           marqueeLog('marquee aborted (under threshold)');
           endTransform();
@@ -1785,14 +1850,14 @@ function SelectionFeature({
         // Full-bleed plate: keep when artboard brushed, or other non-plate content hit.
         const contentHits = filterMarqueeContentHits(document, rawHits, new Set(frameHits));
         marqueeLog(
-          contentHits.length || frameHits.length ? 'marquee up → mixed' : 'marquee up → fallback',
+          contentHits.length || frameHits.length ? 'marquee up ??mixed' : 'marquee up ??fallback',
           { box, contentHits, frameHits, rawHits }
         );
         commitMarqueeSelection({
           contentHits,
           frameHits,
           rawHits,
-          shiftKey: e.shiftKey,
+          shiftKey,
           onSelectMixed,
           onSelectFrames,
           onSelectFrame,
@@ -1803,7 +1868,7 @@ function SelectionFeature({
       }
 
       if (drag.mode === 'blank') {
-        // Attach-pick already applied on pointerdown — do not onSelect on up
+        // Attach-pick already applied on pointerdown ??do not onSelect on up
         // (one-shot clearPick flips attachPickActive off before up; selecting
         // here would steal focus from the host node / double-add chips).
         if (
@@ -1811,19 +1876,19 @@ function SelectionFeature({
           !attachPickActive &&
           clientDistSq <= DRAG_DISTANCE_SQUARED
         ) {
-          const id = hitTest(p.x, p.y, { clientX: e.clientX, clientY: e.clientY });
+          const id = hitTest(p.x, p.y, { clientX, clientY });
           if (id && tryOpenTextEdit(id)) {
             endTransform();
             return;
           }
-          if (id) onSelect([id], { additive: e.shiftKey });
+          if (id) onSelect([id], { additive: shiftKey });
         }
         endTransform();
         return;
       }
 
       if (drag.mode === 'rotate' && drag.center && drag.pointerAngle0 != null) {
-        // Soft-click: restore start pose — do not apply angle jitter.
+        // Soft-click: restore start pose ??do not apply angle jitter.
         if (clientDistSq <= DRAG_DISTANCE_SQUARED) {
           setLiveAngle(drag.angle0 || 0);
           setLiveUnion({ ...drag.union });
@@ -1831,7 +1896,7 @@ function SelectionFeature({
           endTransform();
           return;
         }
-        const { next, delta } = computeRotateDelta(drag, p, e.shiftKey);
+        const { next, delta } = computeRotateDelta(drag, p, shiftKey);
         setLiveAngle(next);
         if (drag.origins.length === 1) {
           onAngleCommit?.(drag.origins[0].nodeId, next);
@@ -1868,8 +1933,8 @@ function SelectionFeature({
 
       if (drag.mode === 'move') {
         // Soft-click: never leave liveUnion on a snap-only nudge while the
-        // document stays put — that desyncs chrome from the shape (worst at
-        // 3%/800% where 8px snap ≈ huge / visible scene delta).
+        // document stays put ??that desyncs chrome from the shape (worst at
+        // 3%/800% where 8px snap ??huge / visible scene delta).
         if (clientDistSq <= DRAG_DISTANCE_SQUARED) {
           setGuides([]);
           setMoveMargins(null);
@@ -1954,7 +2019,7 @@ function SelectionFeature({
           drag,
           dx,
           dy,
-          shiftKey: e.shiftKey,
+          shiftKey,
           isGridMode,
           disableGrid: e.ctrlKey || e.metaKey,
           gridSize,
@@ -2010,7 +2075,7 @@ function SelectionFeature({
       }
       const p = toScene(e.clientX, e.clientY);
       let hit = hitTest(p.x, p.y, { clientX: e.clientX, clientY: e.clientY });
-      // Selection chrome covers the glyph — fall back to the single selected node.
+      // Selection chrome covers the glyph ??fall back to the single selected node.
       if (!hit && target?.closest?.('[data-sel-box]')) {
         const ids = liveOriginsRef.current?.map((o) => o.nodeId) || [];
         if (ids.length === 1) hit = ids[0];
@@ -2034,8 +2099,8 @@ function SelectionFeature({
       }
     };
 
-    // Chrome lives in the unscaled overlay — also listen there for resize/rotate / dblclick.
-    // Infinite paper is 0×0; stage receives empty artboard / shape clicks.
+    // Chrome lives in the unscaled overlay ??also listen there for resize/rotate / dblclick.
+    // Infinite paper is 0?0; stage receives empty artboard / shape clicks.
     hitEl.addEventListener('pointerdown', onDown);
     overlayRoot?.addEventListener('pointerdown', onDown);
     hitEl.addEventListener('dblclick', onDblClick);
@@ -2057,6 +2122,7 @@ function SelectionFeature({
     readOnly,
     attachPickActive,
     hitEl,
+    viewportEl,
     paperEl,
     overlayRoot,
     artboard,
@@ -2077,13 +2143,15 @@ function SelectionFeature({
     listNodeIds,
     queryNodeIdsInRect,
     toScene,
+    zoom,
+    camera,
     snapThreshold,
     isGridMode,
     gridSize,
   ]);
 
   /** Arrow keys nudge selection 1px (Shift = 10px) and show margin labels.
-   *  Grid mode: step = gridSize (Shift = 5×). */
+   *  Grid mode: step = gridSize (Shift = 5?). */
   useEffect(() => {
     if (!enabled || suppressChrome || readOnly) return undefined;
     let hideTimer: ReturnType<typeof setTimeout> | null = null;
@@ -2211,13 +2279,12 @@ function SelectionFeature({
     if (mode === 'resize' && isStrokeShapeType(readNodeShapeType(document, id))) {
       return liveAngle;
     }
-    // Move / box-resize: always use stored angle — avoids click flash when liveAngle lags at 0.
+    // Move / box-resize: always use stored angle ??avoids click flash when liveAngle lags at 0.
     return fromDoc;
   })();
 
   /**
-   * Hover baseline only. Selected shapes use SelectionChrome box stroke —
-   * drawing both stacks a second blue path on top of white knobs (looks hollow).
+   * Hover baseline only. Selected shapes use SelectionChrome box stroke ??   * drawing both stacks a second blue path on top of white knobs (looks hollow).
    */
   const shapeIndicators = (() => {
     if (!enabled || suppressChrome || transforming) return [];
@@ -2253,7 +2320,7 @@ function SelectionFeature({
 
   const selectedSingleId = selectedNodeIds.length === 1 ? selectedNodeIds[0] : null;
 
-  // DPR seam diagnostics — opt-in: window.__RCB_DPR_DEBUG__ = true
+  // DPR seam diagnostics ??opt-in: window.__RCB_DPR_DEBUG__ = true
   useEffect(() => {
     if (!enabled) return;
     if (typeof window === 'undefined') return;
@@ -2321,7 +2388,7 @@ function SelectionFeature({
   // Frames often sit off-screen; measuring to their edge draws a pink gap across
   // empty dotted canvas and looks like a phantom guide. Frame margins still show
   // while dragging via computeMoveMarginResult(containers).
-  // Skip hidden layers — same phantom-guide issue when measuring into empty space.
+  // Skip hidden layers ??same phantom-guide issue when measuring into empty space.
   const spacingOthers =
     selectedBox && !pairBox
       ? (listNodeIds()
@@ -2444,7 +2511,7 @@ function SelectionFeature({
       ))}
 
       {/* Gate on selection: after deselect, Redux clears first but liveUnion
-          lags one frame — without this, line chrome briefly falls back to AABB box.
+          lags one frame ??without this, line chrome briefly falls back to AABB box.
           Image/video generator: blue stroke only (same #3388ff as hover), no resize knobs. */}
       {liveUnion && !suppressChrome && selectionCount > 0 ? (
         <SelectionChrome
@@ -2460,7 +2527,7 @@ function SelectionFeature({
           edgeHandles={
             selectedIsImageGen || selectedIsVideoGen
               ? 'none'
-              : // Video scrubber sits on the bottom edge — keep L/R only so the S handle
+              : // Video scrubber sits on the bottom edge ??keep L/R only so the S handle
                 // does not steal pointer events from the playback bar.
               selectedIsVideo || (!lineChrome && singleNodeData?.key === 'text')
                 ? 'horizontal'

--- a/apps/web/src/components/rcb/selection/chrome/CanvasContextMenu.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/CanvasContextMenu.tsx
@@ -23,6 +23,7 @@ import {
   HiOutlineTrash,
 } from 'react-icons/hi2';
 import { Icon } from '@/components/base';
+import { useChromePointerActivate } from './SelectionToolbarShell';
 
 type CtxAction =
   | 'upload'
@@ -118,6 +119,31 @@ const itemClass =
 
 const PAD = 8;
 
+/**
+ * Menu is `position: fixed` on document.body — use viewport client coords.
+ * Keep the click anchor; only shift when the panel would overflow.
+ * Cap height so a tall menu scrolls instead of pinning to the corner.
+ */
+function clampFixedMenuPos(opts: {
+  left: number;
+  top: number;
+  menuW: number;
+  menuH: number;
+}): { left: number; top: number; maxHeight: number } {
+  const viewW = Math.max(1, window.innerWidth);
+  const viewH = Math.max(1, window.innerHeight);
+  const maxHeight = Math.max(120, viewH - PAD * 2);
+  const h = Math.min(Math.max(1, opts.menuH), maxHeight);
+  const w = Math.min(Math.max(1, opts.menuW), Math.max(1, viewW - PAD * 2));
+  let left = opts.left;
+  let top = opts.top;
+  if (left + w > viewW - PAD) left = viewW - PAD - w;
+  if (left < PAD) left = PAD;
+  if (top + h > viewH - PAD) top = viewH - PAD - h;
+  if (top < PAD) top = PAD;
+  return { left, top, maxHeight };
+}
+
 function MenuItem({
   icon,
   label,
@@ -197,7 +223,6 @@ function ExportSubmenu({
         <div
           ref={flyoutRef}
           className={`absolute ${sideClass} ${vClass} z-[1] min-w-[7.5rem] overflow-hidden rounded-xl bg-[var(--surface)] py-1 shadow-lg ring-1 ring-[var(--line)]`}
-          onPointerDown={(e) => e.stopPropagation()}
         >
           {kind === 'video' ? (
             <>
@@ -227,7 +252,7 @@ function ExportSubmenu({
   );
 }
 
-/** Right-click menu — screen-space portal (not scaled by canvas camera). */
+/** Right-click menu — `fixed` on body with viewport client coords (not scene space). */
 function CanvasContextMenu({
   menu,
   hasNode,
@@ -251,6 +276,7 @@ function CanvasContextMenu({
   onClose,
 }: CanvasContextMenuProps) {
   const { t } = useTranslation();
+  const chromePointer = useChromePointerActivate();
   const deleteEnabled = canDelete ?? hasNode;
   const addToChatEnabled = canAddToChat ?? hasNode;
   const layerEnabled = canLayerActions ?? hasNode;
@@ -258,7 +284,7 @@ function CanvasContextMenu({
   const hideEnabled = canToggleHidden ?? hasNode;
   const lockEnabled = canToggleLocked ?? layerEnabled;
   const panelRef = useRef<HTMLDivElement | null>(null);
-  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+  const [pos, setPos] = useState<{ left: number; top: number; maxHeight: number } | null>(null);
 
   useLayoutEffect(() => {
     if (!menu) {
@@ -266,14 +292,14 @@ function CanvasContextMenu({
       return;
     }
     const el = panelRef.current;
-    const w = el?.offsetWidth || 200;
-    const h = el?.offsetHeight || 420;
-    const maxL = Math.max(PAD, window.innerWidth - w - PAD);
-    const maxT = Math.max(PAD, window.innerHeight - h - PAD);
-    setPos({
-      left: Math.min(Math.max(PAD, menu.clientX), maxL),
-      top: Math.min(Math.max(PAD, menu.clientY), maxT),
-    });
+    setPos(
+      clampFixedMenuPos({
+        left: menu.clientX,
+        top: menu.clientY,
+        menuW: el?.offsetWidth || 200,
+        menuH: el?.offsetHeight || 420,
+      })
+    );
   }, [menu]);
 
   useEffect(() => {
@@ -293,9 +319,13 @@ function CanvasContextMenu({
       <div
         ref={panelRef}
         data-ctx-menu
-        className="fixed z-[70] min-w-[200px] overflow-visible rounded-xl bg-[var(--surface)] py-1 shadow-lg ring-1 ring-[var(--line)]"
-        style={{ left: pos?.left ?? menu.clientX, top: pos?.top ?? menu.clientY }}
-        onPointerDown={(e) => e.stopPropagation()}
+        className="fixed z-[70] min-w-[200px] overflow-y-auto overflow-x-visible rounded-xl bg-[var(--surface)] py-1 shadow-lg ring-1 ring-[var(--line)]"
+        style={{
+          left: pos?.left ?? menu.clientX,
+          top: pos?.top ?? menu.clientY,
+          maxHeight: pos?.maxHeight,
+        }}
+        {...chromePointer}
       >
         <MenuItem
           icon={<HiOutlineChatBubbleLeftRight className={ICON_CLASS} strokeWidth={1.75} />}

--- a/apps/web/src/components/rcb/selection/chrome/SelectionContextToolbar.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/SelectionContextToolbar.tsx
@@ -494,35 +494,33 @@ function SelectionContextToolbar(props: Props): ReactNode {
                     type="button"
                     aria-label="Outline"
                     className={SEL_ICON_BTN}
-                    onClick={() => {
-                      void (async () => {
-                        const hide = message.loading('Outlining…', 0);
-                        try {
-                          const outline = await buildOutlinePathAsync(node);
-                          if (!outline?.pathD) {
-                            message.error('Outline failed');
-                            return;
-                          }
-                          const patch = outlineNodePatch(node, outline);
-                          dispatch(
-                            patchDocumentNode({
-                              nodeId,
-                              patch: {
-                                key: 'shape',
-                                x: patch.x,
-                                y: patch.y,
-                                width: patch.width,
-                                height: patch.height,
-                                attrs: patch.attrs,
-                              },
-                            })
-                          );
-                          requestEnterPathEdit(nodeId, outline.pathD);
-                          message.success('Outlined');
-                        } finally {
-                          hide();
+                    onClick={async () => {
+                      const hide = message.loading('Outlining…', 0);
+                      try {
+                        const outline = await buildOutlinePathAsync(node);
+                        if (!outline?.pathD) {
+                          message.error('Outline failed');
+                          return;
                         }
-                      })();
+                        const patch = outlineNodePatch(node, outline);
+                        dispatch(
+                          patchDocumentNode({
+                            nodeId,
+                            patch: {
+                              key: 'shape',
+                              x: patch.x,
+                              y: patch.y,
+                              width: patch.width,
+                              height: patch.height,
+                              attrs: patch.attrs,
+                            },
+                          })
+                        );
+                        requestEnterPathEdit(nodeId, outline.pathD);
+                        message.success('Outlined');
+                      } finally {
+                        hide();
+                      }
                     }}
                   >
                     <TbVectorBezier className="h-4 w-4" />

--- a/apps/web/src/components/rcb/selection/chrome/SelectionToolbarShell.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/SelectionToolbarShell.tsx
@@ -1,4 +1,11 @@
-import { type CSSProperties, type ReactNode, memo } from 'react';
+import {
+  useRef,
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+  memo,
+} from 'react';
 import {
   RcbOverlayPortal,
   useRcbCamera,
@@ -7,6 +14,67 @@ import {
 import { rcbScreenPxToScene } from '../../core/math';
 import { FloatingToolbar } from '@/components/editor/chrome/FloatingToolbar';
 import { cn } from '@/utils/classnames';
+
+/** Interactive chrome controls inside canvas overlays (toolbars / generators / menus). */
+const CHROME_ACTION_SEL =
+  'button:not([disabled]), [role="button"]:not([aria-disabled="true"]), [role="menuitem"]:not([aria-disabled="true"])';
+
+function chromeActionFromEvent(
+  target: EventTarget | null,
+  root: EventTarget & HTMLElement
+): HTMLElement | null {
+  const el = (target as HTMLElement | null)?.closest?.(CHROME_ACTION_SEL) as HTMLElement | null;
+  if (!el || !root.contains(el)) return null;
+  return el;
+}
+
+/**
+ * Same activation path as canvas node hits: pointer down/up.
+ * `element.click()` runs existing onClick handlers; only the following real
+ * click (after a synthetic activate) is suppressed — not every button click.
+ */
+export function useChromePointerActivate() {
+  const armedRef = useRef<HTMLElement | null>(null);
+  const suppressBrowserClickRef = useRef(false);
+
+  const onPointerDown = (e: ReactPointerEvent<HTMLElement>) => {
+    e.stopPropagation();
+    e.nativeEvent.stopImmediatePropagation?.();
+    suppressBrowserClickRef.current = false;
+    if (e.button !== 0) {
+      armedRef.current = null;
+      return;
+    }
+    armedRef.current = chromeActionFromEvent(e.target, e.currentTarget);
+  };
+
+  const onPointerUp = (e: ReactPointerEvent<HTMLElement>) => {
+    const armed = armedRef.current;
+    armedRef.current = null;
+    if (!armed || e.button !== 0) return;
+    if (chromeActionFromEvent(e.target, e.currentTarget) !== armed) return;
+    e.preventDefault();
+    e.stopPropagation();
+    suppressBrowserClickRef.current = true;
+    armed.click();
+  };
+
+  const onPointerCancel = () => {
+    armedRef.current = null;
+    suppressBrowserClickRef.current = false;
+  };
+
+  const onClickCapture = (e: ReactMouseEvent<HTMLElement>) => {
+    if (!suppressBrowserClickRef.current) return;
+    // Programmatic `.click()` is detail 0 — let it reach the button onClick.
+    if (e.detail === 0) return;
+    suppressBrowserClickRef.current = false;
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  return { onPointerDown, onPointerUp, onPointerCancel, onClickCapture };
+}
 
 /**
  * Title row above frame (must stay in sync with HtmlArtboardFrame).
@@ -60,14 +128,12 @@ export function useSelectionToolbarPlacement(opts: {
   const aboveGap = rcbScreenPxToScene(toolbarAboveClearancePx(hasTitle), zoom);
   const belowGap = rcbScreenPxToScene(SELECTION_TOOLBAR_BELOW_BOX_GAP_PX, zoom);
   const box = opts.box;
-
-  const preferAbove = Boolean(box) && box!.top >= aboveGap;
+  const preferAbove = Boolean(box) && box.top >= aboveGap;
   const left = box ? box.left + box.width / 2 : 0;
-  const top = box
-    ? preferAbove
-      ? box.top - aboveGap
-      : box.top + box.height + belowGap
-    : 0;
+  let top = 0;
+  if (box) {
+    top = preferAbove ? box.top - aboveGap : box.top + box.height + belowGap;
+  }
 
   const style = useRcbScreenToolbarStyle({
     left,
@@ -104,6 +170,7 @@ function SelectionToolbarShell({
   zIndexClassName = 'z-30',
 }: ShellProps) {
   const { style } = useSelectionToolbarPlacement({ box, hasTitleLabel });
+  const chromePointer = useChromePointerActivate();
   if (!box) return null;
 
   return (
@@ -113,10 +180,7 @@ function SelectionToolbarShell({
         {...(isFrameToolbar ? { 'data-frame-toolbar': true } : {})}
         className={cn('pointer-events-auto absolute overflow-visible', zIndexClassName)}
         style={style}
-        onPointerDown={(e) => {
-          e.stopPropagation();
-          e.nativeEvent.stopImmediatePropagation?.();
-        }}
+        {...chromePointer}
       >
         <FloatingToolbar bare={bare} className={className}>
           {children}

--- a/apps/web/src/components/rcb/selection/chrome/index.ts
+++ b/apps/web/src/components/rcb/selection/chrome/index.ts
@@ -10,6 +10,7 @@ export { default as AspectRatioPresetMenu } from './AspectRatioPresetMenu';
 export { AspectPresetGlyph, ELEMENT_ASPECT_PRESETS } from './AspectRatioPresetMenu';
 export {
   SelectionToolbarShell,
+  useChromePointerActivate,
   SELECTION_TOOLBAR_BELOW_BOX_GAP_PX,
   NODE_TITLE_LABEL_GAP_PX,
   NODE_TITLE_LABEL_LINE_PX,

--- a/apps/web/src/components/rcb/shapes/RcbShapeHost.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapeHost.tsx
@@ -100,7 +100,7 @@ function RcbShapeHost({
     let cancelled = false;
     registerShapeHost({ nodeId, root, layer, el: null });
 
-    void (async () => {
+    async function mountShape() {
       const n = document.deltaSetLike?.[nodeId];
       try {
         const el = await nodeToSvgElement(root, layer, document, n, nodeId);
@@ -136,7 +136,8 @@ function RcbShapeHost({
       } catch (err) {
         console.error('RcbShapeHost mount failed', nodeId, err);
       }
-    })();
+    }
+    mountShape();
 
     return () => {
       cancelled = true;

--- a/apps/web/src/components/rcb/tools/BucketFillFeature.tsx
+++ b/apps/web/src/components/rcb/tools/BucketFillFeature.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, memo } from 'react';
 import {
+  rcbResolveViewportEl,
   rcbScreenToScene,
 } from '../core/math';
 import {
   useRcbCamera,
+  useRcbViewportEl,
 } from '../camera/context';
 
 function clientToPaperScene(
@@ -46,6 +48,7 @@ function BucketFillFeature({
   onFill,
 }: Props) {
   const camera = useRcbCamera();
+  const viewportEl = useRcbViewportEl();
   const cameraRef = useRef(camera);
   cameraRef.current = camera;
   const hitRef = useRef(hitTest);
@@ -54,11 +57,12 @@ function BucketFillFeature({
   onFillRef.current = onFill;
 
   useEffect(() => {
-    const hitEl = stageEl || paperEl;
+    const hitEl = rcbResolveViewportEl(viewportEl, stageEl, paperEl);
     if (!enabled || !hitEl) return undefined;
 
     const toScene = (clientX: number, clientY: number) => {
-      if (stageEl) return rcbScreenToScene(cameraRef.current, stageEl, clientX, clientY);
+      const stage = rcbResolveViewportEl(viewportEl, stageEl);
+      if (stage) return rcbScreenToScene(cameraRef.current, stage, clientX, clientY);
       return clientToPaperScene(paperEl, artboard, clientX, clientY);
     };
 
@@ -84,7 +88,7 @@ function BucketFillFeature({
     return () => {
       hitEl.removeEventListener('pointerdown', onDown, true);
     };
-  }, [enabled, paperEl, stageEl, artboard]);
+  }, [enabled, paperEl, stageEl, viewportEl, artboard]);
 
   // Keep fillColor in the dependency list for future cursor tint; unused for hit logic.
   void fillColor;

--- a/apps/web/src/components/rcb/tools/PencilDrawFeature.tsx
+++ b/apps/web/src/components/rcb/tools/PencilDrawFeature.tsx
@@ -14,10 +14,14 @@ import {
 } from './pencilBrushes';
 import { getTintedStampSrc } from './stampTint';
 import {
+  rcbClientDeltaToScene,
+  rcbResolveViewportEl,
   rcbScreenToScene,
+  rcbViewportMetrics,
 } from '../core/math';
 import {
   useRcbCamera,
+  useRcbViewportEl,
 } from '../camera/context';
 import {
   type RcbCamera as CanvasCamera,
@@ -63,8 +67,9 @@ function clientToDrawScene(
   clientX: number,
   clientY: number
 ) {
-  // Prefer the full viewport stage so drawing works outside the finite SVG paper.
-  if (opts.stageEl) return rcbScreenToScene(opts.camera, opts.stageEl, clientX, clientY);
+  // Prefer a *connected* stage — prop can go stale after resize remounts.
+  const stage = rcbResolveViewportEl(opts.stageEl);
+  if (stage) return rcbScreenToScene(opts.camera, stage, clientX, clientY);
   return clientToPaperScene(opts.paperEl, opts.artboard, clientX, clientY);
 }
 
@@ -153,9 +158,12 @@ function PencilDrawFeature({
   onErase,
 }: PencilDrawFeatureProps) {
   const camera = useRcbCamera();
+  const viewportEl = useRcbViewportEl();
   const cameraRef = useRef(camera);
   cameraRef.current = camera;
   const pts = useRef<{ x: number; y: number; pressure?: number }[]>([]);
+  const lastClientRef = useRef<{ x: number; y: number } | null>(null);
+  const strokeScaleRef = useRef({ scaleX: 1, scaleY: 1 });
   const drawing = useRef(false);
   const previewPathRef = useRef<SVGPathElement | null>(null);
   const previewStampsRef = useRef<SVGGElement | null>(null);
@@ -179,9 +187,10 @@ function PencilDrawFeature({
   eraseTargetsRef.current = eraseTargets;
   onEraseRef.current = onErase;
 
+  const liveStage = rcbResolveViewportEl(viewportEl, stageEl);
   const toScene = (clientX: number, clientY: number) =>
     clientToDrawScene(
-      { stageEl, paperEl, artboard, camera: cameraRef.current },
+      { stageEl: liveStage, paperEl, artboard, camera: cameraRef.current },
       clientX,
       clientY
     );
@@ -279,7 +288,7 @@ function PencilDrawFeature({
   };
 
   useEffect(() => {
-    const hitEl = stageEl || paperEl;
+    const hitEl = rcbResolveViewportEl(viewportEl, stageEl, paperEl);
     if (!enabled || !hitEl) return undefined;
 
     const onDown = (e: PointerEvent) => {
@@ -289,9 +298,12 @@ function PencilDrawFeature({
       if (t?.closest?.('[data-sel-toolbar],[data-frame-toolbar],[data-ctx-menu],[data-image-tool-panel],[data-shape-style-panel]')) {
         return;
       }
+      const metrics = rcbViewportMetrics(hitEl);
+      strokeScaleRef.current = { scaleX: metrics.scaleX, scaleY: metrics.scaleY };
       const p = toScene(e.clientX, e.clientY);
       const pressure = pressureRef.current ? pointerPressure(e) : undefined;
       drawing.current = true;
+      lastClientRef.current = { x: e.clientX, y: e.clientY };
       pts.current = [pressure != null ? { ...p, pressure } : p];
       if (eraseModeRef.current) {
         paintTipCursor(p);
@@ -305,12 +317,31 @@ function PencilDrawFeature({
       e.stopPropagation();
     };
 
+    const sampleScenePoint = (e: PointerEvent) => {
+      const lastPt = pts.current[pts.current.length - 1];
+      const lastClient = lastClientRef.current;
+      if (drawing.current && lastPt && lastClient) {
+        const { scaleX, scaleY } = strokeScaleRef.current;
+        const d = rcbClientDeltaToScene(
+          cameraRef.current.zoom,
+          e.clientX - lastClient.x,
+          e.clientY - lastClient.y,
+          scaleX,
+          scaleY
+        );
+        lastClientRef.current = { x: e.clientX, y: e.clientY };
+        return { x: lastPt.x + d.x, y: lastPt.y + d.y };
+      }
+      lastClientRef.current = { x: e.clientX, y: e.clientY };
+      return toScene(e.clientX, e.clientY);
+    };
+
     const onMove = (e: PointerEvent) => {
       if (!drawing.current) {
         paintTipCursor(toScene(e.clientX, e.clientY));
         return;
       }
-      const p = toScene(e.clientX, e.clientY);
+      const p = sampleScenePoint(e);
       const pressure = pressureRef.current ? pointerPressure(e) : undefined;
       const pt = pressure != null ? { ...p, pressure } : p;
       if (eraseModeRef.current) {
@@ -338,6 +369,7 @@ function PencilDrawFeature({
     const finishStroke = (e: PointerEvent, commit: boolean) => {
       if (!drawing.current) return;
       drawing.current = false;
+      lastClientRef.current = null;
       try {
         hitEl.releasePointerCapture?.(e.pointerId);
       } catch {
@@ -420,7 +452,7 @@ function PencilDrawFeature({
       window.removeEventListener('pointercancel', onCancel);
       paintTipCursor(null);
     };
-  }, [enabled, stageEl, paperEl, artboard, onCommit]);
+  }, [enabled, stageEl, paperEl, viewportEl, artboard, onCommit, liveStage]);
 
   useEffect(() => {
     if (!eraseMode) {

--- a/apps/web/src/components/rcb/tools/ShapeDrawFeature.tsx
+++ b/apps/web/src/components/rcb/tools/ShapeDrawFeature.tsx
@@ -1,6 +1,11 @@
 import {
   useRcbScreenToScene,
+  useRcbViewportEl,
 } from '../camera/context';
+import {
+  rcbResolveViewportEl,
+  rcbViewportMetrics,
+} from '../core/math';
 import { useEffect, useRef, useState, type ReactNode, memo } from 'react';
 import { ARROW_HEAD, ptsAttr, shapeVertexPoints } from '@/components/rcb/scene/document/sceneShapes';
 
@@ -14,6 +19,25 @@ function normalizeBox(x0: number, y0: number, x1: number, y1: number) {
     height: Math.max(1, Math.abs(y1 - y0)),
   };
 }
+
+type ShapeDrawSession = {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+  clientX0: number;
+  clientY0: number;
+  /** Continuously updated from pointerdown/move — never from pointerup/cancel. */
+  currentClientX: number;
+  currentClientY: number;
+  scaleX: number;
+  scaleY: number;
+  /** Last pointer position before axis snap (for Shift toggle mid-drag). */
+  rawX1: number;
+  rawY1: number;
+  shift: boolean;
+  pointerId: number;
+};
 
 /**
  * Shift+drag line/arrow: lock to the dominant axis (horizontal or vertical).
@@ -81,16 +105,14 @@ function ShapeDrawFeature({
   onCreate,
 }: ShapeDrawFeatureProps) {
   const toScene = useRcbScreenToScene();
-  const session = useRef<{
-    x0: number;
-    y0: number;
-    x1: number;
-    y1: number;
-    /** Last pointer position before axis snap (for Shift toggle mid-drag). */
-    rawX1: number;
-    rawY1: number;
-    shift: boolean;
-  } | null>(null);
+  const viewportEl = useRcbViewportEl();
+  const toSceneRef = useRef(toScene);
+  const onCreateRef = useRef(onCreate);
+  const shapeKindRef = useRef(shapeKind);
+  toSceneRef.current = toScene;
+  onCreateRef.current = onCreate;
+  shapeKindRef.current = shapeKind;
+  const session = useRef<ShapeDrawSession | null>(null);
   const [preview, setPreview] = useState<{
     x0: number;
     y0: number;
@@ -99,7 +121,7 @@ function ShapeDrawFeature({
   } | null>(null);
 
   useEffect(() => {
-    const hitEl = stageEl || paperEl;
+    const hitEl = rcbResolveViewportEl(viewportEl, stageEl, paperEl);
     if (!enabled || !hitEl) return undefined;
 
     const applyStrokeEnd = (
@@ -109,23 +131,60 @@ function ShapeDrawFeature({
       rawY1: number,
       shiftKey: boolean
     ) => {
-      const kind = shapeKind || 'rect';
+      const kind = shapeKindRef.current || 'rect';
       const isStroke = kind === 'line' || kind === 'arrow';
       if (!isStroke) return { x1: rawX1, y1: rawY1 };
       return snapStrokeAxis(x0, y0, rawX1, rawY1, shiftKey);
     };
 
+    const pointerScene = (clientX: number, clientY: number) =>
+      toSceneRef.current(clientX, clientY);
+
+    const releaseCapture = (pointerId: number) => {
+      try {
+        hitEl.releasePointerCapture?.(pointerId);
+      } catch {
+        /* ignore */
+      }
+    };
+
+    const applyPointerToSession = (
+      s: ShapeDrawSession,
+      clientX: number,
+      clientY: number,
+      shiftKey: boolean
+    ) => {
+      const p = pointerScene(clientX, clientY);
+      const end = applyStrokeEnd(s.x0, s.y0, p.x, p.y, shiftKey);
+      s.currentClientX = clientX;
+      s.currentClientY = clientY;
+      s.rawX1 = p.x;
+      s.rawY1 = p.y;
+      s.shift = shiftKey;
+      s.x1 = end.x1;
+      s.y1 = end.y1;
+      return { p, end };
+    };
+
     const onDown = (e: PointerEvent) => {
       if (e.button !== 0) return;
-      const p = toScene(e.clientX, e.clientY);
+      const p = pointerScene(e.clientX, e.clientY);
+      const metrics = rcbViewportMetrics(hitEl);
       session.current = {
         x0: p.x,
         y0: p.y,
         x1: p.x,
         y1: p.y,
+        clientX0: e.clientX,
+        clientY0: e.clientY,
+        currentClientX: e.clientX,
+        currentClientY: e.clientY,
+        scaleX: metrics.scaleX,
+        scaleY: metrics.scaleY,
         rawX1: p.x,
         rawY1: p.y,
         shift: e.shiftKey,
+        pointerId: e.pointerId,
       };
       setPreview({ x0: p.x, y0: p.y, x1: p.x, y1: p.y });
       hitEl.setPointerCapture?.(e.pointerId);
@@ -134,54 +193,55 @@ function ShapeDrawFeature({
     };
 
     const onMove = (e: PointerEvent) => {
-      if (!session.current) return;
-      const p = toScene(e.clientX, e.clientY);
-      const { x0, y0 } = session.current;
-      const end = applyStrokeEnd(x0, y0, p.x, p.y, e.shiftKey);
-      session.current.rawX1 = p.x;
-      session.current.rawY1 = p.y;
-      session.current.shift = e.shiftKey;
-      session.current.x1 = end.x1;
-      session.current.y1 = end.y1;
-      setPreview({ x0, y0, x1: end.x1, y1: end.y1 });
+      const s = session.current;
+      if (!s || e.pointerId !== s.pointerId) return;
+      // Position state only updates from move (and down). End events may report 0,0.
+      const { end } = applyPointerToSession(s, e.clientX, e.clientY, e.shiftKey);
+      setPreview({ x0: s.x0, y0: s.y0, x1: end.x1, y1: end.y1 });
     };
 
-    const onUp = (e: PointerEvent) => {
-      if (!session.current) return;
-      const p = toScene(e.clientX, e.clientY);
-      const { x0, y0 } = session.current;
-      const kind = shapeKind || 'rect';
+    /**
+     * End events are a lifecycle signal only. Commit geometry from the session's
+     * current point (last down/move). End-event clientX/Y are unreliable on
+     * narrow / touch / device-mode viewports (often 0,0).
+     */
+    const finishSession = (e: PointerEvent) => {
+      const s = session.current;
+      if (!s || e.pointerId !== s.pointerId) return;
+      const kind = shapeKindRef.current || 'rect';
       const isStroke = kind === 'line' || kind === 'arrow';
-      const end = applyStrokeEnd(x0, y0, p.x, p.y, e.shiftKey);
+      const end = applyStrokeEnd(s.x0, s.y0, s.rawX1, s.rawY1, s.shift);
+      const x0 = s.x0;
+      const y0 = s.y0;
       const x1 = end.x1;
       const y1 = end.y1;
+      const box = normalizeBox(x0, y0, x1, y1);
       session.current = null;
       setPreview(null);
-      try {
-        hitEl.releasePointerCapture?.(e.pointerId);
-      } catch {
-        /* ignore */
-      }
+      releaseCapture(e.pointerId);
+
       if (isStroke) {
         if (Math.hypot(x1 - x0, y1 - y0) < 3) return;
-        const box = normalizeBox(x0, y0, x1, y1);
-        onCreate(kind, { ...box, x0, y0, x1, y1 });
+        onCreateRef.current(kind, { ...box, x0, y0, x1, y1 });
         return;
       }
-      let box = normalizeBox(x0, y0, x1, y1);
-      if (box.width < 3 && box.height < 3) return;
-      if (locksSquareAspect(kind)) box = squareLockedBox(box);
-      onCreate(kind, box);
+      let next = box;
+      if (next.width < 3 && next.height < 3) return;
+      if (locksSquareAspect(kind)) next = squareLockedBox(next);
+      onCreateRef.current(kind, next);
     };
 
+    // Move on window so current point stays fresh even outside the stage.
+    // Up/cancel both finish from session current — not from end-event coords.
     hitEl.addEventListener('pointerdown', onDown);
-    hitEl.addEventListener('pointermove', onMove);
-    hitEl.addEventListener('pointerup', onUp);
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', finishSession);
+    window.addEventListener('pointercancel', finishSession);
 
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Shift' || !session.current) return;
       const { x0, y0, rawX1, rawY1 } = session.current;
-      const kind = shapeKind || 'rect';
+      const kind = shapeKindRef.current || 'rect';
       if (kind !== 'line' && kind !== 'arrow') return;
       const shift = e.type === 'keydown';
       const end = snapStrokeAxis(x0, y0, rawX1, rawY1, shift);
@@ -195,12 +255,15 @@ function ShapeDrawFeature({
 
     return () => {
       hitEl.removeEventListener('pointerdown', onDown);
-      hitEl.removeEventListener('pointermove', onMove);
-      hitEl.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', finishSession);
+      window.removeEventListener('pointercancel', finishSession);
       window.removeEventListener('keydown', onKey);
       window.removeEventListener('keyup', onKey);
     };
-  }, [enabled, paperEl, stageEl, toScene, shapeKind, onCreate]);
+    // Intentionally omit toScene/onCreate/shapeKind — read via refs so a parent
+    // re-render cannot tear down listeners mid-drag.
+  }, [enabled, paperEl, stageEl, viewportEl]);
 
   if (!enabled || !preview) return null;
 
@@ -251,6 +314,7 @@ function ShapeDrawFeature({
     }
     return (
       <div
+        data-shape-draw-preview
         className="pointer-events-none absolute z-20"
         style={{ left, top, width: vw, height: vh }}
       >
@@ -326,6 +390,7 @@ function ShapeDrawFeature({
 
   return (
     <div
+      data-shape-draw-preview
       className="pointer-events-none absolute z-20"
       style={{
         left: drawLeft,

--- a/apps/web/src/components/templates/TemplateGrid.tsx
+++ b/apps/web/src/components/templates/TemplateGrid.tsx
@@ -398,18 +398,16 @@ function TemplateGrid({
             onToggle={() => toggle(item.id)}
             onRename={() => setRenameTarget(item)}
             onCommitRename={(name) => commitRenameFor(item, name)}
-            onDelete={() => {
+            onDelete={async () => {
               const id = item.id;
-              void (async () => {
-                try {
-                  await removeProjectFromCloud(id);
-                  dispatch(deleteTemplate(id));
-                  setSelected((prev) => prev.filter((x) => x !== id));
-                  message.destructive(t('common.delete'));
-                } catch {
-                  message.error(t('home.batchDeleteFailed'));
-                }
-              })();
+              try {
+                await removeProjectFromCloud(id);
+                dispatch(deleteTemplate(id));
+                setSelected((prev) => prev.filter((x) => x !== id));
+                message.destructive(t('common.delete'));
+              } catch {
+                message.error(t('home.batchDeleteFailed'));
+              }
             }}
           />
         ))}

--- a/apps/web/src/pages/ActivateEmailPage.tsx
+++ b/apps/web/src/pages/ActivateEmailPage.tsx
@@ -26,7 +26,7 @@ function ActivateEmailPage() {
       setError(t('auth.linkInvalid') || 'Invalid login link');
       return;
     }
-    void (async () => {
+    async function activateLink() {
       try {
         const res = await activateEmailLink({ id: token });
         dispatch(
@@ -52,7 +52,8 @@ function ActivateEmailPage() {
             : '';
         setError(detail || t('auth.linkInvalid') || 'Invalid or expired login link');
       }
-    })();
+    }
+    activateLink();
   }, [dispatch, id, navigate, t]);
 
   return (

--- a/apps/web/src/pages/EditorPage.tsx
+++ b/apps/web/src/pages/EditorPage.tsx
@@ -1011,7 +1011,7 @@ function EditorPage() {
     if (!currentId || !document) return;
     if (sessionReadyForIdRef.current === currentId) return;
     let cancelled = false;
-    void (async () => {
+    async function restoreSession() {
       const session = await getProjectSession(currentId).catch(() => null);
       if (cancelled) return;
       // Do not restore session.camera — enter page always fits content once after load.
@@ -1034,7 +1034,8 @@ function EditorPage() {
         dispatch(setMixedSelection({ nodeIds, frameIds }));
       }
       sessionReadyForIdRef.current = currentId;
-    })();
+    }
+    restoreSession();
     return () => {
       cancelled = true;
     };
@@ -1107,10 +1108,6 @@ function EditorPage() {
       { replace: true }
     );
   }, [currentId, routeProjectId, navigate, location.search]);
-
-  useEffect(() => {
-    setStageEl(stageRef.current);
-  }, [document, frames.length, bootOpen]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -1546,16 +1543,14 @@ function EditorPage() {
                 <button
                   type="button"
                   aria-label={t('editor.home', { defaultValue: '首页' })}
-                  onClick={() => {
-                    void (async () => {
-                      try {
-                        // Always push doc + auto cover on leave (dirty may already be clear).
-                        await flushCurrentProjectNow({ force: true });
-                      } catch {
-                        /* still navigate — local draft already holds bytes */
-                      }
-                      navigate('/home');
-                    })();
+                  onClick={async () => {
+                    try {
+                      // Always push doc + auto cover on leave (dirty may already be clear).
+                      await flushCurrentProjectNow({ force: true });
+                    } catch {
+                      /* still navigate — local draft already holds bytes */
+                    }
+                    navigate('/home');
                   }}
                   className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-[var(--accent-soft)] text-[var(--ink)] shadow-sm ring-1 ring-[var(--line)] transition hover:bg-[var(--line)]"
                 >
@@ -1680,6 +1675,7 @@ function EditorPage() {
                 panBlockSelector={EDITOR_PAN_BLOCK_SELECTOR}
                 background={stageBackground}
                 stageRef={stageRef}
+                onViewportEl={setStageEl}
                 cursor={canvasCursor}
                 defs={<RcbSvgDefs />}
                 showGrid={isGridMode}
@@ -2027,11 +2023,9 @@ function EditorPage() {
             onAttachConsumed={() => setAttachToChat(null)}
             dataTour={agentOpen ? 'editor-agent' : undefined}
             projectName={isMobileViewport ? projectName : undefined}
-            onGoHome={isMobileViewport ? () => {
-              void (async () => {
-                try { await flushCurrentProjectNow({ force: true }); } catch { /* ignore */ }
-                navigate('/home');
-              })();
+            onGoHome={isMobileViewport ? async () => {
+              try { await flushCurrentProjectNow({ force: true }); } catch { /* ignore */ }
+              navigate('/home');
             } : undefined}
             canvasUi={{
               getZoom: () => camera.zoom,

--- a/apps/web/src/pages/GoogleOAuthCallbackPage.tsx
+++ b/apps/web/src/pages/GoogleOAuthCallbackPage.tsx
@@ -40,7 +40,7 @@ function GoogleOAuthCallbackPage() {
       return;
     }
 
-    void (async () => {
+    async function completeGoogleLogin() {
       try {
         const res = await loginGoogle({
           code,
@@ -63,7 +63,8 @@ function GoogleOAuthCallbackPage() {
         const detail = e?.response?.data?.detail || e?.message || 'Google login failed';
         setError(typeof detail === 'string' ? detail : JSON.stringify(detail));
       }
-    })();
+    }
+    completeGoogleLogin();
   }, [dispatch, navigate, params, t]);
 
   return (

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -27,8 +27,6 @@
 
   html {
     font-family: var(--font-sans);
-    /* Discourage browser / trackpad page zoom; canvas has its own camera zoom. */
-    touch-action: manipulation;
   }
 
   body {
@@ -40,7 +38,6 @@
     color: var(--ink);
     -webkit-font-smoothing: antialiased;
     overflow: hidden;
-    touch-action: manipulation;
   }
 
   /* Force chrome controls to inherit PuHuiTi (Tailwind/preflight + portaled UI). */


### PR DESCRIPTION
## Summary
- Stabilize canvas draw/move on tablet/DevTools by using `touch-action: none`, ignoring bogus end-event coords, and keeping viewport scale correction in screen↔scene math.
- Place the right-click menu from the last real pointer position when `contextmenu` reports synthetic `(0,0)`/`(1,1)`, and clamp without pinning to the corner.
- Unify selection/generator toolbar clicks via pointer activate so `onClick` controls keep working under touch.
- Replace `void (async () => {})()` call sites with async functions; stop blocking browser page zoom globally.

## Test plan
- [ ] On desktop: draw/move shapes, open context menu at click, toolbar buttons work
- [ ] In DevTools iPad / ~768px: draw and move follow the pointer
- [ ] Right-click menu appears near the cursor (not top-left)
- [ ] Image generator / selection toolbar buttons are clickable
- [ ] Browser Ctrl/⌘ zoom still works outside the canvas

Made with [Cursor](https://cursor.com)