### PR TITLE
Fix Alembic xdist stamp races for API CI

### DIFF
--- a/apps/api/app/alembic/env.py
+++ b/apps/api/app/alembic/env.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import engine_from_config, pool
 from sqlmodel import SQLModel
 
-from app.core.db import sqlalchemy_database_uri
+from app.core.db import engine, sqlalchemy_database_uri
 from app import models as _models  # noqa: F401 — register table models
 
 config = context.config
@@ -37,15 +36,9 @@ def run_migrations_offline() -> None:
 
 
 def run_migrations_online() -> None:
-    configuration = config.get_section(config.config_ini_section) or {}
-    configuration["sqlalchemy.url"] = get_url()
-    connectable = engine_from_config(
-        configuration,
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-    )
-    url = configuration["sqlalchemy.url"]
-    with connectable.connect() as connection:
+    """Use the app engine so Session and Alembic always hit the same DB."""
+    url = get_url()
+    with engine.connect() as connection:
         context.configure(
             connection=connection,
             target_metadata=target_metadata,

--- a/apps/api/app/core/db.py
+++ b/apps/api/app/core/db.py
@@ -134,18 +134,82 @@ def init_db() -> None:
 
 
 def run_migrations() -> None:
-    """Apply Alembic migrations to ``head`` (idempotent)."""
+    """Apply Alembic migrations to ``head`` (idempotent; safe under multi-process)."""
+    import os
+    import time
+    from contextlib import contextmanager
+
     from alembic import command
     from alembic.config import Config
+    from sqlalchemy.exc import IntegrityError, OperationalError
 
     init_db()
+    uri = sqlalchemy_database_uri()
     cfg = Config(str(_API_ROOT / "alembic.ini"))
     # ConfigParser treats ``%`` as interpolation — escape DB URLs with %XX encoding.
-    cfg.set_main_option("sqlalchemy.url", sqlalchemy_database_uri().replace("%", "%%"))
+    cfg.set_main_option("sqlalchemy.url", uri.replace("%", "%%"))
     # script_location in alembic.ini is relative to apps/api cwd when running CLI;
     # pin absolute path for in-process calls from arbitrary working directories.
     cfg.set_main_option("script_location", str(_API_ROOT / "app" / "alembic"))
-    command.upgrade(cfg, "head")
+
+    @contextmanager
+    def _sqlite_lock():
+        if not uri.startswith("sqlite"):
+            yield
+            return
+        raw = uri.split("sqlite:///", 1)[-1].split("?", 1)[0]
+        db_path = Path(raw)
+        lock_path = db_path.with_name(db_path.name + ".alembic.lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        fh = open(lock_path, "a+b")
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                while True:
+                    try:
+                        msvcrt.locking(fh.fileno(), msvcrt.LK_LOCK, 1)
+                        break
+                    except OSError:
+                        time.sleep(0.05)
+            else:
+                import fcntl
+
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            yield
+        finally:
+            try:
+                if os.name == "nt":
+                    import msvcrt
+
+                    fh.seek(0)
+                    msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+            except Exception:
+                pass
+            fh.close()
+
+    with _sqlite_lock():
+        try:
+            command.upgrade(cfg, "head")
+        except (IntegrityError, OperationalError) as err:
+            # Concurrent stamp under xdist / multi-worker boot.
+            msg = str(err).lower()
+            if "alembic_version" in msg and (
+                "unique" in msg or "duplicate" in msg
+            ):
+                from alembic.runtime.migration import MigrationContext
+
+                try:
+                    with engine.connect() as conn:
+                        if MigrationContext.configure(conn).get_current_revision():
+                            return
+                except Exception:
+                    pass
+            raise
 
 
 def get_session() -> Session:

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -6,23 +6,42 @@ import os
 
 import pytest
 
-# Prefer isolated sqlite for tests (avoid touching developer DB).
-os.environ.setdefault("SQLITE_DB_PATH", "storage/test-recombyn.db")
-os.environ.setdefault("DATABASE_URL", "")
+# xdist workers must not share one SQLite file (Alembic stamp races).
+# Force sqlite for tests — do not inherit developer MySQL from shell/.env.
+_worker = (os.environ.get("PYTEST_XDIST_WORKER") or "").strip()
+_DEFAULT_SQLITE = (
+    f"storage/test-recombyn-{_worker}.db"
+    if _worker
+    else "storage/test-recombyn.db"
+)
+os.environ["DATABASE_URL"] = ""
+os.environ["SQLITE_DB_PATH"] = _DEFAULT_SQLITE
 
-_DEFAULT_SQLITE = os.environ["SQLITE_DB_PATH"]
+
+def _bind_test_sqlite() -> None:
+    """Point settings + engine at this worker's sqlite file."""
+    from app.core.config import settings
+    from app.core.db import reset_engine
+
+    settings.database_url = ""
+    settings.sqlite_db_path = _DEFAULT_SQLITE
+    os.environ["DATABASE_URL"] = ""
+    os.environ["SQLITE_DB_PATH"] = _DEFAULT_SQLITE
+    reset_engine()
 
 
 def restore_default_sqlite_engine() -> None:
     """Undo SQLITE_DB_PATH / engine switches so later tests share the default file."""
-    from app.core.config import settings
-    from app.core.db import reset_engine
+    _bind_test_sqlite()
 
-    settings.sqlite_db_path = _DEFAULT_SQLITE
-    settings.database_url = ""
-    os.environ["SQLITE_DB_PATH"] = _DEFAULT_SQLITE
-    os.environ["DATABASE_URL"] = ""
-    reset_engine()
+
+@pytest.fixture(scope="session", autouse=True)
+def _session_sqlite_schema() -> None:
+    """Migrate once per xdist worker so tests can query without ad-hoc ensure_*."""
+    _bind_test_sqlite()
+    from app.services.db import init_schema
+
+    init_schema()
 
 
 @pytest.fixture()
@@ -32,13 +51,16 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setenv("SQLITE_DB_PATH", str(db_path))
     monkeypatch.setenv("DATABASE_URL", "")
 
-    # Reload settings / app bindings that read env at import time where needed.
     from app.core.config import settings
     from app.core.db import reset_engine
+    from app.services.db import init_schema
+    import app.services.db as db_mod
 
     settings.sqlite_db_path = str(db_path)
     settings.database_url = ""
     reset_engine()
+    db_mod._SCHEMA_READY = False
+    init_schema()
 
     from fastapi.testclient import TestClient
     from app.main import app


### PR DESCRIPTION
﻿## Summary
- Per-xdist-worker SQLite DB + force empty DATABASE_URL in conftest (session autouse migrate)
- File-lock Alembic upgrades; ignore concurrent alembic_version UNIQUE only when already stamped
- Alembic env.py uses the app engine so Session and migrations share one DB

## Test plan
- [x] pytest unit_tests with xdist
- [x] pytest integration_tests
- [ ] CI API Tests green on this PR
