### PR TITLE
Use 3 columns for Me profile feed on iPad

### DIFF
--- a/apps/web/src/components/home/MePage.tsx
+++ b/apps/web/src/components/home/MePage.tsx
@@ -34,8 +34,8 @@ import {
 import { message } from '@/components/base';
 import { getToken } from '@/utils/token';
 
-/** Me profile feed only — 2 cols on phone / iPad (not plaza density). */
-const ME_FLOW_COLUMNS = 'w-full columns-2 gap-4 xl:columns-3 2xl:columns-4';
+/** Me profile feed — 2 cols phone, 3 cols iPad+, denser on wide desktop. */
+const ME_FLOW_COLUMNS = 'w-full columns-2 gap-4 md:columns-3 2xl:columns-4';
 
 /** Edit-profile icon (person + pencil) — stroke follows currentColor. */
 function ProfileEditIcon({ className }: { className?: string }) {


### PR DESCRIPTION
## Summary
- Me Published/Liked waterfall: `md:columns-3` so iPad is 3 columns instead of staying at 2 until `xl`.

## Test plan
- [ ] Phone width: 2 columns
- [ ] iPad / ~768px: 3 columns
- [ ] Wide desktop: 4 columns at 2xl

Made with [Cursor](https://cursor.com)