### PR TITLE
Ship core Agent skills and document Yjs collab

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,22 @@
 **Recombyn** is a **canvas editor + AI Design Agent** (source-available).  
 Design on an infinite canvas; a LangGraph agent edits layers, shapes, text, and layout through conversation — not one-shot image dumps.
 
-Self-host in minutes with Docker Compose (default **MySQL** + Redis + web + API). Local dev can use **SQLite** (empty `DATABASE_URL`), or **PostgreSQL** — see [docs/postgres-switch.md](docs/postgres-switch.md).
+Self-host in minutes with Docker Compose (default **MySQL** + Redis + web + API + **Yjs collab**). Local dev can use **SQLite** (empty `DATABASE_URL`), or **PostgreSQL** — see [docs/postgres-switch.md](docs/postgres-switch.md).
 
 ---
 
 ## Why Recombyn?
 
 - **Real canvas editing** — Frames, shapes, images, video, text; export and share
+- **Live multiplayer** — Yjs sync for the same project (cursors, selection, undo); share view-only or edit
 - **Agent that paints** — Conversation plans and applies canvas ops, not a single static render
 - **Self-host first** — Same stack locally or on a server; your data stays yours
-- **Composable** — Infra seeds + a minimal prompt-pack baseline under `apps/api/data/public/` (full product packs optional via `data/private/` or Admin)
+- **Composable** — Infra seeds + prompt packs + **5 core Agent skills** under `apps/api/data/public/` (full product packs optional via `data/private/` or Admin)
 
 ## Core features
 
 - **Visual editor** — selection, layers, fills, export, share
+- **Realtime collab** — Yjs WebSocket room (`apps/collab`); Live bar in the editor; WSS via nginx `/collab/`
 - **Design Agent** — LangGraph tools / skills; create, edit, and chat with streaming UI
 - **Image import** — local images → editable canvas nodes
 - **Plaza & projects** — inspiration feed and saved work (API)
@@ -66,14 +68,18 @@ docker compose up -d redis   # or: mysql redis
 npm install
 cp apps/api/.env.example apps/api/.env
 npm run dev:api              # empty DATABASE_URL → SQLite
+npm run dev:collab           # Yjs WS on :1234 (optional; Vite DEV defaults collab on)
 npm run dev:web
 ```
+
+Canvas Live / WSS setup: **[docs/self-hosting.md § Canvas multiplayer](docs/self-hosting.md#canvas-multiplayer-yjs--wss)** · [apps/collab/README.md](apps/collab/README.md)
 
 ## Repository layout
 
 ```
-apps/web/          React canvas + Agent UI
-apps/api/          FastAPI — Scene, Agent, plaza, wallet
+apps/web/          React canvas + Agent UI + Yjs client
+apps/api/          FastAPI — Scene, Agent, plaza, wallet, collab tokens
+apps/collab/       Yjs WebSocket server (y-websocket)
 apps/docs/         Help / legal site
 packages/          Shared builders & schemas
 docs/              Architecture + self-hosting

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -23,20 +23,22 @@
 **Recombyn** 是 **画布编辑器 + AI Design Agent**（源码可得 / source-available）。  
 在无限画布上创作；Agent 基于 LangGraph 直接改图层、图形、文字与布局——用对话驱动设计，而不是生成一张死图。
 
-几分钟用 Docker Compose 自托管（默认 **MySQL** + Redis + Web + API）。本地开发可空 `DATABASE_URL` 用 **SQLite**；也可切 **PostgreSQL**（见 [docs/postgres-switch.md](docs/postgres-switch.md)）。
+几分钟用 Docker Compose 自托管（默认 **MySQL** + Redis + Web + API + **Yjs 协作**）。本地开发可空 `DATABASE_URL` 用 **SQLite**；也可切 **PostgreSQL**（见 [docs/postgres-switch.md](docs/postgres-switch.md)）。
 
 ---
 
 ## 为什么选 Recombyn？
 
 - **真·画布编辑** — 画板、形状、图片、视频、文字，可导出与分享
+- **实时多人协作** — 同一项目 Yjs 同步（光标、选区、撤销）；分享可只读或可编辑
 - **Agent 落笔改稿** — 对话规划并执行画布操作，不是一次性出图
 - **自托管优先** — 本地 / 服务器同一套栈，数据在你这边
-- **可组合** — `apps/api/data/public/` 含基建种子 + 最小可跑提示词包；完整产品内容可放 `data/private/` 或 Admin
+- **可组合** — `apps/api/data/public/` 含基建种子 + 提示词包 + **5 个核心 Agent Skill**；完整产品内容可放 `data/private/` 或 Admin
 
 ## 核心能力
 
 - **可视化编辑** — 选区、图层、填充、导出、分享  
+- **实时协作** — Yjs WebSocket（`apps/collab`）；编辑器 Live 状态条；生产经 nginx `/collab/` 走 WSS  
 - **Design Agent** — LangGraph 工具 / 技能；创建 / 编辑 / 闲聊，流式对话 UI  
 - **图片导入** — 本地图片 → 可编辑画布节点  
 - **广场与项目** — 灵感流与作品（API）
@@ -65,14 +67,18 @@ docker compose up -d redis
 npm install
 cp apps/api/.env.example apps/api/.env
 npm run dev:api              # 空 DATABASE_URL → SQLite
+npm run dev:collab           # Yjs WS :1234（可选；Vite DEV 默认开协作）
 npm run dev:web
 ```
+
+画布 Live / WSS：**[docs/self-hosting.md § Canvas multiplayer](docs/self-hosting.md#canvas-multiplayer-yjs--wss)** · [apps/collab/README.md](apps/collab/README.md)
 
 ## 仓库结构
 
 ```
-apps/web/          React 画布 + Agent UI
-apps/api/          FastAPI
+apps/web/          React 画布 + Agent UI + Yjs 客户端
+apps/api/          FastAPI（含 collab room-token）
+apps/collab/       Yjs WebSocket 服务（y-websocket）
 apps/docs/         帮助 / 法律站
 packages/          共享协议
 docs/              架构与自托管（含 Postgres 切换）

--- a/apps/api/data/README.md
+++ b/apps/api/data/README.md
@@ -9,11 +9,13 @@ apps/api/data/
 
 | Location | Git | Role |
 |----------|-----|------|
-| `data/public/` | Tracked | OSS baseline + infra (`canvas_actions`, fonts, stages, minimal prompt packs, …) |
-| `data/private/` | Not in git | Full product prompts / skills / knowledge / tokens / models / cases |
+| `data/public/` | Tracked | OSS baseline + infra (`canvas_actions`, fonts, stages, prompt packs, **core skills**, …) |
+| `data/private/` | Not in git | Full product prompts / extra skills / knowledge / tokens / models / cases |
 
 Loaders use `resolve_data_file` / `resolve_data_dir`: **private wins** when the path exists.
 
 `design_prompt_packs_seed.json` in **public** is a **minimal English runnable baseline** (enough for Agent cold start). Tuned product packs stay in **private** or Admin.
+
+`design_skills_seed.json` in **public** ships the **5 core skills** (`design_methodology`, `vision_extract`, `aesthetics_align`, `canvas_edit`, `image_gen`). Designer workflow skills (`user.*`) stay Admin / private.
 
 Create `data/private/` locally (or on the SaaS host) and drop seed JSON there — same filenames as under `public/`. Optional: `DESIGN_DATA_PRIVATE_DIR` (absolute, or relative to `apps/api`).

--- a/apps/api/data/public/design_skills/README.md
+++ b/apps/api/data/public/design_skills/README.md
@@ -1,6 +1,6 @@
 # Design skills (OSS baseline)
 
-Open-source ships a **minimal** skill set so self-host Agent can create / edit / vision / image-gen.
+Open-source ships **5 core skills** in `design_skills_seed.json` so self-host Agent can create / edit / vision / image-gen out of the box.
 
 ## Namespaces
 

--- a/apps/api/data/public/design_skills_seed.json
+++ b/apps/api/data/public/design_skills_seed.json
@@ -1,4 +1,129 @@
 {
-  "items": [],
-  "_comment": "OSS stub. Put full skills in data/private/design_skills_seed.json"
+  "_comment": "OSS core skills for self-host Agent cold start (create / vision / aesthetics / edit / image). Product workflow skills (user.*) stay Admin or data/private.",
+  "items": [
+    {
+      "skill_key": "design_methodology",
+      "name": "设计方法论",
+      "category": "create",
+      "when_to_use": "从零创作：确认物料与步骤骨架；落层细则另开 layout_ops",
+      "scenes": "all",
+      "sort_weight": 100,
+      "preferred_tools": [
+        "create_frame",
+        "create_shape",
+        "create_text",
+        "create_image",
+        "create_svg",
+        "update_node"
+      ],
+      "prompt_positive": "# 设计方法论\n\n从零创作的步骤骨架。元素用什么 op、放哪、矢量/生图/透明底 → need_skills=[\"user.layout_ops\"]。配色/Banner 像素等数字细则 → need_knowledge（从 Knowledge 目录选）。\n\n## 物料（一句话）\n- **website / 落地页**：导航 → 英雄 → 卖点 → CTA → 页脚\n- **mobile / H5**：单列；主 CTA 在易触区\n- **电商主图**：约 1:1；主体最大；无导航无表单\n- **电商详情**：主图 → 标题价格 → 卖点 → 规格 → 图文\n- **Banner**：文案在中部安全带\n- **poster / 易拉宝**：主视觉 + 信息组；竖长上中下\n- **image**：主体图形；无页面壳\n\n## 步骤\n1. 确认物料、尺寸、必出文案；缺则 ask；未提供的价格/电话不写\n2. 固定尺寸先 create_frame，再板内落层（细则见 user.layout_ops）\n3. 有附图 → need_skills 含 vision_extract；产品工作流（需求整理等）按目录再加 user.*\n4. 节点 id 必须来自 SCENE\n",
+      "prompt_negative": "缺关键信息时不要直接堆 tool_ops；勿编造价格与电话；勿在本 skill 展开落层坐标与 op 对照表。",
+      "triggers": [
+        {
+          "empty_canvas": true,
+          "intent_in": [
+            "create"
+          ]
+        },
+        {
+          "intent_in": [
+            "create"
+          ],
+          "min_prompt_chars": 24
+        }
+      ],
+      "mutex_group": "methodology",
+      "version": 6
+    },
+    {
+      "skill_key": "vision_extract",
+      "name": "看图抽取",
+      "category": "vision",
+      "when_to_use": "用户附图：识别物料并抽取版式、元素、配色",
+      "scenes": "all",
+      "sort_weight": 90,
+      "preferred_tools": [
+        "create_frame",
+        "create_shape",
+        "create_text",
+        "create_image",
+        "update_node"
+      ],
+      "prompt_positive": "# 看图抽取\n\n只写图中可见内容。标明物料：主图 / 商详 / Banner / 海报 / 易拉宝 / 网页或 App / 插画图标。\n\n列出：分区、关键元素与大致位置、主色 3～5、建议宽高或比例。\n主图写主体与角标；商详写模块分段；Banner 写文案是否在中部；竖长图写上中下。\n",
+      "prompt_negative": "图中没有的价格、文案、模块不要补写。",
+      "triggers": [
+        {
+          "has_images": true,
+          "intent_in": [
+            "create"
+          ]
+        }
+      ],
+      "mutex_group": "vision",
+      "version": 5
+    },
+    {
+      "skill_key": "aesthetics_align",
+      "name": "美学对齐",
+      "category": "aesthetics",
+      "when_to_use": "有美学样本时参考构图与配色",
+      "scenes": "all",
+      "sort_weight": 80,
+      "preferred_tools": [
+        "create_frame",
+        "create_shape",
+        "create_text",
+        "create_image",
+        "update_node"
+      ],
+      "prompt_positive": "# 美学对齐\n\n参考样本的构图分区、留白、层级、配色；按当前物料调整疏密。\n结束后 need_aesthetics=false。\n",
+      "prompt_negative": "不要复制样本文案、Logo、二维码、价格数字。",
+      "triggers": [
+        {
+          "need_aesthetics": true
+        }
+      ],
+      "mutex_group": "aesthetics",
+      "version": 5
+    },
+    {
+      "skill_key": "canvas_edit",
+      "name": "画布增改",
+      "category": "edit",
+      "when_to_use": "已有画布上加形、改色、改字、挪位",
+      "scenes": "all",
+      "sort_weight": 70,
+      "preferred_tools": [
+        "create_shape",
+        "create_text",
+        "update_node",
+        "delete_nodes",
+        "move_nodes",
+        "resize_nodes"
+      ],
+      "prompt_positive": "# 画布增改\n\n加形/改色/改字直接 tool_ops；缺省尺寸颜色用合理默认。\n改类型用 update_node，保留 id。\n节点 id 仅使用 SCENE 已有。\n主图保持主体与留白；商详保持模块顺序；Banner 保持安全带内文案。\n",
+      "prompt_negative": "局部修改不要新建空画板；不要用 delete+create 改类型。",
+      "triggers": [],
+      "mutex_group": "",
+      "version": 5
+    },
+    {
+      "skill_key": "image_gen",
+      "name": "生图配图",
+      "category": "image",
+      "when_to_use": "需要 create_image（含艺术字作图）",
+      "scenes": "all",
+      "sort_weight": 60,
+      "preferred_tools": [
+        "create_image",
+        "create_frame",
+        "update_node"
+      ],
+      "prompt_positive": "# 生图配图\n\n`create_image` 的 `genPrompt`（或 `prompt`）：给图像模型的自然语言描述，用来生成位图；不是画布上的可编辑文字节点。\n\n## 选型（由你判断，勿套固定文案品类清单）\n- **create_image**：需要摄影/插画/材质，或文字本身是视觉特效（书法笔触、分色块字、立体挤出等——字体文件做不到）→ 整块当图形生图；prompt 写清要出现的字、风格、配色、是否透明底。\n- **create_text**：需要可编辑、可改字、当图层文字排版的内容（无上述特效）。\n\n用户禁止生图时跳过 create_image；特效字退回简洁 create_text，勿假装有书法字体。\n艺术字可带 letteringText（图上原文），便于 image_process kind=replaceText（meta.originalText+newText）换字。\n未提供的事实信息不要编造进画面。\n尺寸、透明底、叠层位置见 user.layout_ops（勿在此展开）。\n",
+      "prompt_negative": "用户禁止生图时不要 create_image；勿用 create_text 冒充书法/立体艺术字；勿写死「某类文案必须用某 op」。",
+      "triggers": [],
+      "mutex_group": "image",
+      "version": 9
+    }
+  ]
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,17 +4,20 @@
 
 | Path | Role |
 |------|------|
-| `apps/web` | React editor, home, Agent chat |
-| `apps/api` | FastAPI: import, projects/plaza, Design Agent, etc. |
+| `apps/web` | React editor, home, Agent chat, Yjs collab client |
+| `apps/api` | FastAPI: import, projects/plaza, Design Agent, collab room tokens |
+| `apps/collab` | Yjs WebSocket server (`y-websocket`); proxied as `/collab/` |
 | `apps/docs` | User help and legal docs site |
 | `packages/scene-schema` | Scene JSON protocol |
 | `packages/scene-builder-py` | Parse blocks → Scene JSON |
 
-Backend details: [apps/api/README.md](../apps/api/README.md).
+Backend details: [apps/api/README.md](../apps/api/README.md). Collab: [apps/collab/README.md](../apps/collab/README.md) · [self-hosting § multiplayer](./self-hosting.md#canvas-multiplayer-yjs--wss).
 
 ## Web canvas
 
 Mixed scenes of about **5k** nodes stay smooth for daily editing (Chromium pan median ~**17ms**); rectangle-heavy scenes can reach ~**10k**; for very heavy paths, keep roughly **1k–2k** per scene. Implemented with viewport culling + LOD, spatial-index hits, and copy-on-write history. Retest: `npm run test:stress --workspace=apps/web`.
+
+**Realtime collab:** when enabled, the live scene truth is a Y.Doc (synced over WS); Redux is the UI projection. Room tokens from `POST /api/v1/collab/room-token`; view-only peers cannot seed or persist.
 
 ## Backend layers
 
@@ -57,5 +60,5 @@ Async jobs: Redis + Celery (`POST /api/v1/import/jobs`, `source_type=image`).
 
 ## Deploy
 
-Dev: `npm run dev:web` + `npm run dev:api` (+ Redis / Worker as needed)  
-Prod: Docker Compose (web + api + worker + redis)
+Dev: `npm run dev:web` + `npm run dev:api` + `npm run dev:collab` (+ Redis / Worker as needed)  
+Prod: Docker Compose (web + api + worker + redis + **collab**); public HTTPS needs `wss://` and shared `COLLAB_TOKEN_SECRET`

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -8,7 +8,8 @@ Run the full product on your own machine or server with Docker Compose (or local
 |-------|---------|
 | Web editor | http://localhost:3000 |
 | API | http://localhost:8000 (`/docs`) |
-| Collab (Yjs WS) | via web proxy `ws://localhost:3000/collab/…` |
+| Collab (Yjs WS) | compose `collab` · browser via `ws://localhost:3000/collab/…` (prod: `wss://`) |
+| Agent seeds | prompt packs + **5 core skills** from `apps/api/data/public/` |
 | **MySQL 8** | compose service + volume `mysql_data` |
 | Redis | Celery / queues |
 
@@ -25,7 +26,8 @@ Default config loads from seed JSON under `apps/api/data/public/` (optional `pri
 | Seed | Public (git) | Notes |
 |------|--------------|--------|
 | Prompt packs | Minimal English baseline | Enough to avoid `missing prompt pack` on Agent; replace via Admin or `data/private/design_prompt_packs_seed.json` for production quality |
-| Skills / knowledge / tokens / models | Often stub or infra-only | Full product content → `data/private/` (gitignored) |
+| Skills (core) | 5 core playbooks | `design_methodology` / `vision_extract` / `aesthetics_align` / `canvas_edit` / `image_gen` — Agent can create & edit out of the box |
+| Knowledge / tokens / models / cases | Often stub or infra-only | Full product content → `data/private/` (gitignored) |
 | Canvas actions, fonts, dicts, stages | Shipped in public | |
 
 See [data/README.md](../apps/api/data/README.md) and [design_skills/README.md](../apps/api/data/public/design_skills/README.md) (namespaces `core` / `ext` / `user`, ACL, hot reload).


### PR DESCRIPTION
## Summary
- Publish five core Agent skills in `apps/api/data/public/design_skills_seed.json` for self-host cold start.
- Update README (EN/ZH), self-hosting, and architecture docs for Yjs realtime canvas collab + core skills baseline.

## Test plan
- [ ] Fresh API seed inserts the five core skills (methodology / vision / aesthetics / edit / image)
- [ ] README mentions Live/Yjs and links to self-hosting collab section
- [ ] `docs/self-hosting.md` still documents `COLLAB_*` / WSS setup
