### PR TITLE
Remove README footer brand lockup

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,3 @@ See [LICENSE](./LICENSE) for the full text.
 Open source takes time. If Recombyn helps your work, please hit **⭐ Star** in the top-right of the GitHub repo — your support is the best fuel for making it better.
 
 → [https://github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)
-
----
-
-<p align="center">
-  <img src="docs/assets/recombyn-lockup-light.svg" alt="recombyn" height="40" />
-</p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -101,9 +101,3 @@ e2e/               Playwright
 开源不易，如果觉得 Recombyn 对您的工作还有帮助，请帮忙在 GitHub 仓库右上角点个 ⭐ Star。您的支持是让 Recombyn 变得更好最大的动力。
 
 → [https://github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)
-
----
-
-<p align="center">
-  <img src="docs/assets/recombyn-lockup-light.svg" alt="recombyn" height="40" />
-</p>


### PR DESCRIPTION
## Summary
- Remove the centered recombyn lockup image from the bottom of `README.md` and `README.zh-CN.md`.
- Keep the Star section and GitHub link.

## Test plan
- [ ] Preview README on GitHub — no lockup under the Star section

Made with [Cursor](https://cursor.com)