### PR TITLE
Fix video export, small-screen canvas menu, and share chrome

### DIFF
--- a/apps/web/src/components/base/segmented/index.tsx
+++ b/apps/web/src/components/base/segmented/index.tsx
@@ -208,7 +208,7 @@ function SegmentedControl<T extends string = string>({
         return (
           <Tooltip
             key={opt.value}
-            title={opt.title}
+            tip={opt.title}
             placement="top"
             asChild
             triggerClassName={cn('inline-flex', fullWidth && 'min-w-0 flex-1')}

--- a/apps/web/src/components/editor/canvas/contextMenu/useCanvasContextMenu.ts
+++ b/apps/web/src/components/editor/canvas/contextMenu/useCanvasContextMenu.ts
@@ -1,4 +1,10 @@
-import { useEffect, type Dispatch, type RefObject, type SetStateAction } from 'react';
+import {
+  useEffect,
+  useRef,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+} from 'react';
 import { useDispatch } from 'react-redux';
 import { rcbResolveViewportEl, type RcbCamera } from '@/components/rcb';
 import type { ContextMenuState } from '@/components/rcb/selection/chrome/CanvasContextMenu';
@@ -28,7 +34,97 @@ type UseCanvasContextMenuArgs = {
   setCtxMenu: Dispatch<SetStateAction<ContextMenuState | null>>;
 };
 
-/** Right-click / contextmenu → canvas context menu state. */
+const LONG_PRESS_MS = 520;
+const LONG_PRESS_MOVE_PX = 10;
+/** Open on pointercancel only if held long enough (ignore scroll aborts). */
+const CANCEL_OPEN_MIN_MS = 400;
+const OPEN_DEBOUNCE_MS = 400;
+
+const CHROME_SKIP_SEL =
+  '[data-sel-toolbar],[data-frame-toolbar],[data-ctx-menu],[data-export-panel],[data-image-label],[data-frame-label],[data-crop-expand-overlay],[data-crop-expand-toolbar],[data-image-tool-panel],[data-text-inline-editor],[data-video-trim-toolbar],[data-video-playback-bar]';
+const SCENE_COMPOSER_SEL =
+  '[data-image-generator],[data-video-generator],[data-image-quick-edit]';
+
+type LongPress = {
+  pointerId: number;
+  x: number;
+  y: number;
+  target: EventTarget | null;
+  startedAt: number;
+};
+
+function isBogusClient(clientX: number, clientY: number) {
+  return (
+    !Number.isFinite(clientX) ||
+    !Number.isFinite(clientY) ||
+    (clientX <= 2 && clientY <= 2)
+  );
+}
+
+function prefersCoarsePointer() {
+  if (typeof window.matchMedia !== 'function') return false;
+  return (
+    window.matchMedia('(pointer: coarse)').matches ||
+    window.matchMedia('(any-pointer: coarse)').matches
+  );
+}
+
+function isTouchLikePointer(e: PointerEvent, coarse: boolean) {
+  if (e.pointerType === 'touch' || e.pointerType === 'pen') return true;
+  return e.button === 0 && coarse;
+}
+
+function isChromeTarget(target: EventTarget | null) {
+  const el = target as HTMLElement | null;
+  if (!el?.closest) return false;
+  if (el.closest(SCENE_COMPOSER_SEL)) return false;
+  return Boolean(el.closest(CHROME_SKIP_SEL));
+}
+
+function clientInElement(el: HTMLElement, clientX: number, clientY: number) {
+  const r = el.getBoundingClientRect();
+  return (
+    clientX >= r.left &&
+    clientX <= r.right &&
+    clientY >= r.top &&
+    clientY <= r.bottom
+  );
+}
+
+function stageContainsTarget(stage: HTMLElement, target: EventTarget | null) {
+  const node = target as Node | null;
+  if (!node) return false;
+  return node === stage || stage.contains(node);
+}
+
+function findFrameIdAtScene(
+  frames: any[] | undefined,
+  sceneX: number,
+  sceneY: number
+): string | null {
+  if (!Array.isArray(frames)) return null;
+  for (let i = frames.length - 1; i >= 0; i -= 1) {
+    const f = frames[i];
+    if (!f || f.hidden) continue;
+    const fx = Number(f.x) || 0;
+    const fy = Number(f.y) || 0;
+    const fw = Math.max(1, Number(f.width) || 1);
+    const fh = Math.max(1, Number(f.height) || 1);
+    if (sceneX >= fx && sceneX <= fx + fw && sceneY >= fy && sceneY <= fy + fh) {
+      return String(f.id);
+    }
+  }
+  return null;
+}
+
+/**
+ * Canvas context menu — driven only by our pointer gestures (not browser
+ * `contextmenu`, whose coords are often 0/1 on touch). Native menu is suppressed.
+ *
+ * - mouse right button → open on pointerdown/mousedown
+ * - touch / coarse → long-press at down position
+ * - pointercancel after a long hold → open (browser stole the gesture)
+ */
 export function useCanvasContextMenu(args: UseCanvasContextMenuArgs) {
   const {
     readOnly,
@@ -46,170 +142,190 @@ export function useCanvasContextMenu(args: UseCanvasContextMenuArgs) {
   } = args;
   const dispatch = useDispatch();
 
+  const openedAtRef = useRef(0);
+  const cameraRef = useRef(camera);
+  const artboardRef = useRef(artboard);
+  const hitTestRef = useRef(hitTest);
+  const viewportElRef = useRef(viewportEl);
+  const stageElRef = useRef(stageEl);
+  const paperElRef = useRef(paperEl);
+  cameraRef.current = camera;
+  artboardRef.current = artboard;
+  hitTestRef.current = hitTest;
+  viewportElRef.current = viewportEl;
+  stageElRef.current = stageEl;
+  paperElRef.current = paperEl;
+
   useEffect(() => {
     const hitEl = rcbResolveViewportEl(viewportEl, stageEl, paperEl);
     if (readOnly || !hitEl) return undefined;
 
-    const skipSel =
-      '[data-sel-toolbar],[data-frame-toolbar],[data-ctx-menu],[data-export-panel],[data-image-label],[data-frame-label],[data-crop-expand-overlay],[data-crop-expand-toolbar],[data-image-tool-panel],[data-text-inline-editor],[data-video-trim-toolbar],[data-video-playback-bar]';
-    const sceneComposerSel =
-      '[data-image-generator],[data-video-generator],[data-image-quick-edit]';
+    const coarse = prefersCoarsePointer();
+    let longPressTimer: number | null = null;
+    let longPress: LongPress | null = null;
 
-    let openedAt = 0;
-    let lastClientX = Number.NaN;
-    let lastClientY = Number.NaN;
-
-    const isBogusClient = (clientX: number, clientY: number) =>
-      !Number.isFinite(clientX) ||
-      !Number.isFinite(clientY) ||
-      (clientX <= 2 && clientY <= 2);
-
-    const clientInStage = (clientX: number, clientY: number) => {
-      const r = hitEl.getBoundingClientRect();
-      return (
-        clientX >= r.left &&
-        clientX <= r.right &&
-        clientY >= r.top &&
-        clientY <= r.bottom
-      );
-    };
-
-    const isChromeTarget = (target: EventTarget | null) => {
-      const el = target as HTMLElement | null;
-      if (!el?.closest) return false;
-      if (el.closest(sceneComposerSel)) return false;
-      return Boolean(el.closest(skipSel));
-    };
-
-    const noteClient = (clientX: number, clientY: number) => {
-      if (isBogusClient(clientX, clientY) || !clientInStage(clientX, clientY)) return;
-      lastClientX = clientX;
-      lastClientY = clientY;
+    const clearLongPress = () => {
+      if (longPressTimer != null) {
+        window.clearTimeout(longPressTimer);
+        longPressTimer = null;
+      }
+      longPress = null;
     };
 
     const openMenuAt = (clientX: number, clientY: number) => {
       const p = pointerToWorld(
-        camera,
-        { viewportEl, stageEl, paperEl, artboard },
+        cameraRef.current,
+        {
+          viewportEl: viewportElRef.current,
+          stageEl: stageElRef.current,
+          paperEl: paperElRef.current,
+          artboard: artboardRef.current,
+        },
         clientX,
         clientY
       );
-      const id = hitTest(p.x, p.y, { clientX, clientY });
+      const id = hitTestRef.current(p.x, p.y, { clientX, clientY });
       const selected = selectedIdsRef.current;
       if (id && !selected.includes(id)) {
         dispatch(setSelectedNodeIds([id]));
         dispatch(setSelectedNodeId(id));
       }
+
       let frameId: string | null = activeFrameIdRef.current;
       if (!id) {
-        const frames = Array.isArray(documentRef.current?.frames)
-          ? documentRef.current.frames
-          : [];
-        for (let i = frames.length - 1; i >= 0; i -= 1) {
-          const f = frames[i];
-          if (!f || f.hidden) continue;
-          const fx = Number(f.x) || 0;
-          const fy = Number(f.y) || 0;
-          const fw = Math.max(1, Number(f.width) || 1);
-          const fh = Math.max(1, Number(f.height) || 1);
-          if (p.x >= fx && p.x <= fx + fw && p.y >= fy && p.y <= fy + fh) {
-            frameId = String(f.id);
-            if (!selected.length && !selectedFrameIdsRef.current.includes(frameId)) {
-              dispatch(setActiveFrameId(frameId));
-              dispatch(setSelectedNodeIds([]));
-              dispatch(setSelectedNodeId(null));
-            }
-            break;
+        const hitFrameId = findFrameIdAtScene(documentRef.current?.frames, p.x, p.y);
+        if (hitFrameId) {
+          frameId = hitFrameId;
+          if (!selected.length && !selectedFrameIdsRef.current.includes(hitFrameId)) {
+            dispatch(setActiveFrameId(hitFrameId));
+            dispatch(setSelectedNodeIds([]));
+            dispatch(setSelectedNodeId(null));
           }
         }
       }
+
+      const nodeId = id || (selected.length === 1 ? selected[0] : null);
       setCtxMenu({
         clientX,
         clientY,
         sceneX: p.x,
         sceneY: p.y,
-        nodeId: id || (selected.length === 1 ? selected[0] : null),
+        nodeId,
         frameId,
       });
     };
 
-    const openFromRightButton = (
-      clientX: number,
-      clientY: number,
-      target: EventTarget | null,
-      opts?: { allowOutsideStage?: boolean }
-    ) => {
-      if (performance.now() - openedAt < 400) return false;
-      if (!Number.isFinite(clientX) || !Number.isFinite(clientY)) return false;
-      if (!opts?.allowOutsideStage && !clientInStage(clientX, clientY)) return false;
-      if (isChromeTarget(target)) return false;
-      openedAt = performance.now();
+    const tryOpen = (clientX: number, clientY: number, target: EventTarget | null) => {
+      if (performance.now() - openedAtRef.current < OPEN_DEBOUNCE_MS) return;
+      if (isBogusClient(clientX, clientY)) return;
+      if (!clientInElement(hitEl, clientX, clientY)) return;
+      if (isChromeTarget(target)) return;
+      openedAtRef.current = performance.now();
       openMenuAt(clientX, clientY);
-      return true;
+    };
+
+    const startLongPress = (
+      pointerId: number,
+      x: number,
+      y: number,
+      target: EventTarget | null
+    ) => {
+      clearLongPress();
+      longPress = { pointerId, x, y, target, startedAt: performance.now() };
+      longPressTimer = window.setTimeout(() => {
+        const lp = longPress;
+        clearLongPress();
+        if (!lp) return;
+        tryOpen(lp.x, lp.y, lp.target);
+      }, LONG_PRESS_MS);
     };
 
     const onPointerMove = (e: PointerEvent) => {
-      noteClient(e.clientX, e.clientY);
+      if (!longPress || longPress.pointerId !== e.pointerId) return;
+      if (Math.hypot(e.clientX - longPress.x, e.clientY - longPress.y) > LONG_PRESS_MOVE_PX) {
+        clearLongPress();
+      }
     };
 
     const onPointerDown = (e: PointerEvent) => {
-      noteClient(e.clientX, e.clientY);
-      if (e.button !== 2) return;
-      if (!clientInStage(e.clientX, e.clientY)) return;
-      e.preventDefault();
-      e.stopPropagation();
-      openFromRightButton(e.clientX, e.clientY, e.target);
-    };
-
-    const onMouseDown = (e: MouseEvent) => {
-      noteClient(e.clientX, e.clientY);
-      if (e.button !== 2) return;
-      if (!clientInStage(e.clientX, e.clientY)) return;
-      e.preventDefault();
-      e.stopPropagation();
-      openFromRightButton(e.clientX, e.clientY, e.target);
-    };
-
-    const onContextMenu = (e: MouseEvent) => {
-      const stageOk = clientInStage(e.clientX, e.clientY);
-      const hasLast = !isBogusClient(lastClientX, lastClientY);
-      const bogus = isBogusClient(e.clientX, e.clientY);
-      if (!stageOk && !(bogus && hasLast)) return;
-
-      e.preventDefault();
-      e.stopPropagation();
-
-      if (isChromeTarget(e.target)) return;
-
-      let clientX = bogus ? lastClientX : e.clientX;
-      let clientY = bogus ? lastClientY : e.clientY;
-      if (isBogusClient(clientX, clientY)) {
-        const r = hitEl.getBoundingClientRect();
-        clientX = r.left + r.width / 2;
-        clientY = r.top + r.height / 2;
+      if (isChromeTarget(e.target)) {
+        clearLongPress();
+        return;
       }
-      openFromRightButton(clientX, clientY, e.target, {
-        allowOutsideStage: bogus && hasLast,
-      });
+      if (isBogusClient(e.clientX, e.clientY) || !clientInElement(hitEl, e.clientX, e.clientY)) {
+        clearLongPress();
+        return;
+      }
+
+      if (e.button === 2) {
+        clearLongPress();
+        e.preventDefault();
+        e.stopPropagation();
+        tryOpen(e.clientX, e.clientY, e.target);
+        return;
+      }
+
+      if (e.button !== 0 || !isTouchLikePointer(e, coarse)) return;
+      startLongPress(e.pointerId, e.clientX, e.clientY, e.target);
+    };
+
+    /** Some hybrid drivers skip PointerEvent button=2 but still fire MouseEvent. */
+    const onMouseDown = (e: MouseEvent) => {
+      if (e.button !== 2) return;
+      if (isChromeTarget(e.target)) return;
+      if (isBogusClient(e.clientX, e.clientY) || !clientInElement(hitEl, e.clientX, e.clientY)) {
+        return;
+      }
+      clearLongPress();
+      e.preventDefault();
+      e.stopPropagation();
+      tryOpen(e.clientX, e.clientY, e.target);
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      if (longPress && e.pointerId === longPress.pointerId) clearLongPress();
+    };
+
+    const onPointerCancel = (e: PointerEvent) => {
+      if (!longPress) return;
+      if (longPress.pointerId !== e.pointerId && longPress.pointerId !== -1) return;
+      const lp = longPress;
+      const held = performance.now() - lp.startedAt;
+      clearLongPress();
+      if (held < CANCEL_OPEN_MIN_MS) return;
+      tryOpen(lp.x, lp.y, lp.target);
+    };
+
+    /** Suppress native menu only — never open from this event (coords often fake). */
+    const onContextMenu = (e: MouseEvent) => {
+      const onStage =
+        clientInElement(hitEl, e.clientX, e.clientY) ||
+        stageContainsTarget(hitEl, e.target) ||
+        isChromeTarget(e.target);
+      if (!onStage) return;
+      e.preventDefault();
+      e.stopPropagation();
     };
 
     window.addEventListener('pointermove', onPointerMove, { capture: true });
     window.addEventListener('pointerdown', onPointerDown, { capture: true });
     window.addEventListener('mousedown', onMouseDown, { capture: true });
+    window.addEventListener('pointerup', onPointerUp, { capture: true });
+    window.addEventListener('pointercancel', onPointerCancel, { capture: true });
     window.addEventListener('contextmenu', onContextMenu, { capture: true });
     return () => {
+      clearLongPress();
       window.removeEventListener('pointermove', onPointerMove, true);
       window.removeEventListener('pointerdown', onPointerDown, true);
       window.removeEventListener('mousedown', onMouseDown, true);
+      window.removeEventListener('pointerup', onPointerUp, true);
+      window.removeEventListener('pointercancel', onPointerCancel, true);
       window.removeEventListener('contextmenu', onContextMenu, true);
     };
   }, [
     activeFrameIdRef,
-    artboard,
-    camera,
     dispatch,
     documentRef,
-    hitTest,
     paperEl,
     readOnly,
     selectedFrameIdsRef,

--- a/apps/web/src/components/editor/chrome/PenStrokeToolbar.tsx
+++ b/apps/web/src/components/editor/chrome/PenStrokeToolbar.tsx
@@ -401,7 +401,7 @@ function PenStrokeToolbar({
             onMouseLeave={scheduleCloseBrush}
           >
             <Tooltip
-              title={`画笔：${brush.label}`}
+              tip={`画笔：${brush.label}`}
               placement={docked ? 'bottom' : 'top'}
               disabled={eraseMode}
             >
@@ -544,7 +544,7 @@ function PenStrokeToolbar({
           <>
             <span className="mx-0.5 h-4 w-px bg-[var(--line)]" aria-hidden />
             <Tooltip
-              title={pressureEnabled ? '\u538b\u611f\uff1a\u5f00' : '\u538b\u611f\uff1a\u5173'}
+              tip={pressureEnabled ? '\u538b\u611f\uff1a\u5f00' : '\u538b\u611f\uff1a\u5173'}
               placement={docked ? 'bottom' : 'top'}
             >
               <button

--- a/apps/web/src/components/editor/nodes/FrameNode/FrameContextToolbar.tsx
+++ b/apps/web/src/components/editor/nodes/FrameNode/FrameContextToolbar.tsx
@@ -160,7 +160,7 @@ function FrameContextToolbar({ frame }: Props) {
       </FrameSizePresetMenu>
 
       <Tooltip
-        title={
+        tip={
           isLandscape
             ? t('editor.frameToolbar.toPortrait')
             : t('editor.frameToolbar.toLandscape')
@@ -242,7 +242,7 @@ function FrameContextToolbar({ frame }: Props) {
         />
       </label>
       <Tooltip
-        title={
+        tip={
           aspectLocked
             ? t('editor.frameToolbar.unlockAspect')
             : t('editor.frameToolbar.lockAspect')
@@ -287,7 +287,7 @@ function FrameContextToolbar({ frame }: Props) {
       </label>
 
       <Tooltip
-        title={
+        tip={
           canvasLocked
             ? t('editor.frameToolbar.unlockCanvas')
             : t('editor.frameToolbar.lockCanvas')
@@ -314,7 +314,7 @@ function FrameContextToolbar({ frame }: Props) {
       </Tooltip>
 
       <Tooltip
-        title={clipContent ? t('editor.showOverflow') : t('editor.clipOverflow')}
+        tip={clipContent ? t('editor.showOverflow') : t('editor.clipOverflow')}
         placement="top"
       >
         <button

--- a/apps/web/src/components/editor/nodes/ImageNode/ImageFullscreenPreviewButton.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageFullscreenPreviewButton.tsx
@@ -19,7 +19,7 @@ function ImageFullscreenPreviewButton({
   return (
     <>
       <Tooltip
-        title={t('editor.fullscreenPreview', { defaultValue: '全屏预览' })}
+        tip={t('editor.fullscreenPreview', { defaultValue: '全屏预览' })}
         placement="top"
       >
         <button

--- a/apps/web/src/components/editor/nodes/ImageNode/toolPanels/MultiAngleToolPanel.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/toolPanels/MultiAngleToolPanel.tsx
@@ -162,7 +162,7 @@ function MultiAngleToolPanel({
                 const label = angleLabel(preset.key);
                 const tip = `${label}  ${preset.rotate}° / ${preset.tilt}°`;
                 return (
-                  <Tooltip key={preset.key} title={tip} placement="top">
+                  <Tooltip key={preset.key} tip={tip} placement="top">
                     <button
                       type="button"
                       aria-label={tip}

--- a/apps/web/src/components/editor/nodes/ShapeNode/ShapeSelectionToolbar.tsx
+++ b/apps/web/src/components/editor/nodes/ShapeNode/ShapeSelectionToolbar.tsx
@@ -309,7 +309,7 @@ function ShapeSelectionToolbar({
         />
       </label>
       <Tooltip
-        title={
+        tip={
           aspectLocked
             ? t('editor.imageToolbar.unlockAspect')
             : t('editor.imageToolbar.lockAspect')

--- a/apps/web/src/components/editor/panels/AgentDock.tsx
+++ b/apps/web/src/components/editor/panels/AgentDock.tsx
@@ -1119,10 +1119,10 @@ const AGENT_DOCK_MAX_W = 560;
 const AGENT_DOCK_DEFAULT_W = 360;
 
 function clampAgentDockWidth(width: number): number {
-  const viewportCap =
-    typeof window !== 'undefined'
-      ? Math.max(AGENT_DOCK_MIN_W, window.innerWidth - 360)
-      : AGENT_DOCK_MAX_W;
+  let viewportCap = AGENT_DOCK_MAX_W;
+  if (typeof window !== 'undefined') {
+    viewportCap = Math.max(AGENT_DOCK_MIN_W, window.innerWidth - 360);
+  }
   return Math.min(
     AGENT_DOCK_MAX_W,
     viewportCap,
@@ -2160,7 +2160,8 @@ function AgentDock({
   /** Cursor-like: edit a past user message in-place. */
   const [editingUserId, setEditingUserId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState('');
-  const [dockWidth, setDockWidth] = useState(AGENT_DOCK_DEFAULT_W);
+  // First paint must use stored width — a later setState(360→stored) reflows the stage.
+  const [dockWidth, setDockWidth] = useState(readStoredAgentDockWidth);
   const resizeDragRef = useRef<{ startX: number; startW: number } | null>(null);
   const currentId = useSelector((s: any) => s.editor.currentId as string | null);
   const canvasAttachPick = useSelector(
@@ -2220,11 +2221,6 @@ function AgentDock({
     const fid = taskState?.canvas?.last_agent_frame_id;
     if (fid) lastAgentFrameIdRef.current = String(fid);
   }, [sessionId, taskState?.canvas?.last_agent_frame_id]);
-
-  useEffect(() => {
-    setDockWidth(readStoredAgentDockWidth());
-  }, []);
-
 
   useEffect(() => {
     void fetchDesignCatalog()

--- a/apps/web/src/components/editor/panels/DevPropertiesPanel.tsx
+++ b/apps/web/src/components/editor/panels/DevPropertiesPanel.tsx
@@ -16,7 +16,7 @@ import {
   resolveShadow,
   resolveStroke,
 } from '@/components/rcb/scene/document/sceneEffects';
-import { isExportableSceneNode } from '@/components/rcb/scene/document/sceneDocument';
+import { isExportableSceneNode, isVideoNode } from '@/components/rcb/scene/document/sceneDocument';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 
 function formatPx(n: number) {
@@ -380,6 +380,7 @@ function DevPropertiesPanel({
     hoverNodeId || (selectedNodeIds.length === 1 ? selectedNodeIds[0] : null);
   const node = nodeId ? document?.deltaSetLike?.[nodeId] : null;
   const canExportNode = Boolean(allowExport && nodeId && isExportableSceneNode(node));
+  const isVideo = isVideoNode(node);
 
   const [dockWidth, setDockWidth] = useState(INSPECT_DOCK_DEFAULT_W);
   const [colorFormat, setColorFormat] = useState<ColorFormat>('rgba');
@@ -501,9 +502,18 @@ function DevPropertiesPanel({
   );
 
   const copySnippet = async () => {
-    if (!model?.snippet) return;
+    if (!model) return;
+    const text = isVideo
+      ? [
+          `x: ${formatPx(model.left)}px`,
+          `y: ${formatPx(model.top)}px`,
+          `width: ${formatPx(model.width)}px`,
+          `height: ${formatPx(model.height)}px`,
+        ].join('\n')
+      : model.snippet;
+    if (!text) return;
     try {
-      await navigator.clipboard.writeText(model.snippet);
+      await navigator.clipboard.writeText(text);
       message.success(t('editor.devCopied'));
     } catch {
       message.error(t('editor.devCopyFailed'));
@@ -600,15 +610,18 @@ function DevPropertiesPanel({
                 <Metric label="W" value={`${formatPx(model.width)}px`} />
                 <Metric label="H" value={`${formatPx(model.height)}px`} />
               </div>
-              <div className="mt-2 flex flex-wrap items-center gap-2 text-[12px] text-[var(--ink)]">
-                <span className="text-[var(--muted)]">{t('editor.fillRadius')}</span>
-                <span className="tabular-nums">{formatPx(model.radius)}px</span>
-                <span className="text-[var(--muted)]">·</span>
-                <span className="text-[var(--muted)]">{t('editor.fillOpacity')}</span>
-                <span className="tabular-nums">{Math.round(model.opacity * 100)}%</span>
-              </div>
+              {!isVideo ? (
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-[12px] text-[var(--ink)]">
+                  <span className="text-[var(--muted)]">{t('editor.fillRadius')}</span>
+                  <span className="tabular-nums">{formatPx(model.radius)}px</span>
+                  <span className="text-[var(--muted)]">·</span>
+                  <span className="text-[var(--muted)]">{t('editor.fillOpacity')}</span>
+                  <span className="tabular-nums">{Math.round(model.opacity * 100)}%</span>
+                </div>
+              ) : null}
             </Section>
 
+            {!isVideo ? (
             <Section
               title={t('editor.devStyle')}
               right={
@@ -683,7 +696,9 @@ function DevPropertiesPanel({
                 </div>
               </div>
             </Section>
+            ) : null}
 
+            {!isVideo ? (
             <Section
               title={t('editor.devCode')}
               right={
@@ -731,6 +746,7 @@ function DevPropertiesPanel({
                 })}
               </pre>
             </Section>
+            ) : null}
 
             {canExportNode ? (
               <Section title={t('editor.export')}>

--- a/apps/web/src/components/editor/panels/DiffuseMeshEditor.tsx
+++ b/apps/web/src/components/editor/panels/DiffuseMeshEditor.tsx
@@ -245,7 +245,7 @@ function DiffuseMeshEditor({
         </p>
         <div className="flex items-center gap-0.5">
           <Tooltip
-            title={showGuides ? t('editor.fillMeshHideGuides') : t('editor.fillMeshShowGuides')}
+            tip={showGuides ? t('editor.fillMeshHideGuides') : t('editor.fillMeshShowGuides')}
             placement="top"
           >
             <button

--- a/apps/web/src/components/editor/panels/ExportSelectionPanel.tsx
+++ b/apps/web/src/components/editor/panels/ExportSelectionPanel.tsx
@@ -36,10 +36,34 @@ import {
   type ExportImageFormat,
   type ExportSlotConfig,
 } from '@/components/rcb/scene/paint/exportImage';
-import { normalizeDocument, isExportableSceneNode } from '@/components/rcb/scene/document/sceneDocument';
+import {
+  normalizeDocument,
+  isExportableSceneNode,
+  isVideoNode,
+} from '@/components/rcb/scene/document/sceneDocument';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
+import { downloadVideoNodeAsset } from '@/components/editor/nodes/VideoNode/VideoDownloadButton';
 import { cn } from '@/utils/classnames';
 import { SEL_ICON_BTN } from '@/components/rcb/selection/chrome/ToolbarValueSlider';
+
+type VideoExportFormat = 'mp4' | 'mp3';
+
+const VIDEO_FORMAT_OPTIONS: { value: VideoExportFormat; label: string }[] = [
+  { value: 'mp4', label: 'MP4' },
+  { value: 'mp3', label: 'MP3' },
+];
+
+function videoNodesForExport(document: any, ids: string[]) {
+  return ids
+    .map((id) => document?.deltaSetLike?.[id])
+    .filter((node: any) => isVideoNode(node) && String(node?.attrs?.src || '').trim());
+}
+
+function isVideoOnlyExport(document: any, ids: string[], hasCrop: boolean): boolean {
+  if (hasCrop || ids.length === 0) return false;
+  const videos = videoNodesForExport(document, ids);
+  return videos.length === ids.length && videos.length > 0;
+}
 
 const SCALE_OPTIONS = [
   { value: 0.5, label: '0.5x' },
@@ -249,10 +273,12 @@ function ExportSelectionPanel({
     return [];
   }, [crop, crops]);
   const [slot, setSlot] = useState<ExportSlotConfig>(() => defaultSlot());
+  const [videoFormat, setVideoFormat] = useState<VideoExportFormat>('mp4');
   const [compress, setCompress] = useState(false);
   const [busy, setBusy] = useState(false);
   const inline = variant === 'inline';
   const canExport = cropList.length > 0 || ids.length > 0;
+  const videoOnly = isVideoOnlyExport(document, ids, cropList.length > 0);
   const isSvg = slot.format === 'svg';
   const isJpeg = slot.format === 'jpeg';
   const format = slot.format;
@@ -290,9 +316,75 @@ function ExportSelectionPanel({
     { value: 'suffix', label: t('editor.exportSuffix') },
   ];
 
+  const runVideoExport = async () => {
+    const nodes = videoNodesForExport(document, ids);
+    if (!nodes.length) {
+      message.warning(t('editor.noSelectionExport'));
+      return;
+    }
+    const mode = videoFormat === 'mp3' ? 'audio' : 'video';
+    setBusy(true);
+    const hideLoading = message.loading(
+      t(
+        mode === 'audio'
+          ? 'editor.videoToolbar.exportingAudio'
+          : 'editor.videoToolbar.exporting',
+        {
+          defaultValue: mode === 'audio' ? '正在导出音频…' : '正在导出视频…',
+        }
+      ),
+      0
+    );
+    try {
+      for (const node of nodes) {
+        const attrs = node?.attrs || {};
+        await downloadVideoNodeAsset({
+          src: String(attrs.src || ''),
+          name: String(node?.name || attrs.name || name || 'video'),
+          uploadKey: attrs.uploadKey != null ? String(attrs.uploadKey) : null,
+          cropX: attrs.cropX,
+          cropY: attrs.cropY,
+          cropW: attrs.cropW,
+          cropH: attrs.cropH,
+          trimStart: attrs.trimStart,
+          trimEnd: attrs.trimEnd,
+          flipX: attrs.flipX === true || attrs.flipX === 'true',
+          flipY: attrs.flipY === true || attrs.flipY === 'true',
+          mode,
+        });
+      }
+      hideLoading();
+      message.success(
+        t(mode === 'audio' ? 'editor.exportedAudio' : 'editor.exportedVideo', {
+          defaultValue: mode === 'audio' ? '已导出音频' : '已导出视频',
+        })
+      );
+      onClose?.();
+    } catch (err) {
+      hideLoading();
+      console.warn('[export-video]', err);
+      message.error(
+        t(
+          mode === 'audio'
+            ? 'editor.videoToolbar.exportAudioFail'
+            : 'editor.videoToolbar.downloadFail',
+          {
+            defaultValue: mode === 'audio' ? '音频导出失败（可能无音轨）' : '下载失败',
+          }
+        )
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const runExport = async () => {
     if (!canExport) {
       message.warning(t('editor.noSelectionExport'));
+      return;
+    }
+    if (videoOnly) {
+      await runVideoExport();
       return;
     }
     if (!isSvg && !isExportScaleSafe(sourceSize.width, sourceSize.height, slot.scale)) {
@@ -359,71 +451,87 @@ function ExportSelectionPanel({
         </div>
       ) : null}
 
-      <div className={cn('grid grid-cols-3 gap-1.5', inline && 'gap-2')}>
+      {videoOnly ? (
         <Select
           size="small"
           type="filled"
-          value={isSvg ? 1 : slot.scale}
-          options={scaleOptions}
-          disabled={isSvg}
-          onChange={(v) => setSlot((s) => ({ ...s, scale: Number(v) || 1 }))}
-          className={selectFieldClass}
-          placement="bottom-start"
-        />
-        <Select
-          size="small"
-          type="filled"
-          value={slot.affixMode}
-          options={affixOptions}
+          value={videoFormat}
+          options={VIDEO_FORMAT_OPTIONS}
           onChange={(v) =>
-            setSlot((s) => ({
-              ...s,
-              affixMode: parseAffixMode(String(v)),
-            }))
+            setVideoFormat(String(v) === 'mp3' ? 'mp3' : 'mp4')
           }
           className={selectFieldClass}
           placement="bottom-start"
         />
-        <Select
-          size="small"
-          type="filled"
-          value={slot.format}
-          options={VECTOR_FORMAT_OPTIONS}
-          onChange={(v) => {
-            const next = parseExportFormat(String(v));
-            setSlot((s) => ({ ...s, format: next }));
-            if (next !== 'jpeg') setCompress(false);
-          }}
-          className={selectFieldClass}
-          placement="bottom-start"
-        />
-      </div>
+      ) : (
+        <>
+          <div className={cn('grid grid-cols-3 gap-1.5', inline && 'gap-2')}>
+            <Select
+              size="small"
+              type="filled"
+              value={isSvg ? 1 : slot.scale}
+              options={scaleOptions}
+              disabled={isSvg}
+              onChange={(v) => setSlot((s) => ({ ...s, scale: Number(v) || 1 }))}
+              className={selectFieldClass}
+              placement="bottom-start"
+            />
+            <Select
+              size="small"
+              type="filled"
+              value={slot.affixMode}
+              options={affixOptions}
+              onChange={(v) =>
+                setSlot((s) => ({
+                  ...s,
+                  affixMode: parseAffixMode(String(v)),
+                }))
+              }
+              className={selectFieldClass}
+              placement="bottom-start"
+            />
+            <Select
+              size="small"
+              type="filled"
+              value={slot.format}
+              options={VECTOR_FORMAT_OPTIONS}
+              onChange={(v) => {
+                const next = parseExportFormat(String(v));
+                setSlot((s) => ({ ...s, format: next }));
+                if (next !== 'jpeg') setCompress(false);
+              }}
+              className={selectFieldClass}
+              placement="bottom-start"
+            />
+          </div>
 
-      {isJpeg ? (
-        <div className="mt-3 flex items-center gap-1.5 text-[12px] text-[var(--ink)]">
-          <Checkbox
-            size="small"
-            checked={compress}
-            onChange={(e) => setCompress(e.target.checked)}
-          >
-            {t('editor.exportCompress')}
-          </Checkbox>
-          <Tooltip tip={t('editor.exportCompressTip')} placement="top">
-            <button
-              type="button"
-              id={tipId}
-              className="inline-flex text-[var(--muted)]"
-              aria-label={t('editor.exportCompressTip')}
-            >
-              <HiOutlineInformationCircle className="h-3.5 w-3.5" />
-            </button>
-          </Tooltip>
-        </div>
-      ) : null}
+          {isJpeg ? (
+            <div className="mt-3 flex items-center gap-1.5 text-[12px] text-[var(--ink)]">
+              <Checkbox
+                size="small"
+                checked={compress}
+                onChange={(e) => setCompress(e.target.checked)}
+              >
+                {t('editor.exportCompress')}
+              </Checkbox>
+              <Tooltip tip={t('editor.exportCompressTip')} placement="top">
+                <button
+                  type="button"
+                  id={tipId}
+                  className="inline-flex text-[var(--muted)]"
+                  aria-label={t('editor.exportCompressTip')}
+                >
+                  <HiOutlineInformationCircle className="h-3.5 w-3.5" />
+                </button>
+              </Tooltip>
+            </div>
+          ) : null}
+        </>
+      )}
 
       <button
         type="button"
-        disabled={busy || !canExport || !scaleSafe}
+        disabled={busy || !canExport || (!videoOnly && !scaleSafe)}
         onClick={() => void runExport()}
         className="mt-3 flex h-7 w-full items-center justify-center gap-1.5 rounded-xl bg-[var(--ink)] text-[12px] font-medium text-[var(--surface)] disabled:opacity-40"
       >

--- a/apps/web/src/components/editor/panels/ExportSelectionPanel.tsx
+++ b/apps/web/src/components/editor/panels/ExportSelectionPanel.tsx
@@ -65,6 +65,34 @@ function isVideoOnlyExport(document: any, ids: string[], hasCrop: boolean): bool
   return videos.length === ids.length && videos.length > 0;
 }
 
+function videoExportMode(format: VideoExportFormat): 'audio' | 'video' {
+  return format === 'mp3' ? 'audio' : 'video';
+}
+
+function videoExportCopy(
+  mode: 'audio' | 'video',
+  t: (key: string, opts?: Record<string, string>) => string
+) {
+  if (mode === 'audio') {
+    return {
+      loading: t('editor.videoToolbar.exportingAudio', { defaultValue: '正在导出音频…' }),
+      success: t('editor.exportedAudio', { defaultValue: '已导出音频' }),
+      fail: t('editor.videoToolbar.exportAudioFail', {
+        defaultValue: '音频导出失败（可能无音轨）',
+      }),
+    };
+  }
+  return {
+    loading: t('editor.videoToolbar.exporting', { defaultValue: '正在导出视频…' }),
+    success: t('editor.exportedVideo', { defaultValue: '已导出视频' }),
+    fail: t('editor.videoToolbar.downloadFail', { defaultValue: '下载失败' }),
+  };
+}
+
+function isAttrFlagTrue(value: unknown) {
+  return value === true || value === 'true';
+}
+
 const SCALE_OPTIONS = [
   { value: 0.5, label: '0.5x' },
   { value: 1, label: '1x' },
@@ -322,19 +350,10 @@ function ExportSelectionPanel({
       message.warning(t('editor.noSelectionExport'));
       return;
     }
-    const mode = videoFormat === 'mp3' ? 'audio' : 'video';
+    const mode = videoExportMode(videoFormat);
+    const copy = videoExportCopy(mode, t);
     setBusy(true);
-    const hideLoading = message.loading(
-      t(
-        mode === 'audio'
-          ? 'editor.videoToolbar.exportingAudio'
-          : 'editor.videoToolbar.exporting',
-        {
-          defaultValue: mode === 'audio' ? '正在导出音频…' : '正在导出视频…',
-        }
-      ),
-      0
-    );
+    const hideLoading = message.loading(copy.loading, 0);
     try {
       for (const node of nodes) {
         const attrs = node?.attrs || {};
@@ -348,31 +367,18 @@ function ExportSelectionPanel({
           cropH: attrs.cropH,
           trimStart: attrs.trimStart,
           trimEnd: attrs.trimEnd,
-          flipX: attrs.flipX === true || attrs.flipX === 'true',
-          flipY: attrs.flipY === true || attrs.flipY === 'true',
+          flipX: isAttrFlagTrue(attrs.flipX),
+          flipY: isAttrFlagTrue(attrs.flipY),
           mode,
         });
       }
       hideLoading();
-      message.success(
-        t(mode === 'audio' ? 'editor.exportedAudio' : 'editor.exportedVideo', {
-          defaultValue: mode === 'audio' ? '已导出音频' : '已导出视频',
-        })
-      );
+      message.success(copy.success);
       onClose?.();
     } catch (err) {
       hideLoading();
       console.warn('[export-video]', err);
-      message.error(
-        t(
-          mode === 'audio'
-            ? 'editor.videoToolbar.exportAudioFail'
-            : 'editor.videoToolbar.downloadFail',
-          {
-            defaultValue: mode === 'audio' ? '音频导出失败（可能无音轨）' : '下载失败',
-          }
-        )
-      );
+      message.error(copy.fail);
     } finally {
       setBusy(false);
     }
@@ -613,7 +619,7 @@ function ExportSelectionPopover({
   return (
     <>
       <Tooltip
-        title={t('editor.exportImage')}
+        tip={t('editor.exportImage')}
         placement="top"
         disabled={disabled || !canExport || open}
       >
@@ -656,7 +662,14 @@ function ExportSelectionPopover({
 type ExportMode = 'all' | 'selected';
 
 /** Top-bar Export: All Pages / Selected (PNG·JPG·SVG) + JSON. */
-function EditorTopExportButton({ className }: { className?: string }) {
+function EditorTopExportButton({
+  className,
+  iconOnly = false,
+}: {
+  className?: string;
+  /** Compact top bars — icon only, text stays in aria-label. */
+  iconOnly?: boolean;
+}) {
   const { t } = useTranslation();
   const document = useSelector((s: any) => s.editor.document);
   const selectedNodeIds = useSelector(
@@ -782,7 +795,8 @@ function EditorTopExportButton({ className }: { className?: string }) {
         aria-haspopup="menu"
         disabled={busy}
         className={cn(
-          'inline-flex h-8 items-center gap-1.5 rounded-xl bg-[var(--surface)] px-3 text-[13px] font-medium text-[var(--ink)] shadow-sm ring-1 ring-[var(--line)] transition hover:bg-[var(--accent-soft)] disabled:opacity-50',
+          'inline-flex h-8 items-center justify-center rounded-xl bg-[var(--surface)] text-[13px] font-medium text-[var(--ink)] shadow-sm ring-1 ring-[var(--line)] transition hover:bg-[var(--accent-soft)] disabled:opacity-50',
+          iconOnly ? 'w-8 px-0' : 'gap-1.5 px-3',
           className
         )}
         {...getReferenceProps({
@@ -799,7 +813,7 @@ function EditorTopExportButton({ className }: { className?: string }) {
         })}
       >
         <HiOutlineArrowUpTray className="h-4 w-4 shrink-0" strokeWidth={1.75} />
-        {t('editor.export')}
+        {iconOnly ? null : t('editor.export')}
       </button>
 
       <FloatingPortal>

--- a/apps/web/src/components/editor/panels/FillPanel.tsx
+++ b/apps/web/src/components/editor/panels/FillPanel.tsx
@@ -489,7 +489,7 @@ function GradientStopsBar({
 
   return (
     <Tooltip
-      title="选中色标后按 Delete 删除（至少保留 2 个）"
+      tip="选中色标后按 Delete 删除（至少保留 2 个）"
       placement="top"
       triggerClassName="min-w-0 flex-1"
     >
@@ -771,7 +771,7 @@ function FillPanel({
         {panelType === 'image' ? (
           <div className="space-y-2.5">
             <Tooltip
-              title={value.fillImageSrc ? '点击替换图片' : '点击上传图片'}
+              tip={value.fillImageSrc ? '点击替换图片' : '点击上传图片'}
               placement="top"
               triggerClassName="w-full"
             >

--- a/apps/web/src/components/editor/panels/LayerPanel.tsx
+++ b/apps/web/src/components/editor/panels/LayerPanel.tsx
@@ -324,7 +324,7 @@ function LayerStackRowView({
           </span>
         </button>
         <Tooltip
-          title={hidden ? t('editor.contextMenu.show') : t('editor.contextMenu.hide')}
+          tip={hidden ? t('editor.contextMenu.show') : t('editor.contextMenu.hide')}
           placement="top"
         >
           <button
@@ -358,7 +358,7 @@ function LayerStackRowView({
           </button>
         </Tooltip>
         <Tooltip
-          title={locked ? t('editor.contextMenu.unlock') : t('editor.contextMenu.lock')}
+          tip={locked ? t('editor.contextMenu.unlock') : t('editor.contextMenu.lock')}
           placement="top"
         >
           <button
@@ -425,7 +425,7 @@ function LayerStackRowView({
         </span>
       </button>
       <Tooltip
-        title={hidden ? t('editor.contextMenu.show') : t('editor.contextMenu.hide')}
+        tip={hidden ? t('editor.contextMenu.show') : t('editor.contextMenu.hide')}
         placement="top"
       >
         <button
@@ -461,7 +461,7 @@ function LayerStackRowView({
         </button>
       </Tooltip>
       <Tooltip
-        title={locked ? t('editor.contextMenu.unlock') : t('editor.contextMenu.lock')}
+        tip={locked ? t('editor.contextMenu.unlock') : t('editor.contextMenu.lock')}
         placement="top"
       >
         <button

--- a/apps/web/src/components/editor/panels/StylePanelChrome.tsx
+++ b/apps/web/src/components/editor/panels/StylePanelChrome.tsx
@@ -51,7 +51,7 @@ function PanelSegmentedIcons<T extends string>({
         return (
           <Tooltip
             key={id}
-            title={tip}
+            tip={tip}
             placement="top"
             asChild={false}
             triggerClassName={PANEL_ICON_SLOT}
@@ -104,7 +104,7 @@ function PanelToggleIcons<T extends string>({
     <div className={cn(PANEL_ICON_TRACK, className)} role="group">
       {leading && LeadIcon ? (
         <Tooltip
-          title={leading.tip}
+          tip={leading.tip}
           placement="top"
           asChild={false}
           triggerClassName={PANEL_ICON_SLOT}
@@ -129,7 +129,7 @@ function PanelToggleIcons<T extends string>({
         return (
           <Tooltip
             key={id}
-            title={tip}
+            tip={tip}
             placement="top"
             asChild={false}
             triggerClassName={PANEL_ICON_SLOT}
@@ -199,7 +199,7 @@ function StylePanelShell({
         <div className="flex items-center gap-0.5">
           {showLayerToggle ? (
             <Tooltip
-              title={layerVisible ? layerVisibleTipHide : layerVisibleTipShow}
+              tip={layerVisible ? layerVisibleTipHide : layerVisibleTipShow}
               placement="bottom"
             >
               <button

--- a/apps/web/src/components/editor/panels/agent/ImageAspectRatioPicker.tsx
+++ b/apps/web/src/components/editor/panels/agent/ImageAspectRatioPicker.tsx
@@ -901,7 +901,7 @@ function ImageAspectRatioPicker({
           <span>{t('agent.imageSize')}</span>
           {imageLimits?.min_pixels || imageLimits?.max_pixels ? (
             <Tooltip
-              title={t('agent.imageSizeRangeTip', {
+              tip={t('agent.imageSizeRangeTip', {
                 min: formatPixelBudget(Number(imageLimits.min_pixels) || 0),
                 max: formatPixelBudget(Number(imageLimits.max_pixels) || 0),
               })}

--- a/apps/web/src/components/rcb/selection/chrome/CanvasContextMenu.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/CanvasContextMenu.tsx
@@ -129,11 +129,13 @@ const itemClass =
 
 const PAD = 8;
 
-/**
- * Menu is `position: fixed` on document.body — use viewport client coords.
- * Keep the click anchor; only shift when the panel would overflow.
- * No scrollbars: reposition to fit the natural size (overflow hidden).
- */
+type ExportPickAction =
+  | 'exportPng'
+  | 'exportJpg'
+  | 'exportSvg'
+  | 'exportMp4'
+  | 'exportMp3';
+
 function clampFixedMenuPos(opts: {
   left: number;
   top: number;
@@ -151,6 +153,44 @@ function clampFixedMenuPos(opts: {
   if (top + h > viewH - PAD) top = viewH - PAD - h;
   if (top < PAD) top = PAD;
   return { left, top };
+}
+
+function exportFlyoutHeight(kind: 'image' | 'video') {
+  return kind === 'video' ? 88 : 120;
+}
+
+function ExportFormatButtons({
+  kind,
+  onPick,
+}: {
+  kind: 'image' | 'video';
+  onPick: (action: ExportPickAction) => void;
+}) {
+  if (kind === 'video') {
+    return (
+      <>
+        <button type="button" className={itemClass} onClick={() => onPick('exportMp4')}>
+          MP4
+        </button>
+        <button type="button" className={itemClass} onClick={() => onPick('exportMp3')}>
+          MP3
+        </button>
+      </>
+    );
+  }
+  return (
+    <>
+      <button type="button" className={itemClass} onClick={() => onPick('exportPng')}>
+        PNG
+      </button>
+      <button type="button" className={itemClass} onClick={() => onPick('exportJpg')}>
+        JPG
+      </button>
+      <button type="button" className={itemClass} onClick={() => onPick('exportSvg')}>
+        SVG
+      </button>
+    </>
+  );
 }
 
 function MenuItem({
@@ -193,9 +233,7 @@ function ExportSubmenu({
 }: {
   disabled?: boolean;
   kind?: 'image' | 'video';
-  onPick: (
-    action: 'exportPng' | 'exportJpg' | 'exportSvg' | 'exportMp4' | 'exportMp3'
-  ) => void;
+  onPick: (action: ExportPickAction) => void;
 }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -230,7 +268,7 @@ function ExportSubmenu({
     }
     const rect = rowRef.current.getBoundingClientRect();
     const flyoutW = 128;
-    const flyoutH = kind === 'video' ? 88 : 120;
+    const flyoutH = exportFlyoutHeight(kind);
     const preferRight = window.innerWidth - rect.right >= flyoutW + 8;
     const left = preferRight ? rect.right + 4 : Math.max(PAD, rect.left - flyoutW - 4);
     let top = rect.top;
@@ -247,13 +285,13 @@ function ExportSubmenu({
     []
   );
 
-  const pick = (
-    action: 'exportPng' | 'exportJpg' | 'exportSvg' | 'exportMp4' | 'exportMp3'
-  ) => {
+  const pick = (action: ExportPickAction) => {
     clearCloseTimer();
     setOpen(false);
     onPick(action);
   };
+
+  const showFlyout = open && !disabled && flyoutPos;
 
   return (
     <div
@@ -285,7 +323,7 @@ function ExportSubmenu({
         <span className="min-w-0 flex-1 truncate">{t('editor.contextMenu.export')}</span>
         <HiOutlineChevronRight className="h-3.5 w-3.5 shrink-0 text-[var(--muted)]" />
       </button>
-      {open && !disabled && flyoutPos
+      {showFlyout
         ? createPortal(
             <div
               role="menu"
@@ -299,28 +337,7 @@ function ExportSubmenu({
                 e.stopPropagation();
               }}
             >
-              {kind === 'video' ? (
-                <>
-                  <button type="button" className={itemClass} onClick={() => pick('exportMp4')}>
-                    MP4
-                  </button>
-                  <button type="button" className={itemClass} onClick={() => pick('exportMp3')}>
-                    MP3
-                  </button>
-                </>
-              ) : (
-                <>
-                  <button type="button" className={itemClass} onClick={() => pick('exportPng')}>
-                    PNG
-                  </button>
-                  <button type="button" className={itemClass} onClick={() => pick('exportJpg')}>
-                    JPG
-                  </button>
-                  <button type="button" className={itemClass} onClick={() => pick('exportSvg')}>
-                    SVG
-                  </button>
-                </>
-              )}
+              <ExportFormatButtons kind={kind} onPick={pick} />
             </div>,
             window.document.body
           )
@@ -389,6 +406,34 @@ function CanvasContextMenu({
     e.stopPropagation();
   };
 
+  const onBackdropPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const target = e.target as HTMLElement | null;
+    if (target?.closest?.('[data-ctx-menu-flyout]')) return;
+    if (menu) dismiss();
+  };
+
+  const visibilityIcon = targetHidden ? (
+    <HiOutlineEyeSlash className={ICON_CLASS} strokeWidth={1.75} />
+  ) : (
+    <HiOutlineEye className={ICON_CLASS} strokeWidth={1.75} />
+  );
+  const visibilityLabel = targetHidden
+    ? t('editor.contextMenu.show')
+    : t('editor.contextMenu.hide');
+  const lockIcon = targetLocked ? (
+    <HiOutlineLockClosed className={ICON_CLASS} strokeWidth={1.75} />
+  ) : (
+    <HiOutlineLockOpen className={ICON_CLASS} strokeWidth={1.75} />
+  );
+  const lockLabel = targetLocked
+    ? t('editor.contextMenu.unlock')
+    : t('editor.contextMenu.lock');
+  const gridLabel = gridOn
+    ? t('editor.contextMenu.hideGrid')
+    : t('editor.contextMenu.showGrid');
+
   useLayoutEffect(() => {
     if (!menu) {
       setPos(null);
@@ -430,15 +475,9 @@ function CanvasContextMenu({
   return createPortal(
     <>
       <div
+        data-ctx-menu
         className="fixed inset-0 z-[60]"
-        onPointerDown={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          const target = e.target as HTMLElement | null;
-          // Keep menu open while interacting with the export flyout portal.
-          if (target?.closest?.('[data-ctx-menu-flyout]')) return;
-          if (menu) dismiss();
-        }}
+        onPointerDown={onBackdropPointerDown}
         aria-hidden
       />
       {menu ? (
@@ -556,42 +595,22 @@ function CanvasContextMenu({
           />
           <div className="my-1 h-px bg-[var(--line)]" />
           <MenuItem
-            icon={
-              targetHidden ? (
-                <HiOutlineEyeSlash className={ICON_CLASS} strokeWidth={1.75} />
-              ) : (
-                <HiOutlineEye className={ICON_CLASS} strokeWidth={1.75} />
-              )
-            }
-            label={
-              targetHidden ? t('editor.contextMenu.show') : t('editor.contextMenu.hide')
-            }
+            icon={visibilityIcon}
+            label={visibilityLabel}
             shortcut={`${modLabel}+Shift+H`}
             disabled={!hideEnabled}
             onClick={() => runAction('toggleHidden')}
           />
           <MenuItem
-            icon={
-              targetLocked ? (
-                <HiOutlineLockClosed className={ICON_CLASS} strokeWidth={1.75} />
-              ) : (
-                <HiOutlineLockOpen className={ICON_CLASS} strokeWidth={1.75} />
-              )
-            }
-            label={
-              targetLocked ? t('editor.contextMenu.unlock') : t('editor.contextMenu.lock')
-            }
+            icon={lockIcon}
+            label={lockLabel}
             shortcut={`${modLabel}+Shift+K`}
             disabled={!lockEnabled}
             onClick={() => runAction('toggleLocked')}
           />
           <MenuItem
             icon={<IconGrid className={ICON_CLASS} />}
-            label={
-              gridOn
-                ? t('editor.contextMenu.hideGrid')
-                : t('editor.contextMenu.showGrid')
-            }
+            label={gridLabel}
             onClick={() => runAction('toggleGrid')}
           />
           <div className="my-1 h-px bg-[var(--line)]" />

--- a/apps/web/src/components/rcb/selection/chrome/MultiSelectionToolbar.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/MultiSelectionToolbar.tsx
@@ -726,7 +726,7 @@ function MultiSelectionToolbar({
       )}
       {sizeField('w', box.width)}
       <Tooltip
-        title={
+        tip={
           aspectLocked
             ? t('editor.imageToolbar.unlockAspect')
             : t('editor.imageToolbar.lockAspect')

--- a/apps/web/src/components/rcb/selection/chrome/SelectionContextToolbar.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/SelectionContextToolbar.tsx
@@ -664,7 +664,7 @@ function SelectionContextToolbar(props: Props): ReactNode {
                 />
                 <Sep />
                 <Tooltip
-                  title={
+                  tip={
                     imageAspectLocked
                       ? t('editor.imageToolbar.unlockAspect')
                       : t('editor.imageToolbar.lockAspect')

--- a/apps/web/src/pages/EditorPage.tsx
+++ b/apps/web/src/pages/EditorPage.tsx
@@ -1011,28 +1011,13 @@ function EditorPage() {
   const sessionReadyForIdRef = useRef<string | null>(null);
   const didInitialFitRef = useRef(false);
   const gridUserTouchedRef = useRef(false);
-  /** True after the user pans/zooms — stops auto re-fit on stage resize. */
-  const cameraTouchedByUserRef = useRef(false);
-  /** Next camera write is programmatic (fit) — don't count as user touch. */
-  const skipCameraTouchRef = useRef(false);
   useEffect(() => {
     sessionReadyForIdRef.current = null;
     didInitialFitRef.current = false;
     gridUserTouchedRef.current = false;
-    cameraTouchedByUserRef.current = false;
-    skipCameraTouchRef.current = false;
     setCamera(DEFAULT_CAMERA);
     dispatch(setGridMode(false));
   }, [currentId, dispatch]);
-
-  useEffect(() => {
-    if (skipCameraTouchRef.current) {
-      skipCameraTouchRef.current = false;
-      return;
-    }
-    if (!didInitialFitRef.current) return;
-    cameraTouchedByUserRef.current = true;
-  }, [camera.x, camera.y, camera.zoom]);
 
   useEffect(() => {
     if (!currentId || !document) return;
@@ -1370,7 +1355,6 @@ function EditorPage() {
     if (vw < 1 || vh < 1) return;
     const doc = (store.getState() as any).editor?.document;
     const fr: ArtboardFrame[] = Array.isArray(doc?.frames) ? doc.frames : [];
-    skipCameraTouchRef.current = true;
     setCamera(rcbFitCamera({ width: vw, height: vh }, editorContentBounds(doc, fr), 120));
   }, []);
 
@@ -1382,27 +1366,6 @@ function EditorPage() {
     }
     finishBoot();
   }, [onFitView]);
-
-  // Agent dock / inspect panel can change stage size after the first fit. Re-fit
-  // until the user pans or zooms so content does not sit off-center then "run away".
-  useEffect(() => {
-    const el = stageEl;
-    if (!el || typeof ResizeObserver === 'undefined') return undefined;
-    let lastW = el.clientWidth;
-    let lastH = el.clientHeight;
-    const ro = new ResizeObserver(() => {
-      const w = el.clientWidth;
-      const h = el.clientHeight;
-      if (!(w > 8 && h > 8)) return;
-      if (!didInitialFitRef.current || cameraTouchedByUserRef.current) return;
-      if (Math.abs(w - lastW) < 2 && Math.abs(h - lastH) < 2) return;
-      lastW = w;
-      lastH = h;
-      onFitView();
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [stageEl, onFitView]);
 
   const zoomModLabel = zoomModShortcutLabel();
 

--- a/apps/web/src/pages/SharePage.tsx
+++ b/apps/web/src/pages/SharePage.tsx
@@ -92,6 +92,25 @@ function zoomModShortcutLabel() {
   return /Mac|iPhone|iPad/i.test(navigator.platform || navigator.userAgent) ? '⌘' : 'Ctrl';
 }
 
+function useViewportMatch(query: string) {
+  const read = () =>
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+      ? window.matchMedia(query).matches
+      : false;
+  const [matches, setMatches] = useState(read);
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+    const media = window.matchMedia(query);
+    const onChange = () => setMatches(media.matches);
+    onChange();
+    media.addEventListener('change', onChange);
+    return () => media.removeEventListener('change', onChange);
+  }, [query]);
+  return matches;
+}
+
 function shareDocumentFingerprint(doc: unknown): string {
   try {
     return JSON.stringify(doc);
@@ -169,12 +188,12 @@ function SharePage() {
   const [bootOpen, setBootOpen] = useState(true);
   const [bootExiting, setBootExiting] = useState(false);
   const [bootProgress, setBootProgress] = useState(8);
+  /** Narrow preview chrome: icon-only actions so title + buttons do not overlap. */
+  const compactTopBar = useViewportMatch('(max-width: 900px)');
   const stageRef = useRef<HTMLDivElement | null>(null);
   const [stageEl, setStageEl] = useState<HTMLElement | null>(null);
   const docFingerprintRef = useRef('');
   const didInitialFitRef = useRef(false);
-  const cameraTouchedByUserRef = useRef(false);
-  const skipCameraTouchRef = useRef(false);
   const bootOpenRef = useRef(true);
   const bootFinishingRef = useRef(false);
   const bootStartedAt = useRef(Date.now());
@@ -201,8 +220,6 @@ function SharePage() {
 
   useEffect(() => {
     didInitialFitRef.current = false;
-    cameraTouchedByUserRef.current = false;
-    skipCameraTouchRef.current = false;
     bootOpenRef.current = true;
     bootFinishingRef.current = false;
     bootStartedAt.current = Date.now();
@@ -239,15 +256,6 @@ function SharePage() {
     const failSafe = window.setTimeout(() => finishBoot(), 12000);
     return () => window.clearTimeout(failSafe);
   }, [bootOpen, finishBoot]);
-
-  useEffect(() => {
-    if (skipCameraTouchRef.current) {
-      skipCameraTouchRef.current = false;
-      return;
-    }
-    if (!didInitialFitRef.current) return;
-    cameraTouchedByUserRef.current = true;
-  }, [camera.x, camera.y, camera.zoom]);
 
   const canEdit = Boolean(record?.viewerCanEdit);
   const canView = Boolean(record?.viewerCanView);
@@ -287,11 +295,10 @@ function SharePage() {
     const vh = el?.clientHeight || 0;
     if (vw < 1 || vh < 1) return;
     const fr: ArtboardFrame[] = Array.isArray(document?.frames) ? document.frames : [];
-    skipCameraTouchRef.current = true;
     setCamera(rcbFitCamera({ width: vw, height: vh }, previewContentBounds(document, fr), 120));
   }, [document]);
 
-  // Fit once content is on the stage; re-fit on panel resize until the user pans/zooms.
+  // Fit once when content is on the stage — do not re-fit when panels resize.
   useEffect(() => {
     if (!document || !record?.viewerCanView || canEdit) return;
     const el = stageRef.current || stageEl;
@@ -301,25 +308,6 @@ function SharePage() {
     onFitView();
     finishBoot();
   }, [document, record?.viewerCanView, canEdit, stageEl, onFitView, finishBoot]);
-
-  useEffect(() => {
-    const el = stageEl || stageRef.current;
-    if (!el || typeof ResizeObserver === 'undefined') return undefined;
-    let lastW = el.clientWidth;
-    let lastH = el.clientHeight;
-    const ro = new ResizeObserver(() => {
-      const w = el.clientWidth;
-      const h = el.clientHeight;
-      if (!(w > 8 && h > 8)) return;
-      if (!didInitialFitRef.current || cameraTouchedByUserRef.current) return;
-      if (Math.abs(w - lastW) < 2 && Math.abs(h - lastH) < 2) return;
-      lastW = w;
-      lastH = h;
-      onFitView();
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [stageEl, onFitView]);
 
   const zoomPercent = Math.round(camera.zoom * 100);
   const zoomModLabel = zoomModShortcutLabel();
@@ -567,40 +555,45 @@ function SharePage() {
 
   return (
     <div className="relative flex h-full min-h-0 flex-col overflow-hidden bg-[var(--canvas)]">
-      <div className="pointer-events-none absolute left-4 top-3 z-40">
-        <div className="pointer-events-auto flex min-w-0 items-center gap-2">
-          <span className="max-w-[min(16rem,calc(100vw-14rem))] truncate text-[14px] font-medium text-[var(--ink)]">
-            {record.name}
-          </span>
-          <span className="inline-flex h-6 shrink-0 items-center rounded-full bg-[var(--surface)] px-2 text-[11px] font-medium text-[var(--muted)] ring-1 ring-[var(--line)]">
-            {t('editor.sharePreviewOnly', { defaultValue: t('editor.sharePreview') })}
-          </span>
-        </div>
-      </div>
-
       <div
-        className="pointer-events-none absolute top-3 z-40"
+        className="pointer-events-none absolute inset-x-0 top-3 z-40 flex items-center gap-2 pl-4"
         style={{
-          right: inspectOpen ? getInspectDockWidth() + 16 : 16,
+          paddingRight: inspectOpen ? getInspectDockWidth() + 16 : 16,
         }}
       >
-        <div className="pointer-events-auto flex items-center gap-2">
-          {canExport ? <EditorTopExportButton /> : null}
-          <button
-            type="button"
-            onClick={() => setInspectOpen((v) => !v)}
-            className={cn(
-              'inline-flex h-8 items-center gap-1.5 rounded-xl px-3 text-[13px] font-medium shadow-sm ring-1 ring-[var(--line)]',
-              inspectOpen
-                ? 'bg-[var(--ink)] text-[var(--on-brand)]'
-                : 'bg-[var(--surface)] text-[var(--ink)]'
-            )}
-          >
-            <HiOutlineCodeBracket className="h-4 w-4" />
-            {t('editor.devInspect')}
-          </button>
-          <WalletAccountChip />
+        <div className="pointer-events-auto flex min-w-0 flex-1 items-center gap-2">
+          <span className="min-w-0 truncate text-[14px] font-medium text-[var(--ink)]">
+            {record.name}
+          </span>
+          {compactTopBar ? null : (
+            <span className="inline-flex h-6 shrink-0 items-center rounded-full bg-[var(--surface)] px-2 text-[11px] font-medium text-[var(--muted)] ring-1 ring-[var(--line)]">
+              {t('editor.sharePreviewOnly', { defaultValue: t('editor.sharePreview') })}
+            </span>
+          )}
         </div>
+        {/* Narrow + inspect open: panel owns the chrome; keep Export/Inspect/wallet off the sliver. */}
+        {compactTopBar && inspectOpen ? null : (
+          <div className="pointer-events-auto flex shrink-0 items-center gap-1.5">
+            {canExport ? <EditorTopExportButton iconOnly={compactTopBar} /> : null}
+            <button
+              type="button"
+              aria-label={t('editor.devInspect')}
+              title={t('editor.devInspect')}
+              onClick={() => setInspectOpen((v) => !v)}
+              className={cn(
+                'inline-flex h-8 items-center justify-center rounded-xl text-[13px] font-medium shadow-sm ring-1 ring-[var(--line)]',
+                compactTopBar ? 'w-8 px-0' : 'gap-1.5 px-3',
+                inspectOpen
+                  ? 'bg-[var(--ink)] text-[var(--on-brand)]'
+                  : 'bg-[var(--surface)] text-[var(--ink)]'
+              )}
+            >
+              <HiOutlineCodeBracket className="h-4 w-4 shrink-0" />
+              {compactTopBar ? null : t('editor.devInspect')}
+            </button>
+            <WalletAccountChip className={compactTopBar ? 'max-w-[7.5rem]' : undefined} />
+          </div>
+        )}
       </div>
 
       <div className="relative flex min-h-0 flex-1">


### PR DESCRIPTION
## Summary
- Fix inspect/export for video-only selection (MP4/MP3) to match the editor flow.
- Drive canvas context menu from pointer/long-press gestures instead of unreliable browser `contextmenu` coordinates on small screens.
- Fit the camera once on page enter; stop auto re-fit when agent/inspect panels resize.
- Stabilize share preview top chrome on narrow viewports (icon-only actions; hide when inspect is open).
- Replace deprecated `Tooltip` `title` prop with `tip` across the web app.

## Test plan
- [ ] Inspect a video node and export MP4/MP3 from the selection export panel
- [ ] On a small/touch viewport: long-press a canvas node and confirm the context menu opens on the node
- [ ] Enter editor/share: content fits once; toggling agent/inspect does not re-zoom
- [ ] Share preview ≤900px: top actions are icon-only; with inspect open they are hidden; closing inspect restores them
- [ ] Hover tooltips still show (no `title` deprecation warnings on Tooltip)
