### PR TITLE
Unify share boot UI and stabilize canvas camera fit

### DIFF
--- a/apps/web/src/components/editor/canvas/SvgCanvas.tsx
+++ b/apps/web/src/components/editor/canvas/SvgCanvas.tsx
@@ -115,6 +115,7 @@ import {
   setCanvasAttachPickBlocked,
   setPendingCanvasAttach,
   setGridMode,
+  EMPTY_ID_LIST,
 } from '@/store/modules/editor';
 import { requestProjectFlush } from '@/components/editor/useProjectCloudSync';
 import {
@@ -304,7 +305,7 @@ function SvgCanvas({
     (s: any) => (s.editor.document?.activeFrameId as string | null) ?? null
   );
   const selectedFrameIds = useSelector(
-    (s: any) => (s.editor.selectedFrameIds as string[] | undefined) || []
+    (s: any) => (s.editor.selectedFrameIds as string[]) ?? EMPTY_ID_LIST
   );
 
   const paperRef = useRef<HTMLDivElement | null>(null);

--- a/apps/web/src/components/editor/chrome/BucketFillToolbar.tsx
+++ b/apps/web/src/components/editor/chrome/BucketFillToolbar.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Tooltip from '@/components/base/tooltip';
 import { FloatingToolbar } from '@/components/editor/chrome/FloatingToolbar';
@@ -10,24 +10,26 @@ import {
 import { setBucketFill } from '@/store/modules/editor';
 import { cn } from '@/utils/classnames';
 
+function bucketFillToPanelValue(raw: any): FillPanelValue {
+  return {
+    fillType: raw?.fillType || 'solid',
+    fillColor: String(raw?.fillColor || '#333333'),
+    fillOpacity: Number.isFinite(Number(raw?.fillOpacity)) ? Number(raw.fillOpacity) : 100,
+    fillGradient: raw?.fillGradient != null ? String(raw.fillGradient) : undefined,
+    fillImageSrc: raw?.fillImageSrc != null ? String(raw.fillImageSrc) : undefined,
+    fillImageFit: raw?.fillImageFit,
+    fillImageRotate: raw?.fillImageRotate,
+    fillImageAdjust: raw?.fillImageAdjust,
+  };
+}
+
 /**
  * Paint-bucket options: same FillPanel as shape fill (solid / gradient / image).
  */
 function BucketFillToolbar({ className }: { className?: string }) {
   const dispatch = useDispatch();
-  const value = useSelector((s: any) => {
-    const raw = s.editor.bucketFill || {};
-    return {
-      fillType: raw.fillType || 'solid',
-      fillColor: String(raw.fillColor || '#333333'),
-      fillOpacity: Number.isFinite(Number(raw.fillOpacity)) ? Number(raw.fillOpacity) : 100,
-      fillGradient: raw.fillGradient != null ? String(raw.fillGradient) : undefined,
-      fillImageSrc: raw.fillImageSrc != null ? String(raw.fillImageSrc) : undefined,
-      fillImageFit: raw.fillImageFit,
-      fillImageRotate: raw.fillImageRotate,
-      fillImageAdjust: raw.fillImageAdjust,
-    } as FillPanelValue;
-  });
+  const bucketFill = useSelector((s: any) => s.editor.bucketFill);
+  const value = useMemo(() => bucketFillToPanelValue(bucketFill), [bucketFill]);
   const preview = fillPanelPreview(value);
 
   return (

--- a/apps/web/src/components/editor/collab/CollabRoomProvider.tsx
+++ b/apps/web/src/components/editor/collab/CollabRoomProvider.tsx
@@ -33,7 +33,7 @@ import {
   markProjectDraftSynced,
 } from '@/components/editor/projectDraftStore';
 import store from '@/store';
-import { applyCollabDocument, applyCollabScenePatch } from '@/store/modules/editor';
+import { applyCollabDocument, applyCollabScenePatch, EMPTY_ID_LIST } from '@/store/modules/editor';
 import { getToken } from '@/utils/token';
 import {
   bindCollabUndoManager,
@@ -477,10 +477,10 @@ export function CollabRoomProvider({
   const document = useSelector((s: any) => s.editor.document);
   const currentId = useSelector((s: any) => s.editor.currentId as string | null);
   const selectedNodeIds = useSelector(
-    (s: any) => (s.editor.selectedNodeIds as string[]) || []
+    (s: any) => (s.editor.selectedNodeIds as string[]) ?? EMPTY_ID_LIST
   );
   const selectedFrameIds = useSelector(
-    (s: any) => (s.editor.selectedFrameIds as string[]) || []
+    (s: any) => (s.editor.selectedFrameIds as string[]) ?? EMPTY_ID_LIST
   );
   const activeFrameId = useSelector(
     (s: any) => (s.editor.document?.activeFrameId as string | null) || null

--- a/apps/web/src/components/editor/nodes/ImageGeneratorNode/ImageGeneratorCard.tsx
+++ b/apps/web/src/components/editor/nodes/ImageGeneratorNode/ImageGeneratorCard.tsx
@@ -65,6 +65,7 @@ import {
   patchDocumentNode,
   setDocumentFromCanvas,
   startCanvasAttachPick,
+  EMPTY_ID_LIST,
 } from '@/store/modules/editor';
 import { FREE_IMAGE_MODEL_ID } from '@/utils/wallet';
 import { cn } from '@/utils/classnames';
@@ -445,10 +446,10 @@ function ImageGeneratorCard({
   const pickTarget = `node:${nodeId}`;
   const pickingFromCanvas = canvasAttachPick?.target === pickTarget;
   const selectedNodeIds = useSelector(
-    (state: any) => (state.editor?.selectedNodeIds || []) as string[]
+    (state: any) => (state.editor?.selectedNodeIds as string[]) ?? EMPTY_ID_LIST
   );
   const selectedFrameIds = useSelector(
-    (state: any) => (state.editor?.selectedFrameIds || []) as string[]
+    (state: any) => (state.editor?.selectedFrameIds as string[]) ?? EMPTY_ID_LIST
   );
 
   const [prompt, setPrompt] = useState('');

--- a/apps/web/src/components/editor/nodes/ImageGeneratorNode/ImageGeneratorOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/ImageGeneratorNode/ImageGeneratorOverlay.tsx
@@ -4,6 +4,7 @@ import { RcbOverlayPortal } from '@/components/rcb';
 import { isImageGeneratorNode } from '@/components/rcb/scene/document/sceneDocument';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import ImageGeneratorCard from '@/components/editor/nodes/ImageGeneratorNode/ImageGeneratorCard';
+import { EMPTY_ID_LIST } from '@/store/modules/editor';
 
 /**
  * Screen-space Image Generator composers for every generator plate on the canvas.
@@ -20,7 +21,7 @@ function ImageGeneratorOverlay({
   readOnly?: boolean;
 }): ReactNode {
   const selectedNodeIds: string[] = useSelector(
-    (state: any) => state.editor.selectedNodeIds || []
+    (state: any) => (state.editor.selectedNodeIds as string[]) ?? EMPTY_ID_LIST
   );
   const canvasAttachPick = useSelector(
     (state: any) => state.editor.canvasAttachPick as null | { target: string }

--- a/apps/web/src/components/editor/nodes/VideoGeneratorNode/VideoGeneratorCard.tsx
+++ b/apps/web/src/components/editor/nodes/VideoGeneratorNode/VideoGeneratorCard.tsx
@@ -57,6 +57,7 @@ import {
   patchDocumentNode,
   setDocumentFromCanvas,
   startCanvasAttachPick,
+  EMPTY_ID_LIST,
 } from '@/store/modules/editor';
 import { cn } from '@/utils/classnames';
 import { estimateVideoCredits } from '@/utils/imageCredits';
@@ -409,10 +410,10 @@ function VideoGeneratorCard({
   const pickTarget = `node:${nodeId}`;
   const pickingFromCanvas = canvasAttachPick?.target === pickTarget;
   const selectedNodeIds = useSelector(
-    (state: any) => (state.editor?.selectedNodeIds || []) as string[]
+    (state: any) => (state.editor?.selectedNodeIds as string[]) ?? EMPTY_ID_LIST
   );
   const selectedFrameIds = useSelector(
-    (state: any) => (state.editor?.selectedFrameIds || []) as string[]
+    (state: any) => (state.editor?.selectedFrameIds as string[]) ?? EMPTY_ID_LIST
   );
 
   const [prompt, setPrompt] = useState('');

--- a/apps/web/src/components/editor/nodes/VideoGeneratorNode/VideoGeneratorOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/VideoGeneratorNode/VideoGeneratorOverlay.tsx
@@ -4,6 +4,7 @@ import { RcbOverlayPortal } from '@/components/rcb';
 import { isVideoGeneratorNode } from '@/components/rcb/scene/document/sceneDocument';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import VideoGeneratorCard from '@/components/editor/nodes/VideoGeneratorNode/VideoGeneratorCard';
+import { EMPTY_ID_LIST } from '@/store/modules/editor';
 
 /**
  * Screen-space Video Generator composers for every generator plate on the canvas.
@@ -20,7 +21,7 @@ function VideoGeneratorOverlay({
   readOnly?: boolean;
 }): ReactNode {
   const selectedNodeIds: string[] = useSelector(
-    (state: any) => state.editor.selectedNodeIds || []
+    (state: any) => (state.editor.selectedNodeIds as string[]) ?? EMPTY_ID_LIST
   );
   const canvasAttachPick = useSelector(
     (state: any) => state.editor.canvasAttachPick as null | { target: string }

--- a/apps/web/src/components/editor/nodes/VideoNode/VideoTrimSessionHost.tsx
+++ b/apps/web/src/components/editor/nodes/VideoNode/VideoTrimSessionHost.tsx
@@ -15,7 +15,7 @@ import { FloatingToolbar } from '@/components/editor/chrome/FloatingToolbar';
 import { ImageToolSep, imageToolBtn } from '@/components/editor/nodes/ImageNode/imageToolbarShared';
 import { radiiFromAttrs } from '@/components/rcb/scene/document/sceneRadii';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
-import { closeVideoToolPanel, setDocument, setSelectedNodeId, setSelectedNodeIds } from '@/store/modules/editor';
+import { closeVideoToolPanel, setDocument, setSelectedNodeId, setSelectedNodeIds, EMPTY_ID_LIST } from '@/store/modules/editor';
 import { addNodeToDocument } from '@/components/rcb/scene/document/sceneDocument';
 import { message, Tooltip } from '@/components/base';
 import { nanoid } from 'nanoid';
@@ -266,7 +266,9 @@ function VideoTrimSessionHost({ document }: { document: any }): ReactNode {
         keepTime?: number;
       }
   );
-  const selectedNodeIds = useSelector((s: any) => (s.editor.selectedNodeIds || []) as string[]);
+  const selectedNodeIds = useSelector(
+    (s: any) => (s.editor.selectedNodeIds as string[]) ?? EMPTY_ID_LIST
+  );
   const open = panel?.kind === 'trim';
   const nodeId = open ? panel!.nodeId : '';
   const node = nodeId ? document?.deltaSetLike?.[nodeId] : null;

--- a/apps/web/src/components/editor/panels/AgentDock.tsx
+++ b/apps/web/src/components/editor/panels/AgentDock.tsx
@@ -38,6 +38,7 @@ import {
   startCanvasAttachPick,
   clearCanvasAttachPick,
   consumePendingCanvasAttach,
+  EMPTY_ID_LIST,
 } from '@/store/modules/editor';
 import MentionAttachPanel, {
   type MentionAttachItem,
@@ -2167,10 +2168,10 @@ function AgentDock({
   );
   const pickingFromCanvas = canvasAttachPick?.target === 'agent';
   const selectedNodeIds = useSelector(
-    (s: any) => (s.editor.selectedNodeIds || []) as string[]
+    (s: any) => (s.editor.selectedNodeIds as string[]) ?? EMPTY_ID_LIST
   );
   const selectedFrameIds = useSelector(
-    (s: any) => (s.editor.selectedFrameIds || []) as string[]
+    (s: any) => (s.editor.selectedFrameIds as string[]) ?? EMPTY_ID_LIST
   );
   const { projectId: routeProjectId } = useParams<{ projectId?: string }>();
   const location = useLocation();

--- a/apps/web/src/components/editor/panels/DevPropertiesPanel.tsx
+++ b/apps/web/src/components/editor/panels/DevPropertiesPanel.tsx
@@ -8,6 +8,7 @@ import Dropdown from '@/components/base/dropdown';
 import type { MenuItemType } from '@/components/base/dropdown/MenuItem';
 import Tooltip from '@/components/base/tooltip';
 import { ExportSelectionPanel } from '@/components/editor/panels/ExportSelectionPanel';
+import { EMPTY_ID_LIST } from '@/store/modules/editor';
 import { cn } from '@/utils/classnames';
 import { radiiFromAttrs } from '@/components/rcb/scene/document/sceneRadii';
 import {
@@ -371,7 +372,9 @@ function DevPropertiesPanel({
 }) {
   const { t } = useTranslation();
   const document = useSelector((s: any) => s.editor.document);
-  const selectedNodeIds = useSelector((s: any) => (s.editor.selectedNodeIds || []) as string[]);
+  const selectedNodeIds = useSelector(
+    (s: any) => (s.editor.selectedNodeIds as string[]) ?? EMPTY_ID_LIST
+  );
   const hoverNodeId = useSelector((s: any) => s.editor.devHoverNodeId as string | null);
   const nodeId =
     hoverNodeId || (selectedNodeIds.length === 1 ? selectedNodeIds[0] : null);

--- a/apps/web/src/components/editor/panels/ExportSelectionPanel.tsx
+++ b/apps/web/src/components/editor/panels/ExportSelectionPanel.tsx
@@ -12,6 +12,7 @@ import {
 } from '@floating-ui/react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
+import { EMPTY_ID_LIST } from '@/store/modules/editor';
 import {
   HiOutlineArrowDownTray,
   HiOutlineArrowUpTray,
@@ -550,7 +551,9 @@ type ExportMode = 'all' | 'selected';
 function EditorTopExportButton({ className }: { className?: string }) {
   const { t } = useTranslation();
   const document = useSelector((s: any) => s.editor.document);
-  const selectedNodeIds = useSelector((s: any) => s.editor.selectedNodeIds || []) as string[];
+  const selectedNodeIds = useSelector(
+    (s: any) => (s.editor.selectedNodeIds as string[]) ?? EMPTY_ID_LIST
+  );
   const projectName = useSelector((s: any) => {
     const id = s.editor.currentId;
     const row = (s.editor.templates || []).find((item: any) => item.id === id);

--- a/apps/web/src/components/editor/panels/LayerPanel.tsx
+++ b/apps/web/src/components/editor/panels/LayerPanel.tsx
@@ -35,6 +35,7 @@ import {
   setActiveFrameId,
   setSelectedNodeId,
   updateArtboardFrame,
+  EMPTY_ID_LIST,
 } from '@/store/modules/editor';
 
 type LayerStackRow = { kind: 'frame' | 'node'; id: string };
@@ -515,9 +516,9 @@ function LayerPanel({
   const selectedNodeId = useSelector((state: any) => state.editor.selectedNodeId);
   const activeFrameId = useSelector((state: any) => state.editor.document?.activeFrameId);
   const selectedFrameIds = useSelector(
-    (state: any) => (state.editor.selectedFrameIds as string[] | undefined) || []
+    (state: any) => (state.editor.selectedFrameIds as string[]) ?? EMPTY_ID_LIST
   );
-  const historyPast = useSelector((state: any) => state.editor.historyPast || []);
+  const historyPast = useSelector((state: any) => state.editor.historyPast as any[]);
   const nodes = listSceneNodes(document);
   const frames = Array.isArray(document?.frames) ? document.frames : [];
   const frameById = useMemo(() => {

--- a/apps/web/src/components/rcb/canvas/RcbCanvas.tsx
+++ b/apps/web/src/components/rcb/canvas/RcbCanvas.tsx
@@ -235,14 +235,16 @@ function RcbCanvas({
       if (cancelled) return;
       const stage = stageRef.current || viewportEl;
       if (!stage) return;
-      const r = stage.getBoundingClientRect();
-      if (r.width < 40 || r.height < 40) {
+      const vw = stage.clientWidth;
+      const vh = stage.clientHeight;
+      if (vw < 40 || vh < 40) {
         // Stage not laid out yet — retry a few frames.
         if (tries++ < 30) requestAnimationFrame(applyFit);
         return;
       }
       fittedKey.current = key;
-      onCameraChange(rcbFitCamera({ width: r.width, height: r.height }, artboard));
+      // clientWidth/Height match camera.x/y layout space (not visual getBoundingClientRect).
+      onCameraChange(rcbFitCamera({ width: vw, height: vh }, artboard));
     };
     applyFit();
     return () => {
@@ -310,9 +312,20 @@ function RcbCanvas({
       const cam = cameraRef.current;
       markCameraMoving();
 
+      let deltaX = e.deltaX;
+      let deltaY = e.deltaY;
+      // Normalize line/page deltas so trackpads don't pan/zoom by huge jumps.
+      if (e.deltaMode === 1) {
+        deltaX *= 16;
+        deltaY *= 16;
+      } else if (e.deltaMode === 2) {
+        deltaX *= el.clientWidth;
+        deltaY *= el.clientHeight;
+      }
+
       if (e.ctrlKey || e.metaKey) {
         onCameraChange(
-          rcbZoomAtPoint(cam, cam.zoom * (e.deltaY > 0 ? 0.92 : 1.08), local.x, local.y)
+          rcbZoomAtPoint(cam, cam.zoom * (deltaY > 0 ? 0.92 : 1.08), local.x, local.y)
         );
         return;
       }
@@ -320,8 +333,8 @@ function RcbCanvas({
       const sy = local.scaleY > 0 ? local.scaleY : 1;
       onCameraChange({
         ...cam,
-        x: cam.x - e.deltaX / sx,
-        y: cam.y - e.deltaY / sy,
+        x: cam.x - deltaX / sx,
+        y: cam.y - deltaY / sy,
       });
     };
 

--- a/apps/web/src/components/rcb/core/math.ts
+++ b/apps/web/src/components/rcb/core/math.ts
@@ -139,11 +139,14 @@ export function rcbZoomAtPoint(
   return { zoom: z1, x: localX - sceneX * z1, y: localY - sceneY * z1 };
 }
 
-/** Fit scene bounds into the viewport (e.g. document open). */
+/** Fit scene bounds into the viewport (e.g. document open / Shift+1). */
 export function rcbFitCamera(
   viewport: { width: number; height: number },
   bounds: { x?: number; y?: number; width: number; height: number },
-  padding = 72
+  /** Screen-px margin around content. */
+  padding = 120,
+  /** Cap so small scenes do not fill the whole stage. */
+  maxZoom = 0.85
 ): RcbCamera {
   const vw = Math.max(1, viewport.width);
   const vh = Math.max(1, viewport.height);
@@ -151,7 +154,11 @@ export function rcbFitCamera(
   const ah = Math.max(1, bounds.height);
   const ox = bounds.x || 0;
   const oy = bounds.y || 0;
-  const zoom = rcbClampZoom(Math.min((vw - padding * 2) / aw, (vh - padding * 2) / ah, 1));
+  const pad = Math.max(0, padding);
+  const cap = Math.max(0.05, Math.min(8, maxZoom));
+  const zoom = rcbClampZoom(
+    Math.min((vw - pad * 2) / aw, (vh - pad * 2) / ah, cap)
+  );
   return {
     zoom,
     x: (vw - aw * zoom) / 2 - ox * zoom,

--- a/apps/web/src/pages/EditorPage.tsx
+++ b/apps/web/src/pages/EditorPage.tsx
@@ -107,6 +107,7 @@ import {
   setWorkspaceMode,
   updateArtboardFrame,
   pushEditorHistory,
+  EMPTY_ID_LIST,
 } from '@/store/modules/editor';
 import { listSceneNodes, stackZIndex } from '@/components/rcb/scene/document/sceneDocument';
 import { normalizeProjectThumbnailUrls } from '@/utils/projectThumb';
@@ -735,12 +736,14 @@ function EditorPage() {
   const sceneReloadToken = useSelector((state: any) => state.editor.sceneReloadToken);
   const documentPatchToken = useSelector((state: any) => state.editor.documentPatchToken);
   const lastPatchedNodeIds = useSelector(
-    (state: any) => (state.editor.lastPatchedNodeIds as string[]) || []
+    (state: any) => (state.editor.lastPatchedNodeIds as string[]) ?? EMPTY_ID_LIST
   );
   const selectedNodeId = useSelector((state: any) => state.editor.selectedNodeId);
-  const selectedNodeIds = useSelector((state: any) => state.editor.selectedNodeIds || []);
+  const selectedNodeIds = useSelector(
+    (state: any) => (state.editor.selectedNodeIds as string[]) ?? EMPTY_ID_LIST
+  );
   const selectedFrameIds = useSelector(
-    (state: any) => (state.editor.selectedFrameIds as string[] | undefined) || []
+    (state: any) => (state.editor.selectedFrameIds as string[]) ?? EMPTY_ID_LIST
   );
   const currentId = useSelector((state: any) => state.editor.currentId as string | null);
   const templates = useSelector((state: any) => state.editor.templates as any[]);
@@ -844,8 +847,10 @@ function EditorPage() {
     const el = stageEl;
     if (!el || typeof ResizeObserver === 'undefined') return undefined;
     const apply = () => {
-      const r = el.getBoundingClientRect();
-      setStageSize({ width: Math.max(1, r.width), height: Math.max(1, r.height) });
+      setStageSize({
+        width: Math.max(1, el.clientWidth),
+        height: Math.max(1, el.clientHeight),
+      });
     };
     apply();
     const ro = new ResizeObserver(apply);
@@ -1006,13 +1011,28 @@ function EditorPage() {
   const sessionReadyForIdRef = useRef<string | null>(null);
   const didInitialFitRef = useRef(false);
   const gridUserTouchedRef = useRef(false);
+  /** True after the user pans/zooms — stops auto re-fit on stage resize. */
+  const cameraTouchedByUserRef = useRef(false);
+  /** Next camera write is programmatic (fit) — don't count as user touch. */
+  const skipCameraTouchRef = useRef(false);
   useEffect(() => {
     sessionReadyForIdRef.current = null;
     didInitialFitRef.current = false;
     gridUserTouchedRef.current = false;
+    cameraTouchedByUserRef.current = false;
+    skipCameraTouchRef.current = false;
     setCamera(DEFAULT_CAMERA);
     dispatch(setGridMode(false));
   }, [currentId, dispatch]);
+
+  useEffect(() => {
+    if (skipCameraTouchRef.current) {
+      skipCameraTouchRef.current = false;
+      return;
+    }
+    if (!didInitialFitRef.current) return;
+    cameraTouchedByUserRef.current = true;
+  }, [camera.x, camera.y, camera.zoom]);
 
   useEffect(() => {
     if (!currentId || !document) return;
@@ -1317,46 +1337,42 @@ function EditorPage() {
 
   const zoomAtStageCenter = useCallback((nextZoom: number) => {
     const el = stageRef.current;
-    if (!el) {
-      setCamera((c) => zoomAtPoint(c, nextZoom, 0, 0));
-      return;
-    }
-    const r = el.getBoundingClientRect();
-    setCamera((c) => zoomAtPoint(c, nextZoom, r.width / 2, r.height / 2));
+    if (!el) return;
+    // Layout px (clientWidth) — same space as camera.x/y. getBoundingClientRect is visual
+    // and drifts under browser zoom / CSS scale, which makes content jump off-screen.
+    setCamera((c) =>
+      zoomAtPoint(c, nextZoom, el.clientWidth / 2, el.clientHeight / 2)
+    );
   }, []);
 
   const onZoomIn = useCallback(() => {
     setCamera((c) => {
       const el = stageRef.current;
+      if (!el) return c;
       const next = Math.min(8, Number((c.zoom * 1.1).toFixed(4)));
-      if (!el) return { ...c, zoom: next };
-      const r = el.getBoundingClientRect();
-      return zoomAtPoint(c, next, r.width / 2, r.height / 2);
+      return zoomAtPoint(c, next, el.clientWidth / 2, el.clientHeight / 2);
     });
   }, []);
 
   const onZoomOut = useCallback(() => {
     setCamera((c) => {
       const el = stageRef.current;
+      if (!el) return c;
       const next = Math.max(0.05, Number((c.zoom / 1.1).toFixed(4)));
-      if (!el) return { ...c, zoom: next };
-      const r = el.getBoundingClientRect();
-      return zoomAtPoint(c, next, r.width / 2, r.height / 2);
+      return zoomAtPoint(c, next, el.clientWidth / 2, el.clientHeight / 2);
     });
   }, []);
 
   const onFitView = useCallback(() => {
     const el = stageRef.current;
-    const vw = el?.clientWidth || el?.getBoundingClientRect().width || 0;
-    const vh = el?.clientHeight || el?.getBoundingClientRect().height || 0;
-    if (vw < 1 || vh < 1) {
-      zoomAtStageCenter(1);
-      return;
-    }
+    const vw = el?.clientWidth || 0;
+    const vh = el?.clientHeight || 0;
+    if (vw < 1 || vh < 1) return;
     const doc = (store.getState() as any).editor?.document;
     const fr: ArtboardFrame[] = Array.isArray(doc?.frames) ? doc.frames : [];
-    setCamera(rcbFitCamera({ width: vw, height: vh }, editorContentBounds(doc, fr), 48));
-  }, [zoomAtStageCenter]);
+    skipCameraTouchRef.current = true;
+    setCamera(rcbFitCamera({ width: vw, height: vh }, editorContentBounds(doc, fr), 120));
+  }, []);
 
   /** Under boot overlay: center once, then reveal — no top-left flash. */
   const onCanvasReady = useCallback(() => {
@@ -1366,6 +1382,27 @@ function EditorPage() {
     }
     finishBoot();
   }, [onFitView]);
+
+  // Agent dock / inspect panel can change stage size after the first fit. Re-fit
+  // until the user pans or zooms so content does not sit off-center then "run away".
+  useEffect(() => {
+    const el = stageEl;
+    if (!el || typeof ResizeObserver === 'undefined') return undefined;
+    let lastW = el.clientWidth;
+    let lastH = el.clientHeight;
+    const ro = new ResizeObserver(() => {
+      const w = el.clientWidth;
+      const h = el.clientHeight;
+      if (!(w > 8 && h > 8)) return;
+      if (!didInitialFitRef.current || cameraTouchedByUserRef.current) return;
+      if (Math.abs(w - lastW) < 2 && Math.abs(h - lastH) < 2) return;
+      lastW = w;
+      lastH = h;
+      onFitView();
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [stageEl, onFitView]);
 
   const zoomModLabel = zoomModShortcutLabel();
 

--- a/apps/web/src/pages/SharePage.tsx
+++ b/apps/web/src/pages/SharePage.tsx
@@ -22,6 +22,7 @@ import {
   type RcbCamera as CanvasCamera,
 } from '@/components/rcb';
 import SvgCanvas from '@/components/editor/canvas/SvgCanvas';
+import EditorBootOverlay from '@/components/editor/chrome/EditorBootOverlay';
 import HtmlArtboardFrame from '@/components/rcb/frames/HtmlArtboardFrame';
 import {
   listSceneNodes,
@@ -41,12 +42,13 @@ import {
   setDocument,
   setSelectedNodeIds,
   setWorkspaceMode,
+  applyCollabDocument,
+  EMPTY_ID_LIST,
   type ArtboardFrame,
 } from '@/store/modules/editor';
 import { fetchShareApi, type ShareDto } from '@/apis/shares';
 import { buildLoginUrl } from '@/utils/authReturnTo';
 import { cssSolidWithOpacity } from '@/components/base/colorPanel';
-import { applyCollabDocument } from '@/store/modules/editor';
 
 const ZOOM_TRIGGER_BASE =
   'inline-flex h-7 min-w-[2.75rem] items-center justify-center gap-1.5 rounded px-2.5 transition-colors';
@@ -56,6 +58,8 @@ const ZOOM_TRIGGER_IDLE =
 const HUD_ICON = 'h-4 w-4';
 /** Preview tabs poll so linked shares pick up source-project edits without a hard refresh. */
 const SHARE_PREVIEW_POLL_MS = 2500;
+const BOOT_MIN_MS = 520;
+const BOOT_EXIT_MS = 280;
 
 type SceneBox = { x: number; y: number; width: number; height: number };
 
@@ -108,21 +112,6 @@ function unionSceneBox(a: SceneBox | null, b: SceneBox): SceneBox {
   };
 }
 
-function framesBounds(frames: ArtboardFrame[]) {
-  if (!frames.length) return { x: 0, y: 0, width: 0, height: 0 };
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  for (const f of frames) {
-    minX = Math.min(minX, f.x);
-    minY = Math.min(minY, f.y);
-    maxX = Math.max(maxX, f.x + f.width);
-    maxY = Math.max(maxY, f.y + f.height);
-  }
-  return { x: minX, y: minY, width: Math.max(1, maxX - minX), height: Math.max(1, maxY - minY) };
-}
-
 /** Same as editor: artboards + finished scene nodes for zoom-to-fit (no generators). */
 function previewContentBounds(doc: any, frames: ArtboardFrame[]): SceneBox {
   let box: SceneBox | null = null;
@@ -159,13 +148,15 @@ function SharePage() {
   const viewerId = useSelector((s: any) => s.auth?.user?.id as string | undefined);
   const document = useSelector((s: any) => s.editor.document);
   const selectedNodeId = useSelector((s: any) => s.editor.selectedNodeId);
-  const selectedNodeIds = useSelector((s: any) => s.editor.selectedNodeIds || []);
+  const selectedNodeIds = useSelector(
+    (s: any) => (s.editor.selectedNodeIds as string[]) ?? EMPTY_ID_LIST
+  );
   const selectedFrameIds = useSelector(
-    (s: any) => (s.editor.selectedFrameIds as string[] | undefined) || []
+    (s: any) => (s.editor.selectedFrameIds as string[]) ?? EMPTY_ID_LIST
   );
   const documentPatchToken = useSelector((s: any) => s.editor.documentPatchToken);
   const lastPatchedNodeIds = useSelector(
-    (s: any) => (s.editor.lastPatchedNodeIds as string[]) || []
+    (s: any) => (s.editor.lastPatchedNodeIds as string[]) ?? EMPTY_ID_LIST
   );
   const sceneReloadToken = useSelector((s: any) => s.editor.sceneReloadToken);
   const [record, setRecord] = useState<ShareDto | null>(null);
@@ -175,12 +166,88 @@ function SharePage() {
   const [inspectOpen, setInspectOpen] = useState(true);
   const [minimapOpen, setMinimapOpen] = useState(false);
   const [zoomMenuOpen, setZoomMenuOpen] = useState(false);
+  const [bootOpen, setBootOpen] = useState(true);
+  const [bootExiting, setBootExiting] = useState(false);
+  const [bootProgress, setBootProgress] = useState(8);
   const stageRef = useRef<HTMLDivElement | null>(null);
   const [stageEl, setStageEl] = useState<HTMLElement | null>(null);
   const docFingerprintRef = useRef('');
+  const didInitialFitRef = useRef(false);
+  const cameraTouchedByUserRef = useRef(false);
+  const skipCameraTouchRef = useRef(false);
+  const bootOpenRef = useRef(true);
+  const bootFinishingRef = useRef(false);
+  const bootStartedAt = useRef(Date.now());
+  const bootExitTimer = useRef<number | null>(null);
   useEffect(() => {
     setStageEl(stageRef.current);
   }, []);
+
+  const finishBoot = useCallback(() => {
+    if (!bootOpenRef.current || bootFinishingRef.current) return;
+    bootFinishingRef.current = true;
+    const wait = Math.max(0, BOOT_MIN_MS - (Date.now() - bootStartedAt.current));
+    window.setTimeout(() => {
+      setBootProgress(100);
+      setBootExiting(true);
+      bootExitTimer.current = window.setTimeout(() => {
+        bootOpenRef.current = false;
+        setBootOpen(false);
+        setBootExiting(false);
+        bootExitTimer.current = null;
+      }, BOOT_EXIT_MS);
+    }, wait);
+  }, []);
+
+  useEffect(() => {
+    didInitialFitRef.current = false;
+    cameraTouchedByUserRef.current = false;
+    skipCameraTouchRef.current = false;
+    bootOpenRef.current = true;
+    bootFinishingRef.current = false;
+    bootStartedAt.current = Date.now();
+    setBootOpen(true);
+    setBootExiting(false);
+    setBootProgress(8);
+    setCamera(DEFAULT_CAMERA);
+    if (bootExitTimer.current) {
+      window.clearTimeout(bootExitTimer.current);
+      bootExitTimer.current = null;
+    }
+  }, [shareId]);
+
+  useEffect(
+    () => () => {
+      if (bootExitTimer.current) window.clearTimeout(bootExitTimer.current);
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!bootOpen || bootExiting) return undefined;
+    const id = window.setInterval(() => {
+      setBootProgress((p) => {
+        if (p >= 90) return p;
+        return Math.min(90, p + 4 + Math.random() * 10);
+      });
+    }, 380);
+    return () => window.clearInterval(id);
+  }, [bootOpen, bootExiting]);
+
+  useEffect(() => {
+    if (!bootOpen) return undefined;
+    const failSafe = window.setTimeout(() => finishBoot(), 12000);
+    return () => window.clearTimeout(failSafe);
+  }, [bootOpen, finishBoot]);
+
+  useEffect(() => {
+    if (skipCameraTouchRef.current) {
+      skipCameraTouchRef.current = false;
+      return;
+    }
+    if (!didInitialFitRef.current) return;
+    cameraTouchedByUserRef.current = true;
+  }, [camera.x, camera.y, camera.zoom]);
 
   const canEdit = Boolean(record?.viewerCanEdit);
   const canView = Boolean(record?.viewerCanView);
@@ -190,45 +257,69 @@ function SharePage() {
 
   const zoomAtStageCenter = useCallback((nextZoom: number) => {
     const el = stageRef.current;
-    if (!el) {
-      setCamera((c) => ({ ...c, zoom: nextZoom }));
-      return;
-    }
-    const r = el.getBoundingClientRect();
-    setCamera((c) => zoomAtPoint(c, nextZoom, r.width / 2, r.height / 2));
+    if (!el) return;
+    setCamera((c) =>
+      zoomAtPoint(c, nextZoom, el.clientWidth / 2, el.clientHeight / 2)
+    );
   }, []);
 
   const onZoomIn = useCallback(() => {
     setCamera((c) => {
       const el = stageRef.current;
+      if (!el) return c;
       const next = Math.min(8, Number((c.zoom * 1.1).toFixed(4)));
-      if (!el) return { ...c, zoom: next };
-      const r = el.getBoundingClientRect();
-      return zoomAtPoint(c, next, r.width / 2, r.height / 2);
+      return zoomAtPoint(c, next, el.clientWidth / 2, el.clientHeight / 2);
     });
   }, []);
 
   const onZoomOut = useCallback(() => {
     setCamera((c) => {
       const el = stageRef.current;
+      if (!el) return c;
       const next = Math.max(0.05, Number((c.zoom / 1.1).toFixed(4)));
-      if (!el) return { ...c, zoom: next };
-      const r = el.getBoundingClientRect();
-      return zoomAtPoint(c, next, r.width / 2, r.height / 2);
+      return zoomAtPoint(c, next, el.clientWidth / 2, el.clientHeight / 2);
     });
   }, []);
 
   const onFitView = useCallback(() => {
     const el = stageRef.current;
-    const vw = el?.clientWidth || el?.getBoundingClientRect().width || 0;
-    const vh = el?.clientHeight || el?.getBoundingClientRect().height || 0;
-    if (vw < 1 || vh < 1) {
-      zoomAtStageCenter(1);
-      return;
-    }
+    const vw = el?.clientWidth || 0;
+    const vh = el?.clientHeight || 0;
+    if (vw < 1 || vh < 1) return;
     const fr: ArtboardFrame[] = Array.isArray(document?.frames) ? document.frames : [];
-    setCamera(rcbFitCamera({ width: vw, height: vh }, previewContentBounds(document, fr), 48));
-  }, [document, zoomAtStageCenter]);
+    skipCameraTouchRef.current = true;
+    setCamera(rcbFitCamera({ width: vw, height: vh }, previewContentBounds(document, fr), 120));
+  }, [document]);
+
+  // Fit once content is on the stage; re-fit on panel resize until the user pans/zooms.
+  useEffect(() => {
+    if (!document || !record?.viewerCanView || canEdit) return;
+    const el = stageRef.current || stageEl;
+    if (!el || el.clientWidth < 40 || el.clientHeight < 40) return;
+    if (didInitialFitRef.current) return;
+    didInitialFitRef.current = true;
+    onFitView();
+    finishBoot();
+  }, [document, record?.viewerCanView, canEdit, stageEl, onFitView, finishBoot]);
+
+  useEffect(() => {
+    const el = stageEl || stageRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return undefined;
+    let lastW = el.clientWidth;
+    let lastH = el.clientHeight;
+    const ro = new ResizeObserver(() => {
+      const w = el.clientWidth;
+      const h = el.clientHeight;
+      if (!(w > 8 && h > 8)) return;
+      if (!didInitialFitRef.current || cameraTouchedByUserRef.current) return;
+      if (Math.abs(w - lastW) < 2 && Math.abs(h - lastH) < 2) return;
+      lastW = w;
+      lastH = h;
+      onFitView();
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [stageEl, onFitView]);
 
   const zoomPercent = Math.round(camera.zoom * 100);
   const zoomModLabel = zoomModShortcutLabel();
@@ -403,14 +494,14 @@ function SharePage() {
   }, [shareId, record?.viewerCanView, record?.permission, record?.viewerCanEdit, missing, forbidden, dispatch]);
 
   const frames: ArtboardFrame[] = Array.isArray(document?.frames) ? document.frames : [];
-  const worldBounds = frames.length
-    ? framesBounds(frames)
-    : { x: 0, y: 0, width: Number(document?.width) || 794, height: Number(document?.height) || 1123 };
+  // Disable RcbCanvas one-shot autofit — we fit to finished scene content below.
+  const worldBounds = { x: 0, y: 0, width: 0, height: 0 };
+  const contentBounds = previewContentBounds(document, frames);
   const worldSurface = {
     x: 0,
     y: 0,
-    width: Math.max(3600, worldBounds.x + worldBounds.width + 800),
-    height: Math.max(2400, worldBounds.y + worldBounds.height + 800),
+    width: Math.max(3600, contentBounds.x + contentBounds.width + 800, Number(document?.width) || 0),
+    height: Math.max(2400, contentBounds.y + contentBounds.height + 800, Number(document?.height) || 0),
   };
 
   const stageBackground = useMemo(() => {
@@ -468,8 +559,8 @@ function SharePage() {
 
   if (!record || !document || canEdit) {
     return (
-      <div className="flex h-full min-h-[60vh] items-center justify-center bg-[var(--canvas)] text-[13px] text-[var(--muted)]">
-        Loading...
+      <div className="relative flex h-full min-h-0 flex-col overflow-hidden bg-[var(--canvas)]">
+        <EditorBootOverlay progress={bootProgress} exiting={bootExiting} />
       </div>
     );
   }
@@ -522,6 +613,7 @@ function SharePage() {
             emptyDragPans={false}
             background={stageBackground}
             stageRef={stageRef}
+            onViewportEl={setStageEl}
             defs={<RcbSvgDefs />}
           >
             {frames.map((frame) =>
@@ -639,6 +731,8 @@ function SharePage() {
           />
         ) : null}
       </div>
+
+      {bootOpen ? <EditorBootOverlay progress={bootProgress} exiting={bootExiting} /> : null}
     </div>
   );
 }

--- a/apps/web/src/store/modules/editor.ts
+++ b/apps/web/src/store/modules/editor.ts
@@ -92,6 +92,9 @@ function touchOpened(item: any) {
 
 const templates = loadTemplates();
 
+/** Stable empty id list for useSelector fallbacks (avoid `|| []` new refs). */
+export const EMPTY_ID_LIST: string[] = [];
+
 const initialState = {
   templates,
   currentId: null as string | null,


### PR DESCRIPTION
## Summary
- Match share-page loading to the editor boot overlay (logo + progress)
- Fix camera zoom/pan anchoring to layout coordinates; re-fit until user interacts
- Loosen initial fit (120px padding, 85% max zoom) and stabilize Redux selector empty-array refs

## Test plan
- [ ] Open a share link — boot overlay matches editor, then canvas settles with comfortable padding
- [ ] Editor/share: zoom and pan stay anchored; content does not jump off-screen
- [ ] Shift+1 / Fit still frames content with ~120px margin
- [ ] Console no longer warns about unstable useSelector references when using bucket fill / selection