### PR TITLE
Keep view/download share links on the preview page

### DIFF
--- a/apps/api/services/shares/store.py
+++ b/apps/api/services/shares/store.py
@@ -68,17 +68,20 @@ def _link_public(row: Any) -> bool:
 
 
 def actor_can_edit_share(row: Any, *, actor_user_id: str | None) -> bool:
-    """Open full editor: owner always; else permission=edit + listed collaborator."""
+    """Open full editor only for edit links (owner or listed collaborator).
+
+    Preview / download links stay on the share viewer — including when the owner
+    opens their own view link to verify it.
+    """
     actor = (actor_user_id or "").strip()
     if not actor:
         return False
-    owner_id = str(row["owner_id"] or "")
-    # Owner needs the normal editor chrome (tools / layers) even for preview links.
-    if actor == owner_id:
-        return True
     perm = (row["permission"] or "preview").strip().lower()
     if perm != "edit":
         return False
+    owner_id = str(row["owner_id"] or "")
+    if actor == owner_id:
+        return True
     editors = _parse_user_ids(_col(row, "editor_user_ids"))
     return actor in editors
 

--- a/apps/web/src/pages/SharePage.tsx
+++ b/apps/web/src/pages/SharePage.tsx
@@ -165,7 +165,8 @@ function SharePage() {
           setMissing(true);
           return;
         }
-        if (s.viewerCanEdit) {
+        // Only edit-ACL links jump into the editor. View / download stay here.
+        if (s.permission === 'edit' && s.viewerCanEdit) {
           // Owner → live project when known; collaborators stay on the share doc.
           const isOwner = Boolean(viewerId && s.ownerId === viewerId);
           const src = String(s.sourceProjectId || '').trim();


### PR DESCRIPTION
## Summary
- `viewerCanEdit` is true only for `permission=edit` (owner or listed collaborator).
- Share page redirects into the editor only for edit links; view/download stay on the preview viewer.

## Test plan
- [ ] Open a Can view share link while logged in as owner → preview page, not `/editor/...`
- [ ] Open a Can download share link → preview page with Export
- [ ] Open a Can edit share link as owner → still lands in the live editor

Made with [Cursor](https://cursor.com)