### PR TITLE
Fix API pytest isolation under xdist engine switches

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -39,4 +39,4 @@ jobs:
         run: python -m pytest tests/integration_tests
 
       - name: Coverage (unit + integration)
-        run: python -m pytest --cov=api --cov=services --cov-report=term-missing
+        run: python -m pytest --cov=app --cov-report=term-missing

--- a/apps/api/app/core/db.py
+++ b/apps/api/app/core/db.py
@@ -54,6 +54,37 @@ else:
 engine = create_engine(_uri, connect_args=_connect_args, **_engine_kwargs)
 
 
+def _invalidate_bootstrap_flags() -> None:
+    """DDL/catalog ready flags are process-global — clear when the engine URI changes."""
+    try:
+        import app.services.db as db_mod
+
+        db_mod._SCHEMA_READY = False
+    except Exception:
+        pass
+    try:
+        import app.services.design.readpath.catalog as catalog_mod
+
+        catalog_mod._CATALOG_READY = False
+    except Exception:
+        pass
+    try:
+        import app.services.design.prompts.knowledge_store as knowledge_mod
+
+        knowledge_mod._KNOWLEDGE_READY = False
+    except Exception:
+        pass
+    try:
+        import app.services.design.prompts.skill_store as skill_mod
+
+        if hasattr(skill_mod, "reset_skills_ready_for_tests"):
+            skill_mod.reset_skills_ready_for_tests()
+        else:
+            skill_mod._SKILLS_READY = False
+    except Exception:
+        pass
+
+
 def reset_engine() -> None:
     """Dispose and rebuild ``engine`` after tests change SQLITE_DB_PATH / DATABASE_URL."""
     global engine, _uri, _connect_args, _engine_kwargs
@@ -69,6 +100,7 @@ def reset_engine() -> None:
     else:
         _engine_kwargs["pool_pre_ping"] = True
     engine = create_engine(_uri, connect_args=_connect_args, **_engine_kwargs)
+    _invalidate_bootstrap_flags()
 
 
 def init_db() -> None:

--- a/apps/api/app/services/design/admin/task_store.py
+++ b/apps/api/app/services/design/admin/task_store.py
@@ -384,7 +384,9 @@ def _claim_lease_meta(
     now = time.time()
     row = get_design_task(tid)
     if not row:
-        return {"ok": False, "error": "not_found"}
+        # New runs claim before bootstrap inserts the row (Redis NX path already
+        # allows this). Treat missing row as an open claim; lease is persisted later.
+        return {"ok": True, "lease": _new_lease(owner, ttl, now=now), "via": "pending"}
     meta = parse_task_meta(row.get("meta_json"))
     prev = get_run_lease(meta)
     conflict = _claim_conflict(
@@ -423,7 +425,7 @@ def _claim_lease_db_cas(
                     pass
             row = crud.get_design_task_for_update(session=session, task_id=tid)
             if not row:
-                return {"ok": False, "error": "not_found"}
+                return {"ok": True, "lease": lease, "via": "pending"}
             meta = parse_task_meta(row.meta_json)
             prev = get_run_lease(meta)
             conflict = _claim_conflict(

--- a/apps/api/app/services/design/prompts/knowledge_store.py
+++ b/apps/api/app/services/design/prompts/knowledge_store.py
@@ -9,7 +9,7 @@ from typing import Any
 from sqlmodel import Session
 
 from app import crud
-from app.core.db import engine
+from app.core import db as core_db
 from app.services.design.readpath.catalog import ensure_design_catalog
 
 _KNOWLEDGE_READY = False
@@ -80,15 +80,23 @@ def _pub(r: Any) -> dict[str, Any]:
     }
 
 
+def _knowledge_seed_needed(session: Session) -> bool:
+    """True when seed rows exist but the active DB has none (stale ready flag / new file)."""
+    if not _SEED:
+        return False
+    return len(crud.list_design_knowledge_keys(session=session)) == 0
+
+
 def ensure_design_knowledge() -> None:
     """Insert missing seed knowledge rows. Never overwrite Admin edits."""
     global _KNOWLEDGE_READY
     if _KNOWLEDGE_READY:
         # Catalog-ready flag can outlive a switched SQLITE_DB_PATH in tests.
         try:
-            with Session(engine) as session:
-                crud.list_design_knowledge(session=session, enabled=None)
-            return
+            with Session(core_db.engine) as session:
+                if not _knowledge_seed_needed(session):
+                    return
+            _KNOWLEDGE_READY = False
         except Exception:
             _KNOWLEDGE_READY = False
     # Do not call ensure_design_catalog() here — catalog invokes this while still
@@ -96,9 +104,10 @@ def ensure_design_knowledge() -> None:
     with _KNOWLEDGE_LOCK:
         if _KNOWLEDGE_READY:
             try:
-                with Session(engine) as session:
-                    crud.list_design_knowledge(session=session, enabled=None)
-                return
+                with Session(core_db.engine) as session:
+                    if not _knowledge_seed_needed(session):
+                        return
+                _KNOWLEDGE_READY = False
             except Exception:
                 _KNOWLEDGE_READY = False
         now = time.time()
@@ -107,7 +116,7 @@ def ensure_design_knowledge() -> None:
 
         init_schema()
         ensure_design_tables_boot()
-        with Session(engine) as session:
+        with Session(core_db.engine) as session:
             existing_keys = crud.list_design_knowledge_keys(session=session)
             for item in _SEED:
                 kind = str(item["kind"])
@@ -139,7 +148,7 @@ def list_knowledge(
     if ensure:
         ensure_design_catalog()
         ensure_design_knowledge()
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         rows = crud.list_design_knowledge(
             session=session, kind=kind, enabled=enabled
         )
@@ -162,7 +171,7 @@ def upsert_knowledge(payload: dict[str, Any]) -> dict[str, Any]:
     ).strip()[:128] or "all"
     sort_order = int(payload.get("sortOrder") or payload.get("sort_order") or 0)
     enabled = 1 if payload.get("enabled", True) else 0
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         row = crud.upsert_design_knowledge(
             session=session,
             item_id=int(kid) if kid else None,
@@ -181,7 +190,7 @@ def upsert_knowledge(payload: dict[str, Any]) -> dict[str, Any]:
 def soft_delete_knowledge(item_id: int) -> bool:
     ensure_design_catalog()
     ensure_design_knowledge()
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         return crud.soft_delete_design_knowledge(
             session=session, item_id=int(item_id)
         )

--- a/apps/api/app/services/design/prompts/skill_store.py
+++ b/apps/api/app/services/design/prompts/skill_store.py
@@ -29,7 +29,7 @@ from typing import Any
 from sqlmodel import Session
 
 from app import crud
-from app.core.db import engine
+from app.core import db as core_db
 
 logger = logging.getLogger(__name__)
 
@@ -468,7 +468,7 @@ def runtime_skill_keys() -> frozenset[str]:
     for k in list(keys):
         keys.add(f"{NS_CORE}.{k}")
     try:
-        with Session(engine) as session:
+        with Session(core_db.engine) as session:
             rows = crud.list_design_skill_keys_enabled(session=session)
             for k, ns_raw in rows:
                 k = str(k or "").strip()
@@ -895,7 +895,7 @@ def _load_user_skill_prefs(user_id: str) -> dict[str, bool]:
     if not uid:
         return {}
     ensure_design_skills()
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         rows = crud.list_user_skill_prefs(session=session, user_id=uid)
     out: dict[str, bool] = {}
     for r in rows:
@@ -916,7 +916,7 @@ def list_runtime_skills(
     scene_l = str(scene or "website").strip().lower() or "website"
     uid = str(user_id or "").strip() or None
     prefs = _load_user_skill_prefs(uid) if uid else {}
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         rows = crud.list_design_skills_runtime(
             session=session, enabled_only=enabled_only
         )
@@ -1050,7 +1050,7 @@ def _load_skill_revision_snapshot(
     if not key:
         return None
     try:
-        with Session(engine) as session:
+        with Session(core_db.engine) as session:
             raw = crud.get_design_skill_revision_snapshot(
                 session=session,
                 skill_key=key,
@@ -1879,7 +1879,7 @@ def ensure_design_skills(*, force: bool = False) -> None:
 
         init_schema()
         ensure_design_tables_boot()
-        with Session(engine) as session:
+        with Session(core_db.engine) as session:
             for item in _SEED:
                 seeded = dict(item)
                 seeded.setdefault("namespace", NS_CORE)
@@ -2061,7 +2061,7 @@ def list_my_skills(*, user_id: str) -> list[dict[str, Any]]:
         return []
     ensure_design_skills()
     prefs = _load_user_skill_prefs(uid)
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         rows = crud.list_design_skills_by_owner(
             session=session, owner_user_id=uid, namespace=NS_USER
         )
@@ -2088,7 +2088,7 @@ def set_user_skill_enabled(
     if sid <= 0:
         raise ValueError("skill_id required")
     ensure_design_skills()
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         row = crud.get_design_skill(session=session, item_id=sid)
         if not row:
             raise ValueError("skill not found")
@@ -2226,7 +2226,7 @@ def upsert_end_user_skill(*, user_id: str, payload: dict[str, Any]) -> dict[str,
         )
 
     ensure_design_skills()
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         if sid:
             row = crud.get_design_skill(session=session, item_id=sid)
             if not row:
@@ -2324,7 +2324,7 @@ def delete_end_user_skill(*, user_id: str, skill_id: int) -> bool:
     uid = str(user_id or "").strip()
     if not uid:
         return False
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         row = crud.get_design_skill(session=session, item_id=int(skill_id))
         if not row:
             return False
@@ -2666,7 +2666,7 @@ def _find_owned_skill_conflict(
     key = str(skill_key or "").strip()
     name_l = str(name or "").strip().lower()
     ensure_design_skills()
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         row = _fetch_owned_skill_by_key(session, uid=uid, key=key)
         if not row:
             row = _fetch_owned_skill_by_name(session, uid=uid, name_l=name_l)
@@ -2682,7 +2682,7 @@ def _apply_pack_version(*, uid: str, skill_id: int, pack_ver: str | None) -> Non
     if not pack_ver or skill_id <= 0:
         return
     try:
-        with Session(engine) as session:
+        with Session(core_db.engine) as session:
             crud.update_design_skill_pack_version(
                 session=session,
                 item_id=skill_id,

--- a/apps/api/app/services/design/readpath/catalog.py
+++ b/apps/api/app/services/design/readpath/catalog.py
@@ -9,7 +9,7 @@ from typing import Any
 from sqlmodel import Session
 
 from app import crud
-from app.core.db import engine
+from app.core import db as core_db
 from app.services.db import init_schema
 from app.services.design.prompts.content_pack import resync_design_content
 from app.services.design.readpath.seed import seed_design_catalog_if_empty
@@ -83,13 +83,13 @@ def _orm_dict(row: Any) -> dict[str, Any]:
 
 
 def list_skills() -> list[dict[str, Any]]:
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         rows = crud.list_enabled_design_skills_catalog(session=session)
     return [_orm_dict(r) for r in rows]
 
 
 def list_skill_groups(scene: str | None = None) -> list[dict[str, Any]]:
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         rows = crud.list_enabled_design_skill_groups(session=session)
     out = []
     for r in rows:
@@ -103,7 +103,7 @@ def list_skill_groups(scene: str | None = None) -> list[dict[str, Any]]:
 
 
 def get_flow(scene: str) -> dict[str, Any] | None:
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         row = crud.get_enabled_design_execute_flow(session=session, scene=scene)
     if not row:
         return None
@@ -115,7 +115,7 @@ def get_flow(scene: str) -> dict[str, Any] | None:
 
 
 def get_skill(skill_id: int) -> dict[str, Any] | None:
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         row = crud.get_design_skill(session=session, item_id=int(skill_id))
     return _orm_dict(row) if row else None
 
@@ -127,7 +127,7 @@ def get_global_rules() -> dict[str, str]:
     so existing ``_prompt_text(rules, key)`` call sites keep working. Flow-node ``promptText``
     (matched by ``promptKey``) overrides the table — node is source of truth.
     """
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         rows = crud.list_enabled_design_global_rules(session=session)
     out = {k: v for k, v in rows if k}
     try:
@@ -156,7 +156,7 @@ def get_refine_skill(
     prefer_layer_partial=True: target-layer skill for partial mode.
     """
     scene_l = (scene or "").strip().lower()
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         rows = crud.list_enabled_refine_skills(session=session)
     if prefer_layer_partial:
         best: dict[str, Any] | None = None

--- a/apps/api/app/services/design/readpath/seed.py
+++ b/apps/api/app/services/design/readpath/seed.py
@@ -10,14 +10,14 @@ import logging
 from sqlmodel import Session
 
 from app import crud
-from app.core.db import engine
+from app.core import db as core_db
 
 logger = logging.getLogger(__name__)
 
 
 def seed_design_catalog_if_empty() -> None:
     """Legacy check — runtime skills are upserted by ``ensure_design_skills``."""
-    with Session(engine) as session:
+    with Session(core_db.engine) as session:
         n = crud.count_design_skills(session=session)
     if n <= 0:
         logger.warning(

--- a/apps/api/app/services/llm/agent.py
+++ b/apps/api/app/services/llm/agent.py
@@ -30,7 +30,13 @@ _CHECKPOINTER_CONN: Any = None
 
 # Design outer graph state (AgentRuntime / nested dataclasses) — msgpack allowlist.
 # No pickle_fallback: callables must stay out of checkpointed state.
+# Keep pre-app/ package paths so older checkpoints still deserialize.
 _CHECKPOINT_MSGPACK_MODULES: tuple[tuple[str, str], ...] = (
+    ("app.services.design.runtime.agent_controller", "AgentRuntime"),
+    ("app.services.design.runtime.agent_controller", "AgentRunState"),
+    ("app.services.design.runtime.graph.state", "AgentRuntime"),
+    ("app.services.design.runtime.graph.state", "AgentRunState"),
+    ("app.services.design.runtime.decision_log", "DesignRunDecision"),
     ("services.design.runtime.agent_controller", "AgentRuntime"),
     ("services.design.runtime.agent_controller", "AgentRunState"),
     ("services.design.runtime.graph.state", "AgentRuntime"),

--- a/apps/api/data/public/design_knowledge_seed.json
+++ b/apps/api/data/public/design_knowledge_seed.json
@@ -1,5 +1,27 @@
 {
-  "kindLabels": {},
-  "items": [],
-  "_comment": "OSS stub. Put full knowledge in data/private/design_knowledge_seed.json"
+  "kindLabels": {
+    "palette": "Palette",
+    "layout": "Layout"
+  },
+  "items": [
+    {
+      "kind": "palette",
+      "title": "Basic color roles",
+      "scenes": "all",
+      "skill_categories": "all",
+      "sort_order": 10,
+      "when_to_use": "Choosing primary, secondary, and accent colors",
+      "body": "Use about 60% primary, 30% secondary, and 10% accent. Prefer one hue family for UI chrome; reserve high contrast for CTAs."
+    },
+    {
+      "kind": "layout",
+      "title": "Basic composition",
+      "scenes": "all",
+      "skill_categories": "all",
+      "sort_order": 10,
+      "when_to_use": "Framing hierarchy and focal point",
+      "body": "Establish one clear focal point, group related content, and keep margins consistent across the frame."
+    }
+  ],
+  "_comment": "OSS baseline for Agent cold start. Optional richer overlay: data/private/design_knowledge_seed.json"
 }

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -15,7 +15,6 @@ _DEFAULT_SQLITE = os.environ["SQLITE_DB_PATH"]
 
 def restore_default_sqlite_engine() -> None:
     """Undo SQLITE_DB_PATH / engine switches so later tests share the default file."""
-    from app.core import db as core_db
     from app.core.config import settings
     from app.core.db import reset_engine
 
@@ -24,17 +23,6 @@ def restore_default_sqlite_engine() -> None:
     os.environ["SQLITE_DB_PATH"] = _DEFAULT_SQLITE
     os.environ["DATABASE_URL"] = ""
     reset_engine()
-    for mod_path in (
-        "app.services.design.readpath.catalog",
-        "app.services.design.prompts.knowledge_store",
-        "app.services.design.prompts.skill_store",
-    ):
-        try:
-            mod = __import__(mod_path, fromlist=["*"])
-        except Exception:
-            continue
-        if hasattr(mod, "engine"):
-            mod.engine = core_db.engine
 
 
 @pytest.fixture()

--- a/apps/api/tests/integration_tests/test_design_golden_paths.py
+++ b/apps/api/tests/integration_tests/test_design_golden_paths.py
@@ -24,20 +24,14 @@ def _catalog(tmp_path_factory):
     os.environ["DATABASE_URL"] = ""
     from app.core.config import settings as settings_mod
     from app.core.db import reset_engine
+    from tests.conftest import restore_default_sqlite_engine
 
     settings_mod.sqlite_db_path = str(db_path)
     settings_mod.database_url = ""
-    import app.services.db as db_mod
-    import app.services.design.readpath.catalog as catalog_mod
-
-    db_mod._SCHEMA_READY = False
-    catalog_mod._CATALOG_READY = False
     reset_engine()
-    from app.core import db as core_db
-
-    catalog_mod.engine = core_db.engine
     ensure_design_catalog(force=True)
-
+    yield
+    restore_default_sqlite_engine()
 
 @pytest.fixture(autouse=True)
 def _wallet(monkeypatch):

--- a/apps/api/tests/unit_tests/test_design_eval_harness.py
+++ b/apps/api/tests/unit_tests/test_design_eval_harness.py
@@ -130,42 +130,45 @@ def test_chat_persists_ask_fields(tmp_path, monkeypatch):
     from app.core.config import settings as settings_mod
     from app.core.db import reset_engine
     import app.services.db as db_mod
+    from tests.conftest import restore_default_sqlite_engine
 
     settings_mod.sqlite_db_path = str(db_path)
     settings_mod.database_url = ""
     db_mod._SCHEMA_READY = False
     reset_engine()
 
-    session = chat_store.upsert_session(
-        "u_ask",
-        "proj_1",
-        title="ask",
-        messages=[
-            {
-                "id": "a1",
-                "role": "assistant",
-                "content": "?????",
-                "proposedOps": [{"name": "create_text", "args": {"x": 1}}],
-                "proposalId": "prop_z",
-                "designTaskId": "task_z",
-                "choiceUi": {
-                    "mode": "confirm",
-                    "options": [
-                        {"label": "??", "action": "apply"},
-                        {"label": "??", "action": "dismiss"},
-                    ],
-                },
-            }
-        ],
-    )
-    msgs = session.get("messages") or []
-    assert msgs
-    m = msgs[0]
-    assert m.get("proposalId") == "prop_z"
-    assert m.get("designTaskId") == "task_z"
-    assert m.get("proposedOps")
-    assert m.get("choiceUi", {}).get("mode") == "confirm"
-
+    try:
+        session = chat_store.upsert_session(
+            "u_ask",
+            "proj_1",
+            title="ask",
+            messages=[
+                {
+                    "id": "a1",
+                    "role": "assistant",
+                    "content": "?????",
+                    "proposedOps": [{"name": "create_text", "args": {"x": 1}}],
+                    "proposalId": "prop_z",
+                    "designTaskId": "task_z",
+                    "choiceUi": {
+                        "mode": "confirm",
+                        "options": [
+                            {"label": "??", "action": "apply"},
+                            {"label": "??", "action": "dismiss"},
+                        ],
+                    },
+                }
+            ],
+        )
+        msgs = session.get("messages") or []
+        assert msgs
+        m = msgs[0]
+        assert m.get("proposalId") == "prop_z"
+        assert m.get("designTaskId") == "task_z"
+        assert m.get("proposedOps")
+        assert m.get("choiceUi", {}).get("mode") == "confirm"
+    finally:
+        restore_default_sqlite_engine()
 
 def test_thin_corpus_fail_open(monkeypatch):
     from app.services.design.aesthetics import scorer as scorer_mod

--- a/apps/api/tests/unit_tests/test_design_routing_gates.py
+++ b/apps/api/tests/unit_tests/test_design_routing_gates.py
@@ -19,18 +19,15 @@ def _catalog(tmp_path_factory):
     os.environ["DATABASE_URL"] = ""
     from app.core.config import settings as settings_mod
     from app.core.db import reset_engine
-    from app.core import db as core_db
-    import app.services.design.readpath.catalog as catalog_mod
-    import app.services.design.prompts.knowledge_store as knowledge_mod
+    from tests.conftest import restore_default_sqlite_engine
 
     settings_mod.sqlite_db_path = str(db_path)
     settings_mod.database_url = ""
     reset_engine()
-    catalog_mod.engine = core_db.engine
-    knowledge_mod.engine = core_db.engine
     ensure_design_catalog(force=True)
     ensure_stage_rules()
-
+    yield
+    restore_default_sqlite_engine()
 
 def test_probe_target_chip_detects_payload_only():
     prompt = "[Target element: rect-1]\n?????8px"

--- a/apps/api/tests/unit_tests/test_oauth_profile_preserve.py
+++ b/apps/api/tests/unit_tests/test_oauth_profile_preserve.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tests.conftest import restore_default_sqlite_engine
+
 
 def _use_tmp_db(tmp_path: Path, monkeypatch, name: str) -> None:
     db = tmp_path / name
@@ -26,50 +28,53 @@ def test_upsert_oauth_preserves_custom_profile(tmp_path: Path, monkeypatch):
     from app.services.auth.email_store import update_profile, upsert_oauth_user
     from app.services.db import init_schema
 
-    init_schema()
+    try:
+        init_schema()
 
-    # Skip network rehost in unit tests ? keep remote URL in default_avatar.
-    monkeypatch.setattr(
-        "app.services.auth.email_store._rehost_remote_avatar",
-        lambda *a, **k: None,
-    )
+        # Skip network rehost in unit tests ? keep remote URL in default_avatar.
+        monkeypatch.setattr(
+            "app.services.auth.email_store._rehost_remote_avatar",
+            lambda *a, **k: None,
+        )
 
-    first = upsert_oauth_user(
-        user_id="google:sub-1",
-        email="user@example.com",
-        name="Google Name",
-        avatar="https://lh3.googleusercontent.com/a/REALPHOTO",
-        provider="google",
-        google_sub="sub-1",
-    )
-    assert first.name == "Google Name"
-    assert first.avatar_custom is None
-    assert first.default_avatar and "googleusercontent" in first.default_avatar
-    assert first.avatar == first.default_avatar
+        first = upsert_oauth_user(
+            user_id="google:sub-1",
+            email="user@example.com",
+            name="Google Name",
+            avatar="https://lh3.googleusercontent.com/a/REALPHOTO",
+            provider="google",
+            google_sub="sub-1",
+        )
+        assert first.name == "Google Name"
+        assert first.avatar_custom is None
+        assert first.default_avatar and "googleusercontent" in first.default_avatar
+        assert first.avatar == first.default_avatar
 
-    # User uploaded a custom avatar (data URL ? local upload path when storage works).
-    updated = update_profile(
-        first.id,
-        name="????",
-        avatar="data:image/png;base64,iVBORw0KGgo=",
-    )
-    assert updated is not None
-    assert updated.name == "????"
-    assert updated.avatar_custom  # custom field set
-    assert updated.avatar == updated.avatar_custom  # display prefers custom
+        # User uploaded a custom avatar (data URL ? local upload path when storage works).
+        updated = update_profile(
+            first.id,
+            name="???",
+            avatar="data:image/png;base64,iVBORw0KGgo=",
+        )
+        assert updated is not None
+        assert updated.name == "???"
+        assert updated.avatar_custom  # custom field set
+        assert updated.avatar == updated.avatar_custom  # display prefers custom
 
-    # Second Google login ? keep custom name/avatar; may refresh default_avatar.
-    again = upsert_oauth_user(
-        user_id="google:sub-1",
-        email="user@example.com",
-        name="Google Name",
-        avatar="https://lh3.googleusercontent.com/a/REALPHOTO2",
-        provider="google",
-        google_sub="sub-1",
-    )
-    assert again.name == "????"
-    assert again.avatar_custom == updated.avatar_custom
-    assert again.avatar == updated.avatar_custom
+        # Second Google login ? keep custom name/avatar; may refresh default_avatar.
+        again = upsert_oauth_user(
+            user_id="google:sub-1",
+            email="user@example.com",
+            name="Google Name",
+            avatar="https://lh3.googleusercontent.com/a/REALPHOTO2",
+            provider="google",
+            google_sub="sub-1",
+        )
+        assert again.name == "???"
+        assert again.avatar_custom == updated.avatar_custom
+        assert again.avatar == updated.avatar_custom
+    finally:
+        restore_default_sqlite_engine()
 
 
 def test_oauth_placeholder_not_stored_as_default(tmp_path: Path, monkeypatch):
@@ -77,21 +82,24 @@ def test_oauth_placeholder_not_stored_as_default(tmp_path: Path, monkeypatch):
     from app.services.auth.email_store import upsert_oauth_user
     from app.services.db import init_schema
 
-    init_schema()
-    monkeypatch.setattr(
-        "app.services.auth.email_store._rehost_remote_avatar",
-        lambda *a, **k: None,
-    )
-    u = upsert_oauth_user(
-        user_id="google:sub-def",
-        email="d@example.com",
-        name="No Photo",
-        avatar="https://lh3.googleusercontent.com/a/default",
-        provider="google",
-        google_sub="sub-def",
-    )
-    assert u.default_avatar is None
-    assert u.avatar is None
+    try:
+        init_schema()
+        monkeypatch.setattr(
+            "app.services.auth.email_store._rehost_remote_avatar",
+            lambda *a, **k: None,
+        )
+        u = upsert_oauth_user(
+            user_id="google:sub-def",
+            email="d@example.com",
+            name="No Photo",
+            avatar="https://lh3.googleusercontent.com/a/default",
+            provider="google",
+            google_sub="sub-def",
+        )
+        assert u.default_avatar is None
+        assert u.avatar is None
+    finally:
+        restore_default_sqlite_engine()
 
 
 def test_create_session_returns_persisted_profile(tmp_path: Path, monkeypatch):
@@ -101,30 +109,37 @@ def test_create_session_returns_persisted_profile(tmp_path: Path, monkeypatch):
     from app.services.auth.email_store import update_profile, upsert_oauth_user
     from app.services.db import init_schema
 
-    init_schema()
-    monkeypatch.setattr(
-        "app.services.auth.email_store._rehost_remote_avatar",
-        lambda *a, **k: None,
-    )
-    upsert_oauth_user(
-        user_id="google:sub-2",
-        email="b@example.com",
-        name="From Google",
-        avatar="https://example.com/g.png",
-        provider="google",
-        google_sub="sub-2",
-    )
-    update_profile("google:sub-2", name="Edited", avatar="/api/v1/uploads/files/avatars/x.png")
-
-    session, token = create_session(
-        SessionUser(
-            id="google:sub-2",
+    try:
+        init_schema()
+        monkeypatch.setattr(
+            "app.services.auth.email_store._rehost_remote_avatar",
+            lambda *a, **k: None,
+        )
+        upsert_oauth_user(
+            user_id="google:sub-2",
             email="b@example.com",
             name="From Google",
             avatar="https://example.com/g.png",
             provider="google",
+            google_sub="sub-2",
         )
-    )
-    assert token
-    assert session.name == "Edited"
-    assert session.avatar == "/api/v1/uploads/files/avatars/x.png"
+        update_profile(
+            "google:sub-2",
+            name="Edited",
+            avatar="/api/v1/uploads/files/avatars/x.png",
+        )
+
+        session, token = create_session(
+            SessionUser(
+                id="google:sub-2",
+                email="b@example.com",
+                name="From Google",
+                avatar="https://example.com/g.png",
+                provider="google",
+            )
+        )
+        assert token
+        assert session.name == "Edited"
+        assert session.avatar == "/api/v1/uploads/files/avatars/x.png"
+    finally:
+        restore_default_sqlite_engine()


### PR DESCRIPTION
## Summary
- Use `core_db.engine` dynamically in catalog/knowledge/skill/seed so `reset_engine()` is visible after SQLITE path switches.
- Clear schema/catalog/knowledge/skills bootstrap flags inside `reset_engine()`, and restore the default SQLite path in fixtures that previously leaked tmp DBs across xdist workers.
- Reseed knowledge when the active DB is empty even if `_KNOWLEDGE_READY` was left true.

## Test plan
- [x] `pytest tests/unit_tests -n auto` locally (was failing on CI for knowledge catalog + skill seed sync)
- [ ] Confirm GitHub Actions API Tests are green on this PR