### PR TITLE
Polish skill chips, multi-angle panel, and process overlay

### DIFF
--- a/apps/web/src/components/editor/nodes/ImageNode/ImageProcessOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageProcessOverlay.tsx
@@ -88,18 +88,18 @@ function ProcessNodeChrome({
   return (
     <div
       data-scene-node-id={nodeId}
-      className="pointer-events-none absolute z-[29]"
+      className="pointer-events-none absolute z-[1]"
       style={frameStyle}
     >
       <div
         data-image-process-shimmer
-        className="rcb-image-process-shimmer absolute z-[29] overflow-hidden"
+        className="rcb-image-process-shimmer absolute inset-0 overflow-hidden"
         style={shimmerStyle}
         aria-hidden
       />
       <div
         data-image-process-label
-        className="absolute z-[30] whitespace-nowrap rounded-full bg-[rgba(55,55,55,0.72)] px-2.5 py-1 text-[11px] font-medium leading-none text-white shadow-[0_2px_8px_rgba(15,23,42,0.18)]"
+        className="absolute z-[1] whitespace-nowrap rounded-full bg-[rgba(55,55,55,0.72)] px-2.5 py-1 text-[11px] font-medium leading-none text-white shadow-[0_2px_8px_rgba(15,23,42,0.18)]"
         style={pillStyle}
       >
         {label}

--- a/apps/web/src/components/editor/nodes/ImageNode/toolPanels/MultiAngleToolPanel.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/toolPanels/MultiAngleToolPanel.tsx
@@ -10,7 +10,7 @@ import AngleEditorScene, {
 } from './AngleEditorScene';
 import ImageToolPanelShell, {
   IMAGE_TOOL_TOKEN_COST,
-  PanelFooterActions,
+  PanelConfirmCost,
   PanelIconBtn,
   PanelSliderRow,
 } from './ImageToolPanelShell';
@@ -32,9 +32,11 @@ const ROTATE_MAX = 90;
 const TILT_MIN = -60;
 const TILT_MAX = 60;
 
-/** Left preview: narrower column, keep stage height. */
+/** Left preview column width; height stretches with the right column + CTA. */
 const PREVIEW_WIDTH = 240;
-const PREVIEW_HEIGHT = 280;
+
+const confirmBtnClass =
+  'inline-flex h-7 w-full shrink-0 items-center justify-center gap-1 whitespace-nowrap rounded-xl px-2 text-[12px] font-medium leading-none transition-colors bg-[var(--ink)] text-[var(--on-brand)] hover:opacity-90 disabled:bg-[var(--line)] disabled:text-[var(--muted)] disabled:opacity-80';
 
 const clampInt = (v: number, min: number, max: number) =>
   Math.round(Math.max(min, Math.min(max, v)));
@@ -102,29 +104,12 @@ function MultiAngleToolPanel({
           <HiOutlineArrowPath className="h-4 w-4" />
         </PanelIconBtn>
       }
-      footer={
-        <PanelFooterActions
-          onCancel={onCancel}
-          confirmBusy={busy}
-          onConfirm={() => {
-            setBusy(true);
-            onConfirm({
-              rotate,
-              tilt,
-              zoom: scaleValueToIndex(scale) * 50,
-              mode: tab,
-            });
-          }}
-          confirmLabel={t('editor.imageToolbar.useNow')}
-          confirmCost={IMAGE_TOOL_TOKEN_COST.multiAngle}
-        />
-      }
     >
       <div className="flex items-stretch gap-2.5">
-        {/* Left — orbit / skybox preview */}
+        {/* Left — preview stretches to align with Use now */}
         <div
-          className="relative shrink-0 overflow-hidden rounded bg-[var(--canvas)] ring-1 ring-[var(--line)]"
-          style={{ width: PREVIEW_WIDTH, height: PREVIEW_HEIGHT }}
+          className="relative min-h-[280px] shrink-0 self-stretch overflow-hidden rounded bg-[var(--canvas)] ring-1 ring-[var(--line)]"
+          style={{ width: PREVIEW_WIDTH }}
         >
           <AngleEditorScene
             className="h-full w-full"
@@ -138,84 +123,107 @@ function MultiAngleToolPanel({
           />
         </div>
 
-        {/* Right — mode, presets, fine-tune (10px item gaps) */}
-        <div className="flex min-w-0 flex-1 flex-col gap-2.5">
-          <SegmentedControl
-            className="shrink-0"
-            size="sm"
-            fullWidth
-            value={tab}
-            onChange={setTab}
-            options={[
-              { value: 'skybox', label: t('editor.imageToolbar.skybox') },
-              { value: 'camera', label: t('editor.imageToolbar.camera') },
-            ]}
-          />
+        {/* Right — mode, presets, fine-tune + CTA */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex min-h-0 flex-1 flex-col gap-2.5">
+            <SegmentedControl
+              className="shrink-0"
+              size="sm"
+              fullWidth
+              value={tab}
+              onChange={setTab}
+              options={[
+                { value: 'skybox', label: t('editor.imageToolbar.skybox') },
+                { value: 'camera', label: t('editor.imageToolbar.camera') },
+              ]}
+            />
 
-          <div className="min-h-0 flex-1">
-            <div className="mb-2.5 text-[12px] text-[var(--muted)]">
-              {t('editor.imageToolbar.commonAngles')}
+            <div className="min-h-0 flex-1">
+              <div className="mb-2.5 text-[12px] text-[var(--muted)]">
+                {t('editor.imageToolbar.commonAngles')}
+              </div>
+              <div className="grid grid-cols-2 gap-2.5">
+                {ANGLE_PRESET_KEYS.map((preset) => {
+                  const active = activePresetKey === preset.key;
+                  const label = angleLabel(preset.key);
+                  const tip = `${label}  ${preset.rotate}° / ${preset.tilt}°`;
+                  return (
+                    <Tooltip key={preset.key} tip={tip} placement="top">
+                      <button
+                        type="button"
+                        aria-label={tip}
+                        onClick={() => applyPreset(preset)}
+                        className={cn(
+                          'h-8 w-full rounded-xl px-2 text-[12px] font-medium transition-colors',
+                          active
+                            ? 'bg-[var(--ink)] text-[var(--on-brand)]'
+                            : 'bg-[var(--accent-soft)] text-[var(--ink)] hover:bg-[var(--line)]'
+                        )}
+                      >
+                        {label}
+                      </button>
+                    </Tooltip>
+                  );
+                })}
+              </div>
             </div>
-            <div className="grid grid-cols-2 gap-2.5">
-              {ANGLE_PRESET_KEYS.map((preset) => {
-                const active = activePresetKey === preset.key;
-                const label = angleLabel(preset.key);
-                const tip = `${label}  ${preset.rotate}° / ${preset.tilt}°`;
-                return (
-                  <Tooltip key={preset.key} tip={tip} placement="top">
-                    <button
-                      type="button"
-                      aria-label={tip}
-                      onClick={() => applyPreset(preset)}
-                      className={cn(
-                        'h-8 w-full rounded-xl px-2 text-[12px] font-medium transition-colors',
-                        active
-                          ? 'bg-[var(--ink)] text-[var(--on-brand)]'
-                          : 'bg-[var(--accent-soft)] text-[var(--ink)] hover:bg-[var(--line)]'
-                      )}
-                    >
-                      {label}
-                    </button>
-                  </Tooltip>
-                );
-              })}
+
+            <div className="mt-auto flex shrink-0 flex-col gap-2.5">
+              <PanelSliderRow
+                className="py-0"
+                label={t('editor.imageToolbar.rotate')}
+                value={rotate}
+                min={ROTATE_MIN}
+                max={ROTATE_MAX}
+                step={1}
+                display={`${rotate}°`}
+                onChange={setRotateInt}
+                fillFromZero
+              />
+              <PanelSliderRow
+                className="py-0"
+                label={t('editor.imageToolbar.tilt')}
+                value={tilt}
+                min={TILT_MIN}
+                max={TILT_MAX}
+                step={1}
+                display={`${tilt}°`}
+                onChange={setTiltInt}
+                fillFromZero
+              />
+              <PanelSliderRow
+                className="py-0"
+                label={t('editor.imageToolbar.zoom')}
+                value={scaleValueToIndex(scale)}
+                min={0}
+                max={2}
+                step={1}
+                display={scaleLabel}
+                onChange={(v) => setScale(scaleIndexToValue(v))}
+              />
             </div>
           </div>
 
-          <div className="mt-auto flex shrink-0 flex-col gap-2.5">
-            <PanelSliderRow
-              className="py-0"
-              label={t('editor.imageToolbar.rotate')}
-              value={rotate}
-              min={ROTATE_MIN}
-              max={ROTATE_MAX}
-              step={1}
-              display={`${rotate}°`}
-              onChange={setRotateInt}
-              fillFromZero
-            />
-            <PanelSliderRow
-              className="py-0"
-              label={t('editor.imageToolbar.tilt')}
-              value={tilt}
-              min={TILT_MIN}
-              max={TILT_MAX}
-              step={1}
-              display={`${tilt}°`}
-              onChange={setTiltInt}
-              fillFromZero
-            />
-            <PanelSliderRow
-              className="py-0"
-              label={t('editor.imageToolbar.zoom')}
-              value={scaleValueToIndex(scale)}
-              min={0}
-              max={2}
-              step={1}
-              display={scaleLabel}
-              onChange={(v) => setScale(scaleIndexToValue(v))}
-            />
-          </div>
+          <button
+            type="button"
+            disabled={busy}
+            className={cn(confirmBtnClass, 'mt-[10px]')}
+            onClick={() => {
+              setBusy(true);
+              onConfirm({
+                rotate,
+                tilt,
+                zoom: scaleValueToIndex(scale) * 50,
+                mode: tab,
+              });
+            }}
+          >
+            {busy ? (
+              <span className="h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+            ) : null}
+            <span className="truncate">{t('editor.imageToolbar.useNow')}</span>
+            <PanelConfirmCost amount={IMAGE_TOOL_TOKEN_COST.multiAngle} />
+          </button>
         </div>
       </div>
     </ImageToolPanelShell>

--- a/apps/web/src/components/editor/panels/AgentComposerInput.tsx
+++ b/apps/web/src/components/editor/panels/AgentComposerInput.tsx
@@ -25,18 +25,26 @@ const CONTEXT_CHIP_THUMB_CLASS =
 const CONTEXT_ICON_SVG =
   '<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M9 9h6v6H9z"/></svg>';
 
+function isSkillComposerContext(ctx: { kind?: string; key?: string }): boolean {
+  return ctx.kind === 'skill' || Boolean(ctx.key?.startsWith('skill:'));
+}
+
 /** Read-only / history chip matching the composer pill (optional × when `onRemove`). */
 function ContextChipPill({
   label,
   thumbUrl,
+  hideLeadingIcon,
   onRemove,
   className,
 }: {
   label: string;
   thumbUrl?: string;
+  /** Skill chips: label (+ ×) only — no nested-squares placeholder. */
+  hideLeadingIcon?: boolean;
   onRemove?: () => void;
   className?: string;
 }): ReactNode {
+  const showIcon = !thumbUrl && !hideLeadingIcon;
   return (
     <span
       className={cn(
@@ -47,13 +55,13 @@ function ContextChipPill({
     >
       {thumbUrl ? (
         <img src={thumbUrl} alt="" className={CONTEXT_CHIP_THUMB_CLASS} />
-      ) : (
+      ) : showIcon ? (
         <span
           className="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-[3px] bg-[var(--canvas)] text-[var(--muted)] ring-1 ring-[var(--line)]"
           aria-hidden
           dangerouslySetInnerHTML={{ __html: CONTEXT_ICON_SVG }}
         />
-      )}
+      ) : null}
       <span className="truncate font-medium">{label}</span>
       {onRemove ? (
         <button
@@ -418,6 +426,8 @@ function buildChip(
     label: string;
     iconSvg: string;
     thumbUrl?: string;
+    /** Skill chips: label + × only when no logo thumb. */
+    hideLeadingIcon?: boolean;
     onRemove: () => void;
   }
 ): HTMLSpanElement {
@@ -430,8 +440,8 @@ function buildChip(
   // Keep in sync with CONTEXT_CHIP_PILL_CLASS / ContextChipPill.
   chip.className = cn(CONTEXT_CHIP_PILL_CLASS, 'mr-1');
 
-  let leading: HTMLElement;
   const thumb = String(opts.thumbUrl || '').trim();
+  const parts: HTMLElement[] = [];
   if (thumb) {
     chip.classList.add('pl-1', 'pr-0.5');
     const img = document.createElement('img');
@@ -439,20 +449,23 @@ function buildChip(
     img.alt = '';
     img.draggable = false;
     img.className = CONTEXT_CHIP_THUMB_CLASS;
-    leading = img;
-  } else {
+    parts.push(img);
+  } else if (!opts.hideLeadingIcon) {
     chip.classList.add('pl-1.5', 'pr-0.5');
     const icon = document.createElement('span');
     icon.className =
       'inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-[3px] bg-[var(--canvas)] text-[var(--muted)] ring-1 ring-[var(--line)]';
     icon.setAttribute('aria-hidden', 'true');
     icon.innerHTML = opts.iconSvg;
-    leading = icon;
+    parts.push(icon);
+  } else {
+    chip.classList.add('pl-1.5', 'pr-0.5');
   }
 
   const label = document.createElement('span');
   label.className = 'truncate font-medium';
   label.textContent = opts.label;
+  parts.push(label);
 
   const remove = document.createElement('button');
   remove.type = 'button';
@@ -465,8 +478,9 @@ function buildChip(
     e.stopPropagation();
     opts.onRemove();
   });
+  parts.push(remove);
 
-  chip.append(leading, label, remove);
+  chip.append(...parts);
   return chip;
 }
 
@@ -597,6 +611,7 @@ const AgentComposerInput = forwardRef<
       label: ctx.label,
       iconSvg: CONTEXT_ICON,
       thumbUrl: ctx.thumbUrl || ctx.dataUrl,
+      hideLeadingIcon: isSkillComposerContext(ctx),
       onRemove: () => removeContextByKey(ctx.key),
     });
 
@@ -665,6 +680,7 @@ const AgentComposerInput = forwardRef<
           label: ctx.label,
           iconSvg: CONTEXT_ICON,
           thumbUrl: ctx.thumbUrl || ctx.dataUrl,
+          hideLeadingIcon: isSkillComposerContext(ctx),
           onRemove: () => removeContextByKey(ctx.key),
         })
       );

--- a/apps/web/src/components/editor/panels/agent/ChatTurnList.tsx
+++ b/apps/web/src/components/editor/panels/agent/ChatTurnList.tsx
@@ -713,6 +713,7 @@ function UserMessageBody({
             key={`${c.key}-${chipIdx}`}
             label={c.label}
             thumbUrl={c.thumbUrl}
+            hideLeadingIcon={c.kind === 'skill' || c.key.startsWith('skill:')}
             className="mx-0.5"
           />
         );
@@ -727,6 +728,7 @@ function UserMessageBody({
         key={`${c.key}-${chipIdx}`}
         label={c.label}
         thumbUrl={c.thumbUrl}
+        hideLeadingIcon={c.kind === 'skill' || c.key.startsWith('skill:')}
         className="mx-0.5"
       />
     );

--- a/apps/web/src/components/editor/panels/agent/MentionAttachPanel.tsx
+++ b/apps/web/src/components/editor/panels/agent/MentionAttachPanel.tsx
@@ -90,24 +90,22 @@ function MentionAttachPanel({
                       alt=""
                       className="h-7 w-7 shrink-0 rounded border border-[var(--line)] object-cover"
                     />
-                  ) : (
+                  ) : variant === 'skill' ? null : (
                     <span
                       className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-[var(--line)] bg-[var(--surface)] text-[11px] font-semibold text-[var(--muted)]"
                       aria-hidden
                     >
-                      {variant === 'skill' ? '/' : (
-                        <svg
-                          viewBox="0 0 24 24"
-                          width="14"
-                          height="14"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
-                          <rect x="4" y="4" width="16" height="16" rx="2" />
-                          <path d="M9 9h6v6H9z" />
-                        </svg>
-                      )}
+                      <svg
+                        viewBox="0 0 24 24"
+                        width="14"
+                        height="14"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                      >
+                        <rect x="4" y="4" width="16" height="16" rx="2" />
+                        <path d="M9 9h6v6H9z" />
+                      </svg>
                     </span>
                   )}
                   <span className="min-w-0 flex-1">

--- a/apps/web/src/components/rcb/frames/HtmlArtboardFrame.tsx
+++ b/apps/web/src/components/rcb/frames/HtmlArtboardFrame.tsx
@@ -151,14 +151,14 @@ function HtmlArtboardFrame({
           <div
             data-artboard-process-shimmer
             data-frame-id={frame.id}
-            className="rcb-artboard-process-shimmer pointer-events-none absolute z-[29] overflow-hidden"
+            className="rcb-artboard-process-shimmer pointer-events-none absolute z-[1] overflow-hidden"
             style={processOverlayStyle}
             aria-hidden
           />
           <div
             data-artboard-process-label
             data-frame-id={frame.id}
-            className="pointer-events-none absolute z-[30] whitespace-nowrap rounded-full bg-[rgba(55,55,55,0.72)] px-2.5 py-1 text-[11px] font-medium leading-none text-white shadow-[0_2px_8px_rgba(15,23,42,0.18)]"
+            className="pointer-events-none absolute z-[2] whitespace-nowrap rounded-full bg-[rgba(55,55,55,0.72)] px-2.5 py-1 text-[11px] font-medium leading-none text-white shadow-[0_2px_8px_rgba(15,23,42,0.18)]"
             style={processPillStyle}
           >
             {processLabel}


### PR DESCRIPTION
## Summary
- Hide leading icons on skill picker rows and skill chips (composer + chat history)
- Multi-angle panel: remove Cancel, stretch left preview to Use now, add 10px top margin on CTA
- Lower process status pill z-index so it only sits above shimmer, not above titles/toolbars

## Test plan
- [ ] Type `/` in agent composer — skill list has no leading `/` squares
- [ ] Pick a skill — chip shows label + × only (no nested-squares icon)
- [ ] Open Multi-angle — no Cancel; preview bottom aligns with Use now; 10px gap above CTA
- [ ] Run image process (e.g. edit elements) — status pill stays above shimmer, below title/selection chrome