### PR TITLE
Align RCB chrome to world lattice and screen-constant title/toolbar gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ apps/api/storage/results/*
 apps/api/storage/backups/*
 apps/api/storage/*.db
 apps/api/storage/langgraph_*.db
+apps/api/storage/*.alembic.lock
 !apps/api/storage/uploads/.gitkeep
 !apps/api/storage/results/.gitkeep
 !apps/api/storage/backups/.gitkeep

--- a/apps/web/src/components/base/colorPanel/index.tsx
+++ b/apps/web/src/components/base/colorPanel/index.tsx
@@ -47,7 +47,7 @@ export const FILL_SOLID_PRESETS = [
 /** Same grid + transparent (artboard / alpha-capable pickers). */
 export const FILL_ALPHA_PRESETS = ['transparent', ...FILL_SOLID_PRESETS];
 
-/** Fixed panel width (fig.1 reference). */
+/** Fixed panel width. */
 export const COLOR_PANEL_WIDTH = 250;
 /** Preset grid: 9 square swatches per row (2×9). */
 export const COLOR_PANEL_PRESET_COLS = 9;
@@ -143,7 +143,7 @@ export type ColorPanelProps = {
   /** 0–100; shown when showAlpha is true. */
   opacity?: number;
   onOpacityChange?: (opacity: number) => void;
-  /** Show transparency slider + % input (fig.2). */
+  /** Show transparency slider + % input. */
   showAlpha?: boolean;
   /** Panel title, e.g. 画布背景色 / 填充颜色 */
   title?: string;

--- a/apps/web/src/components/base/colorPanel/pickScreenColor.ts
+++ b/apps/web/src/components/base/colorPanel/pickScreenColor.ts
@@ -192,7 +192,7 @@ function pickColorWithLoupe(): Promise<string | null> {
         LOUPE_SIZE
       );
 
-      // Center pixel target (fig.2).
+      // Center pixel target.
       const cx = LOUPE_SIZE / 2;
       const cy = LOUPE_SIZE / 2;
       const s = Math.max(LOUPE_ZOOM, 8);
@@ -266,10 +266,7 @@ function pickColorWithLoupe(): Promise<string | null> {
   });
 }
 
-/**
- * Pick a screen color. Uses Chromium EyeDropper (loupe like fig.2) when available;
- * otherwise falls back to a canvas loupe over the editor stage.
- */
+/** Pick a screen color via EyeDropper when available, else a canvas loupe. */
 export async function pickScreenColor(signal?: AbortSignal): Promise<string | null> {
   const Ctor = (window as unknown as { EyeDropper?: EyeDropperCtor }).EyeDropper;
   if (typeof Ctor === 'function') {

--- a/apps/web/src/components/base/dropdown/DropdownPanel.tsx
+++ b/apps/web/src/components/base/dropdown/DropdownPanel.tsx
@@ -44,9 +44,7 @@ type DropdownPanelItemProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   children: ReactNode;
 };
 
-/**
- * Menu row — full-width soft selected fill (fig. aspect “原始”), fixed height.
- */
+/** Menu row — full-width soft selected fill, fixed height. */
 export const DropdownPanelItem = memo(
   forwardRef<HTMLButtonElement, DropdownPanelItemProps>(function DropdownPanelItem(
     { selected = false, className, children, type = 'button', disabled, ...rest },

--- a/apps/web/src/components/base/segmented/index.tsx
+++ b/apps/web/src/components/base/segmented/index.tsx
@@ -34,7 +34,7 @@ export type SegmentedControlProps<T extends string = string> = {
 };
 
 const TRACK_RADIUS: Record<SegmentedRadius, string> = {
-  /** Soft rect — fill type / stroke icon tracks (fig.1). */
+  /** Soft rect — fill type / stroke icon tracks. */
   xl: 'rounded-md',
   full: 'rounded-full',
 };

--- a/apps/web/src/components/editor/canvas/SvgCanvas.tsx
+++ b/apps/web/src/components/editor/canvas/SvgCanvas.tsx
@@ -41,6 +41,7 @@ import { computeShapeBoolean, type ShapeBox } from '@/components/rcb/selection/s
 import {
   HEAVY_PATH_D_CHARS,
   STROKE_HIT,
+  sceneHitSlop,
   distPointToPathD,
   distPointToSegment,
   hitTestPath2DLocal,
@@ -165,6 +166,8 @@ import {
   STAMP_TINT_READY_EVENT,
   rcbCenterOnPoint,
   getDocumentGridSize,
+  snapCoordToGrid,
+  rcbDefaultPlaceFontSize,
 } from '@/components/rcb';
 import { parseFrameSelId } from '@/components/rcb/selection/SelectionFeature';
 import ImageProcessOverlay from '@/components/editor/nodes/ImageNode/ImageProcessOverlay';
@@ -386,6 +389,8 @@ function SvgCanvas({
     setGeometryTransforming(next);
     if (!next) {
       dragWriteCoalesceRef.current.cancel();
+      // Clear live geom with the Redux document write in onGeometryCommit when
+      // possible. Soft-click / cancelled transforms still need a clear here.
       setVideoLiveGeom(null);
     }
   }, []);
@@ -598,7 +603,7 @@ function SvgCanvas({
       width: Math.max(1, Number(node.width) || 1),
       height: Math.max(1, Number(node.height) || 1),
     };
-    // Chrome sits on the vector path (inflateSelectionBox / strokeChromeOutset = 0).
+    // Control box = path + stroke visual outer (resize / rotate follow ink).
     return inflateSelectionBox(geom, node);
   }, []);
 
@@ -627,14 +632,15 @@ function SvgCanvas({
       const board = boardRef.current;
       // Infinite paper is 0×0 — always use camera zoom (page-space margin).
       const zoom = Math.max(0.05, camera.zoom || 1);
-      // ~12px on screen, at least half the stroke hit pad in world units.
-      const pad = Math.max(STROKE_HIT / 2, 12 / zoom);
+      // ~12 CSS px slop → scene units (must scale with zoom; raw STROKE_HIT as
+      // scene pad ≈ 480px fat finger at 4000% and blocks blank-click deselect).
+      const pad = sceneHitSlop(zoom);
       const allIds = listNodeIds();
       let order = [...allIds].reverse();
       // Large scenes: only test spatially nearby candidates (z-order preserved among them).
       // Falling through the full list made hover O(N) even with an index.
       if (allIds.length >= 48) {
-        const nearby = nodeSpatialIndex.searchPoint(x, y, pad + 64);
+        const nearby = nodeSpatialIndex.searchPoint(x, y, pad + 64 / zoom);
         if (nearby.length) {
           const allow = new Set(nearby.map((n) => n.id));
           order = order.filter((id) => allow.has(id));
@@ -666,7 +672,8 @@ function SvgCanvas({
               ly = dx * Math.sin(rad) + dy * Math.cos(rad) + cy;
             }
             const { strokeWidth: sw } = resolveStroke(node, '#333333');
-            const hitW = Math.max(sw > 0 ? sw : STROKE_HIT, pad * 2);
+            // Painted stroke + screen slop (not Math.max(sw, STROKE_HIT) in scene units).
+            const hitW = Math.max(sw > 0 ? sw : 2, 0) + pad * 2;
             rememberNodePath2D(id, d);
             if (hitTestPath2DLocal(d, lx, ly, { strokeWidth: hitW, lineCap: 'round', lineJoin: 'round' })) {
               return id;
@@ -684,7 +691,7 @@ function SvgCanvas({
             1,
             Number(node.attrs?.borderWidth ?? node.attrs?.['border-width'] ?? 2) || 2
           );
-          const pathPad = Math.max(sw / 2 + 2, 10 / zoom);
+          const pathPad = sw / 2 + sceneHitSlop(zoom, 10);
           // Closed boolean/path fills: hit interior, not only the outline.
           const fillHit = shapeType !== 'pen' && supportsFill(node);
           const inLooseBox =
@@ -712,7 +719,7 @@ function SvgCanvas({
           }
           if (!heavyPath && d) {
             rememberNodePath2D(id, d);
-            const hitW = Math.min(Math.max(sw * 2, pathPad * 2), sw + 24 / zoom);
+            const hitW = sw + pathPad * 2;
             if (
               hitTestPath2DLocal(d, lx, ly, {
                 fill: fillHit,
@@ -732,8 +739,7 @@ function SvgCanvas({
           const svgEl = board?.nodeEls?.get(id);
           if (svgEl && screen) {
             const mode = shapeType === 'pencil' || fillHit ? 'auto' : 'stroke';
-            // Cap temporary stroke width — huge values ≈ AABB at low zoom.
-            const hitW = Math.min(Math.max(sw * 2, pathPad * 2), sw + 24 / zoom);
+            const hitW = sw + pathPad * 2;
             if (
               hitTestSvgNodeAtClient(svgEl, screen.clientX, screen.clientY, {
                 mode,
@@ -800,12 +806,10 @@ function SvgCanvas({
             }
             const { stroke, strokeWidth: sw } = resolveStroke(node, '#333333');
             const align = resolveStrokeAlign(node.attrs);
-            // Outside paints a 2× underlay — widen stroke hit so the outer ink stays clickable.
+            // Match painted ink + screen slop. Never Math.max(sw, 12) in scene units.
             const strokeHit =
               stroke && stroke !== 'transparent' && sw > 0
-                ? align === 'outside'
-                  ? Math.max(sw * 2, pad)
-                  : Math.max(sw, pad)
+                ? (align === 'outside' ? sw * 2 : sw) + pad * 2
                 : 0;
             rememberNodePath2D(id, d);
             if (
@@ -831,18 +835,18 @@ function SvgCanvas({
             const lx = dx * Math.cos(rad) - dy * Math.sin(rad);
             const ly = dx * Math.sin(rad) + dy * Math.cos(rad);
             if (
-              Math.abs(lx) <= hitBox.width / 2 + hitPad * 0.25 &&
-              Math.abs(ly) <= hitBox.height / 2 + hitPad * 0.25
+              Math.abs(lx) <= hitBox.width / 2 + hitPad &&
+              Math.abs(ly) <= hitBox.height / 2 + hitPad
             ) {
               return id;
             }
             continue;
           }
           if (
-            x >= hitBox.left - hitPad * 0.15 &&
-            x <= hitBox.left + hitBox.width + hitPad * 0.15 &&
-            y >= hitBox.top - hitPad * 0.15 &&
-            y <= hitBox.top + hitBox.height + hitPad * 0.15
+            x >= hitBox.left - hitPad &&
+            x <= hitBox.left + hitBox.width + hitPad &&
+            y >= hitBox.top - hitPad &&
+            y <= hitBox.top + hitBox.height + hitPad
           ) {
             return id;
           }
@@ -863,18 +867,18 @@ function SvgCanvas({
           const lx = dx * Math.cos(rad) - dy * Math.sin(rad);
           const ly = dx * Math.sin(rad) + dy * Math.cos(rad);
           if (
-            Math.abs(lx) <= hitBox.width / 2 + hitPad * 0.25 &&
-            Math.abs(ly) <= hitBox.height / 2 + hitPad * 0.25
+            Math.abs(lx) <= hitBox.width / 2 + hitPad &&
+            Math.abs(ly) <= hitBox.height / 2 + hitPad
           ) {
             return id;
           }
           continue;
         }
         if (
-          x >= hitBox.left - hitPad * 0.15 &&
-          x <= hitBox.left + hitBox.width + hitPad * 0.15 &&
-          y >= hitBox.top - hitPad * 0.15 &&
-          y <= hitBox.top + hitBox.height + hitPad * 0.15
+          x >= hitBox.left - hitPad &&
+          x <= hitBox.left + hitBox.width + hitPad &&
+          y >= hitBox.top - hitPad &&
+          y <= hitBox.top + hitBox.height + hitPad
         ) {
           return id;
         }
@@ -1204,7 +1208,7 @@ function SvgCanvas({
       patches: Array<{ nodeId: string; left: number; top: number; width: number; height: number }>,
       options?: { textResizeMode?: 'scale' | 'wrap'; skipHistory?: boolean }
     ) => {
-      // Drop coalesced previews — commit writes the final document once.
+      // Drop coalesced frame previews — commit writes the final document once.
       dragWriteCoalesceRef.current.cancel();
       const doc = documentRef.current;
       const board = boardRef.current;
@@ -1279,6 +1283,9 @@ function SvgCanvas({
       }
       frameGeomHistoryPushedRef.current = false;
       dispatch(setDocumentFromCanvas(next));
+      // Same React turn as Redux doc — HTML plates must not fall back to stale
+      // coords between commit and onTransformingChange(false).
+      setVideoLiveGeom(null);
     },
     [dispatch, readOnly, normalizeGeomPatches, toGeometryPatches, applyFrameGeometryPatches]
   );
@@ -1479,24 +1486,15 @@ function SvgCanvas({
         return;
       }
 
-      // Circles / regular polygons / stars stay proportional: lock to a square.
-      let width = box.width;
-      let height = box.height;
-      let left = box.left;
-      let top = box.top;
-      if (kind === 'circle' || kind === 'polygon' || kind === 'star') {
-        const size = Math.max(3, Math.max(box.width, box.height));
-        left = box.left + (box.width - size) / 2;
-        top = box.top + (box.height - size) / 2;
-        width = size;
-        height = size;
-      }
-      const origin = sceneToDocumentCoords(doc, left, top);
+      // Circles / regular polygons / stars are already squared in ShapeDrawFeature
+      // (visual→geom). Do NOT Math.max(3, size) here — that inflated geom 2→3 and
+      // made committed ink jump from visual 3×3 to 4×4 after center stroke.
+      const origin = sceneToDocumentCoords(doc, box.left, box.top);
       const { id, node } = createShapeNode({
         x: origin.x,
         y: origin.y,
-        width,
-        height,
+        width: box.width,
+        height: box.height,
         shapeType: kind,
         fill: '#FFFFFF',
       });
@@ -1516,14 +1514,26 @@ function SvgCanvas({
       const doc = documentRef.current;
       if (!doc || readOnly) return;
       const autoSize = point.autoSize !== false;
-      const origin = sceneToDocumentCoords(doc, point.x, point.y);
+      const gridSize = getDocumentGridSize(doc);
+      const zoom = Math.max(0.05, camera.zoom || 1);
+      // Screen-constant ~14px so 3000% zoom does not spawn document-14 glyphs.
+      const fontSize = rcbDefaultPlaceFontSize(zoom, 14);
+      const origin = sceneToDocumentCoords(
+        doc,
+        snapCoordToGrid(point.x, gridSize),
+        snapCoordToGrid(point.y, gridSize)
+      );
+      const fixedW = autoSize
+        ? 2
+        : Math.max(gridSize, snapCoordToGrid(Math.max(gridSize, point.width || 160), gridSize));
       const { id, node } = createTextNode({
         x: origin.x,
         y: origin.y,
         text: '',
-        width: autoSize ? 2 : Math.max(16, Math.round(point.width || 160)),
-        height: 20,
+        width: fixedW,
+        // Height comes from measured font metrics — do not hardcode 20.
         autoSize,
+        fontSize,
       });
       const next = addNodeToDocument(doc, id, node);
       documentRef.current = next;
@@ -1533,7 +1543,7 @@ function SvgCanvas({
       setEditingTextId(id);
       finishToSelect();
     },
-    [dispatch, readOnly]
+    [dispatch, readOnly, camera.zoom]
   );
 
   const onTextEditCommit = useCallback(
@@ -1901,11 +1911,39 @@ function SvgCanvas({
     (
       pathD: string,
       box: { left: number; top: number; width: number; height: number },
-      closed: boolean
+      closed: boolean,
+      opts?: { replaceNodeId?: string }
     ) => {
       const doc = documentRef.current;
       if (!doc || readOnly) return;
       const origin = sceneToDocumentCoords(doc, box.left, box.top);
+      const replaceId = opts?.replaceNodeId;
+      if (replaceId && doc.deltaSetLike?.[replaceId]) {
+        const prev = doc.deltaSetLike[replaceId];
+        const prevType = String(prev?.attrs?.shapeType || 'pen');
+        const shapeType = prevType === 'path' ? 'path' : 'pen';
+        dispatch(pushEditorHistory());
+        dispatch(
+          patchDocumentNode({
+            nodeId: replaceId,
+            patch: {
+              x: origin.x,
+              y: origin.y,
+              width: Math.max(1, box.width),
+              height: Math.max(1, box.height),
+              attrs: {
+                shapeType,
+                path: pathD,
+                closed: closed ? 'true' : 'false',
+                'border-color': penStrokeColor,
+                'border-width': penStrokeWidth,
+              },
+            },
+          })
+        );
+        dispatch(setSelectedNodeIds([replaceId]));
+        return;
+      }
       const { id, node } = createShapeNode({
         x: origin.x,
         y: origin.y,
@@ -2943,6 +2981,8 @@ function SvgCanvas({
             stageEl={stageEl}
             strokeColor={penStrokeColor}
             strokeWidth={penStrokeWidth}
+            gridSnap
+            gridSize={getDocumentGridSize(document)}
             onCommit={onPenCommit}
             onCancel={finishToSelect}
             hitTest={hitTest}
@@ -2968,6 +3008,8 @@ function SvgCanvas({
               convertPointMode={pathEditSubtool === 'curve'}
               newStrokeColor={penStrokeColor}
               newStrokeWidth={penStrokeWidth}
+              gridSnap
+              gridSize={getDocumentGridSize(document)}
               onCommitNewShape={({ pathD, box, closed }) => {
                 if (!editingPenId) return;
                 onPathEditUnionNewShape(editingPenId, { pathD, box, closed }, penStrokeWidth);

--- a/apps/web/src/components/editor/canvas/__tests__/dragWriteCoalescer.test.ts
+++ b/apps/web/src/components/editor/canvas/__tests__/dragWriteCoalescer.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createDragWriteCoalescer } from '../dragWriteCoalescer';
+
+describe('createDragWriteCoalescer', () => {
+  it('applies video live geom synchronously (no rAF lag vs SVG preview)', () => {
+    const apply = vi.fn();
+    const c = createDragWriteCoalescer(apply);
+
+    const geom = {
+      v1: { left: 10, top: 20, width: 100, height: 200, angle: 0 },
+    };
+    c.queueVideoGeom(geom);
+
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledWith({ frames: [], videoGeom: geom });
+    expect(c.getPendingVideoGeom()).toEqual(geom);
+  });
+
+  it('still coalesces frame writes to one rAF', async () => {
+    const apply = vi.fn();
+    const c = createDragWriteCoalescer(apply);
+
+    c.queueFrames([{ id: 'f1', x: 1, y: 2, width: 3, height: 4 }]);
+    c.queueFrames([{ id: 'f1', x: 5, y: 6, width: 7, height: 8 }]);
+    expect(apply).not.toHaveBeenCalled();
+
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledWith({
+      frames: [{ id: 'f1', x: 5, y: 6, width: 7, height: 8 }],
+    });
+  });
+});

--- a/apps/web/src/components/editor/canvas/dragWriteCoalescer.ts
+++ b/apps/web/src/components/editor/canvas/dragWriteCoalescer.ts
@@ -3,8 +3,10 @@ import type { VideoGeomOverride } from '@/components/editor/nodes/VideoNode/Vide
 export type FrameGeomLive = { id: string; x: number; y: number; width: number; height: number };
 
 /**
- * Coalesce high-frequency drag writes (frame Redux + video live geom) to one rAF.
- * Keeps pointer-move SVG preview immediate; only Redux/React state is throttled.
+ * Coalesce high-frequency frame Redux writes to one rAF.
+ * Video live geom applies synchronously — SVG preview is already sync, and
+ * rAF-throttled HTML plates leave a second visible layer (SVG poster vs
+ * `<video>`) while moving.
  */
 export function createDragWriteCoalescer(
   apply: (batch: {
@@ -14,21 +16,15 @@ export function createDragWriteCoalescer(
 ) {
   let raf = 0;
   const pendingFrames = new Map<string, FrameGeomLive>();
-  /** Latest intended video overrides (kept after flush for merge-on-move). */
+  /** Latest intended video overrides (kept for merge-on-move / angle preview). */
   let pendingVideo: Record<string, VideoGeomOverride> | null = null;
-  let videoDirty = false;
 
   const runFlush = () => {
     raf = 0;
     const frames = [...pendingFrames.values()];
     pendingFrames.clear();
-    const flushVideo = videoDirty;
-    videoDirty = false;
-    if (!frames.length && !flushVideo) return;
-    apply({
-      frames,
-      videoGeom: flushVideo ? pendingVideo : undefined,
-    });
+    if (!frames.length) return;
+    apply({ frames });
   };
 
   return {
@@ -38,8 +34,7 @@ export function createDragWriteCoalescer(
     },
     queueVideoGeom(next: Record<string, VideoGeomOverride> | null) {
       pendingVideo = next;
-      videoDirty = true;
-      if (!raf) raf = requestAnimationFrame(runFlush);
+      apply({ frames: [], videoGeom: next });
     },
     getPendingVideoGeom() {
       return pendingVideo;
@@ -52,7 +47,6 @@ export function createDragWriteCoalescer(
       }
       pendingFrames.clear();
       pendingVideo = null;
-      videoDirty = false;
     },
   };
 }

--- a/apps/web/src/components/editor/chrome/BucketFillToolbar.tsx
+++ b/apps/web/src/components/editor/chrome/BucketFillToolbar.tsx
@@ -34,7 +34,7 @@ function BucketFillToolbar({ className }: { className?: string }) {
 
   return (
     <div className={cn('pointer-events-auto', className)}>
-      <FloatingToolbar className="gap-1 px-2">
+      <FloatingToolbar className="h-8 gap-1 px-2 py-0">
         <FillPanelPopover
           value={value}
           onChange={(next) => dispatch(setBucketFill(next))}
@@ -48,12 +48,12 @@ function BucketFillToolbar({ className }: { className?: string }) {
             <Tooltip tip="填充颜色" placement="bottom" disabled={open}>
               <span
                 className={cn(
-                  'inline-flex h-8 w-8 items-center justify-center rounded-[4px] transition-colors',
+                  'inline-flex h-6 w-6 items-center justify-center rounded-[4px] transition-colors',
                   open ? 'bg-[var(--accent-soft)]' : 'hover:bg-[var(--accent-soft)]'
                 )}
               >
                 <span
-                  className="relative h-4 w-4 overflow-hidden rounded-full border border-black/15"
+                  className="relative h-3.5 w-3.5 overflow-hidden rounded-full border border-black/15"
                   style={{ background: preview }}
                 />
               </span>

--- a/apps/web/src/components/editor/chrome/EditorToolStrip.tsx
+++ b/apps/web/src/components/editor/chrome/EditorToolStrip.tsx
@@ -49,11 +49,14 @@ import {
 } from '@/components/rcb/scene/document/sceneDocument';
 import { sceneToDocumentCoords } from '@/components/rcb/scene/paint/svgToScene';
 import {
-  rcbCenterOnPoint,
-  rcbFitImageIntoViewport,
+  rcbLayoutGeneratorPlate,
   rcbScreenToScene,
+  GENERATOR_EMPTY_STROKE_OUTSET,
   type RcbCamera,
 } from '@/components/rcb';
+import {
+  getDocumentGridSize,
+} from '@/components/rcb/selection/alignGuides';
 import { cn } from '@/utils/classnames';
 
 const MENU_ICON_CLASS = 'h-4 w-4';
@@ -61,9 +64,68 @@ const TOOL_ICON_CLASS = 'h-4 w-4 shrink-0';
 const STROKE = 1.5;
 const MENU_POPUP = 'min-w-[168px]';
 
+/**
+ * Fit a generator plate into the visible stage, center it, snap painted outer
+ * ink to the document grid (then inset 0.5 for the empty-state center stroke).
+ */
+function layoutGeneratorPlateInView(opts: {
+  document: any;
+  camera: RcbCamera;
+  stageEl: HTMLElement;
+  natural: { width: number; height: number };
+  fit?: { minRatio?: number; maxRatio?: number };
+}): { x: number; y: number; width: number; height: number; debug: Record<string, number> } {
+  const view = opts.stageEl.getBoundingClientRect();
+  const zoom = Math.max(0.05, opts.camera.zoom || 1);
+  const center = rcbScreenToScene(
+    opts.camera,
+    opts.stageEl,
+    view.left + view.width / 2,
+    view.top + view.height / 2
+  );
+  const gridSize = getDocumentGridSize(opts.document);
+  const laid = rcbLayoutGeneratorPlate({
+    natural: opts.natural,
+    viewport: { width: view.width, height: view.height },
+    zoom,
+    center,
+    gridSize,
+    visualOutset: GENERATOR_EMPTY_STROKE_OUTSET,
+    fit: opts.fit,
+  });
+  const origin = sceneToDocumentCoords(opts.document, laid.left, laid.top);
+  const debug = {
+    zoom,
+    viewW: view.width,
+    viewH: view.height,
+    sceneViewW: view.width / zoom,
+    sceneViewH: view.height / zoom,
+    geomW: laid.width,
+    geomH: laid.height,
+    visualL: laid.visual.left,
+    visualT: laid.visual.top,
+    visualW: laid.visual.width,
+    visualH: laid.visual.height,
+    x: origin.x,
+    y: origin.y,
+    gridSize,
+  };
+  if (typeof window !== 'undefined' && (window as any).__RCB_GENERATOR_PLACE_DEBUG__) {
+    // eslint-disable-next-line no-console
+    console.log('[rcb:generator-place]', debug);
+  }
+  return {
+    x: origin.x,
+    y: origin.y,
+    width: laid.width,
+    height: laid.height,
+    debug,
+  };
+}
+
 type LayerIconComponent = ComponentType<SVGProps<SVGSVGElement> & { className?: string }>;
 
-/** One family (Lucide) so layer glyphs share stroke weight and optical size. */
+/** Layer glyphs share one stroke weight / optical size. */
 const layerIconByKind: Record<string, LayerIconComponent> = {
   text: LuType,
   image: LuImage,
@@ -333,24 +395,17 @@ function EditorToolStrip({
     if (camera && stageEl) {
       const view = stageEl.getBoundingClientRect();
       if (view.width > 0 && view.height > 0) {
-        const sized = rcbFitImageIntoViewport(
-          { width: 1024, height: 1024 },
-          view,
-          camera.zoom,
-          { minRatio: 0.28, maxRatio: 0.42 }
-        );
-        width = sized.width;
-        height = sized.height;
-        const center = rcbScreenToScene(
+        const laid = layoutGeneratorPlateInView({
+          document,
           camera,
           stageEl,
-          view.left + view.width / 2,
-          view.top + view.height / 2
-        );
-        const placed = rcbCenterOnPoint(center, { width, height });
-        const origin = sceneToDocumentCoords(document, placed.left, placed.top);
-        x = origin.x;
-        y = origin.y;
+          natural: { width: 1024, height: 1024 },
+          fit: { minRatio: 0.28, maxRatio: 0.42 },
+        });
+        width = laid.width;
+        height = laid.height;
+        x = laid.x;
+        y = laid.y;
       }
     }
     dispatch(
@@ -373,24 +428,17 @@ function EditorToolStrip({
     if (camera && stageEl) {
       const view = stageEl.getBoundingClientRect();
       if (view.width > 0 && view.height > 0) {
-        const sized = rcbFitImageIntoViewport(
-          { width: 1280, height: 720 },
-          view,
-          camera.zoom,
-          { minRatio: 0.28, maxRatio: 0.48 }
-        );
-        width = sized.width;
-        height = sized.height;
-        const center = rcbScreenToScene(
+        const laid = layoutGeneratorPlateInView({
+          document,
           camera,
           stageEl,
-          view.left + view.width / 2,
-          view.top + view.height / 2
-        );
-        const placed = rcbCenterOnPoint(center, { width, height });
-        const origin = sceneToDocumentCoords(document, placed.left, placed.top);
-        x = origin.x;
-        y = origin.y;
+          natural: { width: 1280, height: 720 },
+          fit: { minRatio: 0.28, maxRatio: 0.48 },
+        });
+        width = laid.width;
+        height = laid.height;
+        x = laid.x;
+        y = laid.y;
       }
     }
     dispatch(
@@ -466,24 +514,17 @@ function EditorToolStrip({
       camera && stageEl && document && view && view.width > 0 && view.height > 0
         ? { camera, stageEl, document, view }
         : null;
-    const { width, height } = placeable
-      ? rcbFitImageIntoViewport(natural, placeable.view, placeable.camera.zoom)
-      : fitImageSize(natural.width, natural.height, 2400);
-    let x: number | undefined;
-    let y: number | undefined;
     if (placeable) {
-      const center = rcbScreenToScene(
-        placeable.camera,
-        placeable.stageEl,
-        placeable.view.left + placeable.view.width / 2,
-        placeable.view.top + placeable.view.height / 2
-      );
-      const placed = rcbCenterOnPoint(center, { width, height });
-      const origin = sceneToDocumentCoords(placeable.document, placed.left, placed.top);
-      x = origin.x;
-      y = origin.y;
+      const laid = layoutGeneratorPlateInView({
+        document: placeable.document,
+        camera: placeable.camera,
+        stageEl: placeable.stageEl,
+        natural,
+      });
+      return { width: laid.width, height: laid.height, x: laid.x, y: laid.y };
     }
-    return { width, height, x, y };
+    const { width, height } = fitImageSize(natural.width, natural.height, 2400);
+    return { width, height };
   };
 
   const onPickImage = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -743,7 +784,7 @@ function EditorToolStrip({
         </ToolIcon>
       </ToolBtn>
 
-      {/* 视频生成器 — Remix fill reads heavier than Lucide strokes; soften to match. */}
+      {/* Video generator icon — soften fill weight to match stroke tools. */}
       <ToolBtn tip={L.videoGenerator} disabled={toolsLocked} onClick={spawnVideoGeneratorAtView}>
         <ToolIcon className="h-[18px] w-[18px]">
           <RiVideoAiLine className="opacity-[0.72]" />

--- a/apps/web/src/components/editor/chrome/PathEditToolbar.tsx
+++ b/apps/web/src/components/editor/chrome/PathEditToolbar.tsx
@@ -10,11 +10,11 @@ import { cn } from '@/utils/classnames';
 export type PathEditSubtool = 'select' | 'pen' | 'curve';
 
 const PATH_EDIT_BTN =
-  'inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors text-[var(--ink)] hover:bg-[var(--accent-soft)]';
+  'inline-flex h-6 w-6 items-center justify-center rounded-md transition-colors text-[var(--ink)] hover:bg-[var(--accent-soft)]';
 const PATH_EDIT_BTN_ACTIVE = 'bg-[var(--ink)] text-[var(--on-brand)] hover:bg-[var(--ink)]';
 /** Done / confirm — solid ink square with check. */
 const PATH_EDIT_BTN_DONE =
-  'inline-flex h-7 w-7 items-center justify-center rounded-md bg-[var(--ink)] text-[var(--on-brand)] transition-opacity hover:opacity-90';
+  'inline-flex h-6 w-6 items-center justify-center rounded-md bg-[var(--ink)] text-[var(--on-brand)] transition-opacity hover:opacity-90';
 
 function PathEditToolbar({
   subtool,
@@ -27,7 +27,7 @@ function PathEditToolbar({
 }): ReactNode {
   const { t } = useTranslation();
   return (
-    <FloatingToolbar className="pointer-events-auto gap-2.5 px-3 py-1.5">
+    <FloatingToolbar className="pointer-events-auto h-8 gap-1.5 px-2 py-0">
       <Tooltip tip={t('editor.pathEditSelect', { defaultValue: '选择' })} placement="bottom">
         <button
           type="button"
@@ -36,7 +36,7 @@ function PathEditToolbar({
           className={cn(PATH_EDIT_BTN, subtool === 'select' && PATH_EDIT_BTN_ACTIVE)}
           onClick={() => onSubtoolChange('select')}
         >
-          <LuMousePointer2 className="h-4 w-4" strokeWidth={1.75} />
+          <LuMousePointer2 className="h-3.5 w-3.5" strokeWidth={1.75} />
         </button>
       </Tooltip>
       <Tooltip tip={t('editor.pathEditPen', { defaultValue: '钢笔' })} placement="bottom">
@@ -47,7 +47,7 @@ function PathEditToolbar({
           className={cn(PATH_EDIT_BTN, subtool === 'pen' && PATH_EDIT_BTN_ACTIVE)}
           onClick={() => onSubtoolChange('pen')}
         >
-          <LuPenTool className="h-4 w-4" strokeWidth={1.75} />
+          <LuPenTool className="h-3.5 w-3.5" strokeWidth={1.75} />
         </button>
       </Tooltip>
       <Tooltip tip={t('editor.pathEditCurve', { defaultValue: '曲线' })} placement="bottom">
@@ -58,10 +58,10 @@ function PathEditToolbar({
           className={cn(PATH_EDIT_BTN, subtool === 'curve' && PATH_EDIT_BTN_ACTIVE)}
           onClick={() => onSubtoolChange('curve')}
         >
-          <Icon name="editor-path-curve" width={16} height={16} />
+          <Icon name="editor-path-curve" width={14} height={14} />
         </button>
       </Tooltip>
-      <span className="mx-0.5 h-4 w-px shrink-0 bg-[var(--line)]" aria-hidden />
+      <span className="mx-0.5 h-3.5 w-px shrink-0 bg-[var(--line)]" aria-hidden />
       <Tooltip tip={t('editor.pathEditDone', { defaultValue: '完成 (Esc)' })} placement="bottom">
         <button
           type="button"
@@ -69,7 +69,7 @@ function PathEditToolbar({
           className={PATH_EDIT_BTN_DONE}
           onClick={onExit}
         >
-          <HiCheck className="h-4 w-4" strokeWidth={2.25} />
+          <HiCheck className="h-3.5 w-3.5" strokeWidth={2.25} />
         </button>
       </Tooltip>
     </FloatingToolbar>

--- a/apps/web/src/components/editor/chrome/PenStrokeToolbar.tsx
+++ b/apps/web/src/components/editor/chrome/PenStrokeToolbar.tsx
@@ -336,7 +336,7 @@ function PenStrokeToolbar({
         className
       )}
     >
-      <FloatingToolbar className="relative gap-1 px-2">
+      <FloatingToolbar className="relative h-8 gap-1 px-2 py-0">
         <ColorPanelPopover
           value={color}
           onChange={(hex) => dispatch(setPenStrokeColor(hex))}
@@ -353,13 +353,13 @@ function PenStrokeToolbar({
             <Tooltip tip={'颜色'} placement={docked ? 'bottom' : 'top'}>
               <span
                 className={cn(
-                  'inline-flex h-8 w-8 items-center justify-center rounded-lg transition-colors',
+                  'inline-flex h-6 w-6 items-center justify-center rounded-md transition-colors',
                   open ? 'bg-[var(--accent-soft)]' : 'hover:bg-[var(--accent-soft)]',
                   eraseMode && 'opacity-40'
                 )}
               >
                 <span
-                  className="h-4 w-4 rounded-full border border-black/15"
+                  className="h-3.5 w-3.5 rounded-full border border-black/15"
                   style={{
                     background: hex,
                     opacity: isPencil ? Math.max(0.05, swatchOpacity / 100) : 1,
@@ -370,7 +370,7 @@ function PenStrokeToolbar({
           )}
         </ColorPanelPopover>
 
-        <span className="mx-0.5 h-4 w-px bg-[var(--line)]" aria-hidden />
+        <span className="mx-0.5 h-3.5 w-px bg-[var(--line)]" aria-hidden />
 
         {isPencil ? (
           <div
@@ -395,7 +395,7 @@ function PenStrokeToolbar({
                   setBrushOpen((v) => !v);
                 }}
                 className={cn(
-                  'inline-flex h-8 w-[120px] items-center justify-center rounded-lg px-1.5 transition-colors',
+                  'inline-flex h-6 w-[120px] items-center justify-center rounded-md px-1.5 transition-colors',
                   brushOpen ? 'bg-[var(--accent-soft)]' : 'hover:bg-[var(--accent-soft)]',
                   eraseMode && 'cursor-not-allowed opacity-40'
                 )}
@@ -403,7 +403,7 @@ function PenStrokeToolbar({
                 <BrushStrokePreview
                   brushId={brush.id}
                   color={color}
-                  className="h-4 w-full min-w-0"
+                  className="h-3.5 w-full min-w-0"
                 />
               </button>
             </Tooltip>
@@ -494,15 +494,15 @@ function PenStrokeToolbar({
           </div>
         ) : null}
 
-        {isPencil ? <span className="mx-0.5 h-4 w-px bg-[var(--line)]" aria-hidden /> : null}
+        {isPencil ? <span className="mx-0.5 h-3.5 w-px bg-[var(--line)]" aria-hidden /> : null}
 
         {/* Width: number input, no upper cap */}
         <label
-          className="inline-flex h-8 items-center gap-1.5 rounded-[4px] bg-[var(--accent-soft)] px-2"
+          className="inline-flex h-6 items-center gap-1 rounded-[4px] bg-[var(--accent-soft)] px-1.5"
           onPointerDown={(e) => e.stopPropagation()}
           title={eraseMode ? '橡皮尺寸' : '粗细'}
         >
-          <Icon name="editor-stroke-weight" className="h-4 w-4 shrink-0 text-[var(--ink)]" />
+          <Icon name="editor-stroke-weight" className="h-3.5 w-3.5 shrink-0 text-[var(--ink)]" />
           <input
             type="number"
             min={1}
@@ -510,9 +510,9 @@ function PenStrokeToolbar({
             onChange={(e) =>
               dispatch(setPenStrokeWidth(Math.max(1, Math.round(Number(e.target.value) || 1))))
             }
-            className="w-12 min-w-0 bg-transparent text-[12px] tabular-nums outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            className="w-10 min-w-0 bg-transparent text-[11px] tabular-nums outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           />
-          <span className="shrink-0 text-[11px] text-[var(--muted)]">Px</span>
+          <span className="shrink-0 text-[10px] text-[var(--muted)]">Px</span>
         </label>
 
         {isPencil ? (
@@ -529,17 +529,17 @@ function PenStrokeToolbar({
                 disabled={eraseMode}
                 onClick={() => dispatch(setPencilPressureEnabled(!pressureEnabled))}
                 className={cn(
-                  'inline-flex h-8 w-8 items-center justify-center rounded-lg transition-colors',
+                  'inline-flex h-6 w-6 items-center justify-center rounded-md transition-colors',
                   pressureEnabled
                     ? 'bg-[var(--ink)] text-[var(--on-brand)]'
                     : 'text-[var(--ink)] hover:bg-[var(--accent-soft)]',
                   eraseMode && 'cursor-not-allowed opacity-40'
                 )}
               >
-                <Icon name="editor-pressure" className="h-4 w-4" />
+                <Icon name="editor-pressure" className="h-3.5 w-3.5" />
               </button>
             </Tooltip>
-            <span className="mx-0.5 h-4 w-px bg-[var(--line)]" aria-hidden />
+            <span className="mx-0.5 h-3.5 w-px bg-[var(--line)]" aria-hidden />
             <Tooltip tip={'\u64e6\u76ae\u64e6'} placement={docked ? 'bottom' : 'top'}>
               <button
                 type="button"
@@ -547,28 +547,28 @@ function PenStrokeToolbar({
                 aria-pressed={eraseMode}
                 onClick={() => dispatch(setPencilEraseMode(!eraseMode))}
                 className={cn(
-                  'inline-flex h-8 w-8 items-center justify-center rounded-lg transition-colors',
+                  'inline-flex h-6 w-6 items-center justify-center rounded-md transition-colors',
                   eraseMode
                     ? 'bg-[var(--ink)] text-[var(--on-brand)]'
                     : 'text-[var(--ink)] hover:bg-[var(--accent-soft)]'
                 )}
               >
-                <LuEraser className="h-4 w-4" strokeWidth={1.5} />
+                <LuEraser className="h-3.5 w-3.5" strokeWidth={1.5} />
               </button>
             </Tooltip>
           </>
         ) : (
           <>
-            <span className="mx-0.5 h-4 w-px bg-[var(--line)]" aria-hidden />
+            <span className="mx-0.5 h-3.5 w-px bg-[var(--line)]" aria-hidden />
             <Tooltip tip={`${t('editor.exitPenEdit')} (Esc)`} placement={docked ? 'bottom' : 'top'}>
               <button
                 type="button"
                 aria-label={t('editor.exitPenEdit')}
                 onClick={exitPenEdit}
                 onPointerDown={(e) => e.stopPropagation()}
-                className="inline-flex h-8 w-8 items-center justify-center rounded-lg bg-[var(--ink)] text-[var(--on-brand)] transition-opacity hover:opacity-90"
+                className="inline-flex h-6 w-6 items-center justify-center rounded-md bg-[var(--ink)] text-[var(--on-brand)] transition-opacity hover:opacity-90"
               >
-                <HiOutlineCheck className="h-4 w-4" strokeWidth={2} />
+                <HiOutlineCheck className="h-3.5 w-3.5" strokeWidth={2} />
               </button>
             </Tooltip>
           </>

--- a/apps/web/src/components/editor/nodes/ImageGeneratorNode/ImageGeneratorCard.tsx
+++ b/apps/web/src/components/editor/nodes/ImageGeneratorNode/ImageGeneratorCard.tsx
@@ -17,11 +17,11 @@ import { Dropdown, DropdownPanel, message, Tooltip } from '@/components/base';
 import {
   rcbScreenPxToScene,
   useRcbCamera,
-  useRcbScreenToolbarStyle,
 } from '@/components/rcb';
 import {
   SELECTION_TOOLBAR_BELOW_BOX_GAP_PX,
   useChromePointerActivate,
+  WorldScreenChromeRoot,
 } from '@/components/rcb/selection/chrome/SelectionToolbarShell';
 import AgentComposerInput, {
   chipBaseKey,
@@ -817,31 +817,33 @@ function ImageGeneratorCard({
     );
   };
 
-  // Same placement contract as selection toolbars: centered under the box.
-  const composerStyle = useRcbScreenToolbarStyle({
-    left: sceneBox.x + sceneBox.width / 2,
-    top:
-      sceneBox.y +
-      sceneBox.height +
-      rcbScreenPxToScene(SELECTION_TOOLBAR_BELOW_BOX_GAP_PX, zoom),
-    anchor: 'top',
-  });
+  // Same placement contract as selection toolbars: world-layer under the box.
+  const composerLeft = sceneBox.x + sceneBox.width / 2;
+  const composerTop =
+    sceneBox.y +
+    sceneBox.height +
+    rcbScreenPxToScene(SELECTION_TOOLBAR_BELOW_BOX_GAP_PX, zoom);
 
   return (
     <>
       {showComposer ? (
-        <div
+        <WorldScreenChromeRoot
+          left={composerLeft}
+          top={composerTop}
+          anchor="top"
           data-image-generator
           data-sel-toolbar
           data-scene-node-id={nodeId}
-          className={cn(
-            'pointer-events-auto absolute z-[32] flex h-[200px] w-[500px] flex-col overflow-visible',
-            'rounded-2xl border border-[var(--line)] bg-[var(--surface)]',
-            'shadow-[0_8px_28px_rgba(15,23,42,0.12)]'
-          )}
-          style={composerStyle}
+          className="pointer-events-auto z-[32] overflow-visible"
           {...chromePointer}
         >
+          <div
+            className={cn(
+              'flex h-[200px] w-[500px] flex-col overflow-visible',
+              'rounded-2xl border border-[var(--line)] bg-[var(--surface)]',
+              'shadow-[0_8px_28px_rgba(15,23,42,0.12)]'
+            )}
+          >
           {/* Reference images occupy their own row, using the chat attachment chip. */}
           <div className="flex flex-wrap items-center gap-1.5 px-3 pt-2.5">
             {attachments.map((att) => (
@@ -1068,7 +1070,8 @@ function ImageGeneratorCard({
               </Tooltip>
             </div>
           </div>
-        </div>
+          </div>
+        </WorldScreenChromeRoot>
       ) : null}
 
       {showComposer && mentionOpen ? (

--- a/apps/web/src/components/editor/nodes/ImageGeneratorNode/ImageGeneratorOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/ImageGeneratorNode/ImageGeneratorOverlay.tsx
@@ -1,13 +1,12 @@
 import { useMemo, type ReactNode, memo } from 'react';
 import { useSelector } from 'react-redux';
-import { RcbOverlayPortal } from '@/components/rcb';
 import { isImageGeneratorNode } from '@/components/rcb/scene/document/sceneDocument';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import ImageGeneratorCard from '@/components/editor/nodes/ImageGeneratorNode/ImageGeneratorCard';
 import { EMPTY_ID_LIST } from '@/store/modules/editor';
 
 /**
- * Screen-space Image Generator composers for every generator plate on the canvas.
+ * World-layer Image Generator composers (same lattice as the control box).
  * SVG keeps the hit target; the title row comes from the shared selection label.
  */
 function ImageGeneratorOverlay({
@@ -39,35 +38,33 @@ function ImageGeneratorOverlay({
 
   // Keep cards mounted while transforming — local + attr state must survive hide.
   return (
-    <RcbOverlayPortal>
-      <div
-        className={hidden ? 'pointer-events-none invisible' : undefined}
-        aria-hidden={hidden || undefined}
-      >
-        {ids.map((nodeId) => {
-          const node = document?.deltaSetLike?.[nodeId];
-          if (!node) return null;
-          const { left, top } = nodeLeftTop(document, node);
-          const width = Math.max(1, Number(node.width) || 1);
-          const height = Math.max(1, Number(node.height) || 1);
-          return (
-            <ImageGeneratorCard
-              key={nodeId}
-              nodeId={nodeId}
-              sceneBox={{ x: left, y: top, width, height }}
-              // Title comes from the shared selection label; composer follows it.
-              showComposer={
-                !hidden &&
-                ((selectedNodeIds.length === 1 && selectedNodeIds[0] === nodeId) ||
-                  canvasAttachPick?.target === `node:${nodeId}` ||
-                  pendingCanvasAttach?.target === `node:${nodeId}`)
-              }
-              disabled={readOnly}
-            />
-          );
-        })}
-      </div>
-    </RcbOverlayPortal>
+    <div
+      className={hidden ? 'pointer-events-none invisible' : undefined}
+      aria-hidden={hidden || undefined}
+    >
+      {ids.map((nodeId) => {
+        const node = document?.deltaSetLike?.[nodeId];
+        if (!node) return null;
+        const { left, top } = nodeLeftTop(document, node);
+        const width = Math.max(1, Number(node.width) || 1);
+        const height = Math.max(1, Number(node.height) || 1);
+        return (
+          <ImageGeneratorCard
+            key={nodeId}
+            nodeId={nodeId}
+            sceneBox={{ x: left, y: top, width, height }}
+            // Title comes from the shared selection label; composer follows it.
+            showComposer={
+              !hidden &&
+              ((selectedNodeIds.length === 1 && selectedNodeIds[0] === nodeId) ||
+                canvasAttachPick?.target === `node:${nodeId}` ||
+                pendingCanvasAttach?.target === `node:${nodeId}`)
+            }
+            disabled={readOnly}
+          />
+        );
+      })}
+    </div>
   );
 }
 

--- a/apps/web/src/components/editor/nodes/ImageNode/IconAnnotateToolbar.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/IconAnnotateToolbar.tsx
@@ -21,7 +21,7 @@ const BTN =
 const BTN_ACTIVE = 'bg-white/15 text-white';
 
 /**
- * Icon annotate strip (fig.1): pen · select · text · color · stroke width.
+ * Icon annotate strip: pen · select · text · color · stroke width.
  * No photo tools (remove-bg / upscale / eraser …).
  */
 function IconAnnotateToolbar({ downloadSlot }: Props): ReactNode {

--- a/apps/web/src/components/editor/nodes/ImageNode/ImageProcessOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageProcessOverlay.tsx
@@ -1,9 +1,5 @@
 import { useMemo, type CSSProperties, type ReactNode, memo } from 'react';
-import {
-  RcbOverlayPortal,
-  useRcbCamera,
-  rcbSceneToScreen,
-} from '@/components/rcb';
+import { useRcbCamera, rcbCameraCssZoom } from '@/components/rcb';
 import { radiiFromAttrs } from '@/components/rcb/scene/document/sceneRadii';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 
@@ -14,33 +10,29 @@ function readNodeAngle(node: any) {
   return Number.isFinite(n) ? n : 0;
 }
 
-function useProcessStageBox(document: any, node: any) {
+function useProcessWorldBox(document: any, node: any) {
   const camera = useRcbCamera();
   const { left, top } = nodeLeftTop(document, node);
   const width = Math.max(1, Number(node.width) || 1);
   const height = Math.max(1, Number(node.height) || 1);
-  const z = Math.max(0.05, camera.zoom || 1);
-  const origin = rcbSceneToScreen(camera, left, top);
-  const stageW = width * z;
-  const stageH = height * z;
+  const z = rcbCameraCssZoom(camera);
+  const inv = 1 / z;
   const radii = radiiFromAttrs(node.attrs || {});
   const angle = readNodeAngle(node);
   return {
-    camera,
     left,
     top,
     width,
     height,
     z,
-    origin,
-    stageW,
-    stageH,
+    inv,
     angle,
-    borderRadius: `${radii.tl * z}px ${radii.tr * z}px ${radii.br * z}px ${radii.bl * z}px`,
+    // Radii stay in scene units (shell is under camera scale).
+    borderRadius: `${radii.tl}px ${radii.tr}px ${radii.br}px ${radii.bl}px`,
   };
 }
 
-/** Shimmer plate + status pill, both locked to the node's rotation. */
+/** Shimmer plate + status pill on the world layer (same lattice as the control box). */
 function ProcessNodeChrome({
   nodeId,
   node,
@@ -50,21 +42,26 @@ function ProcessNodeChrome({
   node: any;
   document: any;
 }): ReactNode {
-  const { origin, stageW, stageH, borderRadius, angle } = useProcessStageBox(document, node);
+  const { left, top, width, height, inv, borderRadius, angle } = useProcessWorldBox(
+    document,
+    node
+  );
   const label = String(node.attrs?.processLabel || '处理中');
 
-  const frameStyle = useMemo(
-    (): CSSProperties => ({
+  const frameStyle = useMemo((): CSSProperties => {
+    const style: CSSProperties = {
       position: 'absolute',
-      left: origin.x,
-      top: origin.y,
-      width: stageW,
-      height: stageH,
-      transform: Math.abs(angle) > 0.001 ? `rotate(${angle}deg)` : undefined,
-      transformOrigin: 'center center',
-    }),
-    [origin.x, origin.y, stageW, stageH, angle]
-  );
+      left,
+      top,
+      width,
+      height,
+    };
+    if (Math.abs(angle) > 0.001) {
+      style.transform = `rotate(${angle}deg)`;
+      style.transformOrigin = 'center center';
+    }
+    return style;
+  }, [left, top, width, height, angle]);
 
   const shimmerStyle = useMemo(
     (): CSSProperties => ({
@@ -75,14 +72,16 @@ function ProcessNodeChrome({
     [borderRadius]
   );
 
+  // Counter-scale the pill so typography stays screen-constant under camera zoom.
   const pillStyle = useMemo(
     (): CSSProperties => ({
       position: 'absolute',
       left: '50%',
-      top: stageH - PILL_BOTTOM_PAD_PX,
-      transform: 'translate(-50%, -100%)',
+      top: height - PILL_BOTTOM_PAD_PX * inv,
+      transform: `translate(-50%, -100%) scale(${inv})`,
+      transformOrigin: 'center bottom',
     }),
-    [stageH]
+    [height, inv]
   );
 
   return (
@@ -109,9 +108,8 @@ function ProcessNodeChrome({
 }
 
 /**
- * Screen-fixed shimmer + status pills for image process jobs.
- * The SVG plate stays in world space; shimmer/label are portaled so zoom
- * does not enlarge the sweep animation typography — but they rotate with the node.
+ * World-layer shimmer + status pills for image process jobs.
+ * Same positioning contract as selection chrome — no unscaled overlay portal.
  */
 function ImageProcessOverlay({
   document,
@@ -127,20 +125,20 @@ function ImageProcessOverlay({
       const node = document?.deltaSetLike?.[id];
       if (node?.key !== 'image' && node?.key !== 'video') return false;
       // Include generator plates while generating (same sweep as process jobs).
-      return String(node?.attrs?.processStatus || '') === 'running';
+      return String(node.attrs?.processStatus || '') === 'running';
     });
   }, [document]);
 
   if (hidden || !ids.length) return null;
 
   return (
-    <RcbOverlayPortal>
+    <>
       {ids.map((id) => {
         const node = document.deltaSetLike[id];
         if (!node) return null;
         return <ProcessNodeChrome key={id} nodeId={id} node={node} document={document} />;
       })}
-    </RcbOverlayPortal>
+    </>
   );
 }
 

--- a/apps/web/src/components/editor/nodes/ImageNode/cropExpand/CropExpandOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/cropExpand/CropExpandOverlay.tsx
@@ -277,7 +277,7 @@ type Props = {
   onExpandChange: (next: ExpandFrame) => void;
 };
 
-/** Fig.1 — dashed frame, L-corners, edge bars, grid; expand shows gray margins. */
+/** Dashed frame, L-corners, edge bars, grid; expand shows gray margins. */
 function CropExpandOverlay({
   mode,
   imageBox,
@@ -450,7 +450,7 @@ function CropExpandOverlay({
 
   const dimLabel = `${Math.round(frameWorld.width)} × ${Math.round(frameWorld.height)}`;
 
-  /** L-bracket corner (fig.1). */
+  /** L-bracket corner. */
   const corner = (id: HandlePos): CSSProperties => {
     const arm = 14;
     const thick = 3;

--- a/apps/web/src/components/editor/nodes/ImageNode/toolPanels/AdjustToolPanel.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/toolPanels/AdjustToolPanel.tsx
@@ -72,7 +72,7 @@ export function parseAdjustValues(raw: unknown): AdjustValues {
   return out;
 }
 
-/** Fig.5 — Adjust: category tabs + light/color sliders (live preview via onChange). */
+/** Adjust: category tabs + light/color sliders (live preview via onChange). */
 function AdjustToolPanel({
   initialValues,
   onCancel,

--- a/apps/web/src/components/editor/nodes/ImageNode/toolPanels/AngleEditorScene.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/toolPanels/AngleEditorScene.tsx
@@ -98,8 +98,8 @@ function subjectBoxSize(
 
 /**
  * Multi-angle preview
- * - skybox: wireframe cube only — no sphere / arrows / camera
- * - camera: fixed face-on center image (scale only) + orbiting camera (fig.3)
+ * - skybox: wireframe cube only
+ * - camera: face-on center image + orbiting camera
  */
 function AngleEditorScene({
   mode,
@@ -270,7 +270,7 @@ function AngleEditorScene({
   );
 
   if (mode === 'skybox') {
-    // Wireframe cube only (fig.2). Same orbit as camera mode — Front (0,0) is face-on.
+    // Wireframe cube only. Same orbit as camera mode — Front (0,0) is face-on.
     return (
       <div className={cn('rcb-angle-editor-scene', className)}>
         <div

--- a/apps/web/src/components/editor/nodes/ImageNode/toolPanels/MultiAngleToolPanel.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/toolPanels/MultiAngleToolPanel.tsx
@@ -41,7 +41,7 @@ const confirmBtnClass =
 const clampInt = (v: number, min: number, max: number) =>
   Math.round(Math.max(min, Math.min(max, v)));
 
-/** Multi-angle tool: left preview + right controls (fig. 2 style). */
+/** Multi-angle tool: left preview + right controls. */
 function MultiAngleToolPanel({
   imageSrc,
   onCancel,

--- a/apps/web/src/components/editor/nodes/ShapeNode/GradientHandlesOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/ShapeNode/GradientHandlesOverlay.tsx
@@ -87,10 +87,7 @@ function projectOffset(
   return clamp01(((px - x1) * dx + (py - y1) * dy) / len2);
 }
 
-/**
- * On-canvas gradient editors (fig.2 linear · fig.3 radial · fig.4 angular).
- * World-space geometry; rendered in stage overlay so handles stay sharp.
- */
+/** On-canvas linear / radial / angular gradient editors (world-space overlay). */
 function GradientHandlesOverlay({
   box,
   angle = 0,
@@ -337,7 +334,7 @@ function GradientHandlesOverlay({
     const radius = (rPct / 100) * h;
     const center = rotateLocal(cx, cy, w, h, angle);
     const rim = rotateLocal(cx, cy + radius, w, h, angle);
-    // Side handle (fig.3) — horizontal radius end; maps to same r for circular SVG.
+    // Side handle — horizontal radius end; maps to same r for circular SVG.
     const side = rotateLocal(cx - (rPct / 100) * w, cy, w, h, angle);
 
     body = (

--- a/apps/web/src/components/editor/nodes/TextNode/TextInlineEditor.tsx
+++ b/apps/web/src/components/editor/nodes/TextNode/TextInlineEditor.tsx
@@ -68,7 +68,7 @@ function TextInlineEditor({
   styleRef.current = style;
   const autoSizeRef = useRef(autoSize);
   autoSizeRef.current = autoSize;
-  const boxWidthRef = useRef(resolveTextBoxWidth(node?.width, true));
+  const boxWidthRef = useRef(resolveTextBoxWidth(node?.width, true, style.fontSize));
   const onCommitRef = useRef(onCommit);
   onCommitRef.current = onCommit;
   const onCancelRef = useRef(onCancel);
@@ -106,14 +106,19 @@ function TextInlineEditor({
       ? hasContent
         ? Math.max(nodeW, Math.ceil(measurePlainTextSize(value, style).width))
         : Math.max(2, nodeW)
-      : resolveTextBoxWidth(node?.width, true));
+      : resolveTextBoxWidth(node?.width, true, fontSize));
   boxWidthRef.current = widthWorld;
 
   const contentBox = autoSize
     ? hasContent
       ? measurePlainTextSize(value, style)
-      : { width: widthWorld, height: Math.max(fontSize * lineH, 20) }
-    : measureWrappedTextSize(value || 'M', style, Math.max(24, widthWorld));
+      : // Caret line only — never a document-20px floor (blows up at high zoom).
+        { width: widthWorld, height: Math.ceil(fontSize * lineH) }
+    : measureWrappedTextSize(
+        value || 'M',
+        style,
+        Math.max(Math.ceil(fontSize), widthWorld)
+      );
 
   // Prefer content height (tight, even top/bottom). Grow past nodeH only if wrapping needs it.
   const heightWorld = Math.max(
@@ -139,7 +144,7 @@ function TextInlineEditor({
       return;
     }
     const s = styleRef.current;
-    const boxW = Math.max(24, boxWidthRef.current);
+    const boxW = Math.max(Math.ceil(s.fontSize || 14), boxWidthRef.current);
     const measuredBox = autoSizeRef.current
       ? measurePlainTextSize(trimmed, s)
       : measureWrappedTextSize(trimmed, s, boxW);
@@ -169,14 +174,21 @@ function TextInlineEditor({
     if (!node || node.key !== 'text') return;
     const s = styleRef.current;
     const plain = valueRef.current;
-    const fixedW = resolveTextBoxWidth(node.width, Boolean(plain.trim()));
+    const has = Boolean(plain.trim());
+    const fixedW = resolveTextBoxWidth(node.width, has, s.fontSize);
     const box = autoSizeRef.current
-      ? measurePlainTextSize(plain || ' ', s)
+      ? measurePlainTextSize(has ? plain : 'M', s)
       : measureWrappedTextSize(plain || 'M', s, fixedW);
+    // Empty autoSize: keep the thin caret width — do not inflate to a measured "M"/space.
     const nextW = autoSizeRef.current
-      ? Math.max(Math.round(Number(node.width) || 0), Math.round(box.width))
+      ? has
+        ? Math.max(Math.round(Number(node.width) || 0), Math.round(box.width))
+        : Math.max(1, Math.round(Number(node.width) || Math.ceil((s.fontSize || 14) * 0.15)))
       : Math.round(fixedW);
-    const nextH = Math.max(Math.ceil((s.fontSize || 14) * (s.lineHeight || 1.4)), Math.round(box.height));
+    const nextH = Math.max(
+      Math.ceil((s.fontSize || 14) * (s.lineHeight || 1.4)),
+      Math.round(box.height)
+    );
     const curW = Math.round(Number(node.width) || 0);
     const curH = Math.round(Number(node.height) || 0);
     if (nextW !== curW || nextH !== curH) {
@@ -218,9 +230,9 @@ function TextInlineEditor({
       let nextW = d.width0;
       let nextL = d.left0;
       if (d.side === 'e') {
-        nextW = Math.max(16, d.width0 + dx);
+        nextW = Math.max(fontSize, d.width0 + dx);
       } else {
-        nextW = Math.max(16, d.width0 - dx);
+        nextW = Math.max(fontSize, d.width0 - dx);
         nextL = d.left0 + (d.width0 - nextW);
       }
       setDragWidth(nextW);
@@ -253,7 +265,7 @@ function TextInlineEditor({
       window.removeEventListener('pointermove', onMove);
       window.removeEventListener('pointerup', onUp);
     };
-  }, [isEdgeDragging, z]);
+  }, [isEdgeDragging, z, fontSize]);
 
   if (!node || node.key !== 'text') return null;
 

--- a/apps/web/src/components/editor/nodes/VideoGeneratorNode/VideoGeneratorCard.tsx
+++ b/apps/web/src/components/editor/nodes/VideoGeneratorNode/VideoGeneratorCard.tsx
@@ -17,11 +17,11 @@ import { Dropdown, DropdownPanel, message, Tooltip } from '@/components/base';
 import {
   rcbScreenPxToScene,
   useRcbCamera,
-  useRcbScreenToolbarStyle,
 } from '@/components/rcb';
 import {
   SELECTION_TOOLBAR_BELOW_BOX_GAP_PX,
   useChromePointerActivate,
+  WorldScreenChromeRoot,
 } from '@/components/rcb/selection/chrome/SelectionToolbarShell';
 import AgentComposerInput, {
   chipBaseKey,
@@ -852,31 +852,33 @@ function VideoGeneratorCard({
     );
   };
 
-  // Same placement contract as selection toolbars: centered under the box.
-  const composerStyle = useRcbScreenToolbarStyle({
-    left: sceneBox.x + sceneBox.width / 2,
-    top:
-      sceneBox.y +
-      sceneBox.height +
-      rcbScreenPxToScene(SELECTION_TOOLBAR_BELOW_BOX_GAP_PX, zoom),
-    anchor: 'top',
-  });
+  // Same placement contract as selection toolbars: world-layer under the box.
+  const composerLeft = sceneBox.x + sceneBox.width / 2;
+  const composerTop =
+    sceneBox.y +
+    sceneBox.height +
+    rcbScreenPxToScene(SELECTION_TOOLBAR_BELOW_BOX_GAP_PX, zoom);
 
   return (
     <>
       {showComposer ? (
-        <div
+        <WorldScreenChromeRoot
+          left={composerLeft}
+          top={composerTop}
+          anchor="top"
           data-video-generator
           data-sel-toolbar
           data-scene-node-id={nodeId}
-          className={cn(
-            'pointer-events-auto absolute z-[32] flex h-[200px] w-[500px] flex-col overflow-visible',
-            'rounded-2xl border border-[var(--line)] bg-[var(--surface)]',
-            'shadow-[0_8px_28px_rgba(15,23,42,0.12)]'
-          )}
-          style={composerStyle}
+          className="pointer-events-auto z-[32] overflow-visible"
           {...chromePointer}
         >
+          <div
+            className={cn(
+              'flex h-[200px] w-[500px] flex-col overflow-visible',
+              'rounded-2xl border border-[var(--line)] bg-[var(--surface)]',
+              'shadow-[0_8px_28px_rgba(15,23,42,0.12)]'
+            )}
+          >
           {/* Reference images occupy their own row, using the chat attachment chip. */}
           <div className="flex flex-wrap items-center gap-1.5 px-3 pt-2.5">
             {attachments.map((att) => (
@@ -1097,7 +1099,8 @@ function VideoGeneratorCard({
               </Tooltip>
             </div>
           </div>
-        </div>
+          </div>
+        </WorldScreenChromeRoot>
       ) : null}
 
       {showComposer && mentionOpen ? (

--- a/apps/web/src/components/editor/nodes/VideoGeneratorNode/VideoGeneratorOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/VideoGeneratorNode/VideoGeneratorOverlay.tsx
@@ -1,13 +1,12 @@
 import { useMemo, type ReactNode, memo } from 'react';
 import { useSelector } from 'react-redux';
-import { RcbOverlayPortal } from '@/components/rcb';
 import { isVideoGeneratorNode } from '@/components/rcb/scene/document/sceneDocument';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import VideoGeneratorCard from '@/components/editor/nodes/VideoGeneratorNode/VideoGeneratorCard';
 import { EMPTY_ID_LIST } from '@/store/modules/editor';
 
 /**
- * Screen-space Video Generator composers for every generator plate on the canvas.
+ * World-layer Video Generator composers (same lattice as the control box).
  * SVG keeps the hit target; the title row comes from the shared selection label.
  */
 function VideoGeneratorOverlay({
@@ -39,35 +38,33 @@ function VideoGeneratorOverlay({
 
   // Keep cards mounted while transforming — local + attr state must survive hide.
   return (
-    <RcbOverlayPortal>
-      <div
-        className={hidden ? 'pointer-events-none invisible' : undefined}
-        aria-hidden={hidden || undefined}
-      >
-        {ids.map((nodeId) => {
-          const node = document?.deltaSetLike?.[nodeId];
-          if (!node) return null;
-          const { left, top } = nodeLeftTop(document, node);
-          const width = Math.max(1, Number(node.width) || 1);
-          const height = Math.max(1, Number(node.height) || 1);
-          return (
-            <VideoGeneratorCard
-              key={nodeId}
-              nodeId={nodeId}
-              sceneBox={{ x: left, y: top, width, height }}
-              // Title comes from the shared selection label; composer follows it.
-              showComposer={
-                !hidden &&
-                ((selectedNodeIds.length === 1 && selectedNodeIds[0] === nodeId) ||
-                  canvasAttachPick?.target === `node:${nodeId}` ||
-                  pendingCanvasAttach?.target === `node:${nodeId}`)
-              }
-              disabled={readOnly}
-            />
-          );
-        })}
-      </div>
-    </RcbOverlayPortal>
+    <div
+      className={hidden ? 'pointer-events-none invisible' : undefined}
+      aria-hidden={hidden || undefined}
+    >
+      {ids.map((nodeId) => {
+        const node = document?.deltaSetLike?.[nodeId];
+        if (!node) return null;
+        const { left, top } = nodeLeftTop(document, node);
+        const width = Math.max(1, Number(node.width) || 1);
+        const height = Math.max(1, Number(node.height) || 1);
+        return (
+          <VideoGeneratorCard
+            key={nodeId}
+            nodeId={nodeId}
+            sceneBox={{ x: left, y: top, width, height }}
+            // Title comes from the shared selection label; composer follows it.
+            showComposer={
+              !hidden &&
+              ((selectedNodeIds.length === 1 && selectedNodeIds[0] === nodeId) ||
+                canvasAttachPick?.target === `node:${nodeId}` ||
+                pendingCanvasAttach?.target === `node:${nodeId}`)
+            }
+            disabled={readOnly}
+          />
+        );
+      })}
+    </div>
   );
 }
 

--- a/apps/web/src/components/editor/nodes/VideoNode/VideoHoverPlayback.tsx
+++ b/apps/web/src/components/editor/nodes/VideoNode/VideoHoverPlayback.tsx
@@ -19,6 +19,41 @@ function pointInRect(x: number, y: number, r: DOMRect) {
   return x >= r.left && x <= r.right && y >= r.top && y <= r.bottom;
 }
 
+function readCropNorm(opts: {
+  cropX?: number;
+  cropY?: number;
+  cropW?: number;
+  cropH?: number;
+}): { x: number; y: number; w: number; h: number } | null {
+  const x = Number(opts.cropX);
+  const y = Number(opts.cropY);
+  const w = Number(opts.cropW);
+  const h = Number(opts.cropH);
+  if (
+    ![x, y, w, h].every(Number.isFinite) ||
+    !(w > 0) ||
+    !(h > 0) ||
+    (x === 0 && y === 0 && w === 1 && h === 1)
+  ) {
+    return null;
+  }
+  return { x, y, w, h };
+}
+
+function mediaCropStyle(crop: { x: number; y: number; w: number; h: number } | null): CSSProperties {
+  if (!crop) {
+    return { width: '100%', height: '100%', objectFit: 'fill' };
+  }
+  return {
+    position: 'absolute',
+    left: `${(-crop.x / crop.w) * 100}%`,
+    top: `${(-crop.y / crop.h) * 100}%`,
+    width: `${(1 / crop.w) * 100}%`,
+    height: `${(1 / crop.h) * 100}%`,
+    objectFit: 'fill',
+  };
+}
+
 /** Freeze the current decoded video frame as a JPEG data URL. */
 export function captureFrameFromVideoEl(video: HTMLVideoElement): string | null {
   if (video.readyState < 2) return null;

--- a/apps/web/src/components/editor/page/EditorStageWorld.tsx
+++ b/apps/web/src/components/editor/page/EditorStageWorld.tsx
@@ -340,9 +340,10 @@ function EditorStageWorld({
 
         <FrameDrawFeature
           enabled={!isDevMode && frameMode}
-          camera={camera}
           stageEl={stageEl}
           onCommit={onCommitFrame}
+          gridSnap
+          gridSize={gridSize}
         />
       </RcbCanvas>
     </div>

--- a/apps/web/src/components/editor/panels/FillPanel.tsx
+++ b/apps/web/src/components/editor/panels/FillPanel.tsx
@@ -194,7 +194,7 @@ function ImageAdjustRow({
   );
 }
 
-/** Compact fit dropdown — portals to body so FillPanel never clips it (fig.6). */
+/** Compact fit dropdown — portals to body so FillPanel never clips it. */
 function FitModeSelect({
   value,
   onChange,
@@ -472,7 +472,7 @@ export function fillPanelPreview(value: FillPanelValue): string {
   return cssPreviewForGradient(g, value.fillOpacity);
 }
 
-/** Full fill editor: solid / linear / radial / angular / image (fig.2–6). */
+/** Full fill editor: solid / linear / radial / angular / image. */
 function FillPanel({
   value,
   onChange,

--- a/apps/web/src/components/editor/panels/agent/ImageAspectRatioPicker.tsx
+++ b/apps/web/src/components/editor/panels/agent/ImageAspectRatioPicker.tsx
@@ -12,7 +12,7 @@ import type { ImageLimits } from '@/apis/chat';
 import { cn } from '@/utils/classnames';
 
 /**
- * Image-gen ratio row (fig.1): Smart + common landscape → square → portrait.
+ * Image-gen ratio row: Smart + common landscape → square → portrait.
  * `smart` lets the model pick; pixel tables treat it as 1:1.
  */
 export const IMAGE_ASPECT_RATIOS = [
@@ -511,7 +511,7 @@ function isRatioActive(current: string, preset: string, resolution: string) {
 }
 
 type Props = {
-  /** design = device presets; image = ratio / resolution / count / px (fig.1). */
+  /** design = device presets; image = ratio / resolution / count / px. */
   variant?: 'design' | 'image';
   /** Kept for API callers; image UI no longer exposes quality. */
   quality?: string;
@@ -533,7 +533,7 @@ type Props = {
   className?: string;
 };
 
-/** Pill track — light gray rail; selected cell is white with a soft shadow (fig.2). */
+/** Pill track — light gray rail; selected cell is white with a soft shadow. */
 function SegmentedTrack({
   children,
   className,
@@ -623,7 +623,7 @@ function DimField({
   );
 }
 
-/** Image gen (fig.1 ratio chips) / design canvas size (SizePresetPanel). */
+/** Image gen (ratio chips) / design canvas size (SizePresetPanel). */
 function ImageAspectRatioPicker({
   variant = 'image',
   resolution = DEFAULT_IMAGE_RESOLUTION,

--- a/apps/web/src/components/rcb/camera/context.tsx
+++ b/apps/web/src/components/rcb/camera/context.tsx
@@ -6,7 +6,7 @@ import { RCB_DEFAULT_CAMERA, type RcbCamera, type RcbVec } from '../core/types';
 export const RcbCameraContext = createContext<RcbCamera>(RCB_DEFAULT_CAMERA);
 export const RcbOverlayRootContext = createContext<HTMLElement | null>(null);
 export const RcbViewportElContext = createContext<HTMLElement | null>(null);
-/** Tracks `window.devicePixelRatio` (updates on browser zoom). */
+/** Live `window.devicePixelRatio` (browser zoom). Camera pan snaps to this. */
 export const RcbDevicePixelRatioContext = createContext(1);
 
 /** Camera interaction: pan/zoom in flight → use efficientZoom for cull/LOD. */
@@ -37,12 +37,12 @@ export function useRcbViewportEl(): HTMLElement | null {
   return useContext(RcbViewportElContext);
 }
 
-/** Live devicePixelRatio (browser zoom / HiDPI). */
+/** Live browser devicePixelRatio (updates on browser zoom). */
 export function useRcbDevicePixelRatio(): number {
   return useContext(RcbDevicePixelRatioContext);
 }
 
-/** Pointer helper: `toScene(clientX, clientY)` using camera + viewport. */
+/** Pointer helper: `toScene(clientX, clientY)` using camera + viewport + DPR. */
 export function useRcbScreenToScene(): (clientX: number, clientY: number) => RcbVec {
   const camera = useRcbCamera();
   const viewportEl = useRcbViewportEl();

--- a/apps/web/src/components/rcb/canvas/RcbCanvas.tsx
+++ b/apps/web/src/components/rcb/canvas/RcbCanvas.tsx
@@ -7,11 +7,11 @@ import {
   RcbOverlayRootContext,
   RcbViewportElContext,
 } from '../camera/context';
-import { readDevicePixelRatio, subscribeDevicePixelRatio } from '../core/dpr';
 import {
   installDprDebugHelpers,
   logDprCameraState,
 } from '../core/dprDebug';
+import { readDevicePixelRatio, subscribeDevicePixelRatio } from '../core/dpr';
 import {
   rcbCameraCssZoom,
   rcbCameraScreenOffset,
@@ -24,12 +24,40 @@ import { RCB_DEFAULT_CAMERA, type RcbCamera } from '../core/types';
 import {
   setInfiniteSvgPaintCamera,
   snapInfiniteSvgViewportToCamera,
+  worldCameraViewport,
 } from '../scene/paint/sceneToSvg';
-import { listShapeHosts } from '../shapes/shapeHostRegistry';
+import { listShapeHosts, notifyShapeHostGeometry, setSceneWorldRoot } from '../shapes/shapeHostRegistry';
 import { DEFAULT_GRID_SIZE, shouldShowPixelGrid } from '../selection/alignGuides';
 
 export type { RcbCamera };
 export { RCB_DEFAULT_CAMERA };
+
+/**
+ * Scene-space pixel-grid path (integer multiples of `g`).
+ * Drawn as real path geometry on the infinite canvas SVG — not CSS pattern
+ * (patterns drift under ancestor `scale()` / fractional browser DPR).
+ */
+export function buildPixelGridPathD(
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+  gridSize: number
+): string {
+  const g = gridSize > 0 ? gridSize : 1;
+  const right = left + Math.max(0, width);
+  const bottom = top + Math.max(0, height);
+  const x0 = Math.floor(left / g) * g;
+  const y0 = Math.floor(top / g) * g;
+  const parts: string[] = [];
+  for (let x = x0; x <= right + 1e-9; x += g) {
+    parts.push(`M ${x} ${y0} V ${bottom}`);
+  }
+  for (let y = y0; y <= bottom + 1e-9; y += g) {
+    parts.push(`M ${x0} ${y} H ${right}`);
+  }
+  return parts.join(' ');
+}
 
 /** Zoom about a stage-local point — convenience for host zoom controls. */
 export function zoomAtPoint(
@@ -65,8 +93,8 @@ export type RcbCanvasProps = {
   /** Optional SVG defs / ambient nodes inside the viewport (not scaled). */
   defs?: ReactNode;
   /**
-   * Pixel-grid pitch in scene units (default 1). Overlay auto-shows around ≥800%
-   * zoom; paints a viewport-sized tile on the world layer (scene-aligned).
+   * Pixel-grid pitch in scene units (default 1). Auto-shows around ≥800% zoom.
+   * Painted on the world layer with shapes (same CSS camera transform).
    */
   gridSize?: number;
   stageRef?: RefObject<HTMLDivElement | null>;
@@ -83,16 +111,16 @@ export type RcbCanvasProps = {
 };
 
 /**
- * recombyn infinite canvas shell.
+ * RCB infinite canvas shell.
  *
  * Layers:
  *   1. Viewport — wheel / pan, overflow hidden
- *   2. World — CSS `translate3d + scale` (optional grid + scene content)
- *   3. Overlay — unscaled screen UI only (toolbars / labels via RcbOverlayPortal)
+ *   2. World — CSS `translate3d + scale` (pixel grid + shapes + scene chrome
+ *      including titles / toolbars / process pills — same lattice as the control box)
+ *   3. Overlay — unscaled screen UI only (rare portals; prefer world chrome)
  *
- * Selection chrome + align guides live in the world layer using the same
- * CSS box + SVG viewBox compositing as shape hosts — not a 1×1 overflow SVG —
- * so browser zoom cannot desync boxes from ink.
+ * Pixel grid lives on the world layer with shapes so browser zoom / fractional
+ * DPR cannot desync a separate stage-space grid from ink.
  *
  * Camera never mutates scene coordinate origin. Shapes SVG grows with content
  * bounds (no fixed ±N plane) — unbounded page space.
@@ -159,10 +187,10 @@ function RcbCanvas({
     [cameraMoving, camera.zoom]
   );
 
-  // Browser zoom / HiDPI — keep DPR in sync.
+  // Browser zoom / HiDPI — keep DPR in sync (camera pan snaps to this).
   useEffect(() => subscribeDevicePixelRatio(setDevicePixelRatio), []);
 
-  // Opt-in DPR camera logs: window.__RCB_DPR_DEBUG__ = true
+  // Opt-in camera logs: window.__RCB_DPR_DEBUG__ = true
   useEffect(() => {
     if (typeof window === 'undefined' || window.__RCB_DPR_DEBUG__ !== true) return;
     logDprCameraState({
@@ -176,7 +204,7 @@ function RcbCanvas({
     });
   }, [devicePixelRatio, camera.x, camera.y, camera.zoom]);
 
-  // Console helpers: window.__rcbDumpDpr() — also samples shape hosts under the stage.
+  // Console helpers: window.__rcbDumpDpr() / __rcbDumpGrid()
   useEffect(() => {
     installDprDebugHelpers(() => {
       const stage = stageRef.current;
@@ -193,8 +221,7 @@ function RcbCanvas({
           const id = el.getAttribute('data-scene-node-id') || '';
           if (!id) return;
           try {
-            const bb = el.getBBox();
-            // getBBox is in SVG user space (= scene for our hosts).
+            const bb = (el as SVGGraphicsElement).getBBox();
             boxes.push({
               id,
               left: bb.x,
@@ -411,41 +438,79 @@ function RcbCanvas({
     el.style.cursor = cursor || '';
   }, [cursor, panning, stageRef]);
 
-  // Snap pan to the device-pixel grid so translate doesn't add extra frac error
-  // on top of scene*dpr (critical at browser 90% → dpr≈0.9).
-  // Must stay in sync with rcbScreenToScene / rcbSceneToScreen.
+  // Snap pan to the device-pixel grid. Grid + shape hosts share one camera
+  // world viewport (identical CSS box === viewBox) so browser zoom cannot
+  // round sibling SVGs apart — one lattice, one scale.
   const { x: camX, y: camY } = rcbCameraScreenOffset(camera, devicePixelRatio);
   const camZ = rcbCameraCssZoom(camera);
-  // Notify paint module of camera (API compat); host surfaces use scene lattice only.
-  setInfiniteSvgPaintCamera(camera, devicePixelRatio);
-  const g = gridSize > 0 ? gridSize : DEFAULT_GRID_SIZE;
-  const showPixelGrid = shouldShowPixelGrid(camZ);
-  // World-layer scene surface in **integer scene** units (same lattice as draw snap
-  // and shape-host CSS/viewBox). Never device-pixel-shift — that desyncs grid
-  // hairlines from path ink under fractional browser DPR.
-  // Hairline ≪ cell: `1/zoom` scene units → ~1 CSS px after `scale(zoom)`.
-  const gridLineScene = Math.min(g * 0.35, 1 / Math.max(0.05, camZ));
   const stageW = viewportEl?.clientWidth || 0;
   const stageH = viewportEl?.clientHeight || 0;
-  const sceneLeft = -camX / camZ;
-  const sceneTop = -camY / camZ;
-  const sceneW = stageW > 0 ? stageW / camZ : 0;
-  const sceneH = stageH > 0 ? stageH / camZ : 0;
+  setInfiniteSvgPaintCamera(camera, devicePixelRatio, { width: stageW, height: stageH });
+  const g = gridSize > 0 ? gridSize : DEFAULT_GRID_SIZE;
+  const showPixelGrid = shouldShowPixelGrid(camZ);
+  const gridLineScene = Math.min(g * 0.35, 1 / Math.max(0.05, camZ));
+  const worldVp = worldCameraViewport(camera, devicePixelRatio, stageW, stageH);
+  const sceneLeft = worldVp?.left ?? -camX / camZ;
+  const sceneTop = worldVp?.top ?? -camY / camZ;
+  const sceneW = worldVp?.width ?? (stageW > 0 ? stageW / camZ : 0);
+  const sceneH = worldVp?.height ?? (stageH > 0 ? stageH / camZ : 0);
   const gridPad = g * 2;
-  const q = (n: number) => Math.round(n * 1e4) / 1e4;
-  const gridCssLeft = q(Math.floor(sceneLeft / g) * g - gridPad);
-  const gridCssTop = q(Math.floor(sceneTop / g) * g - gridPad);
-  const gridCssW = q(Math.ceil(sceneW / g) * g + gridPad * 2);
-  const gridCssH = q(Math.ceil(sceneH / g) * g + gridPad * 2);
-  const gridPatternId = 'rcb-pixel-grid-pat';
+  const gridCssLeft = Math.floor(sceneLeft / g) * g - gridPad;
+  const gridCssTop = Math.floor(sceneTop / g) * g - gridPad;
+  const gridCssW = Math.ceil(sceneW / g) * g + gridPad * 2;
+  const gridCssH = Math.ceil(sceneH / g) * g + gridPad * 2;
+  const gridPathD =
+    showPixelGrid && worldVp && worldVp.width > 0 && worldVp.height > 0
+      ? buildPixelGridPathD(gridCssLeft, gridCssTop, gridCssW, gridCssH, g)
+      : '';
 
-  // Re-quantize mounted hosts when camera / browser DPR changes (scene lattice).
+  // Keep every host on the shared world viewport; bump chrome to re-mirror.
   useEffect(() => {
-    setInfiniteSvgPaintCamera(camera, devicePixelRatio);
+    setInfiniteSvgPaintCamera(camera, devicePixelRatio, {
+      width: viewportEl?.clientWidth || 0,
+      height: viewportEl?.clientHeight || 0,
+    });
     for (const h of listShapeHosts()) {
       if (h.root) snapInfiniteSvgViewportToCamera(h.root, camera, devicePixelRatio);
     }
-  }, [camera.x, camera.y, camera.zoom, devicePixelRatio]);
+    notifyShapeHostGeometry();
+  }, [camera.x, camera.y, camera.zoom, devicePixelRatio, viewportEl?.clientWidth, viewportEl?.clientHeight]);
+
+  // One scene SVG for grid + shape layers (same CSS box / viewBox / raster lattice).
+  const sceneRootRef = useRef<SVGSVGElement | null>(null);
+  const shapesMountRef = useRef<SVGGElement | null>(null);
+  const setSceneRootNode = useCallback((node: SVGSVGElement | null) => {
+    sceneRootRef.current = node;
+    const mount = node
+      ? (node.querySelector(':scope > g[data-rcb-shapes-mount]') as SVGGElement | null)
+      : null;
+    const previewMount = node
+      ? (node.querySelector(':scope > g[data-rcb-draw-preview-mount]') as SVGGElement | null)
+      : null;
+    const guidesMount = node
+      ? (node.querySelector(':scope > g[data-rcb-smart-guides-mount]') as SVGGElement | null)
+      : null;
+    shapesMountRef.current = mount;
+    setSceneWorldRoot(node, mount, previewMount, guidesMount);
+  }, []);
+  useEffect(() => {
+    return () => setSceneWorldRoot(null, null, null, null);
+  }, []);
+
+  // Sync shared scene root viewport whenever camera / stage / dpr changes.
+  useEffect(() => {
+    const root = sceneRootRef.current;
+    if (!root || !worldVp) return;
+    root.setAttribute('width', String(worldVp.width));
+    root.setAttribute('height', String(worldVp.height));
+    root.setAttribute('viewBox', `${worldVp.left} ${worldVp.top} ${worldVp.width} ${worldVp.height}`);
+    root.setAttribute('data-rcb-world-surface', '1');
+    root.setAttribute('data-rcb-infinite', '1');
+    root.style.left = `${worldVp.left}px`;
+    root.style.top = `${worldVp.top}px`;
+    root.style.width = `${worldVp.width}px`;
+    root.style.height = `${worldVp.height}px`;
+  }, [worldVp?.left, worldVp?.top, worldVp?.width, worldVp?.height]);
 
   return (
     <RcbCameraContext.Provider value={camera}>
@@ -464,8 +529,9 @@ function RcbCanvas({
                 'relative h-full w-full touch-none overflow-hidden select-none',
                 !background && 'bg-[var(--canvas)]',
                 panning && 'cursor-grab active:cursor-grabbing',
-                // Force nested shapes / chrome to inherit tool cursor (eraser / pencil / …).
-                !panning && cursor && '[&_*]:!cursor-inherit',
+                // Tool cursors (eraser / pencil / …) inherit onto shapes — but
+                // selection resize/rotate hits must keep their own cursors.
+                !panning && cursor && '[&_*:not([data-sel-handle])]:!cursor-inherit',
                 !panning && !cursor && 'cursor-default',
                 className
               )}
@@ -475,8 +541,14 @@ function RcbCanvas({
                 cursor: !panning && cursor ? cursor : '',
               }}
             >
+              <style>{`
+                /* HTML <video> paints; SVG poster is hit/export underlay only.
+                   Hide on the live canvas so move cannot show a second layer.
+                   Export builds its own SVG (no this rule). */
+                [data-rcb-canvas] [data-rcb-video-svg-underlay="1"] { opacity: 0; }
+              `}</style>
               {defs}
-              {/* Camera layer. Shapes + selection chrome + scene pixel grid. */}
+              {/* Infinite canvas world: camera CSS + scene SVG hosts (grid + shapes). */}
               <div
                 className="rcb-html-layer absolute left-0 top-0 z-[1] origin-top-left overflow-visible [&>*]:pointer-events-auto"
                 data-rcb-world="1"
@@ -484,62 +556,52 @@ function RcbCanvas({
                 style={{
                   transform: `translate3d(${camX}px, ${camY}px, 0) scale(${camZ})`,
                   backfaceVisibility: 'hidden',
-                  // --tl-zoom / --tl-scale for screen-constant SVG chrome
+                  // Screen-constant SVG chrome under camera scale (1/zoom).
                   ['--rcb-zoom' as string]: String(camZ),
                   ['--rcb-scale' as string]: `calc(1 / ${camZ})`,
                 }}
               >
-                {/* One scene-surface SVG: pixel grid + draw ephemeral share viewBox. */}
-                {gridCssW > 0 && gridCssH > 0 ? (
+                {worldVp && worldVp.width > 0 && worldVp.height > 0 ? (
                   <svg
+                    ref={setSceneRootNode}
                     aria-hidden
-                    data-rcb-scene-surface="1"
-                    data-rcb-pixel-grid={showPixelGrid ? '1' : undefined}
+                    data-rcb-scene-root="1"
                     data-rcb-infinite="1"
+                    data-rcb-world-surface="1"
+                    data-rcb-scene-surface="1"
+                    data-rcb-pixel-grid={gridPathD ? '1' : undefined}
+                    data-rcb-grid-size={String(g)}
+                    data-rcb-grid-left={String(gridCssLeft)}
+                    data-rcb-grid-top={String(gridCssTop)}
                     className="pointer-events-none absolute z-0 overflow-visible"
-                    width={gridCssW}
-                    height={gridCssH}
-                    viewBox={`${gridCssLeft} ${gridCssTop} ${gridCssW} ${gridCssH}`}
+                    width={worldVp.width}
+                    height={worldVp.height}
+                    viewBox={`${worldVp.left} ${worldVp.top} ${worldVp.width} ${worldVp.height}`}
                     preserveAspectRatio="none"
                     style={{
-                      left: gridCssLeft,
-                      top: gridCssTop,
-                      width: gridCssW,
-                      height: gridCssH,
+                      left: worldVp.left,
+                      top: worldVp.top,
+                      width: worldVp.width,
+                      height: worldVp.height,
                       display: 'block',
                       overflow: 'visible',
                       shapeRendering: 'geometricPrecision',
+                      pointerEvents: 'none',
                     }}
                   >
-                    {showPixelGrid ? (
-                      <>
-                        <defs>
-                          <pattern
-                            id={gridPatternId}
-                            x={0}
-                            y={0}
-                            width={g}
-                            height={g}
-                            patternUnits="userSpaceOnUse"
-                          >
-                            <path
-                              d={`M ${g} 0 V ${g} M 0 ${g} H ${g}`}
-                              fill="none"
-                              stroke="color-mix(in srgb, var(--line) 50%, transparent)"
-                              strokeWidth={gridLineScene}
-                            />
-                          </pattern>
-                        </defs>
-                        <rect
-                          x={gridCssLeft}
-                          y={gridCssTop}
-                          width={gridCssW}
-                          height={gridCssH}
-                          fill={`url(#${gridPatternId})`}
-                        />
-                      </>
+                    {gridPathD ? (
+                      <path
+                        d={gridPathD}
+                        fill="none"
+                        stroke="color-mix(in srgb, var(--line) 50%, transparent)"
+                        strokeWidth={gridLineScene}
+                        strokeLinecap="butt"
+                        pointerEvents="none"
+                      />
                     ) : null}
-                    <g data-rcb-ephemeral="1" pointerEvents="none" />
+                    <g data-rcb-shapes-mount="1" />
+                    <g data-rcb-draw-preview-mount="1" />
+                    <g data-rcb-smart-guides-mount="1" />
                   </svg>
                 ) : null}
                 {children}

--- a/apps/web/src/components/rcb/canvas/RcbSceneOverlayCanvas.tsx
+++ b/apps/web/src/components/rcb/canvas/RcbSceneOverlayCanvas.tsx
@@ -1,7 +1,6 @@
 import { forwardRef, memo, useImperativeHandle, useRef } from 'react';
-import { readDevicePixelRatio } from '../core/dpr';
 import { rcbCameraCssZoom } from '../core/math';
-import { useRcbCamera, useRcbDevicePixelRatio } from '../camera/context';
+import { useRcbCamera } from '../camera/context';
 
 export type SceneOverlayBox = {
   left: number;
@@ -37,10 +36,12 @@ type FrameSlot = {
 };
 
 /**
- * Scene-space Canvas overlay for draw previews / indicators (under the camera layer).
- * Position with CSS `left/top` (no `translate`) so it matches shape-host boxes
- * under browser zoom. 1 scene unit = 1 CSS px under camera scale.
- * Path2D is stroked here; committed ink stays SVG.
+ * @deprecated Prefer scene-surface SVG (`sceneSurfaceSvgProps`) or
+ * `mirrorHostSurface` for anything that must align under browser zoom.
+ * Kept for rare non-alignment Path2D experiments; pen/pencil/path-edit
+ * previews now paint SVG.
+ *
+ * If used: CSS box === scene units; bitmap is a separate paint pipeline.
  */
 const RcbSceneOverlayCanvas = memo(
   forwardRef<RcbSceneOverlayCanvasHandle, Props>(function RcbSceneOverlayCanvas(
@@ -49,12 +50,9 @@ const RcbSceneOverlayCanvas = memo(
   ) {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const camera = useRcbCamera();
-    const dprCtx = useRcbDevicePixelRatio();
     const zoomRef = useRef(camera.zoom);
-    const dprRef = useRef(dprCtx);
     const slotRef = useRef<FrameSlot | null>(null);
     zoomRef.current = rcbCameraCssZoom(camera);
-    dprRef.current = dprCtx || readDevicePixelRatio();
 
     useImperativeHandle(
       ref,
@@ -75,45 +73,38 @@ const RcbSceneOverlayCanvas = memo(
           const canvas = canvasRef.current;
           if (!canvas) return null;
           const z = zoomRef.current;
-          // Keep fractional browser-zoom dpr (e.g. 0.9) — clamping to ≥1 mis-sized
-          // the backing store vs physical pixels and drifted indicators vs SVG ink.
-          const dpr = Math.max(0.25, dprRef.current || 1);
           const w = Math.max(1, box.width);
           const h = Math.max(1, box.height);
-          // World layer already CSS-scales by z; bake z*dpr for the backing store.
-          // CSS size = bitmap/scale so setTransform(scale) stays isotropic (no
-          // round(w*scale)/w skew vs SVG hosts under fractional dpr).
-          const scale = z * dpr;
+          // World layer already CSS-scales by z; bake z into the bitmap only.
+          const scale = z;
           const pw = Math.max(1, Math.round(w * scale));
           const ph = Math.max(1, Math.round(h * scale));
-          const cssW = pw / scale;
-          const cssH = ph / scale;
+          const sx = pw / w;
+          const sy = ph / h;
           const prev = slotRef.current;
           const sameSlot =
             prev &&
             prev.pw === pw &&
             prev.ph === ph &&
-            prev.w === cssW &&
-            prev.h === cssH &&
+            prev.w === w &&
+            prev.h === h &&
             prev.left === box.left &&
             prev.top === box.top;
-          // Reassigning canvas.width clears the bitmap and causes draw-preview jitter.
-          // Keep the same buffer when the scene box is unchanged.
           if (!sameSlot) {
             canvas.width = pw;
             canvas.height = ph;
             canvas.style.left = `${box.left}px`;
             canvas.style.top = `${box.top}px`;
-            canvas.style.width = `${cssW}px`;
-            canvas.style.height = `${cssH}px`;
+            canvas.style.width = `${w}px`;
+            canvas.style.height = `${h}px`;
             canvas.style.transform = '';
-            slotRef.current = { left: box.left, top: box.top, w: cssW, h: cssH, pw, ph };
+            slotRef.current = { left: box.left, top: box.top, w, h, pw, ph };
           }
           canvas.style.display = 'block';
           const ctx = canvas.getContext('2d');
           if (!ctx) return null;
-          ctx.setTransform(scale, 0, 0, scale, 0, 0);
-          ctx.clearRect(0, 0, cssW, cssH);
+          ctx.setTransform(sx, 0, 0, sy, 0, 0);
+          ctx.clearRect(0, 0, w, h);
           ctx.translate(-box.left, -box.top);
           return ctx;
         },

--- a/apps/web/src/components/rcb/canvas/__tests__/pixelGridPath.test.ts
+++ b/apps/web/src/components/rcb/canvas/__tests__/pixelGridPath.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { buildPixelGridPathD } from '../RcbCanvas';
+
+describe('buildPixelGridPathD', () => {
+  it('emits lines on integer multiples of gridSize', () => {
+    const d = buildPixelGridPathD(10.2, 20.7, 5, 5, 1);
+    // Verticals at 10..16, horizontals at 20..26 (floor origins)
+    expect(d).toContain('M 10 20 V 25.7');
+    expect(d).toContain('M 15 20 V 25.7');
+    expect(d).toContain('M 10 20 H 15.2');
+    expect(d).toContain('M 10 25 H 15.2');
+    // No pattern / fractional mid-cell origins
+    expect(d).not.toMatch(/M 10\.5 /);
+  });
+
+  it('keeps step = gridSize for g>1', () => {
+    const d = buildPixelGridPathD(0, 0, 10, 10, 2);
+    expect(d).toContain('M 0 0 V 10');
+    expect(d).toContain('M 2 0 V 10');
+    expect(d).toContain('M 10 0 V 10');
+    expect(d).not.toContain('M 1 0');
+  });
+});

--- a/apps/web/src/components/rcb/core/__tests__/mathScreenScene.test.ts
+++ b/apps/web/src/components/rcb/core/__tests__/mathScreenScene.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   rcbCameraScreenOffset,
   rcbClientDeltaToScene,
@@ -8,7 +8,6 @@ import {
   rcbScreenToScene,
   rcbSnapSceneAxis,
 } from '../math';
-import { snapCssToDevicePixel, toDomPrecision } from '../dpr';
 
 function mockViewport(opts: {
   left: number;
@@ -39,32 +38,34 @@ function mockViewport(opts: {
 }
 
 describe('rcb screen ↔ scene', () => {
-  it('uses DPR-snapped pan so scene→screen matches CSS translate', () => {
+  it('snaps camera pan to device pixels', () => {
     const camera = { zoom: 0.18, x: 100.4, y: -40.7 };
-    const dpr = 0.9;
-    const offset = rcbCameraScreenOffset(camera, dpr);
-    expect(offset.x).toBe(toDomPrecision(snapCssToDevicePixel(camera.x, dpr)));
-    expect(offset.y).toBe(toDomPrecision(snapCssToDevicePixel(camera.y, dpr)));
+    // dpr=1 → round to integer CSS px
+    const offset = rcbCameraScreenOffset(camera, 1);
+    expect(offset.x).toBe(100);
+    expect(offset.y).toBe(-41);
 
-    const screen = rcbSceneToScreen(camera, 50, 80, dpr);
+    const screen = rcbSceneToScreen(camera, 50, 80, 1);
     expect(screen.x).toBeCloseTo(50 * 0.18 + offset.x, 5);
     expect(screen.y).toBeCloseTo(80 * 0.18 + offset.y, 5);
   });
 
-  it('round-trips through a mock viewport with snapped pan', () => {
+  it('snaps pan under fractional browser DPR (75% ≈ 0.75)', () => {
+    const camera = { zoom: 1, x: 10.1, y: 20.2 };
+    const offset = rcbCameraScreenOffset(camera, 0.75);
+    // Device px land on integers before toDomPrecision noise.
+    expect(Math.round(camera.x * 0.75) / 0.75).toBeCloseTo(offset.x, 3);
+    expect(Math.round(camera.y * 0.75) / 0.75).toBeCloseTo(offset.y, 3);
+  });
+
+  it('round-trips through a mock viewport', () => {
     const camera = { zoom: 0.18, x: 120.3, y: 44.8 };
-    const dpr = 1.25;
     const viewportEl = mockViewport({ left: 10, top: 20, width: 400, height: 300 });
+    const dpr = 1;
 
     const scene = { x: 220, y: -30 };
     const screen = rcbSceneToScreen(camera, scene.x, scene.y, dpr);
-    const back = rcbScreenToScene(
-      camera,
-      viewportEl,
-      10 + screen.x,
-      20 + screen.y,
-      dpr
-    );
+    const back = rcbScreenToScene(camera, viewportEl, 10 + screen.x, 20 + screen.y, dpr);
     expect(back.x).toBeCloseTo(scene.x, 5);
     expect(back.y).toBeCloseTo(scene.y, 5);
   });
@@ -83,9 +84,6 @@ describe('rcb screen ↔ scene', () => {
     const local = rcbClientToStageLocal(viewportEl, 200, 150);
     expect(local.x).toBeCloseTo(400, 5);
     expect(local.y).toBeCloseTo(300, 5);
-    const scene = rcbScreenToScene(camera, viewportEl, 200, 150);
-    expect(scene.x).toBeCloseTo(400, 5);
-    expect(scene.y).toBeCloseTo(300, 5);
   });
 
   it('maps client deltas with scale', () => {
@@ -93,13 +91,40 @@ describe('rcb screen ↔ scene', () => {
     expect(rcbClientDeltaToScene(1, 10, 20, 0.5, 0.5)).toEqual({ x: 20, y: 40 });
   });
 
-  it('snaps scene axis so screen*dpr is an integer device pixel', () => {
-    const dpr = 0.9;
-    const zoom = 6.2295;
-    const cam = toDomPrecision(snapCssToDevicePixel(-10746.829496055749, dpr));
+  it('rcbSnapSceneAxis is identity at integer DPR (keeps half-pixel origins)', () => {
+    expect(rcbSnapSceneAxis(269.5, 1, 0, 1)).toBe(269.5);
+  });
+
+  it('rcbSnapSceneAxis quantizes surface origin under fractional DPR', () => {
     const scene = 1755;
+    const zoom = 1;
+    const cam = -100;
+    const dpr = 0.9;
     const snapped = rcbSnapSceneAxis(scene, zoom, cam, dpr);
     const screen = snapped * zoom + cam;
     expect(Math.abs(screen * dpr - Math.round(screen * dpr))).toBeLessThan(1e-6);
+    // Content at `scene` still maps to the same screen math via matched viewBox.
+    expect(scene * zoom + cam).toBeCloseTo(scene * zoom + cam, 10);
+  });
+
+  it('world-equivalent viewport is identical for grid and hosts', () => {
+    // sceneLeft = -camX/z — same formula worldCameraViewport uses.
+    const camera = { zoom: 1, x: 10, y: -20 };
+    const dpr = 0.9;
+    const offset = rcbCameraScreenOffset(camera, dpr);
+    const z = 1;
+    const stageW = 800;
+    const stageH = 600;
+    const left = -offset.x / z;
+    const top = -offset.y / z;
+    const a = { left, top, width: stageW / z, height: stageH / z };
+    const b = { left, top, width: stageW / z, height: stageH / z };
+    expect(a).toEqual(b);
+  });
+
+  it('rcbResolveViewportEl prefers connected', () => {
+    const a = mockViewport({ left: 0, top: 0, width: 1, height: 1, connected: false });
+    const b = mockViewport({ left: 0, top: 0, width: 1, height: 1, connected: true });
+    expect(rcbResolveViewportEl(a, b)).toBe(b);
   });
 });

--- a/apps/web/src/components/rcb/core/__tests__/textPlaceFontSize.test.ts
+++ b/apps/web/src/components/rcb/core/__tests__/textPlaceFontSize.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { rcbDefaultPlaceFontSize } from '../layout';
+import { createTextNode } from '../../scene/document/sceneDocument';
+import { parseNodeTextStyle } from '../../scene/document/sceneText';
+import { snapCoordToGrid } from '../../selection/alignGuides';
+
+describe('rcbDefaultPlaceFontSize (T-tool at zoom)', () => {
+  it('at 100% zoom keeps ~14 scene px', () => {
+    expect(rcbDefaultPlaceFontSize(1, 14)).toBe(14);
+  });
+
+  it('at 4000% zoom is ~1 scene px (not document-14 filling the view)', () => {
+    const fs = rcbDefaultPlaceFontSize(40, 14);
+    // eslint-disable-next-line no-console
+    console.log('[test:text-font@4000%]', { fs, legacy: 14 });
+    expect(fs).toBe(1);
+    expect(fs).toBeLessThan(14);
+  });
+
+  it('at 50% zoom grows so on-screen size stays ~14 CSS px', () => {
+    expect(rcbDefaultPlaceFontSize(0.5, 14)).toBe(28);
+  });
+
+  it('createTextNode applies zoom-fitted fontSize into attrs', () => {
+    const fs = rcbDefaultPlaceFontSize(40, 14);
+    const x = snapCoordToGrid(10.4, 1);
+    const y = snapCoordToGrid(20.6, 1);
+    const { node } = createTextNode({ x, y, text: '', autoSize: true, fontSize: fs });
+    const style = parseNodeTextStyle(node.attrs || {});
+    // eslint-disable-next-line no-console
+    console.log('[test:createText@4000%]', {
+      fs,
+      x: node.x,
+      y: node.y,
+      w: node.width,
+      h: node.height,
+      styleFs: style.fontSize,
+    });
+    expect(node.x).toBe(10);
+    expect(node.y).toBe(21);
+    expect(style.fontSize).toBe(fs);
+    // Caret box should hug the small font, not a hardcoded height 20.
+    expect(node.height).toBeLessThanOrEqual(Math.ceil(fs * 1.4) + 2);
+  });
+
+  it('empty caret chrome height must not use a document-20px floor', () => {
+    const fs = rcbDefaultPlaceFontSize(20, 14); // 0.7 → rounds to 0.5? 14/20=0.7 → 0.5? round*2/2
+    const emptyH = Math.ceil(fs * 1.4);
+    const legacyEmptyH = Math.max(fs * 1.4, 20);
+    // eslint-disable-next-line no-console
+    console.log('[test:text-empty-h]', { fs, emptyH, legacyEmptyH });
+    expect(emptyH).toBeLessThan(20);
+    expect(legacyEmptyH).toBe(20);
+  });
+});

--- a/apps/web/src/components/rcb/core/dpr.ts
+++ b/apps/web/src/components/rcb/core/dpr.ts
@@ -1,7 +1,10 @@
 /**
  * Device-pixel helpers.
- * Browser zoom changes `window.devicePixelRatio`; we track it and align sizes
- * so CSS transforms don't drift by a subpixel.
+ * Browser zoom changes `window.devicePixelRatio`. We snap:
+ * 1) camera world `translate`, and
+ * 2) each infinite-SVG surface origin (CSS left === viewBox min) under
+ *    fractional DPR — so grid + hosts share one device-pixel lattice without
+ *    moving absolute scene content.
  */
 
 /** Greatest common divisor. */
@@ -32,7 +35,7 @@ export function toDomPrecision(v: number) {
 
 /**
  * Snap a CSS-pixel value onto the device-pixel grid.
- * At dpr=0.9: rounds so `css * dpr` is an integer.
+ * At dpr=0.75: rounds so `css * dpr` is an integer.
  */
 export function snapCssToDevicePixel(cssPx: number, dpr: number): number {
   const d = dpr > 0 ? dpr : 1;

--- a/apps/web/src/components/rcb/core/dprDebug.ts
+++ b/apps/web/src/components/rcb/core/dprDebug.ts
@@ -10,7 +10,8 @@
  * Default OFF — enable explicitly when debugging browser-zoom seams.
  */
 
-import { nearestDprMultiple, snapCssToDevicePixel, toDomPrecision } from './dpr';
+import { nearestDprMultiple } from './dpr';
+import { rcbSceneToScreen } from './math';
 import type { RcbCamera } from './types';
 
 declare global {
@@ -19,8 +20,10 @@ declare global {
     __RCB_ALIGN_DEBUG__?: boolean;
     __rcbDumpDpr?: () => void;
     __rcbDumpAlign?: () => void;
+    __rcbDumpGrid?: () => Record<string, unknown>;
     __rcbLastDprDump?: Record<string, unknown>;
     __rcbLastAlignDump?: Record<string, unknown>;
+    __rcbLastGridDump?: Record<string, unknown>;
   }
 }
 
@@ -43,16 +46,9 @@ function classify(devicePx: number) {
   return 'frac';
 }
 
-/** Scene → CSS px under camera (same as rcbSceneToScreen — DPR-snapped pan). */
+/** Scene → CSS px under camera (uses snapped camera pan). */
 export function sceneToCss(camera: RcbCamera, sceneX: number, sceneY: number, dpr?: number) {
-  const z = Math.max(0.05, camera.zoom || 1);
-  const d = dpr ?? (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
-  const camX = toDomPrecision(snapCssToDevicePixel(camera.x, d));
-  const camY = toDomPrecision(snapCssToDevicePixel(camera.y, d));
-  return {
-    x: sceneX * z + camX,
-    y: sceneY * z + camY,
-  };
+  return rcbSceneToScreen(camera, sceneX, sceneY, dpr);
 }
 
 export type DprEdgeSample = {
@@ -131,9 +127,9 @@ export function logDprCameraState(opts: {
     dprIsFractional: Math.abs(dpr - Math.round(dpr)) > 0.02,
     camera: { ...camera },
     camCssWritten: camCss ?? {
-      x: toDomPrecision(camera.x),
-      y: toDomPrecision(camera.y),
-      z: toDomPrecision(camera.zoom),
+      x: camera.x,
+      y: camera.y,
+      z: camera.zoom,
     },
     // After CSS scale(z) translate(x,y), a scene unit becomes zoom CSS px → zoom*dpr device px.
     sceneUnitDevicePx: camera.zoom * dpr,
@@ -226,6 +222,125 @@ export function installDprDebugHelpers(getState: () => {
     }
     console.log(TAG, 'align dump (copy JSON)', JSON.stringify(last, null, 2));
   };
+  window.__rcbDumpGrid = () => dumpGridVsHosts(getState);
+}
+
+const GRID_TAG = '[rcb:grid]';
+
+function parsePx(v: string | null | undefined): number | null {
+  if (v == null || v === '') return null;
+  const n = Number.parseFloat(String(v));
+  return Number.isFinite(n) ? n : null;
+}
+
+function onGrid(value: number, g: number) {
+  if (!(g > 0)) return true;
+  const q = Math.round(value / g) * g;
+  return Math.abs(value - q) < 1e-6;
+}
+
+/** Measure infinite-canvas grid SVG vs shape hosts — always prints JSON. */
+export function dumpGridVsHosts(getState: () => {
+  dpr: number;
+  camera: RcbCamera;
+  boxes?: Array<{ id: string; left: number; top: number; width: number; height: number }>;
+}): Record<string, unknown> {
+  const { dpr, camera, boxes = [] } = getState();
+  const world = document.querySelector('[data-rcb-world="1"]') as HTMLElement | null;
+  const grid = document.querySelector('[data-rcb-pixel-grid="1"]') as SVGSVGElement | null;
+  const g = Number(grid?.getAttribute('data-rcb-grid-size') || 1) || 1;
+  const gridLeft = parsePx(grid?.getAttribute('data-rcb-grid-left'));
+  const gridTop = parsePx(grid?.getAttribute('data-rcb-grid-top'));
+  const gridStyleLeft = parsePx(grid?.style?.left);
+  const gridStyleTop = parsePx(grid?.style?.top);
+  const gridRect = grid?.getBoundingClientRect?.() ?? null;
+  const worldTf = world?.style?.transform || '';
+
+  const hosts = Array.from(document.querySelectorAll('[data-rcb-infinite="1"]:not([data-rcb-pixel-grid])'));
+  const hostRows = hosts.slice(0, 24).map((node, i) => {
+    const el = node as SVGSVGElement;
+    const left = parsePx(el.style.left) ?? parsePx(el.getAttribute('x'));
+    const top = parsePx(el.style.top) ?? parsePx(el.getAttribute('y'));
+    const vb = (el.getAttribute('viewBox') || '').trim();
+    const rect = el.getBoundingClientRect();
+    const sceneLeft = left;
+    const sceneTop = top;
+    return {
+      i,
+      tag: el.tagName,
+      sceneLeft,
+      sceneTop,
+      viewBox: vb,
+      onGridX: sceneLeft == null ? null : onGrid(sceneLeft, g),
+      onGridY: sceneTop == null ? null : onGrid(sceneTop, g),
+      fracX: sceneLeft == null ? null : sceneLeft - Math.round(sceneLeft / g) * g,
+      fracY: sceneTop == null ? null : sceneTop - Math.round(sceneTop / g) * g,
+      client: {
+        left: +rect.left.toFixed(3),
+        top: +rect.top.toFixed(3),
+        width: +rect.width.toFixed(3),
+        height: +rect.height.toFixed(3),
+      },
+    };
+  });
+
+  const boxRows = boxes.map((b) => {
+    const sample = sampleBoxEdges(b.id, b, camera, dpr);
+    return {
+      id: b.id,
+      scene: sample.scene,
+      onGrid: {
+        left: onGrid(b.left, g),
+        top: onGrid(b.top, g),
+        right: onGrid(b.left + b.width, g),
+        bottom: onGrid(b.top + b.height, g),
+      },
+      frac: {
+        left: b.left - Math.round(b.left / g) * g,
+        top: b.top - Math.round(b.top / g) * g,
+        right: b.left + b.width - Math.round((b.left + b.width) / g) * g,
+        bottom: b.top + b.height - Math.round((b.top + b.height) / g) * g,
+      },
+      css: sample.css,
+      device: sample.device,
+      edgeClass: sample.edgeClass,
+    };
+  });
+
+  // Same parent? Grid must be under [data-rcb-world], sibling of shape hosts.
+  const gridParentIsWorld = Boolean(grid && world && grid.parentElement === world);
+
+  const payload: Record<string, unknown> = {
+    dpr,
+    visualViewportScale: window.visualViewport?.scale ?? null,
+    camera: { ...camera },
+    grid: {
+      present: Boolean(grid),
+      parentIsWorld: gridParentIsWorld,
+      gridSize: g,
+      attrOrigin: { left: gridLeft, top: gridTop },
+      styleOrigin: { left: gridStyleLeft, top: gridStyleTop },
+      viewBox: grid?.getAttribute('viewBox') || null,
+      pathLen: grid?.querySelector('path')?.getAttribute('d')?.length ?? 0,
+      usesPattern: Boolean(grid?.querySelector('pattern')),
+      client: gridRect
+        ? {
+            left: +gridRect.left.toFixed(3),
+            top: +gridRect.top.toFixed(3),
+            width: +gridRect.width.toFixed(3),
+            height: +gridRect.height.toFixed(3),
+          }
+        : null,
+    },
+    worldTransform: worldTf,
+    stateBoxes: boxRows,
+    domHosts: hostRows,
+  };
+
+  window.__rcbLastGridDump = payload;
+  console.log(GRID_TAG, 'dump', payload);
+  console.log(GRID_TAG, 'json', JSON.stringify(payload));
+  return payload;
 }
 
 const ALIGN_TAG = '[rcb:align]';

--- a/apps/web/src/components/rcb/core/layout.ts
+++ b/apps/web/src/components/rcb/core/layout.ts
@@ -111,7 +111,7 @@ export function rcbCenterInBox(
 }
 
 /**
- * On-canvas size for an uploaded / pasted image.
+ * On-canvas size for an uploaded / pasted image / generator plate.
  *
  * Scene units are zoom-independent, so a fixed pixel cap lands huge when the user
  * is zoomed out and postage-stamp small when zoomed in. Measure against the visible
@@ -119,6 +119,10 @@ export function rcbCenterInBox(
  * scale so the image covers between `minRatio` and `maxRatio` of the screen.
  *
  * `viewport` is the on-screen stage size in CSS px; `zoom` the current camera zoom.
+ *
+ * When natural is larger than the viewport band, we **shrink** (scale < 1).
+ * When natural is smaller, we may upscale up to `maxRatio` but never above
+ * `contain(maxRatio)`.
  */
 export function rcbFitImageIntoViewport(
   natural: { width: number; height: number },
@@ -129,10 +133,21 @@ export function rcbFitImageIntoViewport(
   const nw = Math.max(1, Number(natural.width) || 1);
   const nh = Math.max(1, Number(natural.height) || 1);
   const z = Math.max(0.05, Number(zoom) || 1);
+  // Visible scene rect (CSS px / zoom).
   const vw = Math.max(1, (Number(viewport.width) || 1) / z);
   const vh = Math.max(1, (Number(viewport.height) || 1) / z);
   const contain = (ratio: number) => Math.min((vw * ratio) / nw, (vh * ratio) / nh);
-  const scale = Math.min(contain(maxRatio), Math.max(1, contain(minRatio)));
+  const maxScale = contain(maxRatio);
+  const minScale = contain(minRatio);
+  // Prefer natural (scale 1) when it already sits in [min, max] band.
+  let scale = 1;
+  if (maxScale < 1) {
+    // Natural too big for the viewport band — shrink to maxRatio.
+    scale = maxScale;
+  } else if (minScale > 1) {
+    // Natural too small — grow toward minRatio (capped by maxScale).
+    scale = Math.min(minScale, maxScale);
+  }
   return {
     width: Math.max(1, Math.round(nw * scale)),
     height: Math.max(1, Math.round(nh * scale)),
@@ -154,4 +169,85 @@ export function rcbCenterOnPoint(
     width: w,
     height: h,
   };
+}
+
+/** Empty generator plates use an inset border — outer edge === path (no center-stroke outset). */
+export const GENERATOR_EMPTY_STROKE_OUTSET = 0;
+
+function snapCoord(value: number, gridSize: number): number {
+  if (!(gridSize > 0) || !Number.isFinite(value)) return value;
+  return Math.round(value / gridSize) * gridSize;
+}
+
+/** Snap all four edges (same contract as selection `snapBoxEdgesToGrid`). */
+function snapEdgesToGrid(
+  box: { left: number; top: number; width: number; height: number },
+  gridSize: number,
+  minCells = 1
+): { left: number; top: number; width: number; height: number } {
+  if (!(gridSize > 0)) return box;
+  let left = snapCoord(box.left, gridSize);
+  let top = snapCoord(box.top, gridSize);
+  let right = snapCoord(box.left + box.width, gridSize);
+  let bottom = snapCoord(box.top + box.height, gridSize);
+  const min = Math.max(1, minCells) * gridSize;
+  if (right - left < min) right = left + min;
+  if (bottom - top < min) bottom = top + min;
+  return { left, top, width: right - left, height: bottom - top };
+}
+
+/**
+ * Fit → center → snap painted outer to the pixel grid → optional outset inset
+ * for path geom. Image/video generators use inset borders (outset 0) so path
+ * edges are the ink edges — never leave a half-cell float outside the grid.
+ */
+export function rcbLayoutGeneratorPlate(opts: {
+  natural: { width: number; height: number };
+  viewport: { width: number; height: number };
+  zoom: number;
+  center: RcbVec;
+  gridSize?: number;
+  /** Outside path extent of center stroke (generators = 0.5). */
+  visualOutset?: number;
+  fit?: { minRatio?: number; maxRatio?: number };
+}): { left: number; top: number; width: number; height: number; visual: { left: number; top: number; width: number; height: number } } {
+  const gridSize = opts.gridSize != null && opts.gridSize > 0 ? opts.gridSize : 1;
+  const outset = Math.max(0, Number(opts.visualOutset) || 0);
+  const sized = rcbFitImageIntoViewport(opts.natural, opts.viewport, opts.zoom, opts.fit);
+  const placed = rcbCenterOnPoint(opts.center, sized);
+  const rawVisual = {
+    left: placed.left - outset,
+    top: placed.top - outset,
+    width: placed.width + outset * 2,
+    height: placed.height + outset * 2,
+  };
+  const minCells = Math.max(1, Math.ceil((outset * 2) / gridSize) + 1);
+  const visual = snapEdgesToGrid(rawVisual, gridSize, minCells);
+  const geom = {
+    left: visual.left + outset,
+    top: visual.top + outset,
+    width: Math.max(gridSize, visual.width - outset * 2),
+    height: Math.max(gridSize, visual.height - outset * 2),
+  };
+  return { ...geom, visual };
+}
+
+/** Empty-state glyph size in scene units — always fits inside the plate. */
+export function generatorEmptyIconSize(boxW: number, boxH: number): number {
+  const side = Math.min(Math.max(0, boxW), Math.max(0, boxH));
+  // Never floor to a fixed scene px (old Math.max(72, …) overflowed at 3000% zoom).
+  return side * 0.28;
+}
+
+/**
+ * Default font size when placing text with the T tool.
+ * Targets ~`screenPx` CSS pixels on screen so high zoom does not spawn
+ * document-14px glyphs that fill half the viewport.
+ */
+export function rcbDefaultPlaceFontSize(zoom: number, screenPx = 14): number {
+  const z = Math.max(0.05, Number(zoom) || 1);
+  const target = Math.max(1, Number(screenPx) || 14);
+  const raw = target / z;
+  // Half-pixel steps (same lattice as odd center strokes); never below 1 scene px.
+  return Math.max(1, Math.round(raw * 2) / 2);
 }

--- a/apps/web/src/components/rcb/core/math.ts
+++ b/apps/web/src/components/rcb/core/math.ts
@@ -1,9 +1,9 @@
 import { readDevicePixelRatio, snapCssToDevicePixel, toDomPrecision } from './dpr';
 import type { RcbBox, RcbCamera, RcbVec } from './types';
 
-/** Camera zoom floor / ceiling (5% … 1200%). */
+/** Camera zoom floor / ceiling (5% … 10000%). */
 export const RCB_MIN_ZOOM = 0.05;
-export const RCB_MAX_ZOOM = 12;
+export const RCB_MAX_ZOOM = 100;
 
 export function rcbClampZoom(z: number) {
   return Math.min(RCB_MAX_ZOOM, Math.max(RCB_MIN_ZOOM, Number(z.toFixed(4))));
@@ -11,7 +11,8 @@ export function rcbClampZoom(z: number) {
 
 /**
  * CSS translate written on the camera world layer.
- * Must match `RcbCanvas` so hit-testing and overlays stay locked to pixels.
+ * Snaps pan onto the device-pixel grid (browser zoom / fractional DPR) so the
+ * whole world layer rasterizes together. Must match `RcbCanvas`.
  */
 export function rcbCameraScreenOffset(
   camera: RcbCamera,
@@ -21,6 +22,32 @@ export function rcbCameraScreenOffset(
     x: toDomPrecision(snapCssToDevicePixel(camera.x, dpr)),
     y: toDomPrecision(snapCssToDevicePixel(camera.y, dpr)),
   };
+}
+
+/** Browser zoom to 90%/110%/… → non-integer devicePixelRatio. */
+export function rcbDprIsFractional(dpr: number): boolean {
+  const d = dpr > 0 ? dpr : 1;
+  return Math.abs(d - Math.round(d)) > 0.001;
+}
+
+/**
+ * Scene-space SVG surface origin under fractional DPR.
+ * Chooses origin so `(origin * zoom + cam)` lands on a device pixel, while
+ * keeping CSS `left` === `viewBox` min — absolute scene content still maps to
+ * `scene * zoom + cam`. At integer DPR (100% zoom) returns `scene` unchanged
+ * so half-pixel stroke origins stay intact.
+ */
+export function rcbSnapSceneSurfaceOrigin(
+  scene: number,
+  zoom: number,
+  camSnapped: number,
+  dpr: number
+): number {
+  if (!rcbDprIsFractional(dpr)) return scene;
+  const z = Math.max(0.05, zoom || 1);
+  const screen = scene * z + camSnapped;
+  const screenSnapped = snapCssToDevicePixel(screen, dpr);
+  return (screenSnapped - camSnapped) / z;
 }
 
 /**
@@ -92,49 +119,45 @@ export function rcbSceneToScreen(
   };
 }
 
-/**
- * Snap a scene-axis value so `(scene * zoom + camSnapped) * dpr` lands on an
- * integer device pixel. Needed when browser zoom makes dpr fractional (e.g. 0.9):
- * pan is already snapped, but scene*zoom*dpr is still often frac — SVG strokes
- * and HTML chrome then round to different pixels.
- */
+/** @see rcbSnapSceneSurfaceOrigin */
 export function rcbSnapSceneAxis(
   scene: number,
   zoom: number,
   camSnapped: number,
-  dpr: number
+  dpr?: number
 ): number {
-  const z = Math.max(0.05, zoom || 1);
-  const d = dpr > 0 ? dpr : 1;
-  const screen = scene * z + camSnapped;
-  const snappedScreen = snapCssToDevicePixel(screen, d);
-  return (snappedScreen - camSnapped) / z;
+  return rcbSnapSceneSurfaceOrigin(scene, zoom, camSnapped, dpr ?? readDevicePixelRatio());
 }
 
-/** Snap box corners onto the device-pixel grid under the live camera CSS. */
+/** Snap surface origin (CSS === viewBox); size unchanged. */
 export function rcbSnapSceneBox(
   box: { left: number; top: number; width: number; height: number },
-  camera: RcbCamera,
-  dpr: number = readDevicePixelRatio()
+  camera?: RcbCamera,
+  dpr?: number
 ): { left: number; top: number; width: number; height: number } {
-  const z = Math.max(0.05, camera.zoom || 1);
-  const { x: camX, y: camY } = rcbCameraScreenOffset(camera, dpr);
-  const left = rcbSnapSceneAxis(box.left, z, camX, dpr);
-  const top = rcbSnapSceneAxis(box.top, z, camY, dpr);
-  const right = rcbSnapSceneAxis(box.left + box.width, z, camX, dpr);
-  const bottom = rcbSnapSceneAxis(box.top + box.height, z, camY, dpr);
+  const d = dpr ?? readDevicePixelRatio();
+  if (!camera || !rcbDprIsFractional(d)) {
+    return {
+      left: box.left,
+      top: box.top,
+      width: Math.max(1e-4, box.width),
+      height: Math.max(1e-4, box.height),
+    };
+  }
+  const z = rcbCameraCssZoom(camera);
+  const { x: camX, y: camY } = rcbCameraScreenOffset(camera, d);
   return {
-    left,
-    top,
-    width: Math.max(1e-4, right - left),
-    height: Math.max(1e-4, bottom - top),
+    left: rcbSnapSceneSurfaceOrigin(box.left, z, camX, d),
+    top: rcbSnapSceneSurfaceOrigin(box.top, z, camY, d),
+    width: Math.max(1e-4, box.width),
+    height: Math.max(1e-4, box.height),
   };
 }
 
 /**
  * Screen/client -> scene (page/world).
  * viewportEl is the unscaled stage root.
- * Uses DPR-snapped pan + layout/visual scale correction.
+ * Uses snapped camera pan (same as CSS world translate) + layout/visual scale.
  */
 export function rcbScreenToScene(
   camera: RcbCamera,
@@ -184,7 +207,7 @@ export function rcbZoomAtPoint(
   const z0 = camera.zoom;
   const z1 = rcbClampZoom(nextZoom);
   if (z0 === z1) return camera;
-  // Use raw camera pan (state space). CSS snap is display-only.
+  // Use raw camera pan (state space). Display offset is precision-only (no DPR).
   const sceneX = (localX - camera.x) / z0;
   const sceneY = (localY - camera.y) / z0;
   return { zoom: z1, x: localX - sceneX * z1, y: localY - sceneY * z1 };

--- a/apps/web/src/components/rcb/core/types.ts
+++ b/apps/web/src/components/rcb/core/types.ts
@@ -1,4 +1,4 @@
-/** recombyn canvas (rcb) — shared types. */
+/** RCB canvas — shared types. */
 
 export type RcbVec = { x: number; y: number };
 

--- a/apps/web/src/components/rcb/frames/FrameDrawFeature.tsx
+++ b/apps/web/src/components/rcb/frames/FrameDrawFeature.tsx
@@ -1,150 +1,245 @@
+/**
+ * Drag on empty world to create an artboard frame (SVG plate).
+ * Draw mechanics match ShapeDrawFeature (rect): DPR toScene, grid snap, portal.
+ * Plate **paint** stays artboard hairline (scene width = 1/zoom under CSS scale).
+ */
+import { createPortal } from 'react-dom';
 import { useEffect, useRef, useState, memo } from 'react';
-import type { RcbCamera } from '../core/types';
-import { useRcbDevicePixelRatio } from '../camera/context';
-import { snapSvgSurfaceBox } from '@/components/rcb/scene/paint/sceneToSvg';
+import {
+  useRcbCamera,
+  useRcbScreenToScene,
+  useRcbViewportEl,
+} from '../camera/context';
+import { snapBoxEdgesToGrid, snapCoordToGrid } from '../selection/alignGuides';
+import { getSceneDrawPreviewMount } from '../shapes/shapeHostRegistry';
+import { FRAME_PLATE_STROKE, framePlateStrokeSceneWidth } from './types';
 
+export { FRAME_PLATE_STROKE, FRAME_PLATE_STROKE_WIDTH, framePlateStrokeSceneWidth } from './types';
 
 type FrameDrawFeatureProps = {
   enabled: boolean;
-  camera: RcbCamera;
   stageEl: HTMLElement | null;
   onCommit: (rect: { x: number; y: number; width: number; height: number }) => void;
+  gridSnap?: boolean;
+  gridSize?: number;
 };
 
-function normalizeRect(x0: number, y0: number, x1: number, y1: number) {
+type DrawBox = { left: number; top: number; width: number; height: number };
+
+function normalizeBox(x0: number, y0: number, x1: number, y1: number): DrawBox {
   const left = Math.min(x0, x1);
   const top = Math.min(y0, y1);
-  return { x: left, y: top, width: Math.abs(x1 - x0), height: Math.abs(y1 - y0) };
-}
-
-function clientToWorld(
-  stageEl: HTMLElement,
-  camera: RcbCamera,
-  clientX: number,
-  clientY: number
-) {
-  const r = stageEl.getBoundingClientRect();
-  const localX = clientX - r.left;
-  const localY = clientY - r.top;
   return {
-    x: (localX - camera.x) / camera.zoom,
-    y: (localY - camera.y) / camera.zoom,
+    left,
+    top,
+    width: Math.max(1, Math.abs(x1 - x0)),
+    height: Math.max(1, Math.abs(y1 - y0)),
   };
 }
 
-/** Drag on empty world to create an artboard frame (SVG plate). */
+/**
+ * Rubber-band → integer plate edges on the grid (artboard content box).
+ * Unlike closed shapes we do **not** inset for center stroke — `createFrame`
+ * rounds to integers, and the plate fill IS the artboard size.
+ */
+export function resolveFrameDrawBox(
+  raw: DrawBox,
+  useGrid: boolean,
+  gridSize: number
+): DrawBox {
+  if (useGrid && gridSize > 0) {
+    const g = snapBoxEdgesToGrid(raw, gridSize, 1);
+    return {
+      left: snapCoordToGrid(g.left, gridSize),
+      top: snapCoordToGrid(g.top, gridSize),
+      width: Math.max(gridSize, snapCoordToGrid(g.width, gridSize)),
+      height: Math.max(gridSize, snapCoordToGrid(g.height, gridSize)),
+    };
+  }
+  return {
+    left: Math.round(raw.left),
+    top: Math.round(raw.top),
+    width: Math.max(1, Math.round(raw.width)),
+    height: Math.max(1, Math.round(raw.height)),
+  };
+}
+
+type Session = {
+  x0: number;
+  y0: number;
+  rawX1: number;
+  rawY1: number;
+  clientX0: number;
+  clientY0: number;
+  currentClientX: number;
+  currentClientY: number;
+  skipGrid: boolean;
+  pointerId: number;
+};
+
 function FrameDrawFeature({
   enabled,
-  camera,
   stageEl,
   onCommit,
+  gridSnap = true,
+  gridSize = 1,
 }: FrameDrawFeatureProps) {
-  const dpr = useRcbDevicePixelRatio();
-  const dragRef = useRef<{ x0: number; y0: number } | null>(null);
-  const [preview, setPreview] = useState<{
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-  } | null>(null);
+  const camera = useRcbCamera();
+  const toScene = useRcbScreenToScene();
+  const viewportEl = useRcbViewportEl();
+  const toSceneRef = useRef(toScene);
+  const onCommitRef = useRef(onCommit);
+  const gridSnapRef = useRef(gridSnap);
+  const gridSizeRef = useRef(gridSize);
+  toSceneRef.current = toScene;
+  onCommitRef.current = onCommit;
+  gridSnapRef.current = gridSnap;
+  gridSizeRef.current = gridSize;
+
+  const session = useRef<Session | null>(null);
+  const [preview, setPreview] = useState<DrawBox | null>(null);
 
   useEffect(() => {
-    if (!enabled || !stageEl) return undefined;
+    if (!enabled) {
+      session.current = null;
+      setPreview(null);
+      return undefined;
+    }
+    const hitEl = stageEl || viewportEl;
+    if (!hitEl) return undefined;
+
+    const snapPoint = (x: number, y: number, skip: boolean) => {
+      if (skip || !gridSnapRef.current || !(gridSizeRef.current > 0)) {
+        return { x, y };
+      }
+      const g = gridSizeRef.current;
+      return { x: snapCoordToGrid(x, g), y: snapCoordToGrid(y, g) };
+    };
 
     const onDown = (e: PointerEvent) => {
       if (e.button !== 0) return;
       const target = e.target as HTMLElement | null;
-      if (target?.closest('[data-frame-label],[data-image-label]')) return;
+      if (target?.closest('[data-frame-label],[data-image-label],[data-sel-toolbar],[data-frame-toolbar]')) {
+        return;
+      }
       e.preventDefault();
-      const p = clientToWorld(stageEl, camera, e.clientX, e.clientY);
-      dragRef.current = { x0: p.x, y0: p.y };
-      setPreview({ x: p.x, y: p.y, width: 0, height: 0 });
-      stageEl.setPointerCapture?.(e.pointerId);
+      e.stopPropagation();
+      const skipGrid = e.ctrlKey || e.metaKey;
+      const p = toSceneRef.current(e.clientX, e.clientY);
+      const origin = snapPoint(p.x, p.y, skipGrid);
+      session.current = {
+        x0: origin.x,
+        y0: origin.y,
+        rawX1: p.x,
+        rawY1: p.y,
+        clientX0: e.clientX,
+        clientY0: e.clientY,
+        currentClientX: e.clientX,
+        currentClientY: e.clientY,
+        skipGrid,
+        pointerId: e.pointerId,
+      };
+      const box = resolveFrameDrawBox(
+        normalizeBox(origin.x, origin.y, origin.x, origin.y),
+        Boolean(gridSnapRef.current && !skipGrid),
+        gridSizeRef.current
+      );
+      setPreview(box);
+      hitEl.setPointerCapture?.(e.pointerId);
     };
 
     const onMove = (e: PointerEvent) => {
-      if (!dragRef.current) return;
-      const p = clientToWorld(stageEl, camera, e.clientX, e.clientY);
-      setPreview(normalizeRect(dragRef.current.x0, dragRef.current.y0, p.x, p.y));
+      const s = session.current;
+      if (!s || e.pointerId !== s.pointerId) return;
+      s.currentClientX = e.clientX;
+      s.currentClientY = e.clientY;
+      const skipGrid = e.ctrlKey || e.metaKey || s.skipGrid;
+      const p = toSceneRef.current(e.clientX, e.clientY);
+      s.rawX1 = p.x;
+      s.rawY1 = p.y;
+      const end = snapPoint(p.x, p.y, skipGrid);
+      const box = resolveFrameDrawBox(
+        normalizeBox(s.x0, s.y0, end.x, end.y),
+        Boolean(gridSnapRef.current && !skipGrid),
+        gridSizeRef.current
+      );
+      setPreview(box);
     };
 
-    const onUp = (e: PointerEvent) => {
-      if (!dragRef.current) return;
-      const p = clientToWorld(stageEl, camera, e.clientX, e.clientY);
-      const rect = normalizeRect(dragRef.current.x0, dragRef.current.y0, p.x, p.y);
-      dragRef.current = null;
+    const finish = (e: PointerEvent) => {
+      const s = session.current;
+      if (!s || e.pointerId !== s.pointerId) return;
+      session.current = null;
       setPreview(null);
       try {
-        stageEl.releasePointerCapture?.(e.pointerId);
+        hitEl.releasePointerCapture?.(e.pointerId);
       } catch {
         /* ignore */
       }
-      if (rect.width >= 24 && rect.height >= 24) {
-        onCommit(rect);
-      }
+      // Same soft-click gate as ShapeDrawFeature — old 24×24 blocked high-zoom draws.
+      const clientDist = Math.hypot(
+        s.currentClientX - s.clientX0,
+        s.currentClientY - s.clientY0
+      );
+      const skipGrid = e.ctrlKey || e.metaKey || s.skipGrid;
+      const p = toSceneRef.current(e.clientX, e.clientY);
+      const end = snapPoint(p.x, p.y, skipGrid);
+      const box = resolveFrameDrawBox(
+        normalizeBox(s.x0, s.y0, end.x, end.y),
+        Boolean(gridSnapRef.current && !skipGrid),
+        gridSizeRef.current
+      );
+      if (clientDist < 4 && box.width < 3 && box.height < 3) return;
+      if (!(box.width >= 1 && box.height >= 1)) return;
+      onCommitRef.current({
+        x: box.left,
+        y: box.top,
+        width: box.width,
+        height: box.height,
+      });
     };
 
-    stageEl.addEventListener('pointerdown', onDown);
+    hitEl.addEventListener('pointerdown', onDown, true);
     window.addEventListener('pointermove', onMove);
-    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointerup', finish);
+    window.addEventListener('pointercancel', finish);
     return () => {
-      stageEl.removeEventListener('pointerdown', onDown);
+      hitEl.removeEventListener('pointerdown', onDown, true);
       window.removeEventListener('pointermove', onMove);
-      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointerup', finish);
+      window.removeEventListener('pointercancel', finish);
     };
-  }, [enabled, stageEl, camera, onCommit]);
+  }, [enabled, stageEl, viewportEl]);
 
   if (!enabled || !preview) return null;
 
-  const showSize = preview.width >= 24 || preview.height >= 24;
   const inv = 1 / Math.max(0.05, camera.zoom || 1);
   const labelFont = 10 * inv;
   const labelGap = 10 * inv;
-  const w = Math.max(1, preview.width);
-  const h = Math.max(1, preview.height);
+  const showSize = preview.width >= 3 || preview.height >= 3;
+  const previewMount = getSceneDrawPreviewMount();
+  if (!previewMount) return null;
+  // Same as idle plate: scene width = 1/zoom (CSS scale thickens non-scaling-stroke).
+  const plateSw = framePlateStrokeSceneWidth(camera.zoom);
 
-  // Same scene-lattice quantize as hosts / pixel grid.
-  const surf = snapSvgSurfaceBox(
-    { left: preview.x, top: preview.y, width: w, height: h },
-    camera,
-    dpr
-  );
-  const x = preview.x;
-  const y = preview.y;
-  return (
-    <svg
-      data-frame-draw-preview
-      data-rcb-infinite="1"
-      className="pointer-events-none absolute overflow-visible"
-      width={surf.width}
-      height={surf.height}
-      viewBox={`${surf.left} ${surf.top} ${surf.width} ${surf.height}`}
-      preserveAspectRatio="none"
-      style={{
-        left: surf.left,
-        top: surf.top,
-        width: surf.width,
-        height: surf.height,
-        overflow: 'visible',
-        display: 'block',
-        shapeRendering: 'geometricPrecision',
-      }}
-      aria-hidden
-    >
+  return createPortal(
+    <g data-frame-draw-preview pointerEvents="none" aria-hidden>
       <rect
-        x={x}
-        y={y}
-        width={w}
-        height={h}
+        x={preview.left}
+        y={preview.top}
+        width={Math.max(1, preview.width)}
+        height={Math.max(1, preview.height)}
         fill="#FFFFFF"
-        stroke="color-mix(in srgb, var(--ink) 12%, transparent)"
-        strokeWidth={1}
-        vectorEffect="non-scaling-stroke"
+        stroke={FRAME_PLATE_STROKE}
+        strokeWidth={plateSw}
+        shapeRendering="crispEdges"
+        strokeLinecap="butt"
+        strokeLinejoin="miter"
       />
       {showSize ? (
         <text
-          x={x + w / 2}
-          y={y - labelGap}
+          x={preview.left + preview.width / 2}
+          y={preview.top - labelGap}
           fill="var(--muted)"
           fontSize={labelFont}
           fontWeight={500}
@@ -156,7 +251,8 @@ function FrameDrawFeature({
           {Math.round(preview.height)}
         </text>
       ) : null}
-    </svg>
+    </g>,
+    previewMount
   );
 }
 

--- a/apps/web/src/components/rcb/frames/HtmlArtboardFrame.tsx
+++ b/apps/web/src/components/rcb/frames/HtmlArtboardFrame.tsx
@@ -1,20 +1,26 @@
-/** Artboard: SVG plate + HTML title / process chrome. */
+/** Artboard: SVG plate + world-layer title / process chrome. */
 import { useLayoutEffect, useMemo, useRef, type CSSProperties, type ReactNode, memo } from 'react';
-import { RcbOverlayPortal, useRcbCamera } from '../camera/context';
-import { rcbSceneToScreen } from '../core/math';
+import { useRcbCamera, useRcbDevicePixelRatio } from '../camera/context';
+import { rcbCameraCssZoom } from '../core/math';
 import {
   createSvgBoard,
-  fitInfiniteSvgToContent,
   seedInfiniteSvgViewport,
+  snapInfiniteSvgViewportToCamera,
 } from '@/components/rcb/scene/paint/sceneToSvg';
 import { append, setAttrs, setFill, setStroke, svgEl } from '@/components/rcb/scene/paint/svgDom';
 import {
+  getSceneShapesMount,
+  getSceneWorldRoot,
   registerShapeHost,
   unregisterShapeHost,
   updateShapeHostElement,
 } from '@/components/rcb/shapes/shapeHostRegistry';
 import NodeTitleLabel from '../selection/chrome/NodeTitleLabel';
 import type { ArtboardFrame } from '@/components/rcb/frames/types';
+import {
+  FRAME_PLATE_STROKE,
+  framePlateStrokeSceneWidth,
+} from '@/components/rcb/frames/types';
 
 type HtmlArtboardFrameProps = {
   frame: ArtboardFrame;
@@ -38,7 +44,8 @@ function paintFramePlate(
   layer: SVGGElement,
   frame: ArtboardFrame,
   selected: boolean,
-  generating: boolean
+  generating: boolean,
+  zoom: number
 ): SVGGElement {
   while (layer.firstChild) layer.removeChild(layer.firstChild);
 
@@ -82,15 +89,20 @@ function paintFramePlate(
   });
   append(g, plate);
   setFill(plate, bg);
-  // Idle: hairline. Selected: host chrome owns the blue box.
+  // Idle: ~1 CSS px hairline after CSS camera scale (not non-scaling-stroke —
+  // that still thickens under parent `scale(zoom)` and AA-fringes off-grid).
+  // Selected: host chrome owns the blue box.
+  plate.removeAttribute('vector-effect');
   if (selected) {
     setStroke(plate, 'none');
+    plate.removeAttribute('shape-rendering');
   } else {
     setStroke(plate, {
-      color: 'color-mix(in srgb, var(--ink) 12%, transparent)',
-      width: 1,
+      color: FRAME_PLATE_STROKE,
+      width: framePlateStrokeSceneWidth(zoom),
     });
-    setAttrs(plate, { 'vector-effect': 'non-scaling-stroke' });
+    // Prefer hard plate edges vs geometricPrecision soft fringe on deselected.
+    setAttrs(plate, { 'shape-rendering': 'crispEdges' });
   }
   return g;
 }
@@ -108,42 +120,38 @@ function HtmlArtboardFrame({
   zIndex = 0,
 }: HtmlArtboardFrameProps): ReactNode {
   const camera = useRcbCamera();
-  const z = Math.max(0.05, camera.zoom || 1);
+  const dpr = useRcbDevicePixelRatio();
+  const z = rcbCameraCssZoom(camera);
+  const inv = 1 / z;
   const hostRef = useRef<HTMLDivElement | null>(null);
+  const layerRef = useRef<SVGGElement | null>(null);
   const generating = String(frame.processStatus || '') === 'running';
   const processLabel = String(frame.processLabel || 'Preparing…');
 
-  const stageBox = useMemo(() => {
-    const origin = rcbSceneToScreen(camera, frame.x, frame.y);
-    return {
-      left: origin.x,
-      top: origin.y,
-      width: frame.width * z,
-      height: frame.height * z,
-    };
-  }, [camera, frame.x, frame.y, frame.width, frame.height, z]);
-
+  // World-layer process chrome (same lattice as the plate / control box).
   const processOverlayStyle = useMemo(
     (): CSSProperties => ({
       position: 'absolute',
-      left: stageBox.left,
-      top: stageBox.top,
-      width: stageBox.width,
-      height: stageBox.height,
+      left: frame.x,
+      top: frame.y,
+      width: frame.width,
+      height: frame.height,
     }),
-    [stageBox.left, stageBox.top, stageBox.width, stageBox.height]
+    [frame.x, frame.y, frame.width, frame.height]
   );
 
   const processPillStyle = useMemo(
     (): CSSProperties => ({
       position: 'absolute',
-      left: stageBox.left + stageBox.width / 2,
-      top: stageBox.top + stageBox.height - 14,
-      transform: 'translate(-50%, -100%)',
+      left: frame.x + frame.width / 2,
+      top: frame.y + frame.height - 14 * inv,
+      transform: `translate(-50%, -100%) scale(${inv})`,
+      transformOrigin: 'center bottom',
     }),
-    [stageBox.left, stageBox.top, stageBox.width, stageBox.height]
+    [frame.x, frame.y, frame.width, frame.height, inv]
   );
 
+  // Zoom in paintKey so idle hairline stays ~1 CSS px after camera scale.
   const paintKey = [
     frame.id,
     frame.x,
@@ -154,6 +162,7 @@ function HtmlArtboardFrame({
     frame.processStatus,
     selected ? 1 : 0,
     generating ? 1 : 0,
+    z.toFixed(4),
   ].join('|');
 
   useLayoutEffect(() => {
@@ -165,29 +174,47 @@ function HtmlArtboardFrame({
     const y = Number(frame.y) || 0;
     const w = Math.max(1, Number(frame.width) || 1);
     const h = Math.max(1, Number(frame.height) || 1);
-    const { root, layer: sceneLayer } = createSvgBoard(host, 1, 1, { infinite: true });
-    seedInfiniteSvgViewport(root, { left: x, top: y, width: w, height: h });
-    setAttrs(root, { 'data-frame-id': frame.id, 'data-rcb-frame-svg': '1' });
-    const el = paintFramePlate(sceneLayer, frame, selected, generating);
+    const worldRoot = getSceneWorldRoot();
+    const shapesMount = getSceneShapesMount();
+    const { root, layer: sceneLayer, shared } = createSvgBoard(host, 1, 1, {
+      infinite: true,
+      sharedRoot: worldRoot,
+      sharedMount: shapesMount,
+    });
+    layerRef.current = sceneLayer;
+    sceneLayer.setAttribute('data-rcb-frame-layer', frame.id);
+    sceneLayer.setAttribute('data-z', String(zIndex));
+    if (!shared) {
+      seedInfiniteSvgViewport(root, { left: x, top: y, width: w, height: h });
+      setAttrs(root, { 'data-frame-id': frame.id, 'data-rcb-frame-svg': '1' });
+      snapInfiniteSvgViewportToCamera(root, camera, dpr);
+    }
+    const el = paintFramePlate(sceneLayer, frame, selected, generating, z);
     registerShapeHost({ nodeId: frame.id, root, layer: sceneLayer, el, kind: 'svg' });
     updateShapeHostElement(frame.id, el);
-    try {
-      fitInfiniteSvgToContent(root, sceneLayer);
-    } catch {
-      /* seeded viewport is enough */
+
+    // Keep frame plate paint order with shapes on the shared mount.
+    if (shared && shapesMount && sceneLayer.parentElement === shapesMount) {
+      const siblings = [...shapesMount.querySelectorAll(':scope > g[data-rcb-shape-layer], :scope > g[data-rcb-frame-layer]')];
+      siblings.sort(
+        (a, b) => (Number(a.getAttribute('data-z')) || 0) - (Number(b.getAttribute('data-z')) || 0)
+      );
+      for (const g of siblings) shapesMount.appendChild(g);
     }
 
     return () => {
       unregisterShapeHost(frame.id);
       try {
-        root.remove();
+        if (shared) sceneLayer.remove();
+        else root.remove();
       } catch {
         /* ignore */
       }
-      host.innerHTML = '';
+      if (!shared) host.innerHTML = '';
+      layerRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [layer, paintKey]);
+  }, [layer, paintKey, zIndex]);
 
   if (layer === 'label') {
     return (
@@ -235,7 +262,7 @@ function HtmlArtboardFrame({
         />
       </div>
       {generating ? (
-        <RcbOverlayPortal>
+        <>
           <div
             data-artboard-process-shimmer
             data-frame-id={frame.id}
@@ -251,7 +278,7 @@ function HtmlArtboardFrame({
           >
             {processLabel}
           </div>
-        </RcbOverlayPortal>
+        </>
       ) : null}
     </>
   );

--- a/apps/web/src/components/rcb/frames/__tests__/frameDrawGrid.test.ts
+++ b/apps/web/src/components/rcb/frames/__tests__/frameDrawGrid.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FRAME_PLATE_STROKE,
+  FRAME_PLATE_STROKE_WIDTH,
+  framePlateStrokeSceneWidth,
+  resolveFrameDrawBox,
+} from '../FrameDrawFeature';
+import { snapCoordToGrid } from '../../selection/alignGuides';
+
+/**
+ * Artboard draw: rect-like snap/commit, but plate chrome stays artboard hairline.
+ * CSS camera `scale(zoom)` thickens non-scaling-stroke — scene width must be 1/zoom.
+ */
+describe('frame draw (artboard) vs rect contract', () => {
+  it('plate stroke stays artboard hairline (not closed-rect #333)', () => {
+    // eslint-disable-next-line no-console
+    console.log('[test:frame-stroke]', {
+      color: FRAME_PLATE_STROKE,
+      width: FRAME_PLATE_STROKE_WIDTH,
+    });
+    expect(FRAME_PLATE_STROKE_WIDTH).toBe(1);
+    expect(FRAME_PLATE_STROKE).not.toBe('#333333');
+    expect(FRAME_PLATE_STROKE.includes('color-mix')).toBe(true);
+  });
+
+  it('idle plate stroke scene width = 1/zoom (no fat border after CSS scale)', () => {
+    const cases = [
+      { zoom: 1, sw: 1 },
+      { zoom: 10, sw: 0.1 },
+      { zoom: 20, sw: 0.05 },
+      { zoom: 224.7 / 100, sw: 1 / (224.7 / 100) },
+    ];
+    for (const c of cases) {
+      const sw = framePlateStrokeSceneWidth(c.zoom);
+      // eslint-disable-next-line no-console
+      console.log('[test:frame-stroke-scene]', {
+        zoom: c.zoom,
+        sw,
+        afterCssScale: sw * c.zoom,
+      });
+      expect(sw).toBeCloseTo(c.sw, 6);
+      // After parent CSS scale(zoom), painted width ≈ 1 CSS px.
+      expect(sw * c.zoom).toBeCloseTo(FRAME_PLATE_STROKE_WIDTH, 6);
+    }
+  });
+
+  it('mid-cell rubber-band snaps plate fill edges onto 1px grid', () => {
+    const raw = { left: 10.4, top: 20.6, width: 15.3, height: 12.2 };
+    const box = resolveFrameDrawBox(raw, true, 1);
+    // eslint-disable-next-line no-console
+    console.log('[test:frame-grid]', { raw, box });
+    expect(box.left).toBe(snapCoordToGrid(box.left, 1));
+    expect(box.top).toBe(snapCoordToGrid(box.top, 1));
+    expect(box.left + box.width).toBe(snapCoordToGrid(box.left + box.width, 1));
+    expect(box.top + box.height).toBe(snapCoordToGrid(box.top + box.height, 1));
+    expect(Number.isInteger(box.left)).toBe(true);
+    expect(Number.isInteger(box.top)).toBe(true);
+  });
+
+  it('high-zoom soft drag 5×4 still commits (legacy 24 min rejected)', () => {
+    const box = resolveFrameDrawBox(
+      { left: 100.2, top: 50.7, width: 4.6, height: 3.4 },
+      true,
+      1
+    );
+    // eslint-disable-next-line no-console
+    console.log('[test:frame-commit-small]', box);
+    expect(box.width).toBeGreaterThanOrEqual(1);
+    expect(box.height).toBeGreaterThanOrEqual(1);
+    expect(box.width < 24 || box.height < 24).toBe(true);
+  });
+
+  it('Ctrl / skip grid still rounds to integer px', () => {
+    const box = resolveFrameDrawBox(
+      { left: 10.4, top: 20.6, width: 15.3, height: 12.2 },
+      false,
+      1
+    );
+    // eslint-disable-next-line no-console
+    console.log('[test:frame-skip-grid]', box);
+    expect(box).toEqual({ left: 10, top: 21, width: 15, height: 12 });
+  });
+
+  it('full flow: raw drag → snap → integer plate payload', () => {
+    const raw = normalize(12.3, 8.7, 40.1, 35.4);
+    const box = resolveFrameDrawBox(raw, true, 1);
+    const payload = { x: box.left, y: box.top, width: box.width, height: box.height };
+    // eslint-disable-next-line no-console
+    console.log('[test:frame-flow]', { raw, payload });
+    expect(Number.isInteger(payload.x)).toBe(true);
+    expect(Number.isInteger(payload.y)).toBe(true);
+    expect(Number.isInteger(payload.width)).toBe(true);
+    expect(Number.isInteger(payload.height)).toBe(true);
+    expect(payload.width).toBeGreaterThan(0);
+    expect(payload.height).toBeGreaterThan(0);
+  });
+});
+
+function normalize(x0: number, y0: number, x1: number, y1: number) {
+  return {
+    left: Math.min(x0, x1),
+    top: Math.min(y0, y1),
+    width: Math.abs(x1 - x0),
+    height: Math.abs(y1 - y0),
+  };
+}

--- a/apps/web/src/components/rcb/frames/frameContentClip.ts
+++ b/apps/web/src/components/rcb/frames/frameContentClip.ts
@@ -6,11 +6,6 @@ function num(v: unknown, fallback = 0): number {
   return Number.isFinite(n) ? n : fallback;
 }
 
-/** Same quantize as infinite SVG hosts / artboard plate. */
-function quantClip(n: number) {
-  return Math.round(n * 1e4) / 1e4;
-}
-
 let clipSeq = 0;
 function nextClipId(prefix: string) {
   clipSeq += 1;
@@ -122,13 +117,13 @@ export function applyFrameContentClip(
   }
   try {
     const { ox, oy } = sceneOrigin(document);
-    const fx = quantClip(num(frame.x) - ox);
-    const fy = quantClip(num(frame.y) - oy);
-    const fw = quantClip(Math.max(1, num(frame.width, 1)));
-    const fh = quantClip(Math.max(1, num(frame.height, 1)));
-    // ~½ device px in scene space — kills AA bleed past the sibling plate SVG.
+    const fx = num(frame.x) - ox;
+    const fy = num(frame.y) - oy;
+    const fw = Math.max(1, num(frame.width, 1));
+    const fh = Math.max(1, num(frame.height, 1));
+    // ~½ CSS px in scene space — kills AA bleed past the sibling plate SVG.
     const z = Math.max(0.05, Number(opts?.zoom) || 1);
-    const inset = quantClip(0.5 / z);
+    const inset = 0.5 / z;
 
     const id = nextClipId('frame-clip');
     const defs = ensureDefs(root);

--- a/apps/web/src/components/rcb/frames/types.ts
+++ b/apps/web/src/components/rcb/frames/types.ts
@@ -1,4 +1,19 @@
 /** Editor artboard frame (document.frames). Canvas domain — not Redux-specific. */
+
+/**
+ * Idle artboard plate chrome — screen-constant hairline (not closed-rect #333).
+ * World camera uses CSS `scale(zoom)`, so `vector-effect: non-scaling-stroke`
+ * still thickens under zoom. Paint stroke in **scene** units = CSS_px / zoom.
+ */
+export const FRAME_PLATE_STROKE = 'color-mix(in srgb, var(--ink) 28%, transparent)';
+/** Target hairline in CSS px after camera scale. */
+export const FRAME_PLATE_STROKE_WIDTH = 1;
+
+/** Scene stroke width so CSS `scale(zoom)` yields ~FRAME_PLATE_STROKE_WIDTH CSS px. */
+export function framePlateStrokeSceneWidth(zoom: number): number {
+  return FRAME_PLATE_STROKE_WIDTH / Math.max(0.05, Number(zoom) || 1);
+}
+
 export type ArtboardFrame = {
   id: string;
   name: string;

--- a/apps/web/src/components/rcb/index.ts
+++ b/apps/web/src/components/rcb/index.ts
@@ -31,6 +31,10 @@ export {
   rcbCenterInBox,
   rcbCenterOnPoint,
   rcbFitImageIntoViewport,
+  rcbLayoutGeneratorPlate,
+  generatorEmptyIconSize,
+  rcbDefaultPlaceFontSize,
+  GENERATOR_EMPTY_STROKE_OUTSET,
   type RcbAlign,
   type RcbBoxLike,
 } from './core/layout';
@@ -54,8 +58,8 @@ export type { RcbCameraMotion } from './camera/context';
 
 export {
   nearestDprMultiple,
-  toDomPrecision,
   snapCssToDevicePixel,
+  toDomPrecision,
   readDevicePixelRatio,
   subscribeDevicePixelRatio,
 } from './core/dpr';

--- a/apps/web/src/components/rcb/scene/__tests__/sceneText.test.ts
+++ b/apps/web/src/components/rcb/scene/__tests__/sceneText.test.ts
@@ -59,7 +59,18 @@ describe('measurePlainTextSize', () => {
     const text = '移动任务页';
     const fontSize = 14;
     const size = measurePlainTextSize(text, { fontSize, lineHeight: 1.4 });
-    expect(size.width).toBe(Math.max(24, text.length * fontSize));
+    expect(size.width).toBe(Math.max(fontSize, text.length * fontSize));
+    expect(size.height).toBe(Math.ceil(fontSize * 1.4));
+  });
+
+  it('at high-zoom fontSize=1 does not keep a document-24px floor', () => {
+    const text = '大撤大撒';
+    const fontSize = 1;
+    const size = measurePlainTextSize(text, { fontSize, lineHeight: 1.4 });
+    // eslint-disable-next-line no-console
+    console.log('[test:text-measure@fs1]', { size, legacyFloor: 24 });
+    expect(size.width).toBeLessThan(24);
+    expect(size.width).toBe(Math.max(fontSize, text.length * fontSize));
     expect(size.height).toBe(Math.ceil(fontSize * 1.4));
   });
 });

--- a/apps/web/src/components/rcb/scene/document/fontCatalogTypes.ts
+++ b/apps/web/src/components/rcb/scene/document/fontCatalogTypes.ts
@@ -8,7 +8,7 @@ export type FontChild = {
   /** Optional file URL — registered as its own @font-face family when set. */
   url?: string;
   format?: FontFaceFormat;
-  /** CSS / Fabric fontWeight when several children share one family name. */
+  /** CSS fontWeight when several children share one family name. */
   weight?: number;
 };
 

--- a/apps/web/src/components/rcb/scene/document/sceneDocument.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneDocument.ts
@@ -378,6 +378,7 @@ export function createTextNode({
   width,
   height,
   autoSize = true,
+  fontSize,
 }: {
   x?: number;
   y?: number;
@@ -386,14 +387,20 @@ export function createTextNode({
   height?: number;
   /** true = hug content; false = fixed wrap width from L/R resize or drag-create. */
   autoSize?: boolean;
+  /** Scene-px font size (T-tool passes zoom-fitted size so high zoom is not huge). */
+  fontSize?: number;
 } = {}) {
   const id = nanoid(10);
   const content = String(text ?? '');
-  const measured = measurePlainTextSize(content || 'M', {});
+  const style =
+    fontSize != null && Number.isFinite(fontSize) && fontSize > 0
+      ? { fontSize: Math.max(1, Number(fontSize)) }
+      : {};
+  const measured = measurePlainTextSize(content || 'M', style);
   // Empty autoSize = caret only (tiny width). Fixed-width keeps the dragged box.
   const w = width ?? (content ? measured.width : autoSize ? 2 : 160);
   const h = height ?? measured.height;
-  const attrs = buildMarkdownTextAttrs(content);
+  const attrs = buildMarkdownTextAttrs(content, style);
   (attrs as any).autoSize = autoSize ? 'true' : 'false';
   return {
     id,
@@ -970,15 +977,19 @@ export function createImageGeneratorNode({
   name?: string;
 } = {}) {
   const id = nanoid(10);
-  const iw = Math.max(120, Math.round(Number(width) || 360));
-  const ih = Math.max(120, Math.round(Number(height) || 360));
+  // Integer quantize — empty gen uses inset border so path === outer ink on the grid.
+  // (Half-pixel was only needed for center strokes.)
+  const iw = Math.max(1, Math.round(Number(width) || 360));
+  const ih = Math.max(1, Math.round(Number(height) || 360));
+  const ix = Math.round(Number(x) || 0);
+  const iy = Math.round(Number(y) || 0);
   return {
     id,
     node: {
       id,
       key: 'image',
-      x: Math.round(Number(x) || 0),
-      y: Math.round(Number(y) || 0),
+      x: ix,
+      y: iy,
       z: 0,
       width: iw,
       height: ih,
@@ -1123,15 +1134,18 @@ export function createVideoGeneratorNode({
   name?: string;
 } = {}) {
   const id = nanoid(10);
-  const iw = Math.max(160, Math.round(Number(width) || 640));
-  const ih = Math.max(120, Math.round(Number(height) || 360));
+  // Integer quantize — inset border means path === outer ink on the grid.
+  const iw = Math.max(1, Math.round(Number(width) || 640));
+  const ih = Math.max(1, Math.round(Number(height) || 360));
+  const ix = Math.round(Number(x) || 0);
+  const iy = Math.round(Number(y) || 0);
   return {
     id,
     node: {
       id,
       key: 'video',
-      x: Math.round(Number(x) || 0),
-      y: Math.round(Number(y) || 0),
+      x: ix,
+      y: iy,
       z: 0,
       width: iw,
       height: ih,
@@ -1179,16 +1193,23 @@ export function createVideoNode({
 } = {}) {
   const id = nanoid(10);
   const d = Number(duration);
+  // Integer quantize only — do NOT floor to 80×60. High-zoom viewport place
+  // yields small scene sizes; independent floors destroy the natural aspect
+  // and stretch the video (object-fit: fill / preserveAspectRatio none).
+  const iw = Math.max(1, Math.round(Number(width) || 640));
+  const ih = Math.max(1, Math.round(Number(height) || 360));
+  const ix = Math.round(Number(x) || 0);
+  const iy = Math.round(Number(y) || 0);
   return {
     id,
     node: {
       id,
       key: 'video',
-      x: Math.round(Number(x) || 0),
-      y: Math.round(Number(y) || 0),
+      x: ix,
+      y: iy,
       z: 0,
-      width: Math.max(80, Math.round(Number(width) || 640)),
-      height: Math.max(60, Math.round(Number(height) || 360)),
+      width: iw,
+      height: ih,
       attrs: {
         src,
         poster: poster || '',

--- a/apps/web/src/components/rcb/scene/document/sceneEffects.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneEffects.ts
@@ -53,7 +53,8 @@ export function resolveStroke(node: any, fallback = '#333333') {
   const stroke = normalizeColor(attrs['border-color'] || attrs.stroke || fallback);
   const opacity = Number(attrs['stroke-opacity'] ?? 100);
   const color = hexWithOpacity(stroke, opacity);
-  const rawW = attrs['border-width'] ?? attrs.strokeWidth;
+  // Document writes `border-width`; some live patches use camelCase.
+  const rawW = attrs['border-width'] ?? attrs.borderWidth ?? attrs.strokeWidth;
   const parsed = rawW == null || rawW === '' ? 1 : parseFloat(String(rawW));
   const strokeWidth = Math.max(0, Number.isFinite(parsed) ? parsed : 0);
   return { stroke: color, strokeWidth };
@@ -76,7 +77,8 @@ function strokePaintMeta(node: any): { align: StrokeAlign; strokeWidth: number }
   // Line/arrow use a dedicated hit height; freehand / pen store padded AABB already.
   if (shapeType === 'line' || shapeType === 'arrow' || shapeType === 'pencil' || shapeType === 'pen')
     return null;
-  if (key === 'image' || key === 'text' || key === 'frame') return null;
+  if (key === 'text' || key === 'frame') return null;
+  if (key === 'image' || key === 'video') return null;
 
   // Same color fallback as sceneToSvg — a missing border-color still paints #333.
   const { stroke, strokeWidth } = resolveStroke(node, '#333333');
@@ -115,8 +117,10 @@ export function strokeVisualOutset(node: any): number {
 }
 
 /**
- * Selection chrome sits on the **vector path** (geometry AABB).
- * strokeAlign is paint-only — do not offset the control box from the path.
+ * How far selection chrome sits outside the geometric box (≥ 0).
+ * Control box = **vector path** (geometry AABB). Stroke align is paint-only —
+ * do not pad the blue box to outer ink. Move/snap still uses visual outer via
+ * `strokeVisualOutset` / `inflateBoxByVisualOutset`.
  */
 export function strokeChromeOutset(node: any): number {
   void node;
@@ -141,9 +145,8 @@ export function strokeIndicatorOutset(node: any): number {
 }
 
 /**
- * Align / snap / spacing boxes — **vector path only** (same as selection chrome).
- * Stroke align is paint-only; never emit outer/inner ink faces (those pulled
- * guides and gap measures onto the stroke edge instead of the path line).
+ * Align / snap / spacing boxes — **vector path only**.
+ * Guides / snap use visual outer separately; selection chrome stays on path.
  */
 export type StrokeBandFace = 'inner' | 'path' | 'outer';
 
@@ -171,7 +174,7 @@ function padBox<T extends { left: number; top: number; width: number; height: nu
   };
 }
 
-/** Selection chrome AABB from geometry (uses strokeChromeOutset — inside insets). */
+/** Selection chrome AABB from geometry (path only — chrome outset is 0). */
 export function inflateBoxByStrokeOutset<
   T extends { left: number; top: number; width: number; height: number },
 >(box: T, node: any): T {
@@ -224,9 +227,8 @@ export function deflateBoxByTextSelectionPad<
 }
 
 /**
- * Selection / snap / guide box = path AABB (+ text pad).
- * strokeAlign does not move chrome — control box stays on the path.
- * Stored geom stays on the path via deflateSelectionBox on commit.
+ * Selection chrome AABB = path geom (+ text pad). Stroke does not expand the
+ * control box — knobs sit on the path; outer-ink snap uses visual outset.
  */
 export function inflateSelectionBox<
   T extends { left: number; top: number; width: number; height: number },

--- a/apps/web/src/components/rcb/scene/document/sceneMarkdown.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneMarkdown.ts
@@ -1,6 +1,6 @@
 /**
  * Lightweight markdown helpers for scene text nodes.
- * Canvas Fabric text renders plain text; `attrs.markdown` keeps the source.
+ * Canvas text renders plain text; `attrs.markdown` keeps the source.
  */
 
 export function markdownToPlain(md: string): string {

--- a/apps/web/src/components/rcb/scene/document/sceneShapes.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneShapes.ts
@@ -353,6 +353,18 @@ export function ptsAttr(pts: Array<[number, number]>) {
 /** Hit/selection thickness for line & arrow nodes (world units). */
 export const STROKE_HIT = 24;
 
+/**
+ * Hit-test slop in **scene** units from a constant screen-pixel budget.
+ * Must divide by zoom — using raw `STROKE_HIT/2` as scene pad makes a ~12u
+ * fat finger at 4000% zoom (~480 CSS px) and blocks blank-click deselect.
+ */
+export function sceneHitSlop(
+  zoom: number,
+  screenPx: number = Math.max(STROKE_HIT / 2, 12)
+): number {
+  return Math.max(0, screenPx) / Math.max(0.05, Number(zoom) || 1);
+}
+
 export type StrokeEndpoints = { x0: number; y0: number; x1: number; y1: number };
 
 /** Build node placement for a free-angle line/arrow from two endpoints. */

--- a/apps/web/src/components/rcb/scene/document/sceneText.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneText.ts
@@ -199,10 +199,10 @@ export function measurePlainTextSize(text: string, style: Partial<TextStyle> = {
     maxW = Math.max(maxW, measureLineWidth(ctx, line.length ? line : ' ', fontSize, letterSpacing));
   }
 
-  // Tight box = ink metrics only (no asymmetric pad — that made selection bottom-heavy
-  // and caused a jump vs the inline editor).
+  // Tight box = ink metrics only. Floor scales with fontSize so high-zoom
+  // (scene font ~1px) does not keep a document-24px-wide empty chrome.
   return {
-    width: Math.max(24, Math.ceil(maxW)),
+    width: Math.max(Math.ceil(fontSize), Math.ceil(maxW)),
     height: Math.max(
       Math.ceil(fontSize * lineHeight),
       Math.ceil(sample.length * fontSize * lineHeight)
@@ -219,7 +219,10 @@ export function measureWrappedTextSize(
   const merged = { ...DEFAULT_TEXT_STYLE, ...style };
   const fontSize = Math.max(1, Number(merged.fontSize) || 14);
   const lineHeight = Math.max(0.8, Number(merged.lineHeight) || 1.4);
-  const boxW = Math.max(24, Math.round(maxWidth) || DEFAULT_TEXT_BOX_WIDTH);
+  const boxW = Math.max(
+    Math.ceil(fontSize),
+    Math.round(maxWidth) || DEFAULT_TEXT_BOX_WIDTH
+  );
   const lines = wrapPlainTextLines(text, merged, boxW);
   return {
     width: boxW,
@@ -232,13 +235,21 @@ export function measureWrappedTextSize(
 }
 
 /** Resolve editor / node width for wrapping (empty caret stays thin until typing). */
-export function resolveTextBoxWidth(nodeWidth: unknown, hasContent: boolean) {
+export function resolveTextBoxWidth(
+  nodeWidth: unknown,
+  hasContent: boolean,
+  fontSize = DEFAULT_TEXT_STYLE.fontSize
+) {
+  const fs = Math.max(1, Number(fontSize) || DEFAULT_TEXT_STYLE.fontSize);
   const w = Number(nodeWidth);
   if (hasContent) {
-    return Math.max(24, Number.isFinite(w) && w > 8 ? Math.round(w) : DEFAULT_TEXT_BOX_WIDTH);
+    return Math.max(
+      Math.ceil(fs),
+      Number.isFinite(w) && w > fs * 0.5 ? Math.round(w) : DEFAULT_TEXT_BOX_WIDTH
+    );
   }
-  if (Number.isFinite(w) && w > 8) return Math.round(w);
-  return 2;
+  if (Number.isFinite(w) && w > fs * 0.5) return Math.round(w);
+  return Math.max(1, Math.round(fs * 0.15));
 }
 
 /** Content height of n line boxes (CSS-style). */

--- a/apps/web/src/components/rcb/scene/paint/exportImage.ts
+++ b/apps/web/src/components/rcb/scene/paint/exportImage.ts
@@ -621,6 +621,7 @@ export async function renderExport(options: ExportImageOptions): Promise<ExportR
         'position:fixed;left:-99999px;top:0;width:1px;height:1px;opacity:0;pointer-events:none;';
       window.document.body.appendChild(ephemeralHost);
       const { root, layer } = createSvgBoard(ephemeralHost, 794, 1123, { infinite: true });
+      root.setAttribute('data-rcb-export-surface', '1');
       const map = await loadSceneOntoSvg(
         root,
         layer,

--- a/apps/web/src/components/rcb/scene/paint/outlineTextFont.ts
+++ b/apps/web/src/components/rcb/scene/paint/outlineTextFont.ts
@@ -197,7 +197,7 @@ export async function outlineTextFromFont(node: any): Promise<OutlineResult | nu
     const baseline = lineTop + ascentPx;
 
     const run = font.layout(raw);
-    // Latin-only face + CJK text → identical .notdef boxes (user fig.1). Bail to canvas.
+    // Latin-only face + CJK text → identical .notdef boxes. Bail to canvas.
     if (runHasMissingGlyphs(run)) {
       console.warn(
         '[outlineTextFont] missing glyphs for face',

--- a/apps/web/src/components/rcb/scene/paint/outlineToPath.ts
+++ b/apps/web/src/components/rcb/scene/paint/outlineToPath.ts
@@ -364,7 +364,7 @@ function intersectOffsetLines(
  * `outward` picks the exterior arc (CCW-always scalloped / bow-tie ends).
  *
  * Step size must stay fine on thick strokes: ~60° samples made a semicircle look like
- * a triangle (fig.1 round tip → fig.2 needle with tip + two shoulder knobs).
+ * a triangle (round tip → needle with tip + two shoulder knobs).
  */
 function appendCircularArcPolyline(
   parts: string[],

--- a/apps/web/src/components/rcb/scene/paint/sceneToSvg.ts
+++ b/apps/web/src/components/rcb/scene/paint/sceneToSvg.ts
@@ -34,6 +34,7 @@ import {
 import type { StrokeAlign, StrokeLinecap, StrokeLinejoin } from '../document/sceneEffects';
 import { isTransparentFill, resolveDocumentBackground, resolveFill } from '../document/sceneFill';
 import { isExportableSceneNode, isImageGeneratorNode, isImageProcessRunning, isNodeHidden, isVideoGeneratorNode } from '../document/sceneDocument';
+import { generatorEmptyIconSize } from '../../core/layout';
 import {
   clampCornerRadii,
   filletPathD,
@@ -60,17 +61,79 @@ import { applyFrameContentClip, detachSceneNodeEl } from '@/components/rcb/frame
 import { getTintedStampSrc } from '@/components/rcb/tools/stampTint';
 import { strokeDashForStyle } from '../document/sceneStrokeStyle';
 import type { RcbCamera } from '@/components/rcb/core/types';
+import {
+  rcbCameraCssZoom,
+  rcbCameraScreenOffset,
+  rcbDprIsFractional,
+  rcbSnapSceneSurfaceOrigin,
+} from '@/components/rcb/core/math';
+import { readDevicePixelRatio } from '@/components/rcb/core/dpr';
 
 const TRANSPARENT_PIXEL_SRC =
   'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
+/** Live camera + DPR + stage size for the shared world viewport (set from RcbCanvas). */
+let paintCamera: RcbCamera | null = null;
+let paintDpr = 1;
+let paintStage = { w: 0, h: 0 };
+
+export function setInfiniteSvgPaintCamera(
+  camera: RcbCamera,
+  dpr?: number,
+  stage?: { width: number; height: number }
+) {
+  paintCamera = camera;
+  if (typeof dpr === 'number' && dpr > 0) paintDpr = dpr;
+  if (stage && stage.width > 0 && stage.height > 0) {
+    paintStage = { w: stage.width, h: stage.height };
+  }
+}
+
+function resolvePaintCamera(camera?: RcbCamera | null): RcbCamera | null {
+  return camera ?? paintCamera;
+}
+
+function resolvePaintDpr(dpr?: number): number {
+  if (typeof dpr === 'number' && dpr > 0) return dpr;
+  if (paintDpr > 0) return paintDpr;
+  return readDevicePixelRatio();
+}
+
 /**
- * Kept for call-site compatibility (RcbCanvas / host remount). Surface boxes no
- * longer depend on live camera/DPR — see snapSurfaceBox.
+ * Editor-only hairline under CSS camera `scale(zoom)`.
+ * Fixed scene widths (e.g. 1.5) become huge screen rings at 800%+ and look
+ * like the control box is larger than the image / generator plate.
  */
-export function setInfiniteSvgPaintCamera(_camera: RcbCamera, _dpr?: number) {
-  void _camera;
-  void _dpr;
+export function editorChromeStrokeSceneWidth(cssPx = 1): number {
+  const cam = resolvePaintCamera();
+  const z = cam ? rcbCameraCssZoom(cam) : 1;
+  return Math.max(1e-4, cssPx / Math.max(0.05, z));
+}
+
+/**
+ * One shared scene viewport for pixel grid + every shape host.
+ * Same CSS `left/top/width/height` === `viewBox` → one raster lattice under
+ * browser zoom (fractional DPR). Content stays in absolute scene coords.
+ */
+export function worldCameraViewport(
+  camera?: RcbCamera | null,
+  dpr?: number,
+  stageW?: number,
+  stageH?: number
+): { left: number; top: number; width: number; height: number } | null {
+  const cam = resolvePaintCamera(camera);
+  const w = typeof stageW === 'number' && stageW > 0 ? stageW : paintStage.w;
+  const h = typeof stageH === 'number' && stageH > 0 ? stageH : paintStage.h;
+  if (!cam || !(w > 0) || !(h > 0)) return null;
+  const d = resolvePaintDpr(dpr);
+  const z = rcbCameraCssZoom(cam);
+  const { x: camX, y: camY } = rcbCameraScreenOffset(cam, d);
+  return {
+    left: -camX / z,
+    top: -camY / z,
+    width: w / z,
+    height: h / z,
+  };
 }
 
 let clipSeq = 0;
@@ -151,7 +214,9 @@ function setSvgImageHref(img: SVGImageElement, href: string) {
 
 /**
  * Stroke paints along the element's vector baseline.
- * Align is paint-only — selection chrome stays on the path (strokeChromeOutset = 0).
+ * Align is paint-only on the path; selection chrome stays on path geom
+ * (`strokeChromeOutset` === 0). Draw uses a separate visual→geom inset when
+ * committing path size.
  *
  * Outside: a 2× underlay stroke behind an opaque fill (fill covers the inner half).
  * Inside: 2× stroke clipped to the fill region.
@@ -1082,16 +1147,35 @@ export async function nodeToSvgElement(
       const plate = appendChild(g, svgEl('path', { d: clipD }));
       // Generator empty uses --gen-empty (light: cool wash #e9eaee; dark: raised surface).
       setFill(plate, isGen ? 'var(--gen-empty)' : '#E5E7EB');
-      setStroke(plate, {
-        color: isGen ? 'var(--line)' : '#9CA3AF',
-        width: isGen ? 1 : 1.5,
-        dasharray: isGen ? undefined : '6 4',
-      });
+      if (isGen) {
+        // Border drawn inset so the painted outer edge === path geom === pixel grid
+        // (center stroke would sit ink on *.5 and look like "half a cell").
+        setStroke(plate, 'none');
+        const sw = editorChromeStrokeSceneWidth(1);
+        const inset = sw / 2;
+        const border = appendChild(
+          g,
+          svgEl('path', {
+            d: roundedRectPath(Math.max(1, boxW - sw), Math.max(1, boxH - sw), cornerR),
+            transform: `translate(${inset},${inset})`,
+            'pointer-events': 'none',
+          })
+        );
+        setFill(border, 'none');
+        setStroke(border, { color: 'var(--line)', width: sw });
+      } else {
+        setStroke(plate, {
+          color: '#9CA3AF',
+          width: editorChromeStrokeSceneWidth(1.5),
+          dasharray: '6 4',
+        });
+      }
       setAttrs(plate, { 'data-radius-body': '1', 'data-baseline': '1' });
       if (isGen) {
         // Solid landscape glyph (sun + two peaks) — flat fill, no frame.
-        // Scale with the plate (~34% of the shorter side); no tiny absolute cap.
-        const iconSize = Math.max(72, Math.min(boxW, boxH) * 0.34);
+        // Scale with the plate; must fit inside (never a fixed 72 scene-px floor).
+        const iconSize = generatorEmptyIconSize(boxW, boxH);
+        if (iconSize >= 4) {
         const ix = (boxW - iconSize) / 2;
         const iy = (boxH - iconSize) / 2;
         const s = iconSize / 24;
@@ -1118,6 +1202,7 @@ export async function nodeToSvgElement(
         );
         setFill(peaks, 'var(--muted)');
         setStroke(peaks, 'none');
+        }
       } else {
         const wash = appendChild(
           g,
@@ -1159,7 +1244,9 @@ export async function nodeToSvgElement(
         if (cssFilter) setStyles(img, { filter: cssFilter });
         const overlay = appendChild(g, svgEl('path', { d: clipD }));
         setFill(overlay, 'rgba(185, 203, 218, 0.28)');
-        setStroke(overlay, { color: '#A8C5E4', width: 1.5 });
+        // Screen hairline — fixed scene 1.5 blows up under camera scale and
+        // reads as "selection larger than the photo" while uploading.
+        setStroke(overlay, { color: '#A8C5E4', width: editorChromeStrokeSceneWidth(1.5) });
         setAttrs(overlay, {
           'pointer-events': 'none',
           'data-radius-body': '1',
@@ -1181,7 +1268,7 @@ export async function nodeToSvgElement(
         defs.appendChild(grad);
         const plate = appendChild(g, svgEl('path', { d: clipD }));
         setFill(plate, urlRef(gid));
-        setStroke(plate, { color: '#A8C5E4', width: 1.5 });
+        setStroke(plate, { color: '#A8C5E4', width: editorChromeStrokeSceneWidth(1.5) });
         setAttrs(plate, { 'data-radius-body': '1', 'data-baseline': '1' });
       }
 
@@ -1259,15 +1346,32 @@ export async function nodeToSvgElement(
       const g = appendChild(parent, svgEl('g'));
       const plate = appendChild(g, svgEl('path', { d: clipD }));
       setFill(plate, isGen ? 'var(--gen-empty)' : '#E5E7EB');
-      setStroke(plate, {
-        color: isGen ? 'var(--line)' : '#9CA3AF',
-        width: isGen ? 1 : 1.5,
-        dasharray: isGen ? undefined : '6 4',
-      });
+      if (isGen) {
+        setStroke(plate, 'none');
+        const sw = editorChromeStrokeSceneWidth(1);
+        const inset = sw / 2;
+        const border = appendChild(
+          g,
+          svgEl('path', {
+            d: roundedRectPath(Math.max(1, boxW - sw), Math.max(1, boxH - sw), cornerR),
+            transform: `translate(${inset},${inset})`,
+            'pointer-events': 'none',
+          })
+        );
+        setFill(border, 'none');
+        setStroke(border, { color: 'var(--line)', width: sw });
+      } else {
+        setStroke(plate, {
+          color: '#9CA3AF',
+          width: editorChromeStrokeSceneWidth(1.5),
+          dasharray: '6 4',
+        });
+      }
       setAttrs(plate, { 'data-radius-body': '1', 'data-baseline': '1' });
       if (isGen) {
         // Soft play triangle only — no frame / plus.
-        const iconSize = Math.max(72, Math.min(boxW, boxH) * 0.34);
+        const iconSize = generatorEmptyIconSize(boxW, boxH);
+        if (iconSize >= 4) {
         const ix = (boxW - iconSize) / 2;
         const iy = (boxH - iconSize) / 2;
         const s = iconSize / 24;
@@ -1288,6 +1392,7 @@ export async function nodeToSvgElement(
         );
         setFill(play, 'var(--muted)');
         setStroke(play, { color: 'var(--muted)', width: 2.75 });
+        }
       }
       tagNode(g, nodeId, 'video', undefined, left, top, boxW, boxH);
       if (isGen || processing) setAttrs(g, { 'data-export-ignore': '1' });
@@ -1313,7 +1418,7 @@ export async function nodeToSvgElement(
       } else {
         const plate = appendChild(g, svgEl('path', { d: clipD }));
         setFill(plate, '#B9CBDA');
-        setStroke(plate, { color: '#A8C5E4', width: 1.5 });
+        setStroke(plate, { color: '#A8C5E4', width: editorChromeStrokeSceneWidth(1.5) });
         setAttrs(plate, { 'data-radius-body': '1' });
       }
       tagNode(g, nodeId, 'video', undefined, left, top, boxW, boxH);
@@ -1325,9 +1430,25 @@ export async function nodeToSvgElement(
     }
 
     const g = appendChild(parent, svgEl('g'));
-    // Live pixels are HTML <video> on the world layer; SVG holds the poster
-    // (export / transform underlay).
+    // Infinite editor: HTML <video> paints. SVG hit/baseline only.
+    // Export boards (`data-rcb-export-surface`) still paint the poster.
+    const svgOwnsPixels = videoSvgOwnsPixels(root);
     const crop = readNodeCropNorm(node);
+    if (src && !processing && !svgOwnsPixels) {
+      const plate = appendChild(g, svgEl('path', { d: clipD }));
+      setFill(plate, 'transparent');
+      setStroke(plate, 'none');
+      setAttrs(plate, {
+        'data-radius-body': '1',
+        'data-baseline': '1',
+        'data-rcb-video-html-hit': '1',
+      });
+      (g as any).__sceneCornerRadii = { ...cornerR };
+      tagNode(g, nodeId, 'video', undefined, left, top, boxW, boxH);
+      if (isGen || isImageProcessRunning(node)) setAttrs(g, { 'data-export-ignore': '1' });
+      applyMeta(g, left, top, meta, boxW, boxH);
+      return g;
+    }
     if (poster) {
       const imgW = crop ? boxW / crop.w : boxW;
       const imgH = crop ? boxH / crop.h : boxH;
@@ -1341,6 +1462,7 @@ export async function nodeToSvgElement(
           x: imgX,
           y: imgY,
           preserveAspectRatio: 'none',
+          'data-rcb-video-svg-underlay': '1',
         })
       );
       setSvgImageHref(img, poster);
@@ -1355,7 +1477,11 @@ export async function nodeToSvgElement(
       const plate = appendChild(g, svgEl('path', { d: clipD }));
       setFill(plate, '#111827');
       setStroke(plate, 'none');
-      setAttrs(plate, { 'data-radius-body': '1', 'data-baseline': '1' });
+      setAttrs(plate, {
+        'data-radius-body': '1',
+        'data-baseline': '1',
+        'data-rcb-video-svg-underlay': '1',
+      });
     }
     void src;
     (g as any).__sceneCornerRadii = { ...cornerR };
@@ -1410,54 +1536,55 @@ function isInfiniteSvgRoot(root: SVGSVGElement) {
   return root.getAttribute('data-rcb-infinite') === '1';
 }
 
-function quantInfiniteScene(n: number) {
-  return Math.round(n * 1e4) / 1e4;
+/**
+ * Whether the SVG board should paint video poster pixels.
+ * Infinite editor hosts also mount HTML `<video>` (VideoNodeOverlay) — painting
+ * a poster there creates a second visible layer (ghost on move). Export boards
+ * mark `data-rcb-export-surface` and keep the poster.
+ */
+export function videoSvgOwnsPixels(root: SVGSVGElement): boolean {
+  if (!isInfiniteSvgRoot(root)) return true;
+  if (root.getAttribute('data-rcb-export-surface') === '1') return true;
+  return false;
 }
 
 type ViewportBox = { minX: number; minY: number; w: number; h: number };
 
 /**
- * Quantize infinite-SVG CSS box === viewBox onto the scene lattice.
- *
- * Do **not** device-pixel-shift per host under fractional browser DPR:
- * each host would get a different fractional origin while the pixel grid
- * stays on integer scene units — strokes then sit mid-cell after browser zoom.
- * Path geometry / draw snap already own grid alignment (incl. *.5 for odd
- * center strokes); the surface only needs stable scene quantize.
+ * Infinite-SVG CSS box === viewBox.
+ * Under fractional browser DPR, snap the origin onto the device-pixel lattice
+ * (matched left + viewBox min) so sibling surfaces (grid / hosts) do not round
+ * apart. Absolute scene content still maps to scene*zoom+cam.
  */
 function snapSurfaceBox(
   box: ViewportBox,
-  _camera?: RcbCamera | null,
-  _dpr?: number
+  camera?: RcbCamera | null,
+  dpr?: number
 ): ViewportBox {
-  void _camera;
-  void _dpr;
+  const w = Math.max(1, box.w);
+  const h = Math.max(1, box.h);
+  const cam = resolvePaintCamera(camera);
+  const d = resolvePaintDpr(dpr);
+  if (!cam || !rcbDprIsFractional(d)) {
+    return { minX: box.minX, minY: box.minY, w, h };
+  }
+  const z = rcbCameraCssZoom(cam);
+  const { x: camX, y: camY } = rcbCameraScreenOffset(cam, d);
   return {
-    minX: quantInfiniteScene(box.minX),
-    minY: quantInfiniteScene(box.minY),
-    w: Math.max(1, quantInfiniteScene(box.w)),
-    h: Math.max(1, quantInfiniteScene(box.h)),
+    minX: rcbSnapSceneSurfaceOrigin(box.minX, z, camX, d),
+    minY: rcbSnapSceneSurfaceOrigin(box.minY, z, camY, d),
+    w,
+    h,
   };
-}
-
-/** Origin-only quantize — keep size stable while panning a host. */
-function snapSurfaceOrigin(
-  minX: number,
-  minY: number,
-  _camera?: RcbCamera | null,
-  _dpr?: number
-): { minX: number; minY: number } {
-  void _camera;
-  void _dpr;
-  return { minX: quantInfiniteScene(minX), minY: quantInfiniteScene(minY) };
 }
 
 function writeInfiniteViewport(
   root: SVGSVGElement,
-  box: ViewportBox,
-  opts?: { lock?: boolean }
+  snapped: ViewportBox,
+  opts?: { lock?: boolean; intent?: ViewportBox }
 ) {
-  const { minX, minY, w, h } = box;
+  const intent = opts?.intent ?? snapped;
+  const { minX, minY, w, h } = snapped;
   const attrs: Record<string, string | number> = {
     width: w,
     height: h,
@@ -1467,6 +1594,11 @@ function writeInfiniteViewport(
     'shape-rendering': 'geometricPrecision',
     'pointer-events': 'none',
     'data-rcb-infinite': '1',
+    // Pre-snap scene intent — re-snap when browser DPR / camera changes.
+    'data-rcb-surface-x': intent.minX,
+    'data-rcb-surface-y': intent.minY,
+    'data-rcb-surface-w': intent.w,
+    'data-rcb-surface-h': intent.h,
   };
   if (opts?.lock) attrs['data-rcb-viewport-locked'] = '1';
   setAttrs(root, attrs);
@@ -1482,6 +1614,15 @@ function writeInfiniteViewport(
   });
 }
 
+function readSurfaceIntent(root: SVGSVGElement): ViewportBox | null {
+  const minX = Number(root.getAttribute('data-rcb-surface-x'));
+  const minY = Number(root.getAttribute('data-rcb-surface-y'));
+  const w = Number(root.getAttribute('data-rcb-surface-w'));
+  const h = Number(root.getAttribute('data-rcb-surface-h'));
+  if (![minX, minY, w, h].every(Number.isFinite) || !(w > 0) || !(h > 0)) return null;
+  return { minX, minY, w, h };
+}
+
 /** Apply a known scene AABB as the infinite SVG CSS box + viewBox (pre-paint). */
 export function seedInfiniteSvgViewport(
   root: SVGSVGElement,
@@ -1489,19 +1630,21 @@ export function seedInfiniteSvgViewport(
   pad = INFINITE_SVG_PAD
 ) {
   if (!isInfiniteSvgRoot(root)) return;
-  const seeded = snapSurfaceBox({
+  const intent: ViewportBox = {
     minX: box.left - pad,
     minY: box.top - pad,
     w: Math.max(1, box.width) + pad * 2,
     h: Math.max(1, box.height) + pad * 2,
-  });
+  };
+  const seeded = snapSurfaceBox(intent);
   // Seed owns the viewport — getBBox fit must not nudge *.5 → integer.
-  writeInfiniteViewport(root, seeded, { lock: true });
+  writeInfiniteViewport(root, seeded, { lock: true, intent });
 }
 
 /**
  * Pan an infinite host SVG with a live node translate (no getBBox refit).
- * Keeps sceneLeft inside the viewBox so ink is not painted in overflow.
+ * No-op for shared world-surface hosts — ink moves via element transform;
+ * the CSS box stays the camera viewport so it stays locked to the grid.
  */
 export function panInfiniteSvgViewport(
   root: SVGSVGElement,
@@ -1509,25 +1652,30 @@ export function panInfiniteSvgViewport(
   dTop: number
 ) {
   if (!isInfiniteSvgRoot(root)) return;
+  if (root.getAttribute('data-rcb-world-surface') === '1') return;
   if (!(dLeft || dTop)) return;
+  const intent = readSurfaceIntent(root);
   const parts = (root.getAttribute('viewBox') || '')
     .trim()
     .split(/[\s,]+/)
     .map(Number);
   if (parts.length < 4 || !parts.every(Number.isFinite)) return;
-  const origin = snapSurfaceOrigin(parts[0] + dLeft, parts[1] + dTop);
-  const w = parts[2];
-  const h = parts[3];
-  setAttrs(root, { viewBox: `${origin.minX} ${origin.minY} ${w} ${h}` });
-  setStyles(root, {
-    left: `${origin.minX}px`,
-    top: `${origin.minY}px`,
-  });
+  const base = intent || { minX: parts[0], minY: parts[1], w: parts[2], h: parts[3] };
+  const nextIntent: ViewportBox = {
+    minX: base.minX + dLeft,
+    minY: base.minY + dTop,
+    w: base.w,
+    h: base.h,
+  };
+  const snapped = snapSurfaceBox(nextIntent);
+  const lock = root.getAttribute('data-rcb-viewport-locked') === '1';
+  writeInfiniteViewport(root, snapped, { lock: lock || undefined, intent: nextIntent });
 }
 
 /**
- * Re-assert host CSS/viewBox quantize after camera pan/zoom or browser zoom.
- * Scene lattice only — does not device-pixel-shift (keeps ink on the pixel grid).
+ * Bind host CSS/viewBox to the shared camera world viewport (same box as the
+ * pixel grid). Falls back to re-snapping a per-host intent when stage size is
+ * not known yet.
  */
 export function snapInfiniteSvgViewportToCamera(
   root: SVGSVGElement,
@@ -1536,16 +1684,28 @@ export function snapInfiniteSvgViewportToCamera(
 ) {
   if (!isInfiniteSvgRoot(root)) return;
   if (camera) setInfiniteSvgPaintCamera(camera, dpr);
+  const world = worldCameraViewport(camera, dpr);
+  if (world) {
+    const intent: ViewportBox = {
+      minX: world.left,
+      minY: world.top,
+      w: world.width,
+      h: world.height,
+    };
+    // Identical box for every host — do not per-origin fractional-shift.
+    writeInfiniteViewport(root, intent, { lock: true, intent });
+    root.setAttribute('data-rcb-world-surface', '1');
+    return;
+  }
   const parts = (root.getAttribute('viewBox') || '')
     .trim()
     .split(/[\s,]+/)
     .map(Number);
   if (parts.length < 4 || !parts.every(Number.isFinite)) return;
-  const next = snapSurfaceBox(
-    { minX: parts[0], minY: parts[1], w: parts[2], h: parts[3] },
-    camera,
-    dpr
-  );
+  const intent =
+    readSurfaceIntent(root) ||
+    ({ minX: parts[0], minY: parts[1], w: parts[2], h: parts[3] } as ViewportBox);
+  const next = snapSurfaceBox(intent, camera, dpr);
   if (
     next.minX === parts[0] &&
     next.minY === parts[1] &&
@@ -1555,13 +1715,10 @@ export function snapInfiniteSvgViewportToCamera(
     return;
   }
   const lock = root.getAttribute('data-rcb-viewport-locked') === '1';
-  writeInfiniteViewport(root, next, lock ? { lock: true } : undefined);
+  writeInfiniteViewport(root, next, { lock: lock || undefined, intent });
 }
 
-/**
- * Same scene-lattice quantize as infinite hosts / pixel grid — use for
- * draw-preview SVGs so CSS left/top/width stay locked to path ink.
- */
+/** Pass-through scene CSS box sizes for React/DOM. Prefer applySceneSurface at call sites. */
 export function snapSvgSurfaceBox(
   box: { left: number; top: number; width: number; height: number },
   camera?: RcbCamera | null,
@@ -1575,7 +1732,10 @@ export function snapSvgSurfaceBox(
   return { left: next.minX, top: next.minY, width: next.w, height: next.h };
 }
 
-/** Apply snapped scene CSS box === viewBox onto an absolute SVG (world layer). */
+/**
+ * World-layer surface: CSS left/top/width/height === viewBox in scene units.
+ * Use for grid, AABB chrome, guides, draw previews.
+ */
 export function applySvgSurfaceBox(
   root: SVGSVGElement,
   box: { left: number; top: number; width: number; height: number },
@@ -1588,6 +1748,7 @@ export function applySvgSurfaceBox(
   root.setAttribute('viewBox', `${s.left} ${s.top} ${s.width} ${s.height}`);
   root.setAttribute('overflow', 'visible');
   root.setAttribute('preserveAspectRatio', 'none');
+  root.setAttribute('data-rcb-infinite', '1');
   root.style.position = 'absolute';
   root.style.overflow = 'visible';
   root.style.display = 'block';
@@ -1598,8 +1759,185 @@ export function applySvgSurfaceBox(
   return s;
 }
 
+/** Alias — prefer this name at new call sites. */
+export const applySceneSurface = applySvgSurfaceBox;
+
+export type HostSurfaceSnapshot = {
+  viewBox: string;
+  left: string;
+  top: string;
+  width: string;
+  height: string;
+  attrWidth: string | null;
+  attrHeight: string | null;
+};
+
+/** Read a mounted shape-host infinite SVG surface (CSS box + viewBox). */
+export function readHostSurface(hostRoot: SVGSVGElement): HostSurfaceSnapshot | null {
+  const viewBox = hostRoot.getAttribute('viewBox') || '';
+  const left = hostRoot.style?.left || '';
+  const top = hostRoot.style?.top || '';
+  if (!viewBox || !left || !top) return null;
+  return {
+    viewBox,
+    left,
+    top,
+    width: hostRoot.style.width || '',
+    height: hostRoot.style.height || '',
+    attrWidth: hostRoot.getAttribute('width'),
+    attrHeight: hostRoot.getAttribute('height'),
+  };
+}
+
+/**
+ * Copy the shape host's CSS box + viewBox onto a chrome twin SVG
+ * so path ink and chrome share one lattice under browser zoom.
+ */
+export function mirrorHostSurface(target: SVGSVGElement, hostRoot: SVGSVGElement): boolean {
+  const s = readHostSurface(hostRoot);
+  if (!s) return false;
+  target.style.position = 'absolute';
+  target.style.overflow = 'visible';
+  target.style.display = 'block';
+  target.style.left = s.left;
+  target.style.top = s.top;
+  target.style.width = s.width || hostRoot.style.width;
+  target.style.height = s.height || hostRoot.style.height;
+  if (s.attrWidth) target.setAttribute('width', s.attrWidth);
+  if (s.attrHeight) target.setAttribute('height', s.attrHeight);
+  target.setAttribute('viewBox', s.viewBox);
+  target.setAttribute('overflow', 'visible');
+  target.setAttribute('preserveAspectRatio', 'none');
+  target.setAttribute('data-rcb-infinite', '1');
+  return true;
+}
+
+/**
+ * Grow an infinite SVG CSS box + viewBox by scene pad without re-snapping.
+ * Needed so resize/rotate hits that sit outside the path geom still receive
+ * pointer events (overflow:visible paints outside the box but does not hit-test).
+ */
+export function expandInfiniteSvgPad(root: SVGSVGElement, pad: number): boolean {
+  const p = Math.max(0, Number(pad) || 0);
+  if (p < 1e-9) return false;
+  const parts = (root.getAttribute('viewBox') || '').trim().split(/[\s,]+/).map(Number);
+  if (parts.length < 4 || parts.some((n) => !Number.isFinite(n))) return false;
+  const [minX, minY, w, h] = parts;
+  const left = minX - p;
+  const top = minY - p;
+  const width = Math.max(1e-4, w + p * 2);
+  const height = Math.max(1e-4, h + p * 2);
+  root.setAttribute('viewBox', `${left} ${top} ${width} ${height}`);
+  root.setAttribute('width', String(width));
+  root.setAttribute('height', String(height));
+  root.style.left = `${left}px`;
+  root.style.top = `${top}px`;
+  root.style.width = `${width}px`;
+  root.style.height = `${height}px`;
+  return true;
+}
+
+/**
+ * Body `<g transform>` matching host ink.
+ * `mirrored`: prefer live host `transform` / `__sceneLeft`; else box translate (+ rotate).
+ */
+export function hostChromeBodyTransform(
+  el: SVGElement | null | undefined,
+  box: { left: number; top: number; width: number; height: number },
+  angleDeg: number,
+  mirrored: boolean
+): string {
+  if (mirrored) {
+    const hostTransform = el?.getAttribute?.('transform') || '';
+    if (hostTransform) return hostTransform;
+    const hl = Number((el as { __sceneLeft?: number } | null | undefined)?.__sceneLeft);
+    const ht = Number((el as { __sceneTop?: number } | null | undefined)?.__sceneTop);
+    const left = Number.isFinite(hl) ? hl : box.left;
+    const top = Number.isFinite(ht) ? ht : box.top;
+    return `translate(${left} ${top})`;
+  }
+  const w = Math.max(1, box.width);
+  const h = Math.max(1, box.height);
+  const angle = Number(angleDeg) || 0;
+  if (Math.abs(angle) > 0.01) {
+    return `translate(${box.left} ${box.top}) rotate(${angle} ${w / 2} ${h / 2})`;
+  }
+  return `translate(${box.left} ${box.top})`;
+}
+
+/** React props for a scene-surface SVG (CSS box === viewBox). */
+export function sceneSurfaceSvgProps(
+  box: { left: number; top: number; width: number; height: number },
+  camera?: RcbCamera | null,
+  dpr?: number
+): {
+  width: number;
+  height: number;
+  viewBox: string;
+  style: {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+    overflow: 'visible';
+    display: 'block';
+    shapeRendering: 'geometricPrecision';
+  };
+} {
+  const s = snapSvgSurfaceBox(box, camera, dpr);
+  return {
+    width: s.width,
+    height: s.height,
+    viewBox: `${s.left} ${s.top} ${s.width} ${s.height}`,
+    style: {
+      left: s.left,
+      top: s.top,
+      width: s.width,
+      height: s.height,
+      overflow: 'visible',
+      display: 'block',
+      shapeRendering: 'geometricPrecision',
+    },
+  };
+}
+
+/** React props mirroring a host surface, or null when host is incomplete. */
+export function hostMirrorSvgProps(hostRoot: SVGSVGElement): {
+  viewBox: string;
+  width: string | undefined;
+  height: string | undefined;
+  style: {
+    left: string;
+    top: string;
+    width: string;
+    height: string;
+    overflow: 'visible';
+    display: 'block';
+    shapeRendering: 'geometricPrecision';
+  };
+} | null {
+  const s = readHostSurface(hostRoot);
+  if (!s) return null;
+  return {
+    viewBox: s.viewBox,
+    width: s.attrWidth || undefined,
+    height: s.attrHeight || undefined,
+    style: {
+      left: s.left,
+      top: s.top,
+      width: s.width || hostRoot.style.width,
+      height: s.height || hostRoot.style.height,
+      overflow: 'visible',
+      display: 'block',
+      shapeRendering: 'geometricPrecision',
+    },
+  };
+}
+
 export function fitInfiniteSvgToContent(root: SVGSVGElement, layer?: SVGElement | null) {
   if (!isInfiniteSvgRoot(root)) return;
+  // Shared world surface — never shrink to content bbox (would desync from grid).
+  if (root.getAttribute('data-rcb-world-surface') === '1') return;
   // Locked after seedInfiniteSvgViewport — preserve half-pixel origins for
   // odd center strokes (visual outer on integer grid). getBBox often reports
   // 269.5 as ~270 and used to rewrite CSS left, which browser zoom amplifies.
@@ -1619,11 +1957,10 @@ export function fitInfiniteSvgToContent(root: SVGSVGElement, layer?: SVGElement 
       Number.isFinite(box.height) &&
       (box.width > 0 || box.height > 0)
     ) {
-      // Quantize so CSS left/top and viewBox stay identical (getBBox floats → 1690.999…).
-      minX = quantInfiniteScene(box.x - INFINITE_SVG_PAD);
-      minY = quantInfiniteScene(box.y - INFINITE_SVG_PAD);
-      w = Math.max(1, quantInfiniteScene(box.width + INFINITE_SVG_PAD * 2));
-      h = Math.max(1, quantInfiniteScene(box.height + INFINITE_SVG_PAD * 2));
+      minX = box.x - INFINITE_SVG_PAD;
+      minY = box.y - INFINITE_SVG_PAD;
+      w = Math.max(1, box.width + INFINITE_SVG_PAD * 2);
+      h = Math.max(1, box.height + INFINITE_SVG_PAD * 2);
     }
   } catch {
     /* empty layer */
@@ -1631,22 +1968,23 @@ export function fitInfiniteSvgToContent(root: SVGSVGElement, layer?: SVGElement 
 
   // Keep a freshly seeded viewport when getBBox only nudges by ≤1px (common
   // 269.5→270 jump from stroke/getBBox). That half-pixel shift desyncs guides.
-  const prevLeft = parseFloat(root.style.left);
-  const prevTop = parseFloat(root.style.top);
-  const prevW = parseFloat(root.style.width);
-  const prevH = parseFloat(root.style.height);
+  const prevIntent = readSurfaceIntent(root);
+  const prevMinX = prevIntent?.minX ?? parseFloat(root.style.left);
+  const prevMinY = prevIntent?.minY ?? parseFloat(root.style.top);
+  const prevW = prevIntent?.w ?? parseFloat(root.style.width);
+  const prevH = prevIntent?.h ?? parseFloat(root.style.height);
   if (
-    [prevLeft, prevTop, prevW, prevH].every(Number.isFinite) &&
-    Math.abs(minX - prevLeft) <= 1 &&
-    Math.abs(minY - prevTop) <= 1 &&
+    [prevMinX, prevMinY, prevW, prevH].every(Number.isFinite) &&
+    Math.abs(minX - prevMinX) <= 1 &&
+    Math.abs(minY - prevMinY) <= 1 &&
     Math.abs(w - prevW) <= 1 &&
     Math.abs(h - prevH) <= 1
   ) {
     return;
   }
 
-  const snapped = snapSurfaceBox({ minX, minY, w, h });
-  writeInfiniteViewport(root, snapped);
+  const intent: ViewportBox = { minX, minY, w, h };
+  writeInfiniteViewport(root, snapSurfaceBox(intent), { intent });
 }
 
 export async function loadSceneOntoSvg(
@@ -2511,9 +2849,23 @@ export function createSvgBoard(
   host: HTMLElement,
   width: number,
   height: number,
-  opts?: { infinite?: boolean }
-) {
+  opts?: {
+    infinite?: boolean;
+    /** Attach a layer `<g>` into the shared world SVG instead of a private root. */
+    sharedRoot?: SVGSVGElement | null;
+    sharedMount?: SVGGElement | null;
+  }
+): { root: SVGSVGElement; layer: SVGGElement; shared: boolean } {
   const infinite = Boolean(opts?.infinite);
+  const sharedRoot = opts?.sharedRoot;
+  const sharedMount = opts?.sharedMount;
+  if (infinite && sharedRoot && sharedMount) {
+    const layer = appendChild(
+      sharedMount,
+      svgEl('g', { id: 'scene-layer', 'data-rcb-shape-layer': '1' })
+    );
+    return { root: sharedRoot, layer, shared: true };
+  }
   const root = createSvgRoot(host);
   if (infinite) {
     applyInfiniteSvgViewport(root);
@@ -2533,5 +2885,5 @@ export function createSvgBoard(
     });
   }
   const layer = appendChild(root, svgEl('g', { id: 'scene-layer' }));
-  return { root, layer };
+  return { root, layer, shared: false };
 }

--- a/apps/web/src/components/rcb/selection/HostPathChrome.tsx
+++ b/apps/web/src/components/rcb/selection/HostPathChrome.tsx
@@ -1,9 +1,15 @@
 /**
- * Path indicator + path handles (host-mirrored SVG under world).
+ * Path indicator + path handles.
+ * Mirrors the shape-host CSS box + viewBox so chrome shares the ink lattice.
  */
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { useRcbCamera, useRcbDevicePixelRatio } from '@/components/rcb/camera/context';
-import { applySvgSurfaceBox } from '@/components/rcb/scene/paint/sceneToSvg';
+import { useRcbCamera } from '@/components/rcb/camera/context';
+import {
+  applySceneSurface,
+  expandInfiniteSvgPad,
+  hostChromeBodyTransform,
+  mirrorHostSurface,
+} from '@/components/rcb/scene/paint/sceneToSvg';
 import { rememberNodePath2D } from '@/components/rcb/scene/document/sceneShapes';
 import {
   getShapeHost,
@@ -13,6 +19,18 @@ import {
 } from '@/components/rcb/shapes/shapeHostRegistry';
 import type { SceneBox } from './alignGuides';
 import { cursorForRotate } from './rotateCornerCursor';
+import {
+  CHROME_HANDLE_HIT_PX,
+  CHROME_HANDLE_VIS_PX,
+  CHROME_LINE_ENDPOINT_HALO_PX,
+  CHROME_LINE_ENDPOINT_HIT_PX,
+  CHROME_LINE_ENDPOINT_VIS_PX,
+  CHROME_ROTATE_GAP_PX,
+  CHROME_ROTATE_HIT_PX,
+  CHROME_STROKE_PX,
+  cursorForResize,
+  rotateHotzoneOutward,
+} from './SelectionChrome';
 import type { RcbCamera } from '@/components/rcb/core/types';
 
 function liveNodeEl(nodeId: string): Element | null {
@@ -65,6 +83,10 @@ export type ShapeOutlineItem = {
   mirrorHostId?: string;
   cornerHandlesOnly?: boolean;
   edgeHandles?: 'all' | 'horizontal' | 'none';
+  /**
+   * Pad from geom-local origin to control box (≥ 0). Normally 0 — box on path.
+   */
+  chromeOutset?: number;
 };
 
 const SVG_NS = 'http://www.w3.org/2000/svg' as const;
@@ -78,13 +100,6 @@ const SEL_EDGE_ATTR = 'data-rcb-sel-edge';
 const SEL_BADGE_ATTR = 'data-rcb-sel-badge';
 /** World-layer mount for path chrome (above shape hosts; does not lift node ink). */
 const SEL_CHROME_LAYER_ATTR = 'data-rcb-sel-chrome-layer';
-const SEL_HANDLE_VIS_PX = 8;
-const SEL_HANDLE_HIT_PX = 18;
-const SEL_LINE_EP_VIS_PX = 8;
-const SEL_LINE_EP_HALO_PX = 22;
-const SEL_LINE_EP_HIT_PX = 28;
-const SEL_ROTATE_HIT_PX = 22;
-const SEL_ROTATE_GAP_PX = 2;
 const SEL_EP_HOVER_STYLE = 'g.sel-hit:hover > .sel-ep-halo { opacity: 1; }';
 
 function ensureSelEpHoverStyle(root: SVGSVGElement) {
@@ -272,14 +287,14 @@ function syncHostSelHandles(
   const w = Math.max(1, o.box.width);
   const h = Math.max(1, o.box.height);
   const color = o.color || '#3388ff';
-  const handleVis = SEL_HANDLE_VIS_PX * inv;
-  const handleHit = SEL_HANDLE_HIT_PX * inv;
+  const handleVis = CHROME_HANDLE_VIS_PX * inv;
+  const handleHit = CHROME_HANDLE_HIT_PX * inv;
   const halfVis = handleVis / 2;
   const halfHit = handleHit / 2;
-  const lineEpVis = SEL_LINE_EP_VIS_PX * inv;
-  const lineEpHit = SEL_LINE_EP_HIT_PX * inv;
-  const rotateHit = SEL_ROTATE_HIT_PX * inv;
-  const rotateGap = SEL_ROTATE_GAP_PX * inv;
+  const lineEpVis = CHROME_LINE_ENDPOINT_VIS_PX * inv;
+  const lineEpHit = CHROME_LINE_ENDPOINT_HIT_PX * inv;
+  const rotateHit = CHROME_ROTATE_HIT_PX * inv;
+  const rotateGap = CHROME_ROTATE_GAP_PX * inv;
 
   // Drop previous handle/rotate/box children (keep path silhouette outline).
   chrome
@@ -297,7 +312,7 @@ function syncHostSelHandles(
       ['w', start[0], start[1]],
       ['e', end[0], end[1]],
     ];
-    const lineEpHalo = SEL_LINE_EP_HALO_PX * inv;
+    const lineEpHalo = CHROME_LINE_ENDPOINT_HALO_PX * inv;
     const root = chrome.ownerSVGElement as SVGSVGElement | null;
     if (root) ensureSelEpHoverStyle(root);
     for (const [dir, lx, ly] of knobs) {
@@ -344,12 +359,18 @@ function syncHostSelHandles(
 
   // Control box + knobs (pen/pencil/path / image / video). No path silhouette when
   // selected — that is toggled via showPath on the outline.
+  // o.box is path geom; chromeOutset is normally 0 (control box on path).
+  const outset = Math.max(0, Number(o.chromeOutset) || 0);
+  const bx = -outset;
+  const by = -outset;
+  const bw = w + outset * 2;
+  const bh = h + outset * 2;
   const box = document.createElementNS(SVG_NS, 'rect');
   box.setAttribute(SEL_BOX_ATTR, o.id);
-  box.setAttribute('x', '0');
-  box.setAttribute('y', '0');
-  box.setAttribute('width', String(w));
-  box.setAttribute('height', String(h));
+  box.setAttribute('x', String(bx));
+  box.setAttribute('y', String(by));
+  box.setAttribute('width', String(bw));
+  box.setAttribute('height', String(bh));
   box.setAttribute('fill', 'none');
   box.setAttribute('stroke', color);
   box.setAttribute('stroke-width', String(stroke));
@@ -359,29 +380,32 @@ function syncHostSelHandles(
   const edgeMode = o.edgeHandles || 'all';
   if (edgeMode === 'none') return;
 
-  const knobs: Array<[string, number, number]> = o.cornerHandlesOnly
+  const knobs: Array<
+    ['n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw', number, number]
+  > = o.cornerHandlesOnly
     ? [
-        ['nw', 0, 0],
-        ['ne', w, 0],
-        ['se', w, h],
-        ['sw', 0, h],
+        ['nw', bx, by],
+        ['ne', bx + bw, by],
+        ['se', bx + bw, by + bh],
+        ['sw', bx, by + bh],
       ]
     : edgeMode === 'horizontal'
       ? [
-          ['w', 0, h / 2],
-          ['e', w, h / 2],
+          ['w', bx, by + bh / 2],
+          ['e', bx + bw, by + bh / 2],
         ]
       : [
-          ['nw', 0, 0],
-          ['n', w / 2, 0],
-          ['ne', w, 0],
-          ['e', w, h / 2],
-          ['se', w, h],
-          ['s', w / 2, h],
-          ['sw', 0, h],
-          ['w', 0, h / 2],
+          ['nw', bx, by],
+          ['n', bx + bw / 2, by],
+          ['ne', bx + bw, by],
+          ['e', bx + bw, by + bh / 2],
+          ['se', bx + bw, by + bh],
+          ['s', bx + bw / 2, by + bh],
+          ['sw', bx, by + bh],
+          ['w', bx, by + bh / 2],
         ];
 
+  const angle = Number(o.angle) || 0;
   for (const [dir, lx, ly] of knobs) {
     const visFill = document.createElementNS(SVG_NS, 'rect');
     visFill.setAttribute('data-rcb-sel-knob', '1');
@@ -414,28 +438,23 @@ function syncHostSelHandles(
     hit.setAttribute('height', String(handleHit));
     hit.setAttribute('fill', 'transparent');
     hit.setAttribute('pointer-events', 'all');
-    hit.style.cursor = 'nwse-resize';
+    hit.style.cursor = cursorForResize(dir, angle);
     chrome.appendChild(hit);
   }
 
   if (o.showRotate) {
     // Transparent corner hotzones only — rotate icon appears as the cursor, not on canvas.
-    const corners: Array<['nw' | 'ne' | 'se' | 'sw', number, number, number]> = [
-      ['nw', 0, 0, 0],
-      ['ne', w, 0, 90],
-      ['se', w, h, 180],
-      ['sw', 0, h, 270],
+    // Axis-aligned outer quadrant so rotate AABB never overlaps resize hits.
+    const corners: Array<['nw' | 'ne' | 'se' | 'sw', number, number, number, number, number]> = [
+      ['nw', bx, by, -1, -1, 0],
+      ['ne', bx + bw, by, 1, -1, 90],
+      ['se', bx + bw, by + bh, 1, 1, 180],
+      ['sw', bx, by + bh, -1, 1, 270],
     ];
-    const cx = w / 2;
-    const cy = h / 2;
-    const angle = Number(o.angle) || 0;
-    for (const [corner, lx, ly, iconDeg] of corners) {
-      const vx = lx - cx;
-      const vy = ly - cy;
-      const len = Math.hypot(vx, vy) || 1;
-      const push = handleHit / 2 + rotateGap + rotateHit / 2;
-      const hx = lx + (vx / len) * push;
-      const hy = ly + (vy / len) * push;
+    const out = rotateHotzoneOutward(handleHit, rotateGap, rotateHit);
+    for (const [corner, lx, ly, signX, signY, iconDeg] of corners) {
+      const hx = lx + signX * out;
+      const hy = ly + signY * out;
       const hit = document.createElementNS(SVG_NS, 'rect');
       hit.setAttribute('data-sel-handle', 'rotate');
       hit.setAttribute('data-rotate-corner', corner);
@@ -458,8 +477,7 @@ function syncHostSelUnionChrome(
   o: ShapeOutlineItem,
   stroke: number,
   inv: number,
-  camera: RcbCamera,
-  dpr: number
+  camera: RcbCamera
 ): boolean {
   const layer = ensureSelChromeLayer();
   if (!layer) return false;
@@ -472,8 +490,8 @@ function syncHostSelUnionChrome(
   const h = Math.max(1, o.box.height);
   const pad = Math.max(
     stroke * 8,
-    SEL_HANDLE_HIT_PX * inv,
-    SEL_ROTATE_HIT_PX * inv + SEL_ROTATE_GAP_PX * inv
+    CHROME_HANDLE_HIT_PX * inv,
+    CHROME_ROTATE_HIT_PX * inv + CHROME_ROTATE_GAP_PX * inv
   );
 
   let root = layer.querySelector(
@@ -491,25 +509,14 @@ function syncHostSelUnionChrome(
     layer.appendChild(root);
   }
 
-  const hostViewBox = hostRoot?.getAttribute?.('viewBox') || '';
-  const hostCssLeft = hostRoot?.style?.left || '';
-  const hostCssTop = hostRoot?.style?.top || '';
-  const hostCssW = hostRoot?.style?.width || '';
-  const hostCssH = hostRoot?.style?.height || '';
-  const mirrored = Boolean(hostRoot && hostViewBox && hostCssLeft && hostCssTop);
-
-  if (mirrored && hostRoot) {
-    root.style.left = hostCssLeft;
-    root.style.top = hostCssTop;
-    root.style.width = hostCssW || hostRoot.style.width;
-    root.style.height = hostCssH || hostRoot.style.height;
-    const attrW = hostRoot.getAttribute('width');
-    const attrH = hostRoot.getAttribute('height');
-    if (attrW) root.setAttribute('width', attrW);
-    if (attrH) root.setAttribute('height', attrH);
-    root.setAttribute('viewBox', hostViewBox);
+  const mirrored = Boolean(hostRoot && mirrorHostSurface(root, hostRoot));
+  if (mirrored) {
+    // Shared world surface already covers the camera viewport — expanding it
+    // by 1/zoom handle pad desyncs chrome from ink. Only pad private hosts.
+    const worldSurface = hostRoot?.getAttribute('data-rcb-world-surface') === '1';
+    if (o.withHandles && !worldSurface) expandInfiniteSvgPad(root, pad);
   } else {
-    applySvgSurfaceBox(
+    applySceneSurface(
       root,
       {
         left: o.box.left - pad,
@@ -517,8 +524,7 @@ function syncHostSelUnionChrome(
         width: w + pad * 2,
         height: h + pad * 2,
       },
-      camera,
-      dpr
+      camera
     );
   }
 
@@ -539,17 +545,16 @@ function syncHostSelUnionChrome(
  * Blue path outline (+ handles) on the world chrome layer (z above all hosts).
  *
  * Accuracy: mirror the shape host SVG's CSS box + viewBox, and copy the paint
- * element's `transform` — same scene mapping as host-injected chrome (no zoom drift).
+ * element's `transform` — same scene mapping as host ink.
  * Occlusion: paint lives on the top world layer so sibling hosts cannot cover it.
  */
 function syncHostSelOutline(
   o: ShapeOutlineItem,
   stroke: number,
   inv: number,
-  camera: RcbCamera,
-  dpr: number
+  camera: RcbCamera
 ): boolean {
-  if (o.unionChrome) return syncHostSelUnionChrome(o, stroke, inv, camera, dpr);
+  if (o.unionChrome) return syncHostSelUnionChrome(o, stroke, inv, camera);
 
   const layer = ensureSelChromeLayer();
   if (!layer) return false;
@@ -590,7 +595,11 @@ function syncHostSelOutline(
   const w = Math.max(1, o.box.width);
   const h = Math.max(1, o.box.height);
   const angle = Number(o.angle) || 0;
-  const pad = Math.max(stroke * 8, SEL_HANDLE_HIT_PX * inv, SEL_ROTATE_HIT_PX * inv + SEL_ROTATE_GAP_PX * inv);
+  const pad = Math.max(
+    stroke * 8,
+    CHROME_HANDLE_HIT_PX * inv,
+    CHROME_ROTATE_HIT_PX * inv + CHROME_ROTATE_GAP_PX * inv
+  );
   const left = o.box.left;
   const top = o.box.top;
 
@@ -609,27 +618,15 @@ function syncHostSelOutline(
     layer.appendChild(root);
   }
 
-  // Prefer an exact twin of the host infinite SVG viewport (same left/top/viewBox
-  // quantization). Fallback: scene-absolute surface snap when host not mounted.
-  const hostViewBox = hostRoot?.getAttribute?.('viewBox') || '';
-  const hostCssLeft = hostRoot?.style?.left || '';
-  const hostCssTop = hostRoot?.style?.top || '';
-  const hostCssW = hostRoot?.style?.width || '';
-  const hostCssH = hostRoot?.style?.height || '';
-  const mirrored = Boolean(hostRoot && hostViewBox && hostCssLeft && hostCssTop);
-
-  if (mirrored && hostRoot) {
-    root.style.left = hostCssLeft;
-    root.style.top = hostCssTop;
-    root.style.width = hostCssW || hostRoot.style.width;
-    root.style.height = hostCssH || hostRoot.style.height;
-    const attrW = hostRoot.getAttribute('width');
-    const attrH = hostRoot.getAttribute('height');
-    if (attrW) root.setAttribute('width', attrW);
-    if (attrH) root.setAttribute('height', attrH);
-    root.setAttribute('viewBox', hostViewBox);
+  // Host-mirrored surface; fallback: scene surface.
+  // World hosts already cover the viewport — do not expandInfiniteSvgPad
+  // (that shifted chrome off ink). Private hosts still need pad for outside hits.
+  const mirrored = Boolean(hostRoot && mirrorHostSurface(root, hostRoot));
+  if (mirrored) {
+    const worldSurface = hostRoot?.getAttribute('data-rcb-world-surface') === '1';
+    if (o.withHandles && !worldSurface) expandInfiniteSvgPad(root, pad);
   } else {
-    applySvgSurfaceBox(
+    applySceneSurface(
       root,
       {
         left: left - pad,
@@ -637,8 +634,7 @@ function syncHostSelOutline(
         width: w + pad * 2,
         height: h + pad * 2,
       },
-      camera,
-      dpr
+      camera
     );
   }
 
@@ -650,26 +646,10 @@ function syncHostSelOutline(
     root.appendChild(chrome);
   }
 
-  // Same transform tree as ink (translate + rotate + flip) — not a re-derived angle.
-  const hostTransform = el?.getAttribute?.('transform') || '';
-  if (mirrored && hostTransform) {
-    chrome.setAttribute('transform', hostTransform);
-  } else if (mirrored) {
-    // Host local origin is scene left/top even when transform attr is briefly empty.
-    const hl = Number((el as any)?.__sceneLeft);
-    const ht = Number((el as any)?.__sceneTop);
-    chrome.setAttribute(
-      'transform',
-      `translate(${Number.isFinite(hl) ? hl : left} ${Number.isFinite(ht) ? ht : top})`
-    );
-  } else if (Math.abs(angle) > 0.01) {
-    chrome.setAttribute(
-      'transform',
-      `translate(${left} ${top}) rotate(${angle} ${w / 2} ${h / 2})`
-    );
-  } else {
-    chrome.setAttribute('transform', `translate(${left} ${top})`);
-  }
+  chrome.setAttribute(
+    'transform',
+    hostChromeBodyTransform(el, o.box, angle, mirrored)
+  );
 
   let outline = chrome.querySelector(
     `:scope > path[${SEL_OUTLINE_ATTR}="${CSS.escape(o.id)}"]`
@@ -701,13 +681,12 @@ function syncHostSelOutline(
   return true;
 }
 
-/** Path chrome overlay (host-mirrored). */
+/** Path chrome overlay (host-mirrored twin SVG on world layer). */
 function ShapeOutlineSvg({ outlines }: { outlines: ShapeOutlineItem[] }) {
   const camera = useRcbCamera();
-  const dpr = useRcbDevicePixelRatio();
   const z = Math.max(0.05, camera.zoom || 1);
   const inv = 1 / z;
-  const stroke = 1.5 * inv;
+  const stroke = CHROME_STROKE_PX * inv;
   const [hostEpoch, setHostEpoch] = useState(0);
   const outlineKey = outlines
     .map((o) => {
@@ -736,7 +715,7 @@ function ShapeOutlineSvg({ outlines }: { outlines: ShapeOutlineItem[] }) {
   useLayoutEffect(() => {
     const current = outlinesRef.current;
     const active = new Set(current.map((o) => o.id));
-    let pending = current.filter((o) => !syncHostSelOutline(o, stroke, inv, camera, dpr));
+    let pending = current.filter((o) => !syncHostSelOutline(o, stroke, inv, camera));
     for (const h of listShapeHosts()) {
       if (!active.has(h.nodeId)) clearHostSelOutline(h.nodeId);
     }
@@ -760,7 +739,7 @@ function ShapeOutlineSvg({ outlines }: { outlines: ShapeOutlineItem[] }) {
     const retry = () => {
       if (!pending.length) return;
       tries += 1;
-      pending = pending.filter((o) => !syncHostSelOutline(o, stroke, inv, camera, dpr));
+      pending = pending.filter((o) => !syncHostSelOutline(o, stroke, inv, camera));
       if (pending.length && tries < 120) raf = requestAnimationFrame(retry);
     };
     if (pending.length) raf = requestAnimationFrame(retry);
@@ -773,7 +752,7 @@ function ShapeOutlineSvg({ outlines }: { outlines: ShapeOutlineItem[] }) {
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [outlineKey, stroke, inv, hostEpoch, camera.x, camera.y, camera.zoom, dpr]);
+  }, [outlineKey, stroke, inv, hostEpoch, camera.x, camera.y, camera.zoom]);
 
   useEffect(() => {
     return () => {

--- a/apps/web/src/components/rcb/selection/SelectionChrome.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionChrome.tsx
@@ -1,7 +1,11 @@
 import { memo, type ReactNode } from 'react';
 import { useRcbCamera, useRcbDevicePixelRatio } from '../camera/context';
-import { toDomPrecision } from '../core/dpr';
-import { snapSvgSurfaceBox } from '@/components/rcb/scene/paint/sceneToSvg';
+import {
+  hostMirrorSvgProps,
+  sceneSurfaceSvgProps,
+  snapSvgSurfaceBox,
+} from '@/components/rcb/scene/paint/sceneToSvg';
+import { getSceneWorldRoot } from '@/components/rcb/shapes/shapeHostRegistry';
 import type { RcbCamera } from '../core/types';
 import { cursorForRotate } from './rotateCornerCursor';
 
@@ -12,7 +16,7 @@ type SelectionChromeProps = {
   box: SceneBox;
   angle?: number;
   showHandles?: boolean;
-  /** Multi-select (Fig.1): only four corner knobs. */
+  /** Multi-select: only four corner knobs. */
   cornerHandlesOnly?: boolean;
   /**
    * `line`: shaft + two free endpoints (length + angle). No box / corners / rotate knob.
@@ -41,30 +45,36 @@ type SelectionChromeProps = {
 };
 
 /**
- * Selection foreground overlay (AABB box + resize / rotate knobs).
- *
- * **One paint contract for all ephemeral canvas UI** (box / brush / shape handles):
- * - Mount under `[data-rcb-world]` (CSS camera translate+scale)
- * - Scene coords in SVG; CSS `left/top/width/height` === `viewBox`
- * - Screen-constant ink: `lineWidth = screenPx / zoom`
- *
- * Path ink indicators use the same world layer but twin the shape-host viewport
- * (`HostPathChrome`) so fractional DPR cannot desync from path stroke.
+ * Selection overlay: AABB box + resize / rotate knobs.
+ * Screen-constant ink: `lineWidth = screenPx / zoom`.
+ * Prefer shared world surface; path chrome may mirror a shape host.
  */
 export const CHROME_STROKE_PX = 1.5;
 export const CHROME_HANDLE_VIS_PX = 8;
 export const CHROME_HANDLE_HIT_PX = 18;
+/** Transparent rotate hotzone (screen px) — shared with HostPathChrome. */
+export const CHROME_ROTATE_HIT_PX = 22;
+export const CHROME_ROTATE_GAP_PX = 2;
+/** Line / arrow endpoint chrome (screen px). */
+export const CHROME_LINE_ENDPOINT_VIS_PX = 8;
+export const CHROME_LINE_ENDPOINT_HALO_PX = 22;
+export const CHROME_LINE_ENDPOINT_HIT_PX = 28;
+export const CHROME_LINE_SHAFT_HIT_PX = 28;
 
-const HANDLE_VIS_PX = CHROME_HANDLE_VIS_PX;
-const HANDLE_HIT_PX = CHROME_HANDLE_HIT_PX;
-const LINE_ENDPOINT_VIS_PX = 8;
-const LINE_ENDPOINT_HALO_PX = 22;
-const LINE_ENDPOINT_HIT_PX = 28;
-const LINE_SHAFT_HIT_PX = 28;
-const STROKE_PX = CHROME_STROKE_PX;
-const ROTATE_HIT_PX = 22;
-const ROTATE_GAP_PX = 2;
 const SEL_BASELINE = '#3388ff';
+
+/**
+ * Scene distance from a corner knob center to the rotate hotzone center.
+ * Axis-aligned into the outer quadrant — diagonal push made the rotate AABB
+ * overlap the resize hit and steal corner clicks after zoom.
+ */
+export function rotateHotzoneOutward(
+  handleHit: number,
+  rotateGap: number,
+  rotateHit: number
+): number {
+  return handleHit / 2 + rotateGap + rotateHit / 2;
+}
 
 /** Scene AABB that covers a (possibly rotated) box plus chrome pad. */
 export function fittedSvgViewport(
@@ -100,17 +110,17 @@ export function fittedSvgViewport(
     maxY = Math.max(maxY, y);
   }
   const p = Math.max(0, pad);
-  minX = toDomPrecision(minX - p);
-  minY = toDomPrecision(minY - p);
+  minX = minX - p;
+  minY = minY - p;
   return {
     minX,
     minY,
-    w: toDomPrecision(Math.max(1, maxX - minX + p * 2)),
-    h: toDomPrecision(Math.max(1, maxY - minY + p * 2)),
+    w: Math.max(1, maxX - minX + p * 2),
+    h: Math.max(1, maxY - minY + p * 2),
   };
 }
 
-/** fittedSvgViewport + same scene-lattice quantize as shape hosts / grid. */
+/** fittedSvgViewport + surface box (raw scene). */
 export function fittedSnappedSvgViewport(
   left: number,
   top: number,
@@ -118,8 +128,8 @@ export function fittedSnappedSvgViewport(
   height: number,
   angleDeg: number,
   pad: number,
-  camera: RcbCamera,
-  dpr: number
+  camera?: RcbCamera,
+  dpr?: number
 ): { minX: number; minY: number; w: number; h: number } {
   const raw = fittedSvgViewport(left, top, width, height, angleDeg, pad);
   const s = snapSvgSurfaceBox(
@@ -131,9 +141,56 @@ export function fittedSnappedSvgViewport(
 }
 
 /**
- * World-layer SVG shell — shared by selection box, brush, and shape-handle overlays.
- * Children paint in **scene** coordinates (not CSS pixels).
- * CSS box === viewBox, scene-lattice quantized (same as hosts / pixel grid).
+ * AABB selection chrome SVG surface.
+ * Prefer the shared world root (same lattice as shape ink + full viewport so
+ * handle hits outside the geom still receive pointers). Never inflate a
+ * per-box surface with 1/zoom handle pads — that resizes the CSS box every
+ * zoom tick and desyncs the blue box from ink.
+ */
+export function selectionChromeSurfaceProps(
+  box: { left: number; top: number; width: number; height: number },
+  angle: number,
+  strokePad: number,
+  camera?: RcbCamera,
+  dpr?: number
+): {
+  width: number | string;
+  height: number | string;
+  viewBox: string;
+  style: {
+    left: number | string;
+    top: number | string;
+    width: number | string;
+    height: number | string;
+    overflow: 'visible';
+    display: 'block';
+    shapeRendering: 'geometricPrecision';
+  };
+} {
+  const worldRoot = getSceneWorldRoot();
+  const mirrored = worldRoot ? hostMirrorSvgProps(worldRoot) : null;
+  if (mirrored) return mirrored;
+  const vp = fittedSnappedSvgViewport(
+    box.left,
+    box.top,
+    box.width,
+    box.height,
+    angle,
+    // Screen-constant stroke only — never floor at 1 scene unit (at 8000%
+    // that is a huge pad and reintroduces chrome/ink drift).
+    Math.max(1e-4, strokePad),
+    camera,
+    dpr
+  );
+  return sceneSurfaceSvgProps(
+    { left: vp.minX, top: vp.minY, width: vp.w, height: vp.h },
+    camera,
+    dpr
+  );
+}
+
+/**
+ * World-layer SVG shell — CSS box === viewBox in scene units.
  */
 export function WorldSvgFrame({
   left,
@@ -157,25 +214,22 @@ export function WorldSvgFrame({
   children: ReactNode;
 }) {
   const camera = useRcbCamera();
-  const dpr = useRcbDevicePixelRatio();
-  const vp = fittedSnappedSvgViewport(left, top, width, height, angle, pad, camera, dpr);
+  const vp = fittedSnappedSvgViewport(left, top, width, height, angle, pad, camera);
+  const surf = sceneSurfaceSvgProps(
+    { left: vp.minX, top: vp.minY, width: vp.w, height: vp.h },
+    camera
+  );
   return (
     <svg
       data-rcb-infinite="1"
       className={`absolute overflow-visible ${zClass}`}
-      width={vp.w}
-      height={vp.h}
-      viewBox={`${vp.minX} ${vp.minY} ${vp.w} ${vp.h}`}
+      width={surf.width}
+      height={surf.height}
+      viewBox={surf.viewBox}
       preserveAspectRatio="none"
       style={{
-        left: vp.minX,
-        top: vp.minY,
-        width: vp.w,
-        height: vp.h,
-        overflow: 'visible',
+        ...surf.style,
         pointerEvents,
-        display: 'block',
-        shapeRendering: 'geometricPrecision',
       }}
       aria-hidden
     >
@@ -258,7 +312,7 @@ const HANDLE_DIR_DEG: Record<ResizeHandle, number> = {
   ne: 315,
 };
 
-function cursorForResize(handle: ResizeHandle, angleDeg: number): string {
+export function cursorForResize(handle: ResizeHandle, angleDeg: number): string {
   const dirs = [
     'e-resize',
     'se-resize',
@@ -368,21 +422,21 @@ function SelectionChrome({
   const z = Math.max(0.05, camera.zoom || 1);
   const inv = 1 / z;
 
-  const left = toDomPrecision(box.left);
-  const top = toDomPrecision(box.top);
-  const w = toDomPrecision(Math.max(1, box.width));
-  const h = toDomPrecision(Math.max(1, box.height));
+  const left = box.left;
+  const top = box.top;
+  const w = Math.max(1, box.width);
+  const h = Math.max(1, box.height);
   const lineMode = variant === 'line';
 
-  const stroke = STROKE_PX * inv;
-  const handleVis = HANDLE_VIS_PX * inv;
-  const handleHit = HANDLE_HIT_PX * inv;
-  const lineEpVis = LINE_ENDPOINT_VIS_PX * inv;
-  const lineEpHalo = LINE_ENDPOINT_HALO_PX * inv;
-  const lineEpHit = LINE_ENDPOINT_HIT_PX * inv;
-  const lineShaftHit = LINE_SHAFT_HIT_PX * inv;
-  const rotateHit = ROTATE_HIT_PX * inv;
-  const rotateGap = ROTATE_GAP_PX * inv;
+  const stroke = CHROME_STROKE_PX * inv;
+  const handleVis = CHROME_HANDLE_VIS_PX * inv;
+  const handleHit = CHROME_HANDLE_HIT_PX * inv;
+  const lineEpVis = CHROME_LINE_ENDPOINT_VIS_PX * inv;
+  const lineEpHalo = CHROME_LINE_ENDPOINT_HALO_PX * inv;
+  const lineEpHit = CHROME_LINE_ENDPOINT_HIT_PX * inv;
+  const lineShaftHit = CHROME_LINE_SHAFT_HIT_PX * inv;
+  const rotateHit = CHROME_ROTATE_HIT_PX * inv;
+  const rotateGap = CHROME_ROTATE_GAP_PX * inv;
   const metaOffset = 16 * inv;
   const metaFont = 10 * inv;
   const halfVis = handleVis / 2;
@@ -427,37 +481,21 @@ function SelectionChrome({
         ]
       : [];
 
-  // Viewport fits the **box outline only** — do NOT include handle / rotate hit
-  // pads here. Those scale with 1/zoom and made the SVG CSS box resize every
-  // zoom tick → path-vs-chrome drift + shake. Handles paint via overflow:visible.
-  const vp = fittedSnappedSvgViewport(
-    left,
-    top,
-    w,
-    h,
-    angle,
-    Math.max(1, stroke),
-    camera,
-    dpr
-  );
+  // World root when available (hits + lattice). Fallback: box outline only —
+  // never include 1/zoom handle pads (that desynced chrome from ink).
+  const surf = selectionChromeSurfaceProps(box, angle, stroke, camera, dpr);
 
   return (
     <svg
       data-rcb-infinite="1"
       className="absolute z-[18] overflow-visible"
-      width={vp.w}
-      height={vp.h}
-      viewBox={`${vp.minX} ${vp.minY} ${vp.w} ${vp.h}`}
+      width={surf.width}
+      height={surf.height}
+      viewBox={surf.viewBox}
       preserveAspectRatio="none"
       style={{
-        left: vp.minX,
-        top: vp.minY,
-        width: vp.w,
-        height: vp.h,
-        overflow: 'visible',
+        ...surf.style,
         pointerEvents: 'none',
-        display: 'block',
-        shapeRendering: 'geometricPrecision',
       }}
       aria-hidden={!showHandles && !interactiveBox}
     >
@@ -616,15 +654,13 @@ function SelectionChrome({
 
       {showRotate && !lineMode
         ? ROTATE_CORNERS.map(({ corner, localX, localY, iconDeg, label }) => {
-            // Fixed hotzone just outside each corner — cursor only, no on-canvas icon.
+            // Axis-aligned outer quadrant — same lattice as resize knobs.
+            const signX = localX === 0 ? -1 : 1;
+            const signY = localY === 0 ? -1 : 1;
+            const out = rotateHotzoneOutward(handleHit, rotateGap, rotateHit);
             const cornerPt = toScene(localX * w, localY * h);
-            const mid = toScene(w / 2, h / 2);
-            const vx = cornerPt.x - mid.x;
-            const vy = cornerPt.y - mid.y;
-            const len = Math.hypot(vx, vy) || 1;
-            const push = handleHit / 2 + rotateGap + rotateHit / 2;
-            const cx = cornerPt.x + (vx / len) * push;
-            const cy = cornerPt.y + (vy / len) * push;
+            const cx = cornerPt.x + signX * out;
+            const cy = cornerPt.y + signY * out;
             return (
               <g key={`rot-${corner}`} className="sel-hit" transform={`translate(${cx} ${cy})`}>
                 <title>{label}</title>

--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -11,6 +11,7 @@ import {
   useRcbViewportEl,
 } from '@/components/rcb/camera/context';
 import {
+  rcbCameraCssZoom,
   rcbClientDeltaToScene,
   rcbClientToStageLocal,
   rcbResolveViewportEl,
@@ -60,6 +61,7 @@ import {
 import {
   TEXT_SELECTION_PAD,
   deflateSelectionBox,
+  inflateBoxByVisualOutset,
   inflateSelectionBox,
   strokeChromeOutset,
   strokeVisualOutset,
@@ -384,6 +386,24 @@ function unionBoxes(boxes: SceneBox[]): SceneBox | null {
     bottom = Math.max(bottom, b.top + b.height);
   });
   return { left, top, width: Math.max(1, right - left), height: Math.max(1, bottom - top) };
+}
+
+/**
+ * Line/arrow nodes use a tall hit AABB (`STROKE_HIT` ≈ 24). Docking the
+ * floating toolbar to that box's top puts it half a hit-height above the shaft
+ * — huge on screen at high zoom. Anchor to the shaft midpoint instead.
+ */
+function toolbarBoxForSelection(
+  box: SceneBox | null | undefined,
+  opts: { lineChrome: boolean; node?: any }
+): SceneBox | null {
+  if (!box) return null;
+  if (!opts.lineChrome) return box;
+  const angle = Number(opts.node?.attrs?.angle) || 0;
+  const ep = strokeEndpointsFromBox(box, angle);
+  const cx = (ep.x0 + ep.x1) / 2;
+  const cy = (ep.y0 + ep.y1) / 2;
+  return { left: cx - 0.5, top: cy - 0.5, width: 1, height: 1 };
 }
 
 type GeometryPatch = {
@@ -726,8 +746,13 @@ type MoveSnapContext = {
   threshold: number;
 };
 
-/** Path AABB for smart guides (geom), not stroke-inflated chrome. */
-function pathBoxForSmartGuide(
+/**
+ * Guide / move-snap box = **painted outer ink** (path + visual outset).
+ * Draw stores path at ±sw/2 so ink sits on the integer grid; snapping the
+ * path itself to the grid yanked ink off-cell. Control box stays on path
+ * (`strokeChromeOutset` === 0) — not the same box as move-snap.
+ */
+function visualGuideBoxForNode(
   id: string,
   document: any,
   chrome: SceneBox | null | undefined
@@ -735,16 +760,17 @@ function pathBoxForSmartGuide(
   if (!chrome) return null;
   if (parseFrameSelId(id)) return { ...chrome };
   const live = liveShapeGeomBox(id);
-  if (live) return live;
-  return deflateSelectionBox({ ...chrome }, document?.deltaSetLike?.[id]);
+  const path = live || deflateSelectionBox({ ...chrome }, document?.deltaSetLike?.[id]);
+  return inflateBoxByVisualOutset(path, document?.deltaSetLike?.[id]);
 }
 
-function pathBoxFromChromeOrigin(
+function visualBoxFromChromeOrigin(
   document: any,
   o: { nodeId: string; box: SceneBox }
 ): SceneBox {
   if (parseFrameSelId(o.nodeId)) return { ...o.box };
-  return deflateSelectionBox({ ...o.box }, document?.deltaSetLike?.[o.nodeId]);
+  const path = deflateSelectionBox({ ...o.box }, document?.deltaSetLike?.[o.nodeId]);
+  return inflateBoxByVisualOutset(path, document?.deltaSetLike?.[o.nodeId]);
 }
 
 function computeMovedUnion(ctx: MoveSnapContext): {
@@ -753,41 +779,74 @@ function computeMovedUnion(ctx: MoveSnapContext): {
   sdy: number;
   guides: SmartGuideLine[];
 } {
-  const pathBoxes = ctx.origins.map((o) => pathBoxFromChromeOrigin(ctx.document, o));
-  const pathUnion =
-    unionOfBoxes(pathBoxes) ||
-    ({
-      left: ctx.union.left,
-      top: ctx.union.top,
-      width: ctx.union.width,
-      height: ctx.union.height,
-    } as SceneBox);
-  let nextPath = {
-    ...pathUnion,
-    left: pathUnion.left + ctx.dx,
-    top: pathUnion.top + ctx.dy,
+  // Snap **painted outer ink** in 1px steps, then apply the same delta to path.
+  // Never fall back to path/chrome as "visual" — that reintroduces half-cell drift.
+  const visualBoxes = ctx.origins.map((o) => visualBoxFromChromeOrigin(ctx.document, o));
+  const visualUnion = unionOfBoxes(visualBoxes);
+  if (!visualUnion) {
+    return {
+      nextUnion: {
+        ...ctx.union,
+        left: ctx.union.left + ctx.dx,
+        top: ctx.union.top + ctx.dy,
+      },
+      sdx: ctx.dx,
+      sdy: ctx.dy,
+      guides: [],
+    };
+  }
+  let nextVisual = {
+    ...visualUnion,
+    left: visualUnion.left + ctx.dx,
+    top: visualUnion.top + ctx.dy,
   };
   let guides: SmartGuideLine[] = [];
   if (!ctx.disableSnap) {
-    const smart = snapMoveToSmartGuides({
-      box: nextPath,
-      targets: ctx.targets,
-      threshold: ctx.threshold,
-      gridSize: ctx.gridSize,
-    });
-    nextPath = smart.box;
-    guides = smart.guides;
-    const snappedX = guides.some((g) => g.kind === 'align' && g.axis === 'x');
-    const snappedY = guides.some((g) => g.kind === 'align' && g.axis === 'y');
-    const grid = snapBoxToGrid(nextPath, ctx.gridSize);
-    nextPath = {
-      ...nextPath,
-      left: snappedX ? nextPath.left : grid.left,
-      top: snappedY ? nextPath.top : grid.top,
-    };
+    if (ctx.gridSize > 0) {
+      // Pixel grid owns translation. Smart guides used to nudge first (and old
+      // code skipped grid on snapped axes) → ink floated between cells while
+      // gap badges still showed "4". Guides are display-only after grid snap.
+      nextVisual = snapBoxToGrid(nextVisual, ctx.gridSize);
+      const shown = snapMoveToSmartGuides({
+        box: nextVisual,
+        targets: ctx.targets,
+        threshold: 0.51,
+        gridSize: ctx.gridSize,
+      });
+      const stillAligned =
+        Math.abs(shown.box.left - nextVisual.left) < 1e-9 &&
+        Math.abs(shown.box.top - nextVisual.top) < 1e-9;
+      guides = stillAligned ? shown.guides : [];
+    } else {
+      const smart = snapMoveToSmartGuides({
+        box: nextVisual,
+        targets: ctx.targets,
+        threshold: ctx.threshold,
+        gridSize: 0,
+      });
+      nextVisual = smart.box;
+      guides = smart.guides;
+    }
   }
-  const sdx = nextPath.left - pathUnion.left;
-  const sdy = nextPath.top - pathUnion.top;
+  const sdx = nextVisual.left - visualUnion.left;
+  const sdy = nextVisual.top - visualUnion.top;
+  if (typeof window !== 'undefined' && (window as any).__RCB_MOVE_GRID_DEBUG__ === true) {
+    // eslint-disable-next-line no-console
+    console.log('[rcb:move-grid]', {
+      dx: ctx.dx,
+      dy: ctx.dy,
+      gridSize: ctx.gridSize,
+      visual0: visualUnion,
+      visual1: nextVisual,
+      path0: ctx.union,
+      sdx,
+      sdy,
+      onGrid:
+        Math.abs(nextVisual.left - Math.round(nextVisual.left / ctx.gridSize) * ctx.gridSize) <
+          1e-9 &&
+        Math.abs(nextVisual.top - Math.round(nextVisual.top / ctx.gridSize) * ctx.gridSize) < 1e-9,
+    });
+  }
   return {
     nextUnion: {
       ...ctx.union,
@@ -829,37 +888,72 @@ function computeResizedUnion(ctx: ResizeSnapContext): {
   const singleNode = singleId ? ctx.document?.deltaSetLike?.[singleId] : null;
   const snapAsPath = Boolean(singleId && !parseFrameSelId(singleId));
   if (!ctx.disableSnap) {
-    const snapBox = snapAsPath ? deflateSelectionBox({ ...next }, singleNode) : next;
-    const smart = snapResizeToSmartGuides({
-      box: snapBox,
-      handle,
-      targets: ctx.targets,
-      threshold: ctx.threshold,
-      min: 8,
-      gridSize: ctx.gridSize,
-    });
-    const snappedPath = smart.box;
-    guides = smart.guides;
-    next = snapAsPath ? inflateSelectionBox({ ...snappedPath }, singleNode) : snappedPath;
-    // Grid only on axes that did not smart-snap.
-    const snappedX = guides.some((g) => g.kind === 'align' && g.axis === 'x');
-    const snappedY = guides.some((g) => g.kind === 'align' && g.axis === 'y');
-    const gridBox = snapAsPath ? snappedPath : next;
-    const grid = snapResizeToGrid(gridBox, handle, ctx.gridSize, 8, {
-      lockAspect,
-      aspectRatio: ctx.drag.aspectRatio,
-    });
-    let left = snappedX ? gridBox.left : grid.left;
-    let top = snappedY ? gridBox.top : grid.top;
-    let right = snappedX ? gridBox.left + gridBox.width : grid.left + grid.width;
-    let bottom = snappedY ? gridBox.top + gridBox.height : grid.top + grid.height;
-    const pathNext = {
-      left,
-      top,
-      width: Math.max(1, right - left),
-      height: Math.max(1, bottom - top),
-    };
-    next = snapAsPath ? inflateSelectionBox(pathNext, singleNode) : pathNext;
+    // Resize the painted outer ink onto the grid, then write path = visual − outset.
+    if (snapAsPath && singleNode) {
+      const path0 = deflateSelectionBox({ ...next }, singleNode);
+      const visual0 = inflateBoxByVisualOutset(path0, singleNode);
+      const smart = snapResizeToSmartGuides({
+        box: visual0,
+        handle,
+        targets: ctx.targets,
+        threshold: ctx.threshold,
+        min: Math.max(8, Math.ceil(strokeVisualOutset(singleNode) * 2) + 1),
+        gridSize: ctx.gridSize,
+      });
+      const gridVisual = snapResizeToGrid(smart.box, handle, ctx.gridSize, 8, {
+        lockAspect,
+        aspectRatio: ctx.drag.aspectRatio,
+      });
+      const outset = Math.max(0, strokeVisualOutset(singleNode));
+      const pathNext = {
+        left: gridVisual.left + outset,
+        top: gridVisual.top + outset,
+        width: Math.max(1, gridVisual.width - outset * 2),
+        height: Math.max(1, gridVisual.height - outset * 2),
+      };
+      const shown = snapResizeToSmartGuides({
+        box: gridVisual,
+        handle,
+        targets: ctx.targets,
+        threshold: 0.51,
+        min: 8,
+        gridSize: ctx.gridSize,
+      });
+      const stillAligned =
+        Math.abs(shown.box.left - gridVisual.left) < 1e-9 &&
+        Math.abs(shown.box.top - gridVisual.top) < 1e-9 &&
+        Math.abs(shown.box.width - gridVisual.width) < 1e-9 &&
+        Math.abs(shown.box.height - gridVisual.height) < 1e-9;
+      guides = stillAligned ? shown.guides : [];
+      next = inflateSelectionBox(pathNext, singleNode);
+    } else {
+      const smart = snapResizeToSmartGuides({
+        box: next,
+        handle,
+        targets: ctx.targets,
+        threshold: ctx.threshold,
+        min: 8,
+        gridSize: ctx.gridSize,
+      });
+      next = snapResizeToGrid(smart.box, handle, ctx.gridSize, 8, {
+        lockAspect,
+        aspectRatio: ctx.drag.aspectRatio,
+      });
+      const shown = snapResizeToSmartGuides({
+        box: next,
+        handle,
+        targets: ctx.targets,
+        threshold: 0.51,
+        min: 8,
+        gridSize: ctx.gridSize,
+      });
+      const stillAligned =
+        Math.abs(shown.box.left - next.left) < 1e-9 &&
+        Math.abs(shown.box.top - next.top) < 1e-9 &&
+        Math.abs(shown.box.width - next.width) < 1e-9 &&
+        Math.abs(shown.box.height - next.height) < 1e-9;
+      guides = stillAligned ? shown.guides : [];
+    }
   }
   next = {
     ...next,
@@ -877,7 +971,7 @@ function computeResizedUnion(ctx: ResizeSnapContext): {
   return { next, textMode, lockAspect, guides };
 }
 
-/** Sibling path AABBs for smart guides (exclude selection + hidden/locked). */
+/** Sibling **visual-outer** AABBs for smart guides (exclude selection + hidden/locked). */
 function collectSmartGuideTargets(
   document: any,
   listNodeIds: () => string[],
@@ -889,7 +983,7 @@ function collectSmartGuideTargets(
     if (excludeIds.has(id)) continue;
     const node = document?.deltaSetLike?.[id];
     if (!node || isNodeHidden(node) || isNodeLocked(node)) continue;
-    const box = pathBoxForSmartGuide(id, document, getNodeBox(id));
+    const box = visualGuideBoxForNode(id, document, getNodeBox(id));
     if (box && box.width > 0 && box.height > 0) out.push(box);
   }
   return out;
@@ -1242,6 +1336,7 @@ function buildShapeOutlines(opts: {
       lineMode,
       shaftEndpoints,
       edgeHandles,
+      chromeOutset: Math.max(0, strokeChromeOutset(node)),
       showRotate:
         withHandles &&
         !lineMode &&
@@ -1253,7 +1348,7 @@ function buildShapeOutlines(opts: {
   }
 
   // Single artboard frame: AABB chrome mirroring the SVG frame host
-  // (same method as generators / rects — plate is SVG, title stays HTML).
+  // (same method as generators / rects — plate + title are world-layer SVG).
   if (
     !opts.inspectDev &&
     !opts.transforming &&
@@ -1297,10 +1392,12 @@ function buildShapeOutlines(opts: {
   if (multiPathOnly) {
     const memberBoxes: SceneBox[] = [];
     for (const id of opts.selectedNodeIds) {
+      const node = opts.document?.deltaSetLike?.[id];
       const live = liveShapeGeomBox(id);
       const fallback = opts.getNodeBox(id);
-      const box = live || (fallback ? deflateSelectionBox(fallback, opts.document?.deltaSetLike?.[id]) : null);
-      if (box) memberBoxes.push(box);
+      const geom =
+        live || (fallback ? deflateSelectionBox(fallback, node) : null);
+      if (geom) memberBoxes.push(inflateSelectionBox(geom, node));
     }
     const union = unionBoxes(memberBoxes);
     if (union) {
@@ -1341,17 +1438,17 @@ function resolveChromeUnion(opts: {
   selectionUnion: SceneBox | null;
   selectedNodeIds: string[];
   selectedFrameIds: string[];
+  document: any;
 }): SceneBox | null {
   const base = opts.transforming ? opts.liveUnion : opts.selectionUnion;
   if (!base || opts.transforming) return base;
-  // Prefer live host geom (single + multi path) so chrome matches path ink.
-  // If a host lags a remount after move/resize, fall back to selectionUnion.
+  // Prefer live host → path chrome (single + multi) so the box tracks remounts.
   if (opts.selectedFrameIds.length === 0 && opts.selectedNodeIds.length >= 1) {
     const lives: SceneBox[] = [];
     for (const id of opts.selectedNodeIds) {
       const live = liveShapeGeomBox(id);
       if (!live) break;
-      lives.push(live);
+      lives.push(inflateSelectionBox(live, opts.document?.deltaSetLike?.[id]));
     }
     if (lives.length === opts.selectedNodeIds.length) {
       const liveUnion = opts.selectedNodeIds.length === 1 ? lives[0] : unionBoxes(lives);
@@ -1469,7 +1566,8 @@ function SelectionFeature({
   const viewportEl = useRcbViewportEl();
   const toScene = useRcbScreenToScene();
   const camera = useRcbCamera();
-  const zoom = Math.max(0.05, camera.zoom || 1);
+  // Same CSS zoom the world layer / grid use (not raw camera.zoom drift).
+  const zoom = Math.max(0.05, rcbCameraCssZoom(camera));
   const workspaceMode = useSelector(
     (s: any) => (s.editor.workspaceMode || 'design') as 'design' | 'dev'
   );
@@ -2351,7 +2449,15 @@ function SelectionFeature({
       if (drag.mode === 'pointing_canvas') {
         setMarquee(null);
         lastTextClickRef.current = null;
-        softSelectFrameAt(toScene, hitTestFrame, onSelectFrame, clientX, clientY);
+        const abs = toScene(clientX, clientY);
+        const frameId = hitTestFrame?.(abs.x, abs.y) ?? null;
+        if (frameId) {
+          softSelectFrameAt(toScene, hitTestFrame, onSelectFrame, clientX, clientY);
+        } else {
+          // Truly empty — ensure selection stays cleared (down already cleared; re-assert).
+          onSelectFrame?.(null);
+          onSelect([]);
+        }
         endTransform();
         return;
       }
@@ -2368,7 +2474,14 @@ function SelectionFeature({
         );
         // Still under brush gate — treat as soft click (select artboard if any).
         if (!passed) {
-          softSelectFrameAt(toScene, hitTestFrame, onSelectFrame, clientX, clientY);
+          const abs = toScene(clientX, clientY);
+          const frameId = hitTestFrame?.(abs.x, abs.y) ?? null;
+          if (frameId) {
+            softSelectFrameAt(toScene, hitTestFrame, onSelectFrame, clientX, clientY);
+          } else {
+            onSelectFrame?.(null);
+            onSelect([]);
+          }
           endTransform();
           return;
         }
@@ -2674,10 +2787,18 @@ function SelectionFeature({
       const step = e.shiftKey ? Math.max(10, gridSize * 10) : Math.max(1, gridSize);
       const dx = e.key === 'ArrowLeft' ? -step : e.key === 'ArrowRight' ? step : 0;
       const dy = e.key === 'ArrowUp' ? -step : e.key === 'ArrowDown' ? step : 0;
-      let nextUnion = { ...union, left: union.left + dx, top: union.top + dy };
-      nextUnion = snapBoxToGrid(nextUnion, gridSize);
-      const sdx = nextUnion.left - union.left;
-      const sdy = nextUnion.top - union.top;
+      // Same visual-outer 1px grid as drag-move (not path half-pixels).
+      const { nextUnion, sdx, sdy } = computeMovedUnion({
+        union,
+        origins,
+        document,
+        dx,
+        dy,
+        disableSnap: false,
+        gridSize,
+        targets: [],
+        threshold: 0,
+      });
       const nextOrigins = origins.map((o) => ({
         nodeId: o.nodeId,
         box: { ...o.box, left: o.box.left + sdx, top: o.box.top + sdy },
@@ -2800,7 +2921,14 @@ function SelectionFeature({
     selectionUnion,
     selectedNodeIds,
     selectedFrameIds,
+    document,
   });
+
+  /** Radius / ellipse knobs sit on path geom (host-local), not visual-outer chrome. */
+  const chromeGeomBox =
+    chromeUnion && singleNodeData
+      ? deflateSelectionBox(chromeUnion, singleNodeData)
+      : chromeUnion;
 
   const hoverImageReplaceId = resolveHoverImageReplaceId({
     inspectDev,
@@ -2879,7 +3007,7 @@ function SelectionFeature({
       !suppressChrome &&
       !selectedIsImageGen ? (
         <CornerRadiusHandlesOverlay
-          box={chromeUnion}
+          box={chromeGeomBox || chromeUnion}
           angle={chromeAngle}
           nodeId={singleId}
           node={singleNodeData}
@@ -2902,7 +3030,7 @@ function SelectionFeature({
       !suppressChrome &&
       !selectedIsImageGen ? (
         <CircleShapeHandlesOverlay
-          box={chromeUnion}
+          box={chromeGeomBox || chromeUnion}
           angle={chromeAngle}
           nodeId={singleId}
           node={singleNodeData}
@@ -2924,7 +3052,7 @@ function SelectionFeature({
       !suppressChrome &&
       !selectedIsImageGen ? (
         <PolygonShapeHandlesOverlay
-          box={chromeUnion}
+          box={chromeGeomBox || chromeUnion}
           angle={chromeAngle}
           nodeId={singleId}
           node={singleNodeData}
@@ -2946,7 +3074,7 @@ function SelectionFeature({
       !suppressChrome &&
       !selectedIsImageGen ? (
         <StarShapeHandlesOverlay
-          box={chromeUnion}
+          box={chromeGeomBox || chromeUnion}
           angle={chromeAngle}
           nodeId={singleId}
           node={singleNodeData}
@@ -2960,7 +3088,10 @@ function SelectionFeature({
         <SelectionContextToolbar
           document={document}
           nodeId={selectedNodeIds[0]}
-          box={chromeUnion}
+          box={toolbarBoxForSelection(chromeUnion, {
+            lineChrome,
+            node: singleNodeData,
+          })}
           edgePadScene={toolbarEdgePadScene}
           onOpenAgent={onOpenAgent}
         />

--- a/apps/web/src/components/rcb/selection/__tests__/chromeStrokeOutset.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/chromeStrokeOutset.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deflateSelectionBox,
+  inflateSelectionBox,
+  inflateBoxByVisualOutset,
+  strokeChromeOutset,
+  strokeVisualOutset,
+} from '../../scene/document/sceneEffects';
+
+/**
+ * Control box = path geom. Stroke paint may extend outside; do not pad the
+ * blue AABB to outer ink. Move/snap still uses strokeVisualOutset separately.
+ */
+describe('selection chrome vs stroke (AABB on path)', () => {
+  const centerStroke = (sw: number) => ({
+    key: 'shape',
+    attrs: {
+      shapeType: 'polygon',
+      'border-width': sw,
+      'border-color': '#333',
+      strokeAlign: 'center',
+      'stroke-enabled': 'true',
+      'stroke-visible': 'true',
+    },
+  });
+
+  it('1px center stroke: chrome = path (not visual ±0.5)', () => {
+    const node = centerStroke(1);
+    const path = { left: 10.5, top: 20.5, width: 4, height: 3 };
+    const chrome = inflateSelectionBox(path, node);
+    const visual = inflateBoxByVisualOutset(path, node);
+
+    // eslint-disable-next-line no-console
+    console.log('[test:chrome-stroke:1px]', {
+      path,
+      chrome,
+      visual,
+      chromeOutset: strokeChromeOutset(node),
+      visualOutset: strokeVisualOutset(node),
+    });
+
+    expect(strokeChromeOutset(node)).toBe(0);
+    expect(strokeVisualOutset(node)).toBe(0.5);
+    expect(chrome).toEqual(path);
+    expect(visual).toEqual({ left: 10, top: 20, width: 5, height: 4 });
+    expect(deflateSelectionBox(chrome, node)).toEqual(path);
+  });
+
+  it('thick center stroke (sw=2): knobs stay on path, not outer ink', () => {
+    const node = centerStroke(2);
+    const path = { left: 10, top: 10, width: 4, height: 3 };
+    const chrome = inflateSelectionBox(path, node);
+    // eslint-disable-next-line no-console
+    console.log('[test:chrome-stroke:2px]', { path, chrome, outset: strokeChromeOutset(node) });
+    expect(strokeChromeOutset(node)).toBe(0);
+    expect(chrome).toEqual(path);
+    const rotateFrom = {
+      nw: { x: chrome.left, y: chrome.top },
+      se: { x: chrome.left + chrome.width, y: chrome.top + chrome.height },
+    };
+    expect(rotateFrom.nw.x).toBe(10);
+    expect(rotateFrom.se.x).toBe(14);
+  });
+
+  it('outside stroke: chrome still on path (no full-sw pad)', () => {
+    const node = {
+      key: 'shape',
+      attrs: {
+        shapeType: 'rect',
+        'border-width': 2,
+        'border-color': '#333',
+        strokeAlign: 'outside',
+        'stroke-enabled': 'true',
+        'stroke-visible': 'true',
+        'fill-color': '#fff',
+      },
+    };
+    const path = { left: 10, top: 10, width: 8, height: 6 };
+    const chrome = inflateSelectionBox(path, node);
+    const visual = inflateBoxByVisualOutset(path, node);
+    // eslint-disable-next-line no-console
+    console.log('[test:chrome-stroke:outside]', { path, chrome, visual });
+    expect(strokeChromeOutset(node)).toBe(0);
+    expect(chrome).toEqual(path);
+    expect(visual).toEqual({ left: 8, top: 8, width: 12, height: 10 });
+  });
+
+  it('inside stroke: chrome stays on path', () => {
+    const node = {
+      key: 'shape',
+      attrs: {
+        shapeType: 'rect',
+        'border-width': 4,
+        'border-color': '#333',
+        strokeAlign: 'inside',
+        'stroke-enabled': 'true',
+        'stroke-visible': 'true',
+        'fill-color': '#fff',
+      },
+    };
+    const path = { left: 10, top: 10, width: 8, height: 6 };
+    const chrome = inflateSelectionBox(path, node);
+    expect(strokeChromeOutset(node)).toBe(0);
+    expect(chrome).toEqual(path);
+  });
+
+  it('polygon knobs + AABB both on path geom', () => {
+    const node = centerStroke(1);
+    const path = { left: 10.5, top: 20.5, width: 4, height: 3 };
+    const chrome = inflateSelectionBox(path, node);
+    const geomForPolygonKnobs = deflateSelectionBox(chrome, node);
+    // eslint-disable-next-line no-console
+    console.log('[test:chrome-stroke:polygon-knobs]', {
+      chrome,
+      geomForPolygonKnobs,
+    });
+    expect(geomForPolygonKnobs).toEqual(path);
+    expect(chrome).toEqual(path);
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/generatorPlaceGrid.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/generatorPlaceGrid.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import {
+  rcbFitImageIntoViewport,
+  rcbLayoutGeneratorPlate,
+  generatorEmptyIconSize,
+  GENERATOR_EMPTY_STROKE_OUTSET,
+} from '../../core/layout';
+import {
+  createImageGeneratorNode,
+  createVideoGeneratorNode,
+  createVideoNode,
+} from '../../scene/document/sceneDocument';
+import { inflateBoxByVisualOutset, strokeVisualOutset } from '../../scene/document/sceneEffects';
+import { snapCoordToGrid } from '../alignGuides';
+
+describe('generator plate place size + grid', () => {
+  it('at 4000% zoom, video fit stays within ~half the visible scene', () => {
+    const zoom = 40;
+    const viewport = { width: 800, height: 600 };
+    const sized = rcbFitImageIntoViewport(
+      { width: 1280, height: 720 },
+      viewport,
+      zoom,
+      { minRatio: 0.28, maxRatio: 0.48 }
+    );
+    const sceneW = viewport.width / zoom;
+    const sceneH = viewport.height / zoom;
+    // eslint-disable-next-line no-console
+    console.log('[test:generator-fit@4000%]', { sized, sceneW, sceneH, zoom });
+    expect(sized.width).toBeLessThanOrEqual(sceneW * 0.5 + 1);
+    expect(sized.height).toBeLessThanOrEqual(sceneH * 0.5 + 1);
+    expect(sized.width).toBeLessThan(80);
+    expect(sized.height).toBeLessThan(80);
+  });
+
+  it('createVideoGeneratorNode does not floor 10×6 up to 160×120', () => {
+    const { node } = createVideoGeneratorNode({ x: 1, y: 2, width: 10, height: 6 });
+    // eslint-disable-next-line no-console
+    console.log('[test:createVideoGenerator]', { w: node.width, h: node.height });
+    expect(node.width).toBe(10);
+    expect(node.height).toBe(6);
+    expect(node.x).toBe(1);
+    expect(node.y).toBe(2);
+  });
+
+  it('createVideoNode keeps high-zoom place aspect (no 80×60 floor)', () => {
+    // 9:16 phone clip placed tiny at ~1200% zoom — old floor made 80×60 → squash.
+    const { node } = createVideoNode({ x: 3, y: 4, width: 9, height: 16 });
+    // eslint-disable-next-line no-console
+    console.log('[test:createVideo-upload-aspect]', {
+      w: node.width,
+      h: node.height,
+      aspect: node.width / node.height,
+    });
+    expect(node.width).toBe(9);
+    expect(node.height).toBe(16);
+    expect(node.width / node.height).toBeCloseTo(9 / 16, 6);
+    expect(node.x).toBe(3);
+    expect(node.y).toBe(4);
+  });
+
+  it('createImageGeneratorNode does not floor 12×12 up to 120', () => {
+    const { node } = createImageGeneratorNode({ width: 12, height: 12 });
+    expect(node.width).toBe(12);
+    expect(node.height).toBe(12);
+  });
+
+  it('empty-gen icon fits inside a small high-zoom plate (no 72px floor)', () => {
+    const box = 18;
+    const icon = generatorEmptyIconSize(box, box);
+    const legacyBroken = Math.max(72, box * 0.34);
+    // eslint-disable-next-line no-console
+    console.log('[test:gen-icon@small]', { box, icon, legacyBroken });
+    expect(icon).toBeLessThan(box);
+    expect(icon).toBeCloseTo(box * 0.28, 6);
+    expect(legacyBroken).toBeGreaterThan(box);
+  });
+
+  it('generator plates have no visual stroke outset (inset border === path)', () => {
+    const { node: img } = createImageGeneratorNode({ x: 0, y: 0, width: 20, height: 20 });
+    const { node: vid } = createVideoGeneratorNode({ x: 0, y: 0, width: 20, height: 12 });
+    expect(strokeVisualOutset(img)).toBe(0);
+    expect(strokeVisualOutset(vid)).toBe(0);
+    expect(GENERATOR_EMPTY_STROKE_OUTSET).toBe(0);
+  });
+
+  it('rcbLayoutGeneratorPlate: path edges on integer grid (no half-cell)', () => {
+    const zoom = 40;
+    const viewport = { width: 900, height: 700 };
+    const laid = rcbLayoutGeneratorPlate({
+      natural: { width: 1280, height: 720 },
+      viewport,
+      zoom,
+      center: { x: 100.37, y: 50.61 },
+      gridSize: 1,
+      visualOutset: GENERATOR_EMPTY_STROKE_OUTSET,
+      fit: { minRatio: 0.28, maxRatio: 0.48 },
+    });
+    const { node } = createVideoGeneratorNode({
+      x: laid.left,
+      y: laid.top,
+      width: laid.width,
+      height: laid.height,
+    });
+    const box = { left: node.x, top: node.y, width: node.width, height: node.height };
+    const ink = inflateBoxByVisualOutset(box, node);
+    // eslint-disable-next-line no-console
+    console.log('[test:generator-layout@4000%]', { laid, node: box, ink });
+    expect(node.x).toBe(snapCoordToGrid(node.x, 1));
+    expect(node.y).toBe(snapCoordToGrid(node.y, 1));
+    expect(node.width).toBe(snapCoordToGrid(node.width, 1));
+    expect(node.height).toBe(snapCoordToGrid(node.height, 1));
+    expect(ink.left).toBe(node.x);
+    expect(ink.top).toBe(node.y);
+    expect(node.width).toBeLessThan(80);
+    // Must not resurrect the old 160 floor.
+    expect(node.width).toBe(laid.width);
+    expect(node.height).toBe(laid.height);
+  });
+
+  it('at 100% zoom, video plate is a sensible fraction of the stage', () => {
+    const sized = rcbFitImageIntoViewport(
+      { width: 1280, height: 720 },
+      { width: 1200, height: 800 },
+      1,
+      { minRatio: 0.28, maxRatio: 0.48 }
+    );
+    // eslint-disable-next-line no-console
+    console.log('[test:generator-fit@100%]', sized);
+    expect(sized.width).toBeGreaterThan(200);
+    expect(sized.width).toBeLessThanOrEqual(1200 * 0.48 + 1);
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/highZoomHitAndMove.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/highZoomHitAndMove.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { STROKE_HIT, sceneHitSlop } from '../../scene/document/sceneShapes';
+import { snapBoxToGrid, snapCoordToGrid } from '../alignGuides';
+
+describe('sceneHitSlop (high-zoom blank click)', () => {
+  it('at 4000% zoom, slop stays ~12 CSS px in scene units (not 12 scene units)', () => {
+    const zoom = 40; // 4000%
+    const pad = sceneHitSlop(zoom);
+    expect(pad).toBeCloseTo(12 / 40, 6);
+    // Old bug: Math.max(STROKE_HIT/2, 12/zoom) === 12 scene u ≈ 480 CSS px.
+    const legacyBroken = Math.max(STROKE_HIT / 2, 12 / zoom);
+    expect(legacyBroken).toBe(12);
+    expect(pad * zoom).toBeLessThan(legacyBroken * zoom / 10);
+  });
+
+  it('click 2 grid cells outside a 1px-stroke rect is outside hit slop at zoom 40', () => {
+    const zoom = 40;
+    const pad = sceneHitSlop(zoom);
+    const sw = 1;
+    const strokeHit = sw + pad * 2; // Path2D stroke width
+    // Outer ink at path + sw/2; hit extends strokeHit/2 from path.
+    const hitOuter = strokeHit / 2;
+    const clickGap = 2; // 2 scene cells past path edge… user marks ~2 cells past ink
+    // Past outer ink by ~2: distance from path ≈ sw/2 + 2
+    const distFromPath = sw / 2 + 2;
+    expect(distFromPath).toBeGreaterThan(hitOuter);
+    expect(pad).toBeLessThan(1);
+  });
+});
+
+describe('move snap at high zoom threshold', () => {
+  it('with grid on, origin snap alone keeps box on lattice (smart must not own position)', () => {
+    // At tiny zoom the smart threshold is huge; production move ignores smart
+    // translation when gridSize>0 and only snapBoxToGrid(visual).
+    const moving = { left: 10.2, top: 10.4, width: 17, height: 15 };
+    const next = snapBoxToGrid(moving, 1);
+    expect(next.left).toBe(snapCoordToGrid(next.left, 1));
+    expect(next.top).toBe(snapCoordToGrid(next.top, 1));
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/moveSnapGrid.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/moveSnapGrid.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import {
+  snapBoxToGrid,
+  snapCoordToGrid,
+  snapMoveToSmartGuides,
+  snapResizeToGrid,
+  snapResizeToSmartGuides,
+} from '../alignGuides';
+import {
+  strokeChromeOutset,
+  inflateBoxByVisualOutset,
+  strokeVisualOutset,
+} from '../../scene/document/sceneEffects';
+import { resolveClosedDrawBoxes } from '../../tools/ShapeDrawFeature';
+
+/**
+ * Production move policy when gridSize > 0:
+ *   nextVisual = snapBoxToGrid(visual0 + delta)   // smart does NOT nudge
+ *   path += (nextVisual - visual0)
+ * Path may stay on *.5; ink outer stays on integer cells.
+ */
+function moveSnapVisualOnly(opts: {
+  path: { left: number; top: number; width: number; height: number };
+  node: any;
+  gridSize: number;
+  dx?: number;
+  dy?: number;
+}) {
+  const visual0 = inflateBoxByVisualOutset(opts.path, opts.node);
+  const dragged = {
+    ...visual0,
+    left: visual0.left + (opts.dx ?? 0),
+    top: visual0.top + (opts.dy ?? 0),
+  };
+  const visual = snapBoxToGrid(dragged, opts.gridSize);
+  const sdx = visual.left - visual0.left;
+  const sdy = visual.top - visual0.top;
+  return {
+    visual,
+    path: {
+      ...opts.path,
+      left: opts.path.left + sdx,
+      top: opts.path.top + sdy,
+    },
+    sdx,
+    sdy,
+  };
+}
+
+function assertInkOnGrid(
+  path: { left: number; top: number; width: number; height: number },
+  node: any,
+  gridSize: number
+) {
+  const ink = inflateBoxByVisualOutset(path, node);
+  expect(ink.left).toBe(snapCoordToGrid(ink.left, gridSize));
+  expect(ink.top).toBe(snapCoordToGrid(ink.top, gridSize));
+  expect(ink.left + ink.width).toBe(snapCoordToGrid(ink.left + ink.width, gridSize));
+  expect(ink.top + ink.height).toBe(snapCoordToGrid(ink.top + ink.height, gridSize));
+}
+
+describe('visual-outer move snap (1px grid)', () => {
+  // Real createShapeNode attrs — resolveStroke reads border-width, not borderWidth.
+  const centerStroke1 = {
+    key: 'shape',
+    attrs: {
+      shapeType: 'rect',
+      'border-width': 1,
+      'border-color': '#333333',
+      strokeAlign: 'center',
+      'stroke-enabled': 'true',
+      'stroke-visible': 'true',
+    },
+  };
+
+  it('chrome stays on path; visual outer is separate (move/snap only)', () => {
+    expect(strokeChromeOutset(centerStroke1)).toBe(0);
+    expect(strokeVisualOutset(centerStroke1)).toBe(0.5);
+    const path = { left: 10.5, top: 8.5, width: 3, height: 2 };
+    const visual = {
+      left: path.left - 0.5,
+      top: path.top - 0.5,
+      width: path.width + 1,
+      height: path.height + 1,
+    };
+    // eslint-disable-next-line no-console
+    console.log('[test:chrome=path]', { path, visual, chromeOutset: 0 });
+    expect(visual.left).toBe(10);
+    expect(visual.top).toBe(8);
+  });
+
+  it('draw → path *.5 → free drag keeps ink on integer grid (1px steps)', () => {
+    const { visual: drawnVis, geom } = resolveClosedDrawBoxes(
+      { left: 10.2, top: 8.4, width: 7.6, height: 7.1 },
+      true,
+      1,
+      'rect'
+    );
+    expect(drawnVis.left).toBe(snapCoordToGrid(drawnVis.left, 1));
+    expect(geom.left).toBe(drawnVis.left + 0.5);
+
+    const moved = moveSnapVisualOnly({
+      path: geom,
+      node: centerStroke1,
+      gridSize: 1,
+      dx: 2.37,
+      dy: -1.61,
+    });
+    // eslint-disable-next-line no-console
+    console.log('[test:draw→move]', {
+      drawnVis,
+      geom,
+      moved,
+      stepX: moved.sdx,
+      stepY: moved.sdy,
+    });
+    assertInkOnGrid(moved.path, centerStroke1, 1);
+    // Steps are whole grid cells (not sub-pixel crawl).
+    expect(Number.isInteger(moved.sdx)).toBe(true);
+    expect(Number.isInteger(moved.sdy)).toBe(true);
+    expect(moved.path.left).toBe(moved.visual.left + 0.5);
+  });
+
+  it('old path-grid snap yanks ink off grid — must not be used', () => {
+    const path = { left: 10.5, top: 10.5, width: 7, height: 7 };
+    const wrong = snapBoxToGrid({ ...path, left: path.left + 2.3, top: path.top }, 1);
+    const wrongInk = inflateBoxByVisualOutset(wrong, centerStroke1);
+    expect(wrongInk.left).not.toBe(snapCoordToGrid(wrongInk.left, 1));
+
+    const right = moveSnapVisualOnly({
+      path,
+      node: centerStroke1,
+      gridSize: 1,
+      dx: 2.3,
+      dy: 0,
+    });
+    assertInkOnGrid(right.path, centerStroke1, 1);
+  });
+
+  it('smart gap "4" must not leave moved ink off-grid (regression)', () => {
+    // Left sibling already on-grid (visual 10..18). Right starts on-grid too.
+    const leftVis = { left: 10, top: 10, width: 8, height: 8 };
+    const rightPath = { left: 22.5, top: 10.5, width: 7, height: 7 };
+    const rightVis0 = inflateBoxByVisualOutset(rightPath, centerStroke1);
+    expect(rightVis0.left).toBe(22);
+
+    // Pointer would place a ~4 cell gap, but with subpixel noise + smart pull.
+    const noisy = {
+      ...rightVis0,
+      left: leftVis.left + leftVis.width + 4 + 0.37,
+      top: rightVis0.top + 0.22,
+    };
+    // Old messy judge: smart nudge first (could land off lattice), then optionally
+    // skip grid on that axis. New policy: grid only.
+    const smart = snapMoveToSmartGuides({
+      box: noisy,
+      targets: [leftVis],
+      threshold: 8,
+      gridSize: 1,
+    });
+    const gridOnly = snapBoxToGrid(noisy, 1);
+    // eslint-disable-next-line no-console
+    console.log('[test:gap4]', { noisy, smart: smart.box, gridOnly });
+
+    const moved = moveSnapVisualOnly({
+      path: rightPath,
+      node: centerStroke1,
+      gridSize: 1,
+      dx: noisy.left - rightVis0.left,
+      dy: noisy.top - rightVis0.top,
+    });
+    assertInkOnGrid(moved.path, centerStroke1, 1);
+    expect(moved.visual.left).toBe(gridOnly.left);
+    expect(moved.visual.top).toBe(gridOnly.top);
+  });
+
+  it('repair: path already integer (ink *.5) — one drag puts ink back on grid', () => {
+    // After old path-snap bug: path on integers → ink floats between cells.
+    const brokenPath = { left: 14, top: 11, width: 7, height: 7 };
+    const brokenInk = inflateBoxByVisualOutset(brokenPath, centerStroke1);
+    expect(brokenInk.left).toBe(13.5);
+    expect(brokenInk.left).not.toBe(snapCoordToGrid(brokenInk.left, 1));
+
+    const fixed = moveSnapVisualOnly({
+      path: brokenPath,
+      node: centerStroke1,
+      gridSize: 1,
+      dx: 0.01,
+      dy: 0.01,
+    });
+    // eslint-disable-next-line no-console
+    console.log('[test:repair]', { brokenPath, fixed });
+    assertInkOnGrid(fixed.path, centerStroke1, 1);
+  });
+
+  it('resize visual edge then inset path keeps ink on grid', () => {
+    const path = { left: 10.5, top: 10.5, width: 7, height: 7 };
+    const visual0 = inflateBoxByVisualOutset(path, centerStroke1);
+    const smart = snapResizeToSmartGuides({
+      box: { ...visual0, width: visual0.width + 2.4 },
+      handle: 'e',
+      targets: [],
+      threshold: 8,
+      min: 2,
+      gridSize: 1,
+    });
+    const gridVisual = snapResizeToGrid(smart.box, 'e', 1, 2);
+    const outset = strokeVisualOutset(centerStroke1);
+    const pathNext = {
+      left: gridVisual.left + outset,
+      top: gridVisual.top + outset,
+      width: Math.max(1, gridVisual.width - outset * 2),
+      height: Math.max(1, gridVisual.height - outset * 2),
+    };
+    assertInkOnGrid(pathNext, centerStroke1, 1);
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/nodeTitleAbove.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/nodeTitleAbove.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest';
+import {
+  NODE_TITLE_LABEL_GAP_PX,
+  NODE_TITLE_LABEL_LINE_PX,
+  SELECTION_HANDLE_CLEARANCE_PX,
+  SELECTION_TOOLBAR_ABOVE_BOX_GAP_PX,
+  SELECTION_TOOLBAR_ABOVE_LABEL_GAP_PX,
+  SELECTION_TOOLBAR_BELOW_BOX_GAP_PX,
+  selectionToolbarAboveAnchorScene,
+  toolbarAboveClearancePx,
+  toolbarAboveScreenGapPx,
+} from '../chrome/SelectionToolbarShell';
+import {
+  nodeTitleLabelWorldPlacement,
+  nodeTitleScreenGapPx,
+} from '../chrome/NodeTitleLabel';
+import { expandInfiniteSvgPad } from '../../scene/paint/sceneToSvg';
+import {
+  CHROME_HANDLE_HIT_PX,
+  CHROME_STROKE_PX,
+  cursorForResize,
+  selectionChromeSurfaceProps,
+} from '../SelectionChrome';
+import { rcbScreenPxToScene } from '../../core/math';
+
+const CANVAS_ZOOMS = [0.5, 1, 2.247, 10, 71.61, 80, 100] as const;
+const VIEWPORT_SCALES = [0.75, 0.9, 1, 1.1, 1.25] as const;
+
+describe('nodeTitleLabelWorldPlacement — SVG knob contract', () => {
+  it('clips the name so it cannot overlap the size column on a narrow plate', () => {
+    const box = { left: 0, top: 10, width: 32, height: 32 };
+    const zoom = 12.84;
+    const place = nodeTitleLabelWorldPlacement(box, zoom, {
+      sizeText: '32 × 32',
+    });
+    expect(place.nameMaxWidth).toBeGreaterThanOrEqual(0);
+    expect(place.nameX + place.nameMaxWidth).toBeLessThanOrEqual(
+      place.sizeX - place.sizeReserve + 1e-9
+    );
+    // eslint-disable-next-line no-console
+    console.log('[test:title-overflow]', {
+      zoom,
+      nameMaxWidth: place.nameMaxWidth,
+      sizeReserve: place.sizeReserve,
+      boxWidth: box.width,
+    });
+  });
+
+  it('uses scene = screenPx/zoom like SelectionChrome handles (no CSS counter-scale)', () => {
+    const box = { left: 2, top: 4, width: 11, height: 15 };
+    const zoom = 80;
+    const place = nodeTitleLabelWorldPlacement(box, zoom);
+    const inv = 1 / zoom;
+
+    expect(place.fontSize).toBeCloseTo(11 * inv, 10);
+    expect(place.iconSize).toBeCloseTo(12 * inv, 10);
+    expect(place.gapScene).toBeCloseTo(NODE_TITLE_LABEL_GAP_PX * inv, 10);
+    expect(place.lineScene).toBeCloseTo(NODE_TITLE_LABEL_LINE_PX * inv, 10);
+    expect(place.labelBottomScene).toBeLessThan(box.top);
+    expect(place.labelTopScene).toBeLessThan(place.labelBottomScene);
+    // Title lives fully above the plate.
+    expect(place.labelTopScene + place.lineScene).toBeCloseTo(place.labelBottomScene, 10);
+    // eslint-disable-next-line no-console
+    console.log('[test:title-svg@8000%]', {
+      zoom,
+      fontSize: place.fontSize,
+      handleVisLike: 8 * inv,
+      labelTopScene: place.labelTopScene,
+      boxTop: box.top,
+      gapScreen: (box.top - place.labelBottomScene) * zoom,
+    });
+  });
+
+  it.each([...CANVAS_ZOOMS])(
+    'keeps a 10 layout-px gap above the plate at canvas zoom %s',
+    (zoom) => {
+      const box = { left: 0, top: 24, width: 15, height: 24 };
+      const place = nodeTitleLabelWorldPlacement(box, zoom);
+      const gap = nodeTitleScreenGapPx(place, box.top, zoom, 1);
+      expect(gap).toBeCloseTo(NODE_TITLE_LABEL_GAP_PX, 6);
+      expect(place.labelBottomScene).toBeLessThan(box.top);
+      expect(place.labelTopScene).toBeLessThan(box.top);
+      // Screen-constant type: font * zoom === 11
+      expect(place.fontSize * zoom).toBeCloseTo(11, 6);
+      // eslint-disable-next-line no-console
+      console.log('[test:title-gap@canvas]', {
+        zoom,
+        gapLayoutPx: gap,
+        fontScreenPx: place.fontSize * zoom,
+      });
+    }
+  );
+
+  it.each([...VIEWPORT_SCALES])(
+    'scales the 10px title gap with viewportScale %s',
+    (viewportScale) => {
+      const box = { left: 0, top: 24, width: 15, height: 24 };
+      const zoom = 71.61;
+      const place = nodeTitleLabelWorldPlacement(box, zoom);
+      const visual = nodeTitleScreenGapPx(place, box.top, zoom, viewportScale);
+      expect(visual).toBeCloseTo(NODE_TITLE_LABEL_GAP_PX * viewportScale, 6);
+      // eslint-disable-next-line no-console
+      console.log('[test:title-gap@viewport]', {
+        zoom,
+        viewportScale,
+        visualGapPx: visual,
+      });
+    }
+  );
+});
+
+describe('toolbar 20px outside node @ canvas + browser zoom', () => {
+  it('uses a 10px title gap and 20px toolbar gaps from the node', () => {
+    expect(NODE_TITLE_LABEL_GAP_PX).toBe(10);
+    expect(SELECTION_TOOLBAR_ABOVE_BOX_GAP_PX).toBe(20);
+    expect(SELECTION_TOOLBAR_BELOW_BOX_GAP_PX).toBe(20);
+    expect(toolbarAboveClearancePx(false)).toBe(20);
+    expect(toolbarAboveClearancePx(true)).toBe(
+      NODE_TITLE_LABEL_GAP_PX +
+        NODE_TITLE_LABEL_LINE_PX +
+        SELECTION_TOOLBAR_ABOVE_LABEL_GAP_PX
+    );
+  });
+
+  it.each([...CANVAS_ZOOMS])(
+    'untitled toolbar bottom stays 20px + handle clear above plate at zoom %s',
+    (zoom) => {
+      const boxTop = 40;
+      const gap = toolbarAboveScreenGapPx(boxTop, zoom, false);
+      expect(gap).toBeCloseTo(
+        SELECTION_TOOLBAR_ABOVE_BOX_GAP_PX + SELECTION_HANDLE_CLEARANCE_PX,
+        6
+      );
+      const anchor = selectionToolbarAboveAnchorScene(boxTop, zoom, false);
+      expect(anchor).toBeLessThan(boxTop);
+      expect(rcbScreenPxToScene(SELECTION_TOOLBAR_ABOVE_BOX_GAP_PX, zoom)).toBeCloseTo(
+        SELECTION_TOOLBAR_ABOVE_BOX_GAP_PX / zoom,
+        8
+      );
+      // eslint-disable-next-line no-console
+      console.log('[test:toolbar-gap@canvas]', { zoom, gapLayoutPx: gap, anchor });
+    }
+  );
+
+  it.each([...CANVAS_ZOOMS])(
+    'titled toolbar clears title (10+16+8) + handle at zoom %s',
+    (zoom) => {
+      const boxTop = 40;
+      const gap = toolbarAboveScreenGapPx(boxTop, zoom, true);
+      expect(gap).toBeCloseTo(
+        toolbarAboveClearancePx(true) + SELECTION_HANDLE_CLEARANCE_PX,
+        6
+      );
+      const box = { left: 0, top: boxTop, width: 15, height: 24 };
+      const title = nodeTitleLabelWorldPlacement(box, zoom);
+      const toolbarAnchor = selectionToolbarAboveAnchorScene(boxTop, zoom, true);
+      expect(toolbarAnchor).toBeLessThan(title.labelTopScene);
+      // eslint-disable-next-line no-console
+      console.log('[test:toolbar-above-title@canvas]', {
+        zoom,
+        toolbarAnchor,
+        titleTop: title.labelTopScene,
+      });
+    }
+  );
+
+  it.each([...VIEWPORT_SCALES])(
+    'toolbar gap tracks viewportScale %s',
+    (viewportScale) => {
+      const boxTop = 40;
+      const zoom = 2.247;
+      const visual = toolbarAboveScreenGapPx(boxTop, zoom, true, 0, viewportScale);
+      const expected =
+        (toolbarAboveClearancePx(true) + SELECTION_HANDLE_CLEARANCE_PX) *
+        viewportScale;
+      expect(visual).toBeCloseTo(expected, 6);
+    }
+  );
+});
+
+describe('selectionChromeSurfaceProps (no handle-pad drift)', () => {
+  it('fallback surface at 8000% is stroke-padded only — not handle-hit padded', () => {
+    const box = { left: 2, top: 4, width: 11, height: 15 };
+    const zoom = 80;
+    const stroke = CHROME_STROKE_PX / zoom;
+    const handleHit = CHROME_HANDLE_HIT_PX / zoom;
+    const surf = selectionChromeSurfaceProps(
+      box,
+      0,
+      stroke,
+      { x: 0, y: 0, zoom },
+      1
+    );
+    const vb = (surf.viewBox || '').split(/[\s,]+/).map(Number);
+    const [, , vw, vh] = vb;
+    expect(vw).toBeLessThan(box.width + 2 * handleHit);
+    expect(vh).toBeLessThan(box.height + 2 * handleHit);
+    expect(vw).toBeLessThanOrEqual(box.width + 2 * stroke + 1);
+    expect(vh).toBeLessThanOrEqual(box.height + 2 * stroke + 1);
+  });
+});
+
+describe('expandInfiniteSvgPad (private host handle hits only)', () => {
+  it('grows viewBox + CSS box so corner hits outside path still lie inside the SVG', () => {
+    const root = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    root.setAttribute('viewBox', '10 20 11 15');
+    root.setAttribute('width', '11');
+    root.setAttribute('height', '15');
+    root.style.left = '10px';
+    root.style.top = '20px';
+    root.style.width = '11px';
+    root.style.height = '15px';
+
+    const zoom = 80;
+    const inv = 1 / zoom;
+    const pad = CHROME_HANDLE_HIT_PX * inv;
+    expect(expandInfiniteSvgPad(root, pad)).toBe(true);
+
+    const vb = (root.getAttribute('viewBox') || '').split(/\s+/).map(Number);
+    expect(vb[0]).toBeCloseTo(10 - pad, 8);
+    expect(vb[1]).toBeCloseTo(20 - pad, 8);
+    expect(vb[2]).toBeCloseTo(11 + pad * 2, 8);
+    expect(vb[3]).toBeCloseTo(15 + pad * 2, 8);
+  });
+});
+
+describe('cursorForResize still direction-correct', () => {
+  it('edge handles stay axis cursors at angle 0', () => {
+    expect(cursorForResize('n', 0)).toBe('n-resize');
+    expect(cursorForResize('e', 0)).toBe('e-resize');
+    expect(cursorForResize('se', 0)).toBe('se-resize');
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/smartGuideMarks.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/smartGuideMarks.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import { snapMoveToSmartGuides } from '../alignGuides';
+
+/**
+ * Edge-align guides must mark corners AND edge midpoints (上中/下中/左中/右中).
+ * Old pathMarksForAlign only put × on corners — mid-edge looked "missing".
+ * × arms on the stroke also read as broken segments at high zoom (paint is dots now).
+ */
+describe('smart guide marks (corners + edge mids, continuous line)', () => {
+  it('left-edge align exposes TL / left-mid / BL on both boxes', () => {
+    const moving = { left: 10, top: 8, width: 12, height: 10 };
+    const target = { left: 10, top: 30, width: 8, height: 14 };
+    const { guides } = snapMoveToSmartGuides({
+      box: moving,
+      targets: [target],
+      threshold: 0.51,
+      gridSize: 1,
+    });
+    const vert = guides.find((g) => g.kind === 'align' && g.axis === 'x' && g.at === 10);
+    expect(vert && vert.kind === 'align').toBe(true);
+    if (!vert || vert.kind !== 'align') return;
+
+    const marks = vert.marks || [];
+    // eslint-disable-next-line no-console
+    console.log('[test:guides-marks:left-edge]', {
+      at: vert.at,
+      from: vert.from,
+      to: vert.to,
+      marks,
+    });
+
+    // Continuous span covering both boxes (not two broken stubs).
+    expect(vert.from).toBeLessThanOrEqual(8);
+    expect(vert.to).toBeGreaterThanOrEqual(44);
+
+    const has = (x: number, y: number) =>
+      marks.some((m) => Math.abs(m.x - x) < 1e-9 && Math.abs(m.y - y) < 1e-9);
+
+    // Moving: TL, left-mid (左中), BL
+    expect(has(10, 8)).toBe(true);
+    expect(has(10, 8 + 5)).toBe(true);
+    expect(has(10, 18)).toBe(true);
+    // Target: TL, left-mid, BL
+    expect(has(10, 30)).toBe(true);
+    expect(has(10, 30 + 7)).toBe(true);
+    expect(has(10, 44)).toBe(true);
+  });
+
+  it('top-edge align exposes TL / top-mid (上中) / TR', () => {
+    const moving = { left: 10, top: 20, width: 12, height: 8 };
+    const target = { left: 40, top: 20, width: 10, height: 6 };
+    const { guides } = snapMoveToSmartGuides({
+      box: moving,
+      targets: [target],
+      threshold: 0.51,
+      gridSize: 1,
+    });
+    const hor = guides.find((g) => g.kind === 'align' && g.axis === 'y' && g.at === 20);
+    expect(hor && hor.kind === 'align').toBe(true);
+    if (!hor || hor.kind !== 'align') return;
+
+    const marks = hor.marks || [];
+    // eslint-disable-next-line no-console
+    console.log('[test:guides-marks:top-edge]', { marks, from: hor.from, to: hor.to });
+
+    const has = (x: number, y: number) =>
+      marks.some((m) => Math.abs(m.x - x) < 1e-9 && Math.abs(m.y - y) < 1e-9);
+
+    expect(has(10, 20)).toBe(true);
+    expect(has(10 + 6, 20)).toBe(true); // 上中
+    expect(has(22, 20)).toBe(true);
+    expect(has(40, 20)).toBe(true);
+    expect(has(40 + 5, 20)).toBe(true);
+    expect(has(50, 20)).toBe(true);
+  });
+
+  it('right-edge align exposes TR / right-mid (右中) / BR', () => {
+    const moving = { left: 30, top: 8, width: 10, height: 12 };
+    const target = { left: 20, top: 30, width: 20, height: 10 };
+    // moving.right = 40, target.right = 40
+    const { guides } = snapMoveToSmartGuides({
+      box: moving,
+      targets: [target],
+      threshold: 0.51,
+      gridSize: 1,
+    });
+    const vert = guides.find((g) => g.kind === 'align' && g.axis === 'x' && g.at === 40);
+    expect(vert && vert.kind === 'align').toBe(true);
+    if (!vert || vert.kind !== 'align') return;
+    const marks = vert.marks || [];
+    // eslint-disable-next-line no-console
+    console.log('[test:guides-marks:right-edge]', { marks });
+    const has = (x: number, y: number) =>
+      marks.some((m) => Math.abs(m.x - x) < 1e-9 && Math.abs(m.y - y) < 1e-9);
+    expect(has(40, 8)).toBe(true);
+    expect(has(40, 8 + 6)).toBe(true); // 右中
+    expect(has(40, 20)).toBe(true);
+    expect(has(40, 30)).toBe(true);
+    expect(has(40, 30 + 5)).toBe(true);
+    expect(has(40, 40)).toBe(true);
+  });
+
+  it('bottom-edge align exposes BL / bottom-mid (下中) / BR', () => {
+    const moving = { left: 10, top: 10, width: 12, height: 10 };
+    const target = { left: 40, top: 14, width: 10, height: 6 };
+    // moving.bottom = 20, target.bottom = 20
+    const { guides } = snapMoveToSmartGuides({
+      box: moving,
+      targets: [target],
+      threshold: 0.51,
+      gridSize: 1,
+    });
+    const hor = guides.find((g) => g.kind === 'align' && g.axis === 'y' && g.at === 20);
+    expect(hor && hor.kind === 'align').toBe(true);
+    if (!hor || hor.kind !== 'align') return;
+    const marks = hor.marks || [];
+    // eslint-disable-next-line no-console
+    console.log('[test:guides-marks:bottom-edge]', { marks });
+    const has = (x: number, y: number) =>
+      marks.some((m) => Math.abs(m.x - x) < 1e-9 && Math.abs(m.y - y) < 1e-9);
+    expect(has(10, 20)).toBe(true);
+    expect(has(10 + 6, 20)).toBe(true); // 下中
+    expect(has(22, 20)).toBe(true);
+    expect(has(40, 20)).toBe(true);
+    expect(has(40 + 5, 20)).toBe(true);
+    expect(has(50, 20)).toBe(true);
+  });
+
+  it('center-line align still marks box centers (not only corners)', () => {
+    const moving = { left: 10, top: 10, width: 10, height: 10 };
+    const target = { left: 40, top: 10, width: 10, height: 10 };
+    const { guides } = snapMoveToSmartGuides({
+      box: moving,
+      targets: [target],
+      threshold: 0.51,
+      gridSize: 1,
+    });
+    const midY = guides.find((g) => g.kind === 'align' && g.axis === 'y' && g.at === 15);
+    expect(midY && midY.kind === 'align').toBe(true);
+    if (!midY || midY.kind !== 'align') return;
+    // eslint-disable-next-line no-console
+    console.log('[test:guides-marks:center]', midY.marks);
+    expect(midY.marks?.some((m) => m.x === 15 && m.y === 15)).toBe(true);
+    expect(midY.marks?.some((m) => m.x === 45 && m.y === 15)).toBe(true);
+  });
+
+  it('guide from/to is one continuous span (not multi stubs)', () => {
+    const moving = { left: 5, top: 0, width: 4, height: 4 };
+    const a = { left: 5, top: 20, width: 4, height: 4 };
+    const b = { left: 5, top: 40, width: 4, height: 4 };
+    const { guides } = snapMoveToSmartGuides({
+      box: moving,
+      targets: [a, b],
+      threshold: 0.51,
+      gridSize: 1,
+    });
+    const verts = guides.filter((g) => g.kind === 'align' && g.axis === 'x' && g.at === 5);
+    // eslint-disable-next-line no-console
+    console.log(
+      '[test:guides-continuous]',
+      verts.map((g) => (g.kind === 'align' ? { at: g.at, from: g.from, to: g.to } : null))
+    );
+    expect(verts.length).toBe(1);
+    if (verts[0]?.kind !== 'align') return;
+    expect(verts[0].from).toBe(0);
+    expect(verts[0].to).toBe(44);
+  });
+});
+
+describe('snap tip lattice (1px mouse bias)', () => {
+  it('snapped tip lands on nearest corner or edge mid (no free float)', async () => {
+    const { snapPenAnchorPoint } = await import('../../tools/PenDrawFeature');
+    const raw = { x: 14.6, y: 11.4 };
+    const tip = snapPenAnchorPoint(raw.x, raw.y, 1, false);
+    // eslint-disable-next-line no-console
+    console.log('[test:snap-tip:1px]', {
+      raw,
+      tip,
+      delta: { x: tip.x - raw.x, y: tip.y - raw.y },
+    });
+    // Near (14.6,11.4): horizontal edge mid (14.5,11) beats corner (15,11).
+    expect(tip).toEqual({ x: 14.5, y: 11 });
+  });
+
+  it('when pointer already on corner, tip equals pointer (0 bias)', async () => {
+    const { snapPenAnchorPoint } = await import('../../tools/PenDrawFeature');
+    const raw = { x: 20, y: 30 };
+    const tip = snapPenAnchorPoint(raw.x, raw.y, 1, false);
+    // eslint-disable-next-line no-console
+    console.log('[test:snap-tip:on-corner]', { raw, tip });
+    expect(tip).toEqual(raw);
+  });
+
+  it('when pointer already on edge mid, tip equals pointer', async () => {
+    const { snapPenAnchorPoint } = await import('../../tools/PenDrawFeature');
+    const raw = { x: 14, y: 11.5 };
+    const tip = snapPenAnchorPoint(raw.x, raw.y, 1, false);
+    // eslint-disable-next-line no-console
+    console.log('[test:snap-tip:on-edge-mid]', { raw, tip });
+    expect(tip).toEqual(raw);
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/smartGuidesLattice.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/smartGuidesLattice.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { sceneSurfaceSvgProps, worldCameraViewport } from '../../scene/paint/sceneToSvg';
+import type { RcbCamera } from '../../core/types';
+import { snapMoveToSmartGuides } from '../alignGuides';
+
+/**
+ * Smart guides used to paint on a per-bounds `sceneSurfaceSvgProps` SVG.
+ * At fractional DPR that surface origin snaps independently from the shared
+ * world viewport → orange guides drift vs the pixel grid / shapes.
+ * Guides must portal into `data-rcb-smart-guides-mount` on the world SVG.
+ */
+describe('smart guides lattice (browser zoom / fractional DPR)', () => {
+  const camera: RcbCamera = { x: 12.3, y: 45.6, zoom: 8 };
+
+  it('legacy per-box guide surface drifts from world viewport at dpr 0.9', () => {
+    const dpr = 0.9;
+    const world = worldCameraViewport(camera, dpr, 800, 600);
+    expect(world).not.toBeNull();
+
+    // Typical guide AABB around two snapped visual rects (screenshot case).
+    const guideBox = { left: 95.2, top: 40.7, width: 48, height: 28 };
+    const surf = sceneSurfaceSvgProps(guideBox, camera, dpr);
+
+    // Fractional DPR snaps the sibling SVG origin away from raw scene box.
+    expect(surf.style.left !== guideBox.left || surf.style.top !== guideBox.top).toBe(true);
+    // That origin is not the shared world surface — two lattices → visible offset.
+    expect(surf.style.left).not.toBe(world!.left);
+    expect(surf.style.top).not.toBe(world!.top);
+
+    // eslint-disable-next-line no-console
+    console.log('[test:guides-lattice:legacy-drift]', {
+      dpr,
+      zoom: camera.zoom,
+      world: { left: world!.left, top: world!.top },
+      guideSurf: { left: surf.style.left, top: surf.style.top },
+      delta: {
+        x: surf.style.left - world!.left,
+        y: surf.style.top - world!.top,
+      },
+    });
+  });
+
+  it('world viewport is the single lattice (portal target identity)', () => {
+    const dpr = 0.9;
+    const a = worldCameraViewport(camera, dpr, 800, 600);
+    const b = worldCameraViewport(camera, dpr, 800, 600);
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a!.left).toBe(b!.left);
+    expect(a!.top).toBe(b!.top);
+    expect(a!.width).toBe(b!.width);
+    expect(a!.height).toBe(b!.height);
+
+    // eslint-disable-next-line no-console
+    console.log('[test:guides-lattice:world]', a);
+  });
+
+  it('align guide `at` stays on visual outer edges (integer when ink is on grid)', () => {
+    // Two 1px-stroke closed shapes: path *.5 → visual outer integers.
+    const moving = { left: 10, top: 8, width: 12, height: 10 };
+    const target = { left: 26, top: 8, width: 12, height: 10 };
+    const { box, guides } = snapMoveToSmartGuides({
+      box: moving,
+      targets: [target],
+      threshold: 0.51,
+      gridSize: 1,
+    });
+
+    expect(box.left).toBe(10);
+    expect(box.top).toBe(8);
+
+    const aligns = guides.filter((g) => g.kind === 'align');
+    expect(aligns.length).toBeGreaterThan(0);
+    for (const g of aligns) {
+      if (g.kind !== 'align') continue;
+      // Edge / mid of integer visual box: integer or *.5 (odd size mid).
+      const frac = Math.abs(g.at % 1);
+      expect(frac < 1e-9 || Math.abs(frac - 0.5) < 1e-9).toBe(true);
+    }
+
+    // Top edges align → horizontal guide at y=8 (on grid line).
+    const topGuide = aligns.find((g) => g.kind === 'align' && g.axis === 'y' && g.at === 8);
+    expect(topGuide).toBeTruthy();
+
+    // eslint-disable-next-line no-console
+    console.log('[test:guides-align:on-grid]', {
+      box,
+      aligns: aligns.map((g) =>
+        g.kind === 'align' ? { axis: g.axis, at: g.at, marks: g.marks?.length } : null
+      ),
+    });
+  });
+
+  it('center guide may sit on *.5 when visual height is odd — not a lattice bug', () => {
+    const moving = { left: 10, top: 8, width: 11, height: 9 };
+    const target = { left: 30, top: 8, width: 11, height: 9 };
+    const { guides } = snapMoveToSmartGuides({
+      box: moving,
+      targets: [target],
+      threshold: 0.51,
+      gridSize: 1,
+    });
+    const midY = guides.find(
+      (g) => g.kind === 'align' && g.axis === 'y' && Math.abs(g.at - (8 + 9 / 2)) < 1e-9
+    );
+    expect(midY).toBeTruthy();
+    expect(midY && midY.kind === 'align' ? midY.at : null).toBe(12.5);
+
+    // eslint-disable-next-line no-console
+    console.log('[test:guides-align:mid-half]', { at: 12.5, reason: 'odd visual height' });
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/videoImageLayerParity.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/videoImageLayerParity.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'vitest';
+import {
+  nodeToSvgElement,
+  previewSvgNodeGeometry,
+  videoSvgOwnsPixels,
+} from '../../scene/paint/sceneToSvg';
+
+function svgRoot(attrs: Record<string, string>) {
+  const root = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  for (const [k, v] of Object.entries(attrs)) root.setAttribute(k, v);
+  const layer = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+  root.appendChild(layer);
+  return { root, layer };
+}
+
+function imageNode(box: { x: number; y: number; width: number; height: number }) {
+  return {
+    key: 'image',
+    x: box.x,
+    y: box.y,
+    width: box.width,
+    height: box.height,
+    attrs: { src: 'https://example.com/a.png' },
+  };
+}
+
+function videoNode(box: { x: number; y: number; width: number; height: number }) {
+  return {
+    key: 'video',
+    x: box.x,
+    y: box.y,
+    width: box.width,
+    height: box.height,
+    attrs: {
+      src: 'https://example.com/a.mp4',
+      poster: 'https://example.com/poster.jpg',
+    },
+  };
+}
+
+const box = { x: 10, y: 20, width: 28, height: 38 };
+const doc = { x: 0, y: 0, deltaSetLike: {} };
+
+/**
+ * Images are single-layer SVG. Videos also mount HTML <video> on the infinite
+ * canvas — SVG must not paint a second visible bitmap or move leaves a ghost.
+ */
+describe('image vs video paint layers', () => {
+  it('videoSvgOwnsPixels: world surface → HTML owns pixels', () => {
+    const { root } = svgRoot({
+      'data-rcb-infinite': '1',
+      'data-rcb-world-surface': '1',
+    });
+    expect(videoSvgOwnsPixels(root)).toBe(false);
+  });
+
+  it('videoSvgOwnsPixels: export surface → SVG owns pixels', () => {
+    const { root } = svgRoot({
+      'data-rcb-infinite': '1',
+      'data-rcb-export-surface': '1',
+    });
+    expect(videoSvgOwnsPixels(root)).toBe(true);
+  });
+
+  it('videoSvgOwnsPixels: private infinite host (no world flag) → HTML still mounts, SVG must not paint', () => {
+    const { root } = svgRoot({ 'data-rcb-infinite': '1' });
+    expect(videoSvgOwnsPixels(root)).toBe(false);
+  });
+
+  it('image on world surface paints one <image> (single layer, like today)', async () => {
+    const { root, layer } = svgRoot({
+      'data-rcb-infinite': '1',
+      'data-rcb-world-surface': '1',
+    });
+    const el = await nodeToSvgElement(root, layer, doc, imageNode(box), 'img1');
+    expect(el).toBeTruthy();
+    expect(el!.querySelectorAll('image').length).toBe(1);
+    // eslint-disable-next-line no-console
+    console.log('[test:image-layer]', {
+      images: el!.querySelectorAll('image').length,
+      key: el!.getAttribute('data-scene-node-key'),
+    });
+  });
+
+  it('video on world surface paints zero <image> (HTML plate is the only bitmap)', async () => {
+    const { root, layer } = svgRoot({
+      'data-rcb-infinite': '1',
+      'data-rcb-world-surface': '1',
+    });
+    const el = await nodeToSvgElement(root, layer, doc, videoNode(box), 'vid1');
+    expect(el).toBeTruthy();
+    expect(el!.getAttribute('data-scene-node-key')).toBe('video');
+    expect(el!.querySelectorAll('image').length).toBe(0);
+    expect(el!.querySelector('[data-baseline="1"],[data-rcb-video-html-hit="1"]')).toBeTruthy();
+    // eslint-disable-next-line no-console
+    console.log('[test:video-world-layer]', {
+      images: el!.querySelectorAll('image').length,
+      hit: Boolean(el!.querySelector('[data-baseline="1"],[data-rcb-video-html-hit="1"]')),
+    });
+  });
+
+  it('video on private infinite host also paints zero <image> (same HTML overlay)', async () => {
+    const { root, layer } = svgRoot({ 'data-rcb-infinite': '1' });
+    const el = await nodeToSvgElement(root, layer, doc, videoNode(box), 'vid2');
+    expect(el).toBeTruthy();
+    expect(el!.querySelectorAll('image').length).toBe(0);
+    // eslint-disable-next-line no-console
+    console.log('[test:video-private-host-layer]', {
+      images: el!.querySelectorAll('image').length,
+    });
+  });
+
+  it('video on export surface still paints poster <image>', async () => {
+    const { root, layer } = svgRoot({
+      'data-rcb-infinite': '1',
+      'data-rcb-export-surface': '1',
+    });
+    const el = await nodeToSvgElement(root, layer, doc, videoNode(box), 'vid3');
+    expect(el).toBeTruthy();
+    expect(el!.querySelectorAll('image').length).toBe(1);
+    // eslint-disable-next-line no-console
+    console.log('[test:video-export-layer]', {
+      images: el!.querySelectorAll('image').length,
+    });
+  });
+});
+
+describe('video move preview geom == HTML plate override', () => {
+  it('previewSvgNodeGeometry updates __scene* to the same box VideoNodeOverlay must use', async () => {
+    const { root, layer } = svgRoot({
+      'data-rcb-infinite': '1',
+      'data-rcb-world-surface': '1',
+    });
+    const node = videoNode(box);
+    const el = await nodeToSvgElement(root, layer, doc, node, 'vid-move');
+    expect(el).toBeTruthy();
+    const nodeEls = new Map<string, SVGElement>([['vid-move', el!]]);
+    const moved = { left: 50, top: 60, width: 28, height: 38 };
+    expect(previewSvgNodeGeometry(nodeEls, 'vid-move', moved)).toBe(true);
+    const anyEl = el as any;
+    const svgGeom = {
+      left: Number(anyEl.__sceneLeft),
+      top: Number(anyEl.__sceneTop),
+      width: Number(anyEl.sceneWidth),
+      height: Number(anyEl.sceneHeight),
+    };
+    // Same numbers the HTML plate reads from geometryOverrides / publishVideoLiveGeom.
+    const htmlOverride = { ...moved, angle: 0 };
+    // eslint-disable-next-line no-console
+    console.log('[test:video-move-geom]', { svgGeom, htmlOverride });
+    expect(svgGeom).toEqual({
+      left: htmlOverride.left,
+      top: htmlOverride.top,
+      width: htmlOverride.width,
+      height: htmlOverride.height,
+    });
+  });
+});

--- a/apps/web/src/components/rcb/selection/alignGuides.ts
+++ b/apps/web/src/components/rcb/selection/alignGuides.ts
@@ -20,7 +20,7 @@ export type SmartGuideAlign = {
   at: number;
   from: number;
   to: number;
-  /** Path keypoints (×) on this guide. */
+  /** Path keypoints on this guide (corners + edge midpoints). */
   marks?: Array<{ x: number; y: number }>;
 };
 
@@ -74,7 +74,7 @@ function mergeMarks(
   return out;
 }
 
-/** Path keypoints (×) for one box on an align guide. */
+/** Path keypoints on an align guide: corners + edge midpoints (上中/下中/左中/右中). */
 function pathMarksForAlign(
   box: SceneBox,
   axis: 'x' | 'y',
@@ -82,23 +82,32 @@ function pathMarksForAlign(
   eps: number
 ): Array<{ x: number; y: number }> {
   if (!(box.width > 0) || !(box.height > 0)) return [];
+  const midX = box.left + box.width / 2;
+  const midY = box.top + box.height / 2;
+  const right = box.left + box.width;
+  const bottom = box.top + box.height;
+
   if (axis === 'y') {
     const hit = boxYMarks(box).find((m) => Math.abs(m.value - at) <= eps);
     if (!hit) return [];
     const y = at;
-    if (hit.role === 'mid') return [{ x: box.left + box.width / 2, y }];
+    // Center line: only the box center. Edge line: L / mid / R (上中·下中).
+    if (hit.role === 'mid') return [{ x: midX, y }];
     return [
       { x: box.left, y },
-      { x: box.left + box.width, y },
+      { x: midX, y },
+      { x: right, y },
     ];
   }
   const hit = boxXMarks(box).find((m) => Math.abs(m.value - at) <= eps);
   if (!hit) return [];
   const x = at;
-  if (hit.role === 'mid') return [{ x, y: box.top + box.height / 2 }];
+  // Center line: only the box center. Edge line: T / mid / B (左中·右中).
+  if (hit.role === 'mid') return [{ x, y: midY }];
   return [
     { x, y: box.top },
-    { x, y: box.top + box.height },
+    { x, y: midY },
+    { x, y: bottom },
   ];
 }
 
@@ -338,7 +347,7 @@ export function snapMoveToSmartGuides(opts: {
   box: SceneBox;
   targets: SceneBox[];
   threshold: number;
-  /** Skip snaps that leave the origin on a half-grid. */
+  /** Skip snaps that leave the box origin off the document grid. */
   gridSize?: number;
 }): { box: SceneBox; guides: SmartGuideLine[] } {
   const { box, targets, threshold } = opts;
@@ -371,13 +380,8 @@ export function snapMoveToSmartGuides(opts: {
         const abs = Math.abs(delta);
         if (abs > threshold) continue;
         const nextLeft = box.left + delta;
-        if (
-          gridSize > 0 &&
-          (m.role === 'mid' || tm.role === 'mid') &&
-          !isOnGrid(nextLeft, gridSize)
-        ) {
-          continue;
-        }
+        // Path control box / visual outer must stay on grid — reject snaps that leave it.
+        if (gridSize > 0 && !isOnGrid(nextLeft, gridSize)) continue;
         if (bestX && abs > bestX.abs + 1e-9) continue;
         if (
           bestX &&
@@ -396,13 +400,7 @@ export function snapMoveToSmartGuides(opts: {
         const abs = Math.abs(delta);
         if (abs > threshold) continue;
         const nextTop = box.top + delta;
-        if (
-          gridSize > 0 &&
-          (m.role === 'mid' || tm.role === 'mid') &&
-          !isOnGrid(nextTop, gridSize)
-        ) {
-          continue;
-        }
+        if (gridSize > 0 && !isOnGrid(nextTop, gridSize)) continue;
         if (bestY && abs > bestY.abs + 1e-9) continue;
         if (
           bestY &&
@@ -458,7 +456,7 @@ export function snapResizeToSmartGuides(opts: {
   targets: SceneBox[];
   threshold: number;
   min?: number;
-  /** Skip mid marks that would park a resized edge on a half-grid. */
+  /** Skip target marks that are off the document grid. */
   gridSize?: number;
 }): { box: SceneBox; guides: SmartGuideLine[] } {
   const { box, handle, targets, threshold } = opts;
@@ -487,7 +485,7 @@ export function snapResizeToSmartGuides(opts: {
     for (const tm of targetsMarks) {
       const abs = Math.abs(tm.value - edge);
       if (abs > threshold) continue;
-      if (gridSize > 0 && tm.role === 'mid' && !isOnGrid(tm.value, gridSize)) continue;
+      if (gridSize > 0 && !isOnGrid(tm.value, gridSize)) continue;
       if (best && abs > best.abs + 1e-9) continue;
       if (best && Math.abs(abs - best.abs) <= 1e-9 && roleRank(tm.role) > roleRank(best.role)) {
         continue;

--- a/apps/web/src/components/rcb/selection/chrome/CircleShapeHandlesOverlay.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/CircleShapeHandlesOverlay.tsx
@@ -24,12 +24,18 @@ import {
   notifyShapeHostGeometry,
 } from '@/components/rcb/shapes/shapeHostRegistry';
 import type { SceneBox } from '../alignGuides';
-import { WorldSvgFrame, WorldScreenBadge } from '../SelectionChrome';
+import {
+  CHROME_HANDLE_HIT_PX,
+  CHROME_HANDLE_VIS_PX,
+  CHROME_STROKE_PX,
+  WorldSvgFrame,
+  WorldScreenBadge,
+} from '../SelectionChrome';
 
 const DRAG_DISTANCE_SQUARED = 16;
-const KNOB_VIS_PX = 8;
-const KNOB_HIT_PX = 18;
-const KNOB_STROKE_PX = 1.5;
+const KNOB_VIS_PX = CHROME_HANDLE_VIS_PX;
+const KNOB_HIT_PX = CHROME_HANDLE_HIT_PX;
+const KNOB_STROKE_PX = CHROME_STROKE_PX;
 /** Arc / start knobs sit slightly inside the rim so they clear resize chrome. */
 const ARC_RIM_INSET_PX = 10;
 

--- a/apps/web/src/components/rcb/selection/chrome/CornerRadiusHandlesOverlay.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/CornerRadiusHandlesOverlay.tsx
@@ -8,8 +8,13 @@
 import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react';
 import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { previewSvgNodeCornerRadii, snapSvgSurfaceBox } from '@/components/rcb/scene/paint/sceneToSvg';
-import { useRcbCamera, useRcbDevicePixelRatio } from '@/components/rcb/camera/context';
+import {
+  hostChromeBodyTransform,
+  hostMirrorSvgProps,
+  previewSvgNodeCornerRadii,
+  sceneSurfaceSvgProps,
+} from '@/components/rcb/scene/paint/sceneToSvg';
+import { useRcbCamera } from '@/components/rcb/camera/context';
 import {
   clampCornerRadii,
   cornerVertexCount,
@@ -23,7 +28,6 @@ import {
   type CornerRadii,
   type SharpCornerSite,
 } from '@/components/rcb/scene/document/sceneRadii';
-import { strokeChromeOutset } from '@/components/rcb/scene/document/sceneEffects';
 import { patchDocumentNode } from '@/store/modules/editor';
 import {
   getShapeHost,
@@ -32,7 +36,12 @@ import {
   subscribeShapeHosts,
 } from '@/components/rcb/shapes/shapeHostRegistry';
 import type { SceneBox } from '../alignGuides';
-import { WorldScreenBadge } from '../SelectionChrome';
+import {
+  CHROME_HANDLE_HIT_PX,
+  CHROME_HANDLE_VIS_PX,
+  CHROME_STROKE_PX,
+  WorldScreenBadge,
+} from '../SelectionChrome';
 
 /** Soft-click threshold (screen px²) — match SelectionFeature. */
 const DRAG_DISTANCE_SQUARED = 16;
@@ -41,9 +50,9 @@ const DRAG_DISTANCE_SQUARED = 16;
  * Screen-constant sizes under world CSS camera scale(z) — same contract as
  * SelectionChrome / path chrome knobs (scene = screenPx / zoom).
  */
-const RADIUS_VIS_PX = 8;
-const RADIUS_HIT_PX = 18;
-const RADIUS_STROKE_PX = 1.5;
+const RADIUS_VIS_PX = CHROME_HANDLE_VIS_PX;
+const RADIUS_HIT_PX = CHROME_HANDLE_HIT_PX;
+const RADIUS_STROKE_PX = CHROME_STROKE_PX;
 const RADIUS_REVEAL_DIST_PX = 56;
 /**
  * When R≈0 (or R is still small), seat this many screen px inside the corner
@@ -60,9 +69,8 @@ function liveNodeEl(nodeId: string): Element | null {
 }
 
 /**
- * Twin the shape-host infinite SVG viewport (HostPathChrome sel-knob contract).
- * Local children paint in host-local box space (0..w, 0..h); sceneChildren stay
- * in absolute scene coords (badges).
+ * Twin the shape-host SVG viewport.
+ * Local children: host-local box; sceneChildren: absolute scene (badges).
  */
 function HostMirroredKnobSvg({
   nodeId,
@@ -78,7 +86,6 @@ function HostMirroredKnobSvg({
   sceneChildren?: ReactNode;
 }) {
   const camera = useRcbCamera();
-  const dpr = useRcbDevicePixelRatio();
   const [hostEpoch, setHostEpoch] = useState(0);
   useEffect(() => subscribeShapeHosts(() => setHostEpoch((n) => n + 1)), []);
 
@@ -88,49 +95,24 @@ function HostMirroredKnobSvg({
   const w = Math.max(1, box.width);
   const h = Math.max(1, box.height);
   const pad = 32;
-
-  const hostViewBox = hostRoot?.getAttribute?.('viewBox') || '';
-  const hostCssLeft = hostRoot?.style?.left || '';
-  const hostCssTop = hostRoot?.style?.top || '';
-  const hostCssW = hostRoot?.style?.width || '';
-  const hostCssH = hostRoot?.style?.height || '';
-  const mirrored = Boolean(hostRoot && hostViewBox && hostCssLeft && hostCssTop);
   void hostEpoch;
 
-  const hostTransform = el?.getAttribute?.('transform') || '';
-  let bodyTransform: string;
-  if (mirrored && hostTransform) {
-    bodyTransform = hostTransform;
-  } else if (mirrored) {
-    const hl = Number((el as any)?.__sceneLeft);
-    const ht = Number((el as any)?.__sceneTop);
-    bodyTransform = `translate(${Number.isFinite(hl) ? hl : box.left} ${Number.isFinite(ht) ? ht : box.top})`;
-  } else if (Math.abs(angle) > 0.001) {
-    bodyTransform = `translate(${box.left} ${box.top}) rotate(${angle} ${w / 2} ${h / 2})`;
-  } else {
-    bodyTransform = `translate(${box.left} ${box.top})`;
-  }
+  const mirror = hostRoot ? hostMirrorSvgProps(hostRoot) : null;
+  const mirrored = Boolean(mirror);
+  const bodyTransform = hostChromeBodyTransform(el, box, angle, mirrored);
 
-  if (mirrored && hostRoot) {
-    const attrW = hostRoot.getAttribute('width');
-    const attrH = hostRoot.getAttribute('height');
+  if (mirror) {
     return (
       <svg
         data-rcb-infinite="1"
         className="absolute z-[28] overflow-visible"
         preserveAspectRatio="none"
-        viewBox={hostViewBox}
-        width={attrW || undefined}
-        height={attrH || undefined}
+        viewBox={mirror.viewBox}
+        width={mirror.width}
+        height={mirror.height}
         style={{
-          left: hostCssLeft,
-          top: hostCssTop,
-          width: hostCssW || hostRoot.style.width,
-          height: hostCssH || hostRoot.style.height,
-          overflow: 'visible',
+          ...mirror.style,
           pointerEvents: 'none',
-          display: 'block',
-          shapeRendering: 'geometricPrecision',
         }}
         aria-hidden
       >
@@ -142,15 +124,14 @@ function HostMirroredKnobSvg({
     );
   }
 
-  const surf = snapSvgSurfaceBox(
+  const surf = sceneSurfaceSvgProps(
     {
       left: box.left - pad,
       top: box.top - pad,
       width: w + pad * 2,
       height: h + pad * 2,
     },
-    camera,
-    dpr
+    camera
   );
 
   return (
@@ -158,18 +139,12 @@ function HostMirroredKnobSvg({
       data-rcb-infinite="1"
       className="absolute z-[28] overflow-visible"
       preserveAspectRatio="none"
-      viewBox={`${surf.left} ${surf.top} ${surf.width} ${surf.height}`}
       width={surf.width}
       height={surf.height}
+      viewBox={surf.viewBox}
       style={{
-        left: surf.left,
-        top: surf.top,
-        width: surf.width,
-        height: surf.height,
-        overflow: 'visible',
+        ...surf.style,
         pointerEvents: 'none',
-        display: 'block',
-        shapeRendering: 'geometricPrecision',
       }}
       aria-hidden
     >
@@ -398,8 +373,9 @@ function CornerRadiusHandlesOverlay({
   const revealDist = RADIUS_REVEAL_DIST_PX;
   const k = 1 / z;
   const parkScene = RADIUS_PARK_PX * k;
-  // `box` is the chrome AABB; path sites are geometry-local.
-  const geomOutset = strokeChromeOutset(node);
+  // `box` prop is path geom (caller deflates visual chrome). Host-mirrored
+  // local space is also geom — path sites need no chrome pad.
+  const geomOutset = 0;
   const halfSide = Math.min(w, h) / 2;
 
   const radiusHandleInset = (r: number) => radiusSeatInset(r, halfSide, parkScene);

--- a/apps/web/src/components/rcb/selection/chrome/MultiSelectionToolbar.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/MultiSelectionToolbar.tsx
@@ -591,7 +591,7 @@ function MultiSelectionToolbar({
     );
   };
 
-  // Fig.1 — selected group: 解除编组 | export
+  // Selected group: 解除编组 | export
   if (groupId) {
     return (
       <SelectionToolbarShell box={box}>

--- a/apps/web/src/components/rcb/selection/chrome/NodeTitleLabel.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/NodeTitleLabel.tsx
@@ -1,11 +1,26 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode, memo } from 'react';
-import { LuFrame, LuImage, LuImagePlus, LuFilm } from 'react-icons/lu';
-import { RiVideoAiLine } from 'react-icons/ri';
-import { RcbOverlayPortal, useRcbCamera, rcbSceneToScreen } from '@/components/rcb';
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  memo,
+} from 'react';
+import {
+  useRcbCamera,
+  useRcbDevicePixelRatio,
+  rcbCameraCssZoom,
+  rcbSceneToScreen,
+  RcbOverlayPortal,
+} from '@/components/rcb';
 import {
   NODE_TITLE_LABEL_GAP_PX,
   NODE_TITLE_LABEL_LINE_PX,
 } from './SelectionToolbarShell';
+import { selectionChromeSurfaceProps } from '../SelectionChrome';
 
 type NodeTitleLabelBox = {
   left: number;
@@ -20,45 +35,197 @@ type Props = {
   /** Scene-space AABB of the node / frame. */
   box: NodeTitleLabelBox;
   name: string;
-  /** Displayed size (usually node width × height). */
   sizeWidth: number;
   sizeHeight: number;
-  /** Hit-test / dismiss marker — frame uses `data-frame-label`, image `data-image-label`. */
+  /** Hit-test marker: `data-frame-label` | `data-image-label`. */
   dataAttr: 'frame-label' | 'image-label';
-  /** Leading glyph — defaults from `dataAttr` when omitted. */
   icon?: NodeTitleIcon;
-  /** Extra data attrs (e.g. frame id / node id). */
   dataProps?: Record<string, string>;
-  /** Node rotation (deg) — title rides above the top edge of the rotated box. */
+  /** Degrees; title follows the rotated top edge. */
   angle?: number;
-  /** Hide while moving / transforming. */
   hidden?: boolean;
   onSelect?: () => void;
   onRename?: (name: string) => void;
-  /** Drag the label to move the target (frames). */
   onMove?: (x: number, y: number, opts?: { skipGrid?: boolean }) => void;
   onMoveStart?: () => void;
   onMoveEnd?: () => void;
-  /** Scene origin used as drag baseline (`frame.x` / `node.x`). */
   originX?: number;
   originY?: number;
   renameAriaLabel?: string;
 };
 
-function TitleIcon({ kind }: { kind: NodeTitleIcon }) {
-  const cls = 'h-3 w-3 shrink-0 text-[var(--muted)]';
-  if (kind === 'frame') return <LuFrame className={cls} strokeWidth={2} aria-hidden />;
-  if (kind === 'image-generator') return <LuImagePlus className={cls} strokeWidth={2} aria-hidden />;
-  if (kind === 'video-generator') {
-    return <RiVideoAiLine className={cls} aria-hidden />;
+const MUTED = 'var(--muted)';
+/** Edit overlay font (matches idle SVG 11px after camera scale). */
+const TITLE_EDIT_FONT_PX = 11;
+
+function rotateLocalToScene(
+  lx: number,
+  ly: number,
+  box: NodeTitleLabelBox,
+  angleDeg: number
+): { x: number; y: number } {
+  if (Math.abs(angleDeg) < 0.001) {
+    return { x: box.left + lx, y: box.top + ly };
   }
-  if (kind === 'video') return <LuFilm className={cls} strokeWidth={2} aria-hidden />;
-  return <LuImage className={cls} strokeWidth={2} aria-hidden />;
+  const rad = (angleDeg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const cx = box.width / 2;
+  const cy = box.height / 2;
+  const dx = lx - cx;
+  const dy = ly - cy;
+  return {
+    x: box.left + cx + dx * cos - dy * sin,
+    y: box.top + cy + dx * sin + dy * cos,
+  };
 }
 
 /**
- * Shared title row above frames and selected images: `icon Name` · `W × H`.
- * Screen-fixed typography (does not grow with zoom) — same metrics as SelectionToolbarShell.
+ * Scene-space title layout: `scene = screenPx / zoom` under camera scale.
+ */
+export function nodeTitleLabelWorldPlacement(
+  box: NodeTitleLabelBox,
+  zoom: number,
+  opts?: { sizeText?: string }
+): {
+  inv: number;
+  gapScene: number;
+  lineScene: number;
+  fontSize: number;
+  iconSize: number;
+  labelBottomScene: number;
+  labelTopScene: number;
+  textY: number;
+  iconX: number;
+  iconY: number;
+  nameX: number;
+  sizeX: number;
+  /** Name column width before the size text (overflow clip). */
+  nameMaxWidth: number;
+  sizeReserve: number;
+  hitLeft: number;
+  hitTop: number;
+  hitWidth: number;
+  hitHeight: number;
+} {
+  const z = Math.max(0.05, zoom || 1);
+  const inv = 1 / z;
+  const gapScene = NODE_TITLE_LABEL_GAP_PX * inv;
+  const lineScene = NODE_TITLE_LABEL_LINE_PX * inv;
+  const fontSize = 11 * inv;
+  const iconSize = 12 * inv;
+  const labelBottomScene = box.top - gapScene;
+  const labelTopScene = labelBottomScene - lineScene;
+  const textY = labelTopScene + lineScene * 0.5;
+  const gapIcon = 4 * inv;
+  const gapNameSize = 8 * inv;
+  const sizeText = opts?.sizeText ?? '000 × 000';
+  const sizeReserve = Math.max(fontSize * 3, sizeText.length * fontSize * 0.62);
+  const nameX = box.left + iconSize + gapIcon;
+  const sizeX = box.left + Math.max(1, box.width);
+  const nameMaxWidth = Math.max(0, sizeX - gapNameSize - sizeReserve - nameX);
+  return {
+    inv,
+    gapScene,
+    lineScene,
+    fontSize,
+    iconSize,
+    labelBottomScene,
+    labelTopScene,
+    textY,
+    iconX: box.left,
+    iconY: textY - iconSize * 0.5,
+    nameX,
+    sizeX,
+    nameMaxWidth,
+    sizeReserve,
+    hitLeft: box.left,
+    hitTop: labelTopScene,
+    hitWidth: Math.max(1, box.width),
+    hitHeight: lineScene,
+  };
+}
+
+/** Stage layout px from plate top → title bottom. */
+export function nodeTitleScreenGapPx(
+  place: { labelBottomScene: number },
+  boxTop: number,
+  cameraZoom: number,
+  viewportScale = 1
+): number {
+  const z = Math.max(0.05, cameraZoom || 1);
+  const sx = viewportScale > 0 ? viewportScale : 1;
+  return (boxTop - place.labelBottomScene) * z * sx;
+}
+
+/** 24×24 stroke icons, scaled into scene via `size`. */
+function TitleIconSvg({
+  kind,
+  x,
+  y,
+  size,
+}: {
+  kind: NodeTitleIcon;
+  x: number;
+  y: number;
+  size: number;
+}) {
+  const s = size / 24;
+  const common = {
+    fill: 'none' as const,
+    stroke: MUTED,
+    strokeWidth: 2,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+  };
+  let path: ReactNode = null;
+  if (kind === 'frame') {
+    path = (
+      <>
+        <rect x={3} y={3} width={18} height={18} rx={2} {...common} />
+        <path d="M3 9h18" {...common} />
+        <path d="M9 21V9" {...common} />
+      </>
+    );
+  } else if (kind === 'image-generator') {
+    path = (
+      <>
+        <rect x={3} y={3} width={18} height={18} rx={2} {...common} />
+        <circle cx={9} cy={9} r={2} {...common} />
+        <path d="M21 15l-5-5L5 21" {...common} />
+        <path d="M16 5h5v5" {...common} />
+        <path d="M21 5l-6 6" {...common} />
+      </>
+    );
+  } else if (kind === 'video-generator') {
+    path = (
+      <>
+        <rect x={2} y={6} width={14} height={12} rx={2} {...common} />
+        <path d="M16 10l6-3v10l-6-3z" {...common} />
+        <path d="M8 3v3M12 3v3" {...common} />
+      </>
+    );
+  } else if (kind === 'video') {
+    path = (
+      <>
+        <rect x={2} y={5} width={20} height={14} rx={2} {...common} />
+        <path d="M10 9l5 3-5 3z" {...common} fill={MUTED} />
+      </>
+    );
+  } else {
+    path = (
+      <>
+        <rect x={3} y={3} width={18} height={18} rx={2} {...common} />
+        <circle cx={9} cy={9} r={2} {...common} />
+        <path d="M21 15l-5-5L5 21" {...common} />
+      </>
+    );
+  }
+  return <g transform={`translate(${x} ${y}) scale(${s})`}>{path}</g>;
+}
+
+/**
+ * Title row above frames / images / generators (world SVG, `px/zoom`).
  */
 function NodeTitleLabel({
   box,
@@ -83,7 +250,6 @@ function NodeTitleLabel({
   const [draft, setDraft] = useState(name);
   const [labelDragging, setLabelDragging] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const rootRef = useRef<HTMLDivElement | null>(null);
   const labelDragRef = useRef<{
     originX: number;
     originY: number;
@@ -92,26 +258,29 @@ function NodeTitleLabel({
     started: boolean;
   } | null>(null);
   const camera = useRcbCamera();
-  const z = Math.max(0.05, camera.zoom || 1);
+  const dpr = useRcbDevicePixelRatio();
+  const z = rcbCameraCssZoom(camera);
+  const rotated = Math.abs(angle) > 0.001;
+  const clipUid = useId().replace(/:/g, '');
+  const sizeText = `${Math.round(sizeWidth)} × ${Math.round(sizeHeight)}`;
 
   useEffect(() => {
     if (!editing) setDraft(name);
   }, [name, editing]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!editing) return;
     const el = inputRef.current;
     if (!el) return;
-    el.focus();
+    el.focus({ preventScroll: true });
     el.select();
   }, [editing]);
 
   useEffect(() => {
     if (!editing) return undefined;
     const onPointerDown = (e: PointerEvent) => {
-      const root = rootRef.current;
-      const target = e.target as Node | null;
-      if (root && target && root.contains(target)) return;
+      const t = e.target as Element | null;
+      if (t?.closest?.('[data-rcb-title-edit="1"]')) return;
       window.requestAnimationFrame(() => {
         const el = inputRef.current;
         const value = (el?.value ?? '').trim() || name;
@@ -124,37 +293,75 @@ function NodeTitleLabel({
     return () => window.removeEventListener('pointerdown', onPointerDown, true);
   }, [editing, name, onRename]);
 
-  const stageBox = useMemo(() => {
-    const origin = rcbSceneToScreen(camera, box.left, box.top);
-    return {
-      left: origin.x,
-      top: origin.y,
-      width: Math.max(1, box.width * z),
-      height: Math.max(1, box.height * z),
-    };
-  }, [camera, box.left, box.top, box.width, box.height, z]);
-
-  const frameStyle = useMemo(
-    (): CSSProperties => ({
-      left: stageBox.left,
-      top: stageBox.top,
-      width: stageBox.width,
-      height: stageBox.height,
-      transform: Math.abs(angle) > 0.001 ? `rotate(${angle}deg)` : undefined,
-      transformOrigin: 'center center',
-    }),
-    [stageBox, angle]
+  const place = useMemo(
+    () => nodeTitleLabelWorldPlacement(box, z, { sizeText }),
+    [box.left, box.top, box.width, box.height, z, sizeText]
   );
 
-  const labelStyle = useMemo(
-    (): CSSProperties => ({
-      left: 0,
-      top: -NODE_TITLE_LABEL_GAP_PX - NODE_TITLE_LABEL_LINE_PX,
-      width: '100%',
-      height: NODE_TITLE_LABEL_LINE_PX,
-    }),
-    []
+  // Prefer shared world lattice; pad includes title strip so glyphs are not clipped.
+  const surf = useMemo(
+    () =>
+      selectionChromeSurfaceProps(
+        box,
+        angle,
+        place.gapScene + place.lineScene,
+        camera,
+        dpr
+      ),
+    [
+      box.left,
+      box.top,
+      box.width,
+      box.height,
+      angle,
+      place.gapScene,
+      place.lineScene,
+      camera,
+      dpr,
+    ]
   );
+
+  const iconKind: NodeTitleIcon =
+    icon || (dataAttr === 'frame-label' ? 'frame' : 'image');
+
+  const bodyTransform = rotated
+    ? `translate(${box.left} ${box.top}) rotate(${angle} ${box.width / 2} ${box.height / 2})`
+    : null;
+
+  /** Local coords when rotated; else absolute scene. */
+  const local = rotated
+    ? {
+        iconX: 0,
+        iconY: -(place.gapScene + place.lineScene) + (place.lineScene - place.iconSize) * 0.5,
+        nameX: place.iconSize + 4 * place.inv,
+        sizeX: Math.max(1, box.width),
+        textY: -(place.gapScene + place.lineScene * 0.5),
+        hitX: 0,
+        hitY: -(place.gapScene + place.lineScene),
+        hitW: Math.max(1, box.width),
+        hitH: place.lineScene,
+        nameMaxWidth: Math.max(
+          0,
+          Math.max(1, box.width) -
+            (place.iconSize + 4 * place.inv) -
+            8 * place.inv -
+            place.sizeReserve
+        ),
+      }
+    : {
+        iconX: place.iconX,
+        iconY: place.iconY,
+        nameX: place.nameX,
+        sizeX: place.sizeX,
+        textY: place.textY,
+        hitX: place.hitLeft,
+        hitY: place.hitTop,
+        hitW: place.hitWidth,
+        hitH: place.hitHeight,
+        nameMaxWidth: place.nameMaxWidth,
+      };
+
+  const nameClipId = `rcb-title-name-${clipUid}`;
 
   const commit = () => {
     const next = draft.trim() || name;
@@ -169,110 +376,188 @@ function NodeTitleLabel({
     dataAttr === 'frame-label'
       ? { 'data-frame-label': true as const }
       : { 'data-image-label': true as const };
-  const iconKind: NodeTitleIcon =
-    icon || (dataAttr === 'frame-label' ? 'frame' : 'image');
+
+  const onLabelPointerDown = (e: ReactPointerEvent<SVGRectElement>) => {
+    e.stopPropagation();
+    if (editing) return;
+    onSelect?.();
+    if (!onMove || e.button !== 0) return;
+    labelDragRef.current = {
+      originX,
+      originY,
+      clientX0: e.clientX,
+      clientY0: e.clientY,
+      started: false,
+    };
+    const onMoveWin = (ev: PointerEvent) => {
+      const drag = labelDragRef.current;
+      if (!drag) return;
+      const dx = (ev.clientX - drag.clientX0) / z;
+      const dy = (ev.clientY - drag.clientY0) / z;
+      if (!drag.started) {
+        if (Math.hypot(dx, dy) < 3) return;
+        drag.started = true;
+        setLabelDragging(true);
+        onMoveStart?.();
+      }
+      onMove(Math.round(drag.originX + dx), Math.round(drag.originY + dy), {
+        skipGrid: ev.ctrlKey || ev.metaKey,
+      });
+    };
+    const onUpWin = () => {
+      const wasDragging = labelDragRef.current?.started;
+      labelDragRef.current = null;
+      setLabelDragging(false);
+      window.removeEventListener('pointermove', onMoveWin);
+      window.removeEventListener('pointerup', onUpWin);
+      if (wasDragging) onMoveEnd?.();
+    };
+    window.addEventListener('pointermove', onMoveWin);
+    window.addEventListener('pointerup', onUpWin);
+  };
+
+  const labelBody = (
+    <>
+      <defs>
+        <clipPath id={nameClipId}>
+          <rect
+            x={local.nameX}
+            y={local.hitY}
+            width={Math.max(0, local.nameMaxWidth)}
+            height={local.hitH}
+          />
+        </clipPath>
+      </defs>
+      <rect
+        {...attrProps}
+        {...dataProps}
+        x={local.hitX}
+        y={local.hitY}
+        width={local.hitW}
+        height={local.hitH}
+        fill="transparent"
+        style={{ pointerEvents: 'all', cursor: onMove ? 'grab' : 'default' }}
+        onPointerDown={onLabelPointerDown}
+        onDoubleClick={(e) => {
+          if (!onRename) return;
+          e.preventDefault();
+          e.stopPropagation();
+          onSelect?.();
+          setDraft(name);
+          setEditing(true);
+        }}
+      />
+      <TitleIconSvg kind={iconKind} x={local.iconX} y={local.iconY} size={place.iconSize} />
+      {!editing ? (
+        <text
+          x={local.nameX}
+          y={local.textY}
+          fill={MUTED}
+          fontSize={place.fontSize}
+          fontWeight={500}
+          fontFamily="ui-sans-serif, system-ui, sans-serif"
+          textAnchor="start"
+          dominantBaseline="central"
+          clipPath={`url(#${nameClipId})`}
+          style={{ pointerEvents: 'none' }}
+        >
+          {name}
+        </text>
+      ) : null}
+      <text
+        x={local.sizeX}
+        y={local.textY}
+        fill={MUTED}
+        fontSize={place.fontSize}
+        fontWeight={500}
+        fontFamily="ui-sans-serif, system-ui, sans-serif"
+        textAnchor="end"
+        dominantBaseline="central"
+        opacity={0.8}
+        style={{ pointerEvents: 'none' }}
+      >
+        {sizeText}
+      </text>
+    </>
+  );
+
+  // Unscaled overlay + scene→screen; anchor at text center then translateY(-50%).
+  const editLocalX = rotated ? local.nameX : place.nameX - box.left;
+  const editLocalY = rotated ? local.textY : place.textY - box.top;
+  const editScene = rotateLocalToScene(editLocalX, editLocalY, box, angle);
+  const editScreen = rcbSceneToScreen(camera, editScene.x, editScene.y, dpr);
+  const editScreenW = Math.max(44, local.nameMaxWidth * z);
+
+  const editInput =
+    editing && onRename ? (
+      <RcbOverlayPortal>
+        <div
+          data-rcb-title-edit="1"
+          data-text-inline-editor
+          className="pointer-events-auto absolute z-[40] overflow-hidden"
+          style={{
+            left: editScreen.x,
+            top: editScreen.y,
+            width: editScreenW,
+            height: NODE_TITLE_LABEL_LINE_PX,
+            transform: 'translateY(-50%)',
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          <input
+            ref={inputRef}
+            value={draft}
+            aria-label={renameAriaLabel || name}
+            className="block w-full appearance-none border-0 bg-transparent p-0 font-medium leading-none text-[var(--ink)] shadow-none outline-none ring-0"
+            style={{
+              fontSize: TITLE_EDIT_FONT_PX,
+              lineHeight: `${NODE_TITLE_LABEL_LINE_PX}px`,
+              height: NODE_TITLE_LABEL_LINE_PX,
+              margin: 0,
+              padding: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                commit();
+              }
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                setDraft(name);
+                setEditing(false);
+              }
+              e.stopPropagation();
+            }}
+          />
+        </div>
+      </RcbOverlayPortal>
+    ) : null;
 
   return (
-    <RcbOverlayPortal>
-      <div className="pointer-events-none absolute z-[6]" style={frameStyle}>
-        <div
-          ref={rootRef}
-          {...attrProps}
-          {...dataProps}
-          className="pointer-events-auto absolute flex w-full items-center justify-between gap-2 text-[11px] font-medium leading-none text-[var(--muted)]"
-          style={labelStyle}
-          onPointerDown={(e) => {
-            e.stopPropagation();
-            if (editing) return;
-            onSelect?.();
-            if (!onMove || e.button !== 0) return;
-            labelDragRef.current = {
-              originX,
-              originY,
-              clientX0: e.clientX,
-              clientY0: e.clientY,
-              started: false,
-            };
-            const onMoveWin = (ev: PointerEvent) => {
-              const drag = labelDragRef.current;
-              if (!drag) return;
-              const dx = (ev.clientX - drag.clientX0) / z;
-              const dy = (ev.clientY - drag.clientY0) / z;
-              if (!drag.started) {
-                if (Math.hypot(dx, dy) < 3) return;
-                drag.started = true;
-                setLabelDragging(true);
-                onMoveStart?.();
-              }
-              onMove(Math.round(drag.originX + dx), Math.round(drag.originY + dy), {
-                skipGrid: ev.ctrlKey || ev.metaKey,
-              });
-            };
-            const onUpWin = () => {
-              const wasDragging = labelDragRef.current?.started;
-              labelDragRef.current = null;
-              setLabelDragging(false);
-              window.removeEventListener('pointermove', onMoveWin);
-              window.removeEventListener('pointerup', onUpWin);
-              if (wasDragging) onMoveEnd?.();
-            };
-            window.addEventListener('pointermove', onMoveWin);
-            window.addEventListener('pointerup', onUpWin);
-          }}
-        >
-          <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
-            <TitleIcon kind={iconKind} />
-            {editing && onRename ? (
-              <input
-                ref={inputRef}
-                value={draft}
-                aria-label={renameAriaLabel || name}
-                size={Math.max(1, draft.length || 1)}
-                className="h-4 appearance-none border-0 bg-transparent p-0 text-[11px] font-medium leading-none text-[var(--ink)] shadow-none outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0"
-                style={{
-                  width: `${Math.max(1, draft.length || 1)}ch`,
-                  fieldSizing: 'content',
-                } as CSSProperties}
-                onChange={(e) => setDraft(e.target.value)}
-                onBlur={commit}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.preventDefault();
-                    commit();
-                  }
-                  if (e.key === 'Escape') {
-                    e.preventDefault();
-                    setDraft(name);
-                    setEditing(false);
-                  }
-                }}
-                onPointerDown={(e) => e.stopPropagation()}
-              />
-            ) : (
-              <button
-                type="button"
-                className="truncate text-left leading-none text-[var(--muted)] hover:text-[var(--ink)]"
-                onDoubleClick={(e) => {
-                  if (!onRename) return;
-                  e.preventDefault();
-                  e.stopPropagation();
-                  onSelect?.();
-                  setDraft(name);
-                  setEditing(true);
-                }}
-              >
-                {name}
-              </button>
-            )}
-          </div>
-          <span className="shrink-0 tabular-nums leading-none text-[var(--muted)] opacity-80">
-            {Math.round(sizeWidth)}
-            {' × '}
-            {Math.round(sizeHeight)}
-          </span>
-        </div>
-      </div>
-    </RcbOverlayPortal>
+    <>
+      <svg
+        data-rcb-infinite="1"
+        data-rcb-node-title="1"
+        className="absolute z-[1000002] overflow-visible"
+        width={surf.width}
+        height={surf.height}
+        viewBox={surf.viewBox}
+        preserveAspectRatio="none"
+        style={{
+          ...surf.style,
+          pointerEvents: 'none',
+        }}
+        aria-hidden={false}
+      >
+        {bodyTransform ? <g transform={bodyTransform}>{labelBody}</g> : labelBody}
+      </svg>
+      {editInput}
+    </>
   );
 }
 

--- a/apps/web/src/components/rcb/selection/chrome/PolygonShapeHandlesOverlay.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/PolygonShapeHandlesOverlay.tsx
@@ -30,13 +30,19 @@ import {
   notifyShapeHostGeometry,
 } from '@/components/rcb/shapes/shapeHostRegistry';
 import type { SceneBox } from '../alignGuides';
-import { WorldSvgFrame, WorldScreenBadge } from '../SelectionChrome';
+import {
+  CHROME_HANDLE_HIT_PX,
+  CHROME_HANDLE_VIS_PX,
+  CHROME_STROKE_PX,
+  WorldSvgFrame,
+  WorldScreenBadge,
+} from '../SelectionChrome';
 
 const DRAG_DISTANCE_SQUARED = 16;
 const SIDES_DRAG_STEP_PX = 14;
-const KNOB_VIS_PX = 8;
-const KNOB_HIT_PX = 18;
-const KNOB_STROKE_PX = 1.5;
+const KNOB_VIS_PX = CHROME_HANDLE_VIS_PX;
+const KNOB_HIT_PX = CHROME_HANDLE_HIT_PX;
+const KNOB_STROKE_PX = CHROME_STROKE_PX;
 /** Min inward seat when R=0 so the knob clears the vertex / resize chrome. */
 const RADIUS_MIN_INSET_PX = 18;
 

--- a/apps/web/src/components/rcb/selection/chrome/SelectionToolbarShell.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/SelectionToolbarShell.tsx
@@ -1,21 +1,18 @@
 import {
   useRef,
   type CSSProperties,
+  type HTMLAttributes,
   type PointerEvent as ReactPointerEvent,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
   memo,
 } from 'react';
-import {
-  RcbOverlayPortal,
-  useRcbCamera,
-  useRcbScreenToolbarStyle,
-} from '../../camera/context';
-import { rcbScreenPxToScene } from '../../core/math';
+import { useRcbCamera } from '../../camera/context';
+import { rcbCameraCssZoom, rcbScreenPxToScene } from '../../core/math';
 import { FloatingToolbar } from '@/components/editor/chrome/FloatingToolbar';
 import { cn } from '@/utils/classnames';
 
-/** Interactive chrome controls inside canvas overlays (toolbars / generators / menus). */
+/** Interactive controls inside canvas overlays (toolbars / generators / menus). */
 const CHROME_ACTION_SEL =
   'button:not([disabled]), [role="button"]:not([aria-disabled="true"]), [role="menuitem"]:not([aria-disabled="true"])';
 
@@ -29,9 +26,8 @@ function chromeActionFromEvent(
 }
 
 /**
- * Same activation path as canvas node hits: pointer down/up.
- * `element.click()` runs existing onClick handlers; only the following real
- * click (after a synthetic activate) is suppressed — not every button click.
+ * Activate chrome buttons on pointer down/up (same path as node hits).
+ * Suppresses the following real click after a synthetic `.click()`.
  */
 export function useChromePointerActivate() {
   const armedRef = useRef<HTMLElement | null>(null);
@@ -77,22 +73,21 @@ export function useChromePointerActivate() {
 }
 
 /**
- * Title row above frame (must stay in sync with HtmlArtboardFrame).
- * Screen pixels — independent of zoom.
+ * Title row gaps above the frame (screen px → scene via /zoom).
  */
-export const NODE_TITLE_LABEL_GAP_PX = 6;
+export const NODE_TITLE_LABEL_GAP_PX = 10;
 export const NODE_TITLE_LABEL_LINE_PX = 16;
 
-/** Air between title top and toolbar bottom when docking above a titled node. */
-export const SELECTION_TOOLBAR_ABOVE_LABEL_GAP_PX = 10;
+/** Gap between title top and toolbar bottom (above dock, titled). */
+export const SELECTION_TOOLBAR_ABOVE_LABEL_GAP_PX = 8;
 
-/** Air between box edge and toolbar when there is no title row. */
-export const SELECTION_TOOLBAR_ABOVE_BOX_GAP_PX = 12;
+/** Gap between box edge and toolbar when there is no title. */
+export const SELECTION_TOOLBAR_ABOVE_BOX_GAP_PX = 20;
 
-/** Air between box bottom and toolbar top when docking below. */
-export const SELECTION_TOOLBAR_BELOW_BOX_GAP_PX = 8;
+/** Gap between box bottom and toolbar top (below dock). */
+export const SELECTION_TOOLBAR_BELOW_BOX_GAP_PX = 20;
 
-/** Half selection knob + air — knobs sit outside the chrome edge. */
+/** Half knob + air outside the chrome edge. */
 export const SELECTION_HANDLE_CLEARANCE_PX = 6;
 
 export type SelectionToolbarBox = {
@@ -102,7 +97,7 @@ export type SelectionToolbarBox = {
   height: number;
 };
 
-/** Screen px from selection top → toolbar anchor (toolbar bottom when above). */
+/** Screen px from selection top → toolbar bottom (above dock). */
 export function toolbarAboveClearancePx(hasTitleLabel: boolean) {
   if (!hasTitleLabel) return SELECTION_TOOLBAR_ABOVE_BOX_GAP_PX;
   return (
@@ -112,29 +107,109 @@ export function toolbarAboveClearancePx(hasTitleLabel: boolean) {
   );
 }
 
+/** Scene Y of the toolbar bottom edge when docking above `boxTop`. */
+export function selectionToolbarAboveAnchorScene(
+  boxTop: number,
+  zoom: number,
+  hasTitleLabel: boolean,
+  edgePadScene = 0
+): number {
+  const z = Math.max(0.05, zoom || 1);
+  const handleClear = SELECTION_HANDLE_CLEARANCE_PX / z;
+  const clear = handleClear + Math.max(0, edgePadScene);
+  return boxTop - toolbarAboveClearancePx(hasTitleLabel) / z - clear;
+}
+
 /**
- * Shared world-space placement for selection / frame floating toolbars.
- * With `anchor: 'bottom'`, `top` is the bottom edge of the toolbar (clears titles).
+ * Stage layout px from plate top → toolbar bottom (above dock).
+ * Pass `viewportScale` when an ancestor CSS-scales the stage.
+ */
+export function toolbarAboveScreenGapPx(
+  boxTop: number,
+  zoom: number,
+  hasTitleLabel: boolean,
+  edgePadScene = 0,
+  viewportScale = 1
+): number {
+  const z = Math.max(0.05, zoom || 1);
+  const sx = viewportScale > 0 ? viewportScale : 1;
+  const anchor = selectionToolbarAboveAnchorScene(
+    boxTop,
+    z,
+    hasTitleLabel,
+    edgePadScene
+  );
+  return (boxTop - anchor) * z * sx;
+}
+
+/**
+ * World-layer HTML chrome under camera `scale(zoom)`.
+ * Nested: outer `scale(1/zoom)` at the scene anchor, inner %-translate.
+ */
+export function WorldScreenChromeRoot({
+  left,
+  top,
+  anchor = 'bottom',
+  className,
+  style,
+  children,
+  ...rest
+}: {
+  left: number;
+  top: number;
+  anchor?: 'bottom' | 'top';
+  className?: string;
+  style?: CSSProperties;
+  children: ReactNode;
+} & Omit<HTMLAttributes<HTMLDivElement>, 'style' | 'children'>) {
+  const camera = useRcbCamera();
+  const inv = 1 / rcbCameraCssZoom(camera);
+  return (
+    <div
+      className={className}
+      style={{
+        position: 'absolute',
+        left,
+        top,
+        transform: `scale(${inv})`,
+        transformOrigin: '0 0',
+        ...style,
+      }}
+      {...rest}
+    >
+      <div
+        style={{
+          transform:
+            anchor === 'bottom' ? 'translate(-50%, -100%)' : 'translate(-50%, 0)',
+          width: 'max-content',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * World-space placement for selection / frame floating toolbars.
+ * With `anchor: 'bottom'`, `top` is the toolbar bottom edge.
  */
 export function useSelectionToolbarPlacement(opts: {
   box: SelectionToolbarBox | null | undefined;
-  /** Image / frame name+size row above the box. */
   hasTitleLabel?: boolean;
-  /**
-   * Extra scene-space pad outside the chrome box (e.g. center-stroke ink beyond
-   * the path face). Added on top of handle clearance.
-   */
+  /** Extra scene pad outside the chrome (e.g. stroke ink beyond the path). */
   edgePadScene?: number;
 }): {
-  style: CSSProperties;
   preferAbove: boolean;
   left: number;
   top: number;
+  anchor: 'bottom' | 'top';
 } {
-  const { zoom } = useRcbCamera();
+  const camera = useRcbCamera();
+  const zoom = rcbCameraCssZoom(camera);
   const hasTitle = Boolean(opts.hasTitleLabel);
-  const handleClear = rcbScreenPxToScene(SELECTION_HANDLE_CLEARANCE_PX, zoom);
   const edgePad = Math.max(0, Number(opts.edgePadScene) || 0);
+  const handleClear = rcbScreenPxToScene(SELECTION_HANDLE_CLEARANCE_PX, zoom);
   const clear = handleClear + edgePad;
   const aboveGap = rcbScreenPxToScene(toolbarAboveClearancePx(hasTitle), zoom) + clear;
   const belowGap = rcbScreenPxToScene(SELECTION_TOOLBAR_BELOW_BOX_GAP_PX, zoom) + clear;
@@ -143,36 +218,32 @@ export function useSelectionToolbarPlacement(opts: {
   const left = box ? box.left + box.width / 2 : 0;
   let top = 0;
   if (box) {
-    top = preferAbove ? box.top - aboveGap : box.top + box.height + belowGap;
+    top = preferAbove
+      ? selectionToolbarAboveAnchorScene(box.top, zoom, hasTitle, edgePad)
+      : box.top + box.height + belowGap;
   }
 
-  const style = useRcbScreenToolbarStyle({
+  return {
+    preferAbove,
     left,
     top,
-    anchor: preferAbove ? 'bottom' : 'top',
-  });
-
-  return { style, preferAbove, left, top };
+    anchor: (preferAbove ? 'bottom' : 'top') as 'bottom' | 'top',
+  };
 }
 
 type ShellProps = {
   box: SelectionToolbarBox | null | undefined;
   hasTitleLabel?: boolean;
-  /** Scene-space pad beyond chrome for outer stroke ink. */
+  /** Scene pad beyond chrome for outer stroke ink. */
   edgePadScene?: number;
   children: ReactNode;
   className?: string;
-  /** Mark as frame toolbar for hit-testing / dismiss selectors. */
   isFrameToolbar?: boolean;
-  /** Transparent / unstyled inner (icon image tools). */
   bare?: boolean;
   zIndexClassName?: string;
 };
 
-/**
- * Portal + screen-fixed placement + chrome for selection toolbars.
- * Keeps Frame / Image / Shape bars aligned so titles are never covered.
- */
+/** World-layer selection toolbars (clears titles; aligns Frame / Image / Shape). */
 function SelectionToolbarShell({
   box,
   hasTitleLabel = false,
@@ -183,24 +254,28 @@ function SelectionToolbarShell({
   bare = false,
   zIndexClassName = 'z-30',
 }: ShellProps) {
-  const { style } = useSelectionToolbarPlacement({ box, hasTitleLabel, edgePadScene });
+  const { left, top, anchor } = useSelectionToolbarPlacement({
+    box,
+    hasTitleLabel,
+    edgePadScene,
+  });
   const chromePointer = useChromePointerActivate();
   if (!box) return null;
 
   return (
-    <RcbOverlayPortal>
-      <div
-        data-sel-toolbar
-        {...(isFrameToolbar ? { 'data-frame-toolbar': true } : {})}
-        className={cn('pointer-events-auto absolute overflow-visible', zIndexClassName)}
-        style={style}
-        {...chromePointer}
-      >
-        <FloatingToolbar bare={bare} className={className}>
-          {children}
-        </FloatingToolbar>
-      </div>
-    </RcbOverlayPortal>
+    <WorldScreenChromeRoot
+      left={left}
+      top={top}
+      anchor={anchor}
+      data-sel-toolbar
+      {...(isFrameToolbar ? { 'data-frame-toolbar': true } : {})}
+      className={cn('pointer-events-auto overflow-visible', zIndexClassName)}
+      {...chromePointer}
+    >
+      <FloatingToolbar bare={bare} className={className}>
+        {children}
+      </FloatingToolbar>
+    </WorldScreenChromeRoot>
   );
 }
 

--- a/apps/web/src/components/rcb/selection/chrome/SmartGuidesOverlay.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/SmartGuidesOverlay.tsx
@@ -1,14 +1,23 @@
 /**
- * Smart guides: Path2D on RcbSceneOverlayCanvas (same stack as pen / shape draw).
- * Scene coords only — no separate host/fallback SVG (those drift under browser zoom).
+ * Smart guides as scene-space SVG under the shared world surface.
+ * Must portal into `data-rcb-smart-guides-mount` — a sibling
+ * `sceneSurfaceSvgProps` SVG snaps its origin independently under fractional
+ * browser DPR and drifts vs the pixel grid (same bug as shape draw preview).
+ * Snap math stays in alignGuides; this file only paints.
+ *
+ * Paint contract: one continuous stroke per guide, then small dots at marks.
+ * Do not draw × arms on the guide — those read as "broken" segments at high zoom.
  */
-import { useEffect, useLayoutEffect, useRef } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import { useRcbCamera } from '@/components/rcb/camera/context';
 import { CHROME_STROKE_PX } from '../SelectionChrome';
 import { SMART_GUIDE_COLOR, type SmartGuideGap, type SmartGuideLine } from '../alignGuides';
-import RcbSceneOverlayCanvas, {
-  type RcbSceneOverlayCanvasHandle,
-} from '@/components/rcb/canvas/RcbSceneOverlayCanvas';
+import {
+  getSceneSmartGuidesMount,
+  getSceneWorldEpoch,
+  subscribeShapeHosts,
+} from '../../shapes/shapeHostRegistry';
 
 const GUIDE_STROKE = SMART_GUIDE_COLOR;
 
@@ -16,187 +25,60 @@ function isGapGuide(g: SmartGuideLine): g is SmartGuideGap {
   return g.kind === 'gap';
 }
 
-function guideBounds(guides: SmartGuideLine[]): {
-  minX: number;
-  minY: number;
-  maxX: number;
-  maxY: number;
-} | null {
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  for (const g of guides) {
-    if (isGapGuide(g)) {
-      if (g.axis === 'x') {
-        minX = Math.min(minX, g.from, g.to);
-        maxX = Math.max(maxX, g.from, g.to);
-        minY = Math.min(minY, g.at);
-        maxY = Math.max(maxY, g.at);
-      } else {
-        minY = Math.min(minY, g.from, g.to);
-        maxY = Math.max(maxY, g.from, g.to);
-        minX = Math.min(minX, g.at);
-        maxX = Math.max(maxX, g.at);
-      }
-      continue;
-    }
-    if (g.axis === 'x') {
-      minX = Math.min(minX, g.at);
-      maxX = Math.max(maxX, g.at);
-      minY = Math.min(minY, g.from, g.to);
-      maxY = Math.max(maxY, g.from, g.to);
-    } else {
-      minY = Math.min(minY, g.at);
-      maxY = Math.max(maxY, g.at);
-      minX = Math.min(minX, g.from, g.to);
-      maxX = Math.max(maxX, g.from, g.to);
-    }
-    for (const m of g.marks || []) {
-      minX = Math.min(minX, m.x);
-      maxX = Math.max(maxX, m.x);
-      minY = Math.min(minY, m.y);
-      maxY = Math.max(maxY, m.y);
-    }
-  }
-  if (!Number.isFinite(minX)) return null;
-  return { minX, minY, maxX, maxY };
-}
-
-function paintBadge(
-  ctx: CanvasRenderingContext2D,
-  text: string,
-  x: number,
-  y: number,
-  inv: number,
-  anchor: 'below' | 'right'
-) {
+function GuideBadge({
+  text,
+  x,
+  y,
+  inv,
+  anchor,
+}: {
+  text: string;
+  x: number;
+  y: number;
+  inv: number;
+  anchor: 'below' | 'right';
+}) {
   const fontSize = 11 * inv;
   const padX = 5.5 * inv;
   const padY = 2.25 * inv;
   const radius = 4 * inv;
   const gap = 6 * inv;
-  ctx.font = `600 ${fontSize}px system-ui, sans-serif`;
-  const tw = Math.max(14 * inv, ctx.measureText(String(text)).width);
+  const tw = Math.max(14 * inv, String(text).length * fontSize * 0.62);
   const th = fontSize * 1.2;
   const w = tw + padX * 2;
   const h = th + padY * 2;
-  let cx = x;
-  let cy = y;
-  if (anchor === 'below') cy = y + gap + h / 2;
-  else cx = x + gap + w / 2;
-
-  ctx.beginPath();
-  if (typeof ctx.roundRect === 'function') {
-    ctx.roundRect(cx - w / 2, cy - h / 2, w, h, radius);
-  } else {
-    ctx.rect(cx - w / 2, cy - h / 2, w, h);
-  }
-  ctx.fillStyle = GUIDE_STROKE;
-  ctx.fill();
-  ctx.fillStyle = '#fff';
-  ctx.textAlign = 'center';
-  ctx.textBaseline = 'middle';
-  ctx.fillText(String(text), cx, cy);
+  const cx = anchor === 'right' ? x + gap + w / 2 : x;
+  const cy = anchor === 'below' ? y + gap + h / 2 : y;
+  return (
+    <g>
+      <rect
+        x={cx - w / 2}
+        y={cy - h / 2}
+        width={w}
+        height={h}
+        rx={radius}
+        ry={radius}
+        fill={GUIDE_STROKE}
+      />
+      <text
+        x={cx}
+        y={cy}
+        fill="#fff"
+        fontSize={fontSize}
+        fontWeight={600}
+        fontFamily="system-ui, sans-serif"
+        textAnchor="middle"
+        dominantBaseline="central"
+      >
+        {text}
+      </text>
+    </g>
+  );
 }
 
-function paintPathMark(
-  ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  arm: number,
-  stroke: number
-) {
-  ctx.strokeStyle = GUIDE_STROKE;
-  ctx.lineWidth = stroke;
-  ctx.lineCap = 'butt';
-  ctx.beginPath();
-  ctx.moveTo(x - arm, y - arm);
-  ctx.lineTo(x + arm, y + arm);
-  ctx.moveTo(x + arm, y - arm);
-  ctx.lineTo(x - arm, y + arm);
-  ctx.stroke();
-}
-
-function paintGuidesOnCtx(
-  ctx: CanvasRenderingContext2D,
-  guides: SmartGuideLine[],
-  stroke: number,
-  tip: number,
-  inv: number
-) {
-  const markArm = 3.5 * inv;
-  ctx.strokeStyle = GUIDE_STROKE;
-  ctx.fillStyle = GUIDE_STROKE;
-  ctx.lineWidth = stroke;
-  ctx.lineCap = 'butt';
-  ctx.lineJoin = 'miter';
-
-  for (const g of guides) {
-    if (isGapGuide(g)) {
-      const x0 = g.axis === 'x' ? Math.min(g.from, g.to) : g.at;
-      const x1 = g.axis === 'x' ? Math.max(g.from, g.to) : g.at;
-      const y0 = g.axis === 'y' ? Math.min(g.from, g.to) : g.at;
-      const y1 = g.axis === 'y' ? Math.max(g.from, g.to) : g.at;
-      ctx.beginPath();
-      if (g.axis === 'x') {
-        ctx.moveTo(x0, g.at);
-        ctx.lineTo(x1, g.at);
-      } else {
-        ctx.moveTo(g.at, y0);
-        ctx.lineTo(g.at, y1);
-      }
-      ctx.stroke();
-
-      ctx.beginPath();
-      if (g.axis === 'x') {
-        ctx.moveTo(x0 + tip, g.at - tip);
-        ctx.lineTo(x0, g.at);
-        ctx.lineTo(x0 + tip, g.at + tip);
-        ctx.moveTo(x1 - tip, g.at - tip);
-        ctx.lineTo(x1, g.at);
-        ctx.lineTo(x1 - tip, g.at + tip);
-      } else {
-        ctx.moveTo(g.at - tip, y0 + tip);
-        ctx.lineTo(g.at, y0);
-        ctx.lineTo(g.at + tip, y0 + tip);
-        ctx.moveTo(g.at - tip, y1 - tip);
-        ctx.lineTo(g.at, y1);
-        ctx.lineTo(g.at + tip, y1 - tip);
-      }
-      ctx.stroke();
-
-      const midX = g.axis === 'x' ? (g.from + g.to) / 2 : g.at;
-      const midY = g.axis === 'y' ? (g.from + g.to) / 2 : g.at;
-      paintBadge(ctx, String(g.dist), midX, midY, inv, g.axis === 'x' ? 'below' : 'right');
-      continue;
-    }
-
-    ctx.beginPath();
-    if (g.axis === 'x') {
-      ctx.moveTo(g.at, g.from);
-      ctx.lineTo(g.at, g.to);
-    } else {
-      ctx.moveTo(g.from, g.at);
-      ctx.lineTo(g.to, g.at);
-    }
-    ctx.stroke();
-    for (const m of g.marks || []) {
-      paintPathMark(ctx, m.x, m.y, markArm, stroke);
-    }
-  }
-}
-
-/** Clear leftover guide groups injected into shape hosts by older builds. */
-function clearLegacyHostGuides() {
-  if (typeof document === 'undefined') return;
-  document.querySelectorAll('[data-rcb-smart-guides]').forEach((n) => {
-    try {
-      n.remove();
-    } catch {
-      /* ignore */
-    }
-  });
+/** Filled dot on a guide — does not interrupt the continuous stroke. */
+function GuideMarkDot({ x, y, r }: { x: number; y: number; r: number }) {
+  return <circle cx={x} cy={y} r={r} fill={GUIDE_STROKE} stroke="none" />;
 }
 
 export default function SmartGuidesOverlay({
@@ -204,59 +86,108 @@ export default function SmartGuidesOverlay({
   mirrorNodeId: _mirrorNodeId = null,
 }: {
   guides: SmartGuideLine[];
-  /** Kept for call-site compat; Path2D overlay does not host-mirror. */
+  /** Kept for call-site compat. */
   mirrorNodeId?: string | null;
 }) {
   const camera = useRcbCamera();
-  const overlayRef = useRef<RcbSceneOverlayCanvasHandle>(null);
-  const guidesRef = useRef(guides);
-  guidesRef.current = guides;
-
   const z = Math.max(0.05, camera.zoom || 1);
   const inv = 1 / z;
+  // Keep ≥1 CSS px under camera scale so the guide never drops to a dashed hairline.
   const stroke = Math.max(1 / z, CHROME_STROKE_PX / z);
   const tip = 5 * inv;
-  const guideKey = guides
-    .map((g) =>
-      isGapGuide(g)
-        ? `g:${g.axis}:${g.from}:${g.to}:${g.at}:${g.dist}`
-        : `a:${g.axis}:${g.at}:${g.from}:${g.to}:${(g.marks || [])
-            .map((m) => `${m.x},${m.y}`)
-            .join(';')}`
-    )
-    .join('|');
+  const markR = Math.max(stroke * 2, 3.5 * inv);
 
-  useEffect(() => {
-    clearLegacyHostGuides();
-    return () => {
-      clearLegacyHostGuides();
-      overlayRef.current?.clear();
-    };
-  }, []);
+  // Remount when shared world SVG appears / is replaced.
+  const [, setWorldEpoch] = useState(() => getSceneWorldEpoch());
+  useEffect(
+    () =>
+      subscribeShapeHosts(() => {
+        setWorldEpoch((prev) => {
+          const next = getSceneWorldEpoch();
+          return prev === next ? prev : next;
+        });
+      }),
+    []
+  );
+  const guidesMount = getSceneSmartGuidesMount();
 
-  useLayoutEffect(() => {
-    const handle = overlayRef.current;
-    const list = guidesRef.current;
-    if (!handle) return;
-    if (!list.length) {
-      handle.clear();
-      return;
-    }
-    const bounds = guideBounds(list);
-    if (!bounds) {
-      handle.clear();
-      return;
-    }
-    const pad = Math.max(36 * inv, stroke * 10, tip * 8);
-    const ctx = handle.beginFrame({
-      left: bounds.minX - pad,
-      top: bounds.minY - pad,
-      width: Math.max(1, bounds.maxX - bounds.minX + pad * 2),
-      height: Math.max(1, bounds.maxY - bounds.minY + pad * 2),
+  const nodes = useMemo(() => {
+    if (!guides.length) return null;
+    const out: ReactNode[] = [];
+    guides.forEach((g, i) => {
+      if (isGapGuide(g)) {
+        const x0 = g.axis === 'x' ? Math.min(g.from, g.to) : g.at;
+        const x1 = g.axis === 'x' ? Math.max(g.from, g.to) : g.at;
+        const y0 = g.axis === 'y' ? Math.min(g.from, g.to) : g.at;
+        const y1 = g.axis === 'y' ? Math.max(g.from, g.to) : g.at;
+        const midX = g.axis === 'x' ? (g.from + g.to) / 2 : g.at;
+        const midY = g.axis === 'y' ? (g.from + g.to) / 2 : g.at;
+        out.push(
+          <g key={`gap-${i}`}>
+            <line
+              x1={g.axis === 'x' ? x0 : g.at}
+              y1={g.axis === 'x' ? g.at : y0}
+              x2={g.axis === 'x' ? x1 : g.at}
+              y2={g.axis === 'x' ? g.at : y1}
+              stroke={GUIDE_STROKE}
+              strokeWidth={stroke}
+              strokeLinecap="butt"
+              shapeRendering="geometricPrecision"
+            />
+            {g.axis === 'x' ? (
+              <path
+                d={`M ${x0 + tip} ${g.at - tip} L ${x0} ${g.at} L ${x0 + tip} ${g.at + tip} M ${x1 - tip} ${g.at - tip} L ${x1} ${g.at} L ${x1 - tip} ${g.at + tip}`}
+                fill="none"
+                stroke={GUIDE_STROKE}
+                strokeWidth={stroke}
+              />
+            ) : (
+              <path
+                d={`M ${g.at - tip} ${y0 + tip} L ${g.at} ${y0} L ${g.at + tip} ${y0 + tip} M ${g.at - tip} ${y1 - tip} L ${g.at} ${y1} L ${g.at + tip} ${y1 - tip}`}
+                fill="none"
+                stroke={GUIDE_STROKE}
+                strokeWidth={stroke}
+              />
+            )}
+            <GuideBadge
+              text={String(g.dist)}
+              x={midX}
+              y={midY}
+              inv={inv}
+              anchor={g.axis === 'x' ? 'below' : 'right'}
+            />
+          </g>
+        );
+        return;
+      }
+      // Continuous align stroke first; dots on top (no × that reads as dashed).
+      out.push(
+        <g key={`align-${i}`}>
+          <line
+            x1={g.axis === 'x' ? g.at : g.from}
+            y1={g.axis === 'x' ? g.from : g.at}
+            x2={g.axis === 'x' ? g.at : g.to}
+            y2={g.axis === 'x' ? g.to : g.at}
+            stroke={GUIDE_STROKE}
+            strokeWidth={stroke}
+            strokeLinecap="butt"
+            shapeRendering="geometricPrecision"
+          />
+          {(g.marks || []).map((m, mi) => (
+            <GuideMarkDot key={mi} x={m.x} y={m.y} r={markR} />
+          ))}
+        </g>
+      );
     });
-    if (!ctx) return;
-    paintGuidesOnCtx(ctx, list, stroke, tip, inv);
-  }, [guideKey, stroke, tip, inv, camera.x, camera.y, camera.zoom]);
+    return out;
+  }, [guides, inv, stroke, tip, markR]);
 
-  return <RcbSceneOverlayCanvas ref={overlayRef} zClass="z-[1000000]" />;
+  if (!nodes || !guidesMount) return null;
+
+  return createPortal(
+    <g data-rcb-smart-guides="1" pointerEvents="none" aria-hidden>
+      {nodes}
+    </g>,
+    guidesMount
+  );
 }

--- a/apps/web/src/components/rcb/selection/chrome/StarShapeHandlesOverlay.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/StarShapeHandlesOverlay.tsx
@@ -29,13 +29,19 @@ import {
   notifyShapeHostGeometry,
 } from '@/components/rcb/shapes/shapeHostRegistry';
 import type { SceneBox } from '../alignGuides';
-import { WorldSvgFrame, WorldScreenBadge } from '../SelectionChrome';
+import {
+  CHROME_HANDLE_HIT_PX,
+  CHROME_HANDLE_VIS_PX,
+  CHROME_STROKE_PX,
+  WorldSvgFrame,
+  WorldScreenBadge,
+} from '../SelectionChrome';
 
 const DRAG_DISTANCE_SQUARED = 16;
 const SIDES_DRAG_STEP_PX = 14;
-const KNOB_VIS_PX = 8;
-const KNOB_HIT_PX = 18;
-const KNOB_STROKE_PX = 1.5;
+const KNOB_VIS_PX = CHROME_HANDLE_VIS_PX;
+const KNOB_HIT_PX = CHROME_HANDLE_HIT_PX;
+const KNOB_STROKE_PX = CHROME_STROKE_PX;
 const RADIUS_MIN_INSET_PX = 18;
 
 function liveNodeEl(nodeId: string): Element | null {

--- a/apps/web/src/components/rcb/selection/chrome/index.ts
+++ b/apps/web/src/components/rcb/selection/chrome/index.ts
@@ -7,6 +7,7 @@ export { default as AspectRatioPresetMenu } from './AspectRatioPresetMenu';
 export { AspectPresetGlyph, ELEMENT_ASPECT_PRESETS } from './AspectRatioPresetMenu';
 export {
   SelectionToolbarShell,
+  WorldScreenChromeRoot,
   useChromePointerActivate,
   SELECTION_TOOLBAR_BELOW_BOX_GAP_PX,
   NODE_TITLE_LABEL_GAP_PX,

--- a/apps/web/src/components/rcb/shapes/RcbShapeHost.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapeHost.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, type CSSProperties, memo } from 'react';
+import { useEffect, useRef, useState, type CSSProperties, memo } from 'react';
 import { useRcbCamera } from '@/components/rcb/camera/context';
+import { rcbCameraCssZoom } from '@/components/rcb/core/math';
 import { applyFrameContentClip } from '@/components/rcb/frames/frameContentClip';
 import { strokeVisualOutset } from '@/components/rcb/scene/document/sceneEffects';
 import {
@@ -15,8 +16,12 @@ import {
   parseLayerOpacity,
 } from '@/components/rcb/selection/chrome/BlendModeControl';
 import {
+  getSceneShapesMount,
+  getSceneWorldEpoch,
+  getSceneWorldRoot,
   getSharedNodeEls,
   registerShapeHost,
+  subscribeShapeHosts,
   unregisterShapeHost,
   updateShapeHostElement,
 } from '@/components/rcb/shapes/shapeHostRegistry';
@@ -57,9 +62,8 @@ function setHostPaintOpacity(el: Element | null | undefined, hidden: boolean) {
 
 /**
  * One paint host per scene node under the camera world layer.
- * Committed ink is SVG (vector stays sharp under CSS camera zoom).
- * Canvas Path2D caches geometry for hit-test + draw-tool overlays (see sceneShapes).
- * Only mounted while in (or near) the viewport — see RcbShapesLayer culling.
+ * Prefers the shared scene-world SVG (grid + shapes, one raster lattice).
+ * Falls back to a private infinite SVG when the world root is not mounted yet.
  */
 function RcbShapeHost({
   nodeId,
@@ -71,9 +75,21 @@ function RcbShapeHost({
   const camera = useRcbCamera();
   const hostRef = useRef<HTMLDivElement | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const layerRef = useRef<SVGGElement | null>(null);
   const bootRef = useRef(0);
   const forceHiddenRef = useRef(forceHidden);
   forceHiddenRef.current = forceHidden;
+  const [worldEpoch, setWorldEpoch] = useState(() => getSceneWorldEpoch());
+  useEffect(
+    () =>
+      subscribeShapeHosts(() => {
+        setWorldEpoch((prev) => {
+          const next = getSceneWorldEpoch();
+          return prev === next ? prev : next;
+        });
+      }),
+    []
+  );
   const node = document?.deltaSetLike?.[nodeId];
   const blendMode = parseBlendMode(node?.attrs?.blendMode, { allowPassThrough: false });
   const layerOpacity = parseLayerOpacity(node?.attrs?.opacity, 1);
@@ -119,6 +135,12 @@ function RcbShapeHost({
     node?.attrs?.shapeType,
     node?.attrs?.brushStyle,
     node?.attrs?.pathPressure,
+    // Empty generator / process hairlines are screen-constant (css/zoom) — remount on zoom.
+    String(node?.attrs?.processStatus || '') === 'running' ||
+    node?.attrs?.imageGenerator ||
+    node?.attrs?.videoGenerator
+      ? rcbCameraCssZoom(camera).toFixed(3)
+      : '',
   ].join('|');
 
   useEffect(() => {
@@ -129,10 +151,20 @@ function RcbShapeHost({
     const n = document.deltaSetLike?.[nodeId];
     let cancelled = false;
 
-    const { root, layer } = createSvgBoard(host, 1, 1, { infinite: true });
-    // Seed CSS box from node AABB before paint — avoids 1×1→fit jump under browser zoom.
+    const { root, layer, shared } = createSvgBoard(host, 1, 1, {
+      infinite: true,
+      sharedRoot: getSceneWorldRoot(),
+      sharedMount: getSceneShapesMount(),
+    });
+    layerRef.current = layer;
+    layer.setAttribute('data-rcb-shape-id', nodeId);
+    layer.style.opacity = forceHiddenRef.current ? '0' : String(layerOpacity);
+    if (blendCss) layer.style.mixBlendMode = blendCss;
+    else layer.style.removeProperty('mix-blend-mode');
+
+    // Private-host seed only — shared world viewport is owned by RcbCanvas.
     let seedBox: { left: number; top: number; width: number; height: number } | null = null;
-    if (n) {
+    if (!shared && n) {
       try {
         const { left, top } = nodeLeftTop(document, n);
         const w = Math.max(1, Number(n.width) || 1);
@@ -170,11 +202,12 @@ function RcbShapeHost({
           el.setAttribute('opacity', '1');
           if (forceHiddenRef.current) setHostPaintOpacity(el, true);
           applyFrameContentClip(root, el, document, n, { zoom: camera.zoom });
-          const shared = getSharedNodeEls();
-          if (shared) shared.set(nodeId, el);
+          const sharedMap = getSharedNodeEls();
+          if (sharedMap) sharedMap.set(nodeId, el);
           else nodeEls.set(nodeId, el);
           updateShapeHostElement(nodeId, el);
         }
+        if (shared) return;
         try {
           const before = {
             left: root.style.left,
@@ -183,8 +216,6 @@ function RcbShapeHost({
             height: root.style.height,
             viewBox: root.getAttribute('viewBox'),
           };
-          // Freehand / open paths can grow past the seed AABB — allow getBBox fit.
-          // Closed shapes keep the locked seed (preserves *.5 stroke-on-grid).
           const shapeType = String(n?.attrs?.shapeType || '');
           const unlockFit =
             shapeType === 'pen' ||
@@ -223,14 +254,16 @@ function RcbShapeHost({
       hostJumpLog('host.unmount', { nodeId, paintToken: String(paintToken).slice(0, 120) });
       unregisterShapeHost(nodeId);
       try {
-        root.remove();
+        if (shared) layer.remove();
+        else root.remove();
       } catch {
         /* ignore */
       }
-      host.innerHTML = '';
+      if (!shared) host.innerHTML = '';
+      layerRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nodeId, reloadToken, paintToken]);
+  }, [nodeId, reloadToken, paintToken, worldEpoch]);
 
   // Toggle hide without remounting (enter / leave inline text edit).
   useEffect(() => {
@@ -238,7 +271,29 @@ function RcbShapeHost({
       getSharedNodeEls()?.get(nodeId) ||
       (hostRef.current?.querySelector?.('[data-scene-node-id]') as Element | null);
     setHostPaintOpacity(el, forceHidden);
-  }, [forceHidden, nodeId, paintToken, reloadToken]);
+    const layer = layerRef.current;
+    if (layer) layer.style.opacity = forceHidden ? '0' : String(layerOpacity);
+  }, [forceHidden, nodeId, paintToken, reloadToken, layerOpacity]);
+
+  useEffect(() => {
+    const layer = layerRef.current;
+    if (!layer) return;
+    if (blendCss) layer.style.mixBlendMode = blendCss;
+    else layer.style.removeProperty('mix-blend-mode');
+  }, [blendCss, paintToken]);
+
+  // Keep SVG paint order ≈ document z when sharing one scene root.
+  useEffect(() => {
+    const layer = layerRef.current;
+    const mount = getSceneShapesMount();
+    if (!layer || !mount || layer.parentElement !== mount) return;
+    layer.setAttribute('data-z', String(zIndex));
+    const siblings = [...mount.querySelectorAll(':scope > g[data-rcb-shape-layer]')];
+    siblings.sort(
+      (a, b) => (Number(a.getAttribute('data-z')) || 0) - (Number(b.getAttribute('data-z')) || 0)
+    );
+    for (const g of siblings) mount.appendChild(g);
+  }, [zIndex, paintToken]);
 
   return (
     <div
@@ -247,8 +302,9 @@ function RcbShapeHost({
       className="pointer-events-none absolute left-0 top-0 overflow-visible"
       style={{
         zIndex,
-        opacity: forceHidden ? 0 : layerOpacity,
-        mixBlendMode: (blendCss || undefined) as CSSProperties['mixBlendMode'],
+        // Shared-world paint lives in the scene SVG; wrap is a React anchor only.
+        opacity: getSceneWorldRoot() ? 1 : forceHidden ? 0 : layerOpacity,
+        mixBlendMode: (getSceneWorldRoot() ? undefined : blendCss || undefined) as CSSProperties['mixBlendMode'],
       }}
     >
       <div

--- a/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
@@ -1,14 +1,13 @@
 import { useEffect, useMemo, useState, memo } from 'react';
-import { useRcbCamera, useRcbCameraMotion, useRcbDevicePixelRatio, useRcbViewportEl } from '../camera/context';
+import { useRcbCamera, useRcbCameraMotion, useRcbViewportEl } from '../camera/context';
 import { rcbViewportSceneBounds } from '../core/math';
-import { toDomPrecision } from '../core/dpr';
 import {
   RcbSpatialIndex,
   boxesIntersect,
   nodeSceneAabb,
 } from '../core/spatialIndex';
 import { isNodeHidden, stackZIndex } from '@/components/rcb/scene/document/sceneDocument';
-import { nodeLeftTop, snapSvgSurfaceBox } from '@/components/rcb/scene/paint/sceneToSvg';
+import { nodeLeftTop, sceneSurfaceSvgProps } from '@/components/rcb/scene/paint/sceneToSvg';
 import { HEAVY_PATH_D_CHARS } from '@/components/rcb/scene/document/sceneShapes';
 import RcbShapeHost from './RcbShapeHost';
 
@@ -140,7 +139,6 @@ function RcbShapesLayer({
   spatialIndex = null,
 }: Props) {
   const camera = useRcbCamera();
-  const dpr = useRcbDevicePixelRatio();
   const { moving, efficientZoom } = useRcbCameraMotion();
   const viewportEl = useRcbViewportEl();
   const [stageSize, setStageSize] = useState({ width: 0, height: 0 });
@@ -280,14 +278,14 @@ function RcbShapesLayer({
     if (![minX, minY, maxX, maxY].every(Number.isFinite)) return null;
     const pad = 2;
     const raw = {
-      left: toDomPrecision(minX - pad),
-      top: toDomPrecision(minY - pad),
-      width: toDomPrecision(Math.max(1, maxX - minX + pad * 2)),
-      height: toDomPrecision(Math.max(1, maxY - minY + pad * 2)),
+      left: minX - pad,
+      top: minY - pad,
+      width: Math.max(1, maxX - minX + pad * 2),
+      height: Math.max(1, maxY - minY + pad * 2),
     };
-    const s = snapSvgSurfaceBox(raw, camera, dpr);
-    return { minX: s.left, minY: s.top, w: s.width, h: s.height };
-  }, [document, proxyIds, hiddenNodeId, camera.x, camera.y, camera.zoom, dpr]);
+    const s = sceneSurfaceSvgProps(raw, camera);
+    return { minX: s.style.left, minY: s.style.top, w: s.width, h: s.height };
+  }, [document, proxyIds, hiddenNodeId, camera.x, camera.y, camera.zoom]);
 
   if (!document || !visibleIds.length) return null;
 

--- a/apps/web/src/components/rcb/shapes/shapeHostRegistry.ts
+++ b/apps/web/src/components/rcb/shapes/shapeHostRegistry.ts
@@ -99,6 +99,48 @@ export function clearShapeHosts() {
   hosts.clear();
 }
 
+/** One SVG under `[data-rcb-world]` — grid + all shape layers share this lattice. */
+let sceneWorldRoot: SVGSVGElement | null = null;
+let sceneShapesMount: SVGGElement | null = null;
+let sceneDrawPreviewMount: SVGGElement | null = null;
+let sceneSmartGuidesMount: SVGGElement | null = null;
+let sceneWorldEpoch = 0;
+
+export function setSceneWorldRoot(
+  root: SVGSVGElement | null,
+  shapesMount: SVGGElement | null,
+  drawPreviewMount: SVGGElement | null = null,
+  smartGuidesMount: SVGGElement | null = null
+) {
+  sceneWorldRoot = root;
+  sceneShapesMount = shapesMount;
+  sceneDrawPreviewMount = drawPreviewMount;
+  sceneSmartGuidesMount = smartGuidesMount;
+  sceneWorldEpoch += 1;
+  bumpHostEpoch();
+}
+
+export function getSceneWorldRoot() {
+  return sceneWorldRoot;
+}
+
+export function getSceneShapesMount() {
+  return sceneShapesMount;
+}
+
+export function getSceneDrawPreviewMount() {
+  return sceneDrawPreviewMount;
+}
+
+/** Align/gap guides — must share world SVG lattice (not a sibling surface). */
+export function getSceneSmartGuidesMount() {
+  return sceneSmartGuidesMount;
+}
+
+export function getSceneWorldEpoch() {
+  return sceneWorldEpoch;
+}
+
 /**
  * Recover a host after HMR / race cleared the module Map but the DOM mini-board remains.
  */

--- a/apps/web/src/components/rcb/tools/PenDrawFeature.tsx
+++ b/apps/web/src/components/rcb/tools/PenDrawFeature.tsx
@@ -2,21 +2,152 @@ import {
   useRcbCamera,
   useRcbScreenToScene,
 } from '../camera/context';
-import { useEffect, useLayoutEffect, useRef, useState, memo } from 'react';
+import { useEffect, useRef, useState, memo, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import {
   CLOSE_THRESHOLD,
   localizeAnchors,
   penAnchorsToD,
   boundsOfAnchors,
   withMirroredHandles,
+  resolvePenPlaceAction,
+  reversePenAnchors,
+  penSubpathsFromD,
+  offsetAnchors,
   type PenAnchor,
 } from './penPath';
-import RcbSceneOverlayCanvas, {
-  type RcbSceneOverlayCanvasHandle,
-} from '../canvas/RcbSceneOverlayCanvas';
 import { isEditablePathNode } from '../scene/paint/outlineToPath';
-import { strokeCachedPath2D } from '@/components/rcb/scene/document/sceneShapes';
+import { nodeLeftTop } from '../scene/paint/sceneToSvg';
 import { PEN_CURSOR } from './PencilDrawFeature';
+import { snapCoordToGrid } from '../selection/alignGuides';
+import {
+  getSceneDrawPreviewMount,
+  getSceneWorldEpoch,
+  subscribeShapeHosts,
+} from '../shapes/shapeHostRegistry';
+
+function dist2(ax: number, ay: number, bx: number, by: number) {
+  const dx = ax - bx;
+  const dy = ay - by;
+  return dx * dx + dy * dy;
+}
+
+function isGridCorner(x: number, y: number, g: number) {
+  const qx = Math.round(x / g) * g;
+  const qy = Math.round(y / g) * g;
+  return Math.abs(x - qx) < 1e-9 && Math.abs(y - qy) < 1e-9;
+}
+
+/**
+ * Snap pen anchors to the pixel-grid lattice (hold Ctrl to skip):
+ * - cell **corners** (i, j)
+ * - **edge midpoints** (i+½, j) / (i, j+½) — 网格边缘线中间
+ *
+ * Cell centers (½,½) are not snap targets (not on an edge line).
+ */
+export function snapPenAnchorPoint(
+  x: number,
+  y: number,
+  gridSize: number,
+  skip = false
+): { x: number; y: number } {
+  if (skip || !(gridSize > 0)) return { x, y };
+  const g = gridSize;
+  const half = g / 2;
+  const gx0 = Math.floor(x / g) * g;
+  const gy0 = Math.floor(y / g) * g;
+
+  let bestX = snapCoordToGrid(x, g);
+  let bestY = snapCoordToGrid(y, g);
+  let bestD = dist2(x, y, bestX, bestY);
+  let bestCorner = isGridCorner(bestX, bestY, g);
+
+  const consider = (cx: number, cy: number) => {
+    const d = dist2(x, y, cx, cy);
+    const corner = isGridCorner(cx, cy, g);
+    if (d < bestD - 1e-12) {
+      bestD = d;
+      bestX = cx;
+      bestY = cy;
+      bestCorner = corner;
+      return;
+    }
+    if (Math.abs(d - bestD) <= 1e-12) {
+      // Tie: prefer corners, then lower x, then lower y (stable).
+      if (corner && !bestCorner) {
+        bestX = cx;
+        bestY = cy;
+        bestCorner = true;
+        return;
+      }
+      if (corner === bestCorner && (cx < bestX - 1e-12 || (Math.abs(cx - bestX) <= 1e-12 && cy < bestY))) {
+        bestX = cx;
+        bestY = cy;
+        bestCorner = corner;
+      }
+    }
+  };
+
+  // Local 3×3 corners + edge mids around the containing cell.
+  for (let ix = -1; ix <= 2; ix += 1) {
+    for (let iy = -1; iy <= 2; iy += 1) {
+      const cx = gx0 + ix * g;
+      const cy = gy0 + iy * g;
+      consider(cx, cy);
+      // Mid of horizontal edge (on horizontal grid line).
+      if (iy <= 1) consider(cx + half, cy);
+      // Mid of vertical edge (on vertical grid line).
+      if (ix <= 1) consider(cx, cy + half);
+    }
+  }
+
+  return { x: bestX, y: bestY };
+}
+
+export { resolvePenPlaceAction, reversePenAnchors } from './penPath';
+
+/**
+ * Empty draft + click near an open pen/path endpoint → resume that stroke
+ * (so re-clicking the same landing links instead of starting a disconnected path).
+ */
+export function findOpenPenEndpointResume(
+  document: any,
+  x: number,
+  y: number,
+  threshold: number
+): { nodeId: string; anchors: PenAnchor[] } | null {
+  const set = document?.deltaSetLike;
+  if (!set || !(threshold > 0)) return null;
+  let best: { nodeId: string; anchors: PenAnchor[]; dist: number } | null = null;
+  for (const id of Object.keys(set)) {
+    const node = set[id];
+    if (!isEditablePathNode(node)) continue;
+    const closed =
+      node.attrs?.closed === true ||
+      node.attrs?.closed === 'true' ||
+      /\sZ\s*$/i.test(String(node.attrs?.path || node.attrs?.d || ''));
+    if (closed) continue;
+    const raw = String(node.attrs?.path || node.attrs?.d || '');
+    if (!raw.trim()) continue;
+    const { left, top } = nodeLeftTop(document, node);
+    const subs = penSubpathsFromD(raw);
+    for (const s of subs) {
+      if (s.closed || s.anchors.length < 2) continue;
+      const scene = offsetAnchors(s.anchors, left, top);
+      const first = scene[0];
+      const last = scene[scene.length - 1];
+      const dFirst = Math.hypot(x - first.x, y - first.y);
+      const dLast = Math.hypot(x - last.x, y - last.y);
+      if (dLast <= threshold && (!best || dLast < best.dist)) {
+        best = { nodeId: id, anchors: scene, dist: dLast };
+      }
+      if (dFirst <= threshold && (!best || dFirst < best.dist)) {
+        best = { nodeId: id, anchors: reversePenAnchors(scene), dist: dFirst };
+      }
+    }
+  }
+  return best ? { nodeId: best.nodeId, anchors: best.anchors } : null;
+}
 
 type HandleSide = 'in' | 'out';
 
@@ -34,10 +165,14 @@ type PenDrawFeatureProps = {
   stageEl?: HTMLElement | null;
   strokeColor?: string;
   strokeWidth?: number;
+  /** Snap anchors to document grid corners (default on). Hold Ctrl to place free. */
+  gridSnap?: boolean;
+  gridSize?: number;
   onCommit: (
     pathD: string,
     box: { left: number; top: number; width: number; height: number },
-    closed: boolean
+    closed: boolean,
+    opts?: { replaceNodeId?: string }
   ) => void;
   onCancel?: () => void;
   hitTest?: (
@@ -72,7 +207,7 @@ type AnchorDraw = {
   r: number;
   fill: string;
   strokeColor: string;
-  /** Soft halo (close-target / hover) — same canvas as ink so knobs stay seated. */
+  /** Soft halo (close-target / hover) — same SVG as ink so knobs stay seated. */
   ringR?: number;
 };
 
@@ -83,45 +218,42 @@ type HandleDraw = {
   active: boolean;
 };
 
-function paintAnchorKnob(
-  ctx: CanvasRenderingContext2D,
-  a: AnchorDraw,
-  strokeW: number
-) {
-  if (a.ringR != null && a.ringR > a.r) {
-    ctx.beginPath();
-    ctx.arc(a.x, a.y, a.ringR, 0, Math.PI * 2);
-    ctx.strokeStyle = SEL_BASELINE;
-    ctx.globalAlpha = 0.45;
-    ctx.lineWidth = strokeW;
-    ctx.stroke();
-    ctx.globalAlpha = 1;
-  }
-  ctx.beginPath();
-  ctx.arc(a.x, a.y, a.r, 0, Math.PI * 2);
-  ctx.fillStyle = a.fill;
-  ctx.fill();
-  ctx.strokeStyle = a.strokeColor;
-  ctx.lineWidth = strokeW;
-  ctx.stroke();
+function AnchorKnobSvg({ a, strokeW }: { a: AnchorDraw; strokeW: number }) {
+  return (
+    <g>
+      {a.ringR != null && a.ringR > a.r ? (
+        <circle
+          cx={a.x}
+          cy={a.y}
+          r={a.ringR}
+          fill="none"
+          stroke={SEL_BASELINE}
+          strokeWidth={strokeW}
+          opacity={0.45}
+        />
+      ) : null}
+      <circle
+        cx={a.x}
+        cy={a.y}
+        r={a.r}
+        fill={a.fill}
+        stroke={a.strokeColor}
+        strokeWidth={strokeW}
+      />
+    </g>
+  );
 }
 
-function paintHandleDiamond(
-  ctx: CanvasRenderingContext2D,
-  h: HandleDraw,
-  strokeW: number
-) {
-  ctx.beginPath();
-  ctx.moveTo(h.x, h.y - h.r);
-  ctx.lineTo(h.x + h.r, h.y);
-  ctx.lineTo(h.x, h.y + h.r);
-  ctx.lineTo(h.x - h.r, h.y);
-  ctx.closePath();
-  ctx.fillStyle = h.active ? SEL_BASELINE : '#fff';
-  ctx.fill();
-  ctx.strokeStyle = h.active ? SEL_BASELINE : '#383838';
-  ctx.lineWidth = strokeW;
-  ctx.stroke();
+function HandleDiamondSvg({ h, strokeW }: { h: HandleDraw; strokeW: number }) {
+  const d = `M ${h.x} ${h.y - h.r} L ${h.x + h.r} ${h.y} L ${h.x} ${h.y + h.r} L ${h.x - h.r} ${h.y} Z`;
+  return (
+    <path
+      d={d}
+      fill={h.active ? SEL_BASELINE : '#fff'}
+      stroke={h.active ? SEL_BASELINE : '#383838'}
+      strokeWidth={strokeW}
+    />
+  );
 }
 
 function hitHandle(
@@ -247,6 +379,8 @@ function PenDrawFeature({
   stageEl = null,
   strokeColor = '#333333',
   strokeWidth = 2,
+  gridSnap = true,
+  gridSize = 1,
   onCommit,
   onCancel,
   hitTest,
@@ -271,12 +405,18 @@ function PenDrawFeature({
   const prevCursorRef = useRef<string>('');
   /** Last click on an existing anchor ??second click within window ??corner. */
   const lastAnchorTapRef = useRef<{ index: number; t: number } | null>(null);
+  /** When set, finish() patches this open path instead of creating a new node. */
+  const resumeNodeIdRef = useRef<string | null>(null);
   const onCommitRef = useRef(onCommit);
   const onCancelRef = useRef(onCancel);
   const strokeWidthRef = useRef(strokeWidth);
+  const gridSnapRef = useRef(gridSnap);
+  const gridSizeRef = useRef(gridSize);
   onCommitRef.current = onCommit;
   onCancelRef.current = onCancel;
   strokeWidthRef.current = strokeWidth;
+  gridSnapRef.current = gridSnap;
+  gridSizeRef.current = gridSize;
   anchorsRef.current = anchors;
   selectedHandleRef.current = selectedHandle;
 
@@ -299,6 +439,7 @@ function PenDrawFeature({
     draggingRef.current = false;
     dragKindRef.current = null;
     lastAnchorTapRef.current = null;
+    resumeNodeIdRef.current = null;
   };
 
   /**
@@ -329,8 +470,9 @@ function PenDrawFeature({
     };
     const local = localizeAnchors(list, origin.left, origin.top);
     const d = penAnchorsToD(local, closed);
+    const replaceNodeId = resumeNodeIdRef.current || undefined;
     resetDraft();
-    onCommitRef.current(d, origin, closed);
+    onCommitRef.current(d, origin, closed, replaceNodeId ? { replaceNodeId } : undefined);
     if (leave) onCancelRef.current?.();
   };
 
@@ -350,7 +492,8 @@ function PenDrawFeature({
       };
       const local = localizeAnchors(list, origin.left, origin.top);
       const d = penAnchorsToD(local, false);
-      onCommitRef.current(d, origin, false);
+      const replaceNodeId = resumeNodeIdRef.current || undefined;
+      onCommitRef.current(d, origin, false, replaceNodeId ? { replaceNodeId } : undefined);
     }
     resetDraft();
   }, [enabled]);
@@ -363,11 +506,11 @@ function PenDrawFeature({
       const y = Number(detail.y);
       if (!Number.isFinite(x) || !Number.isFinite(y)) return;
       if (anchorsRef.current.length > 0) return;
-      const anchor = { x, y };
+      const anchor = snapPenAnchorPoint(x, y, gridSizeRef.current, !gridSnapRef.current);
       placingRef.current = null;
       draggingRef.current = false;
       setAnchors([anchor]);
-      setCursor({ x, y });
+      setCursor(anchor);
       setSelectedHandle(null);
       setHoverHandle(null);
       setHoverAnchor(null);
@@ -388,8 +531,15 @@ function PenDrawFeature({
     const nearClose = (p: { x: number; y: number }) => {
       const list = anchorsRef.current;
       if (list.length < 2) return false;
-      const first = list[0];
-      return Math.hypot(p.x - first.x, p.y - first.y) <= CLOSE_THRESHOLD;
+      // Hover/close halo: tip on the first landing (same rule as click close).
+      const action = resolvePenPlaceAction({
+        anchors: list,
+        snapped: p,
+        raw: p,
+        anchorHitRadius: Math.max(radii().anchor, CLOSE_THRESHOLD / Math.max(1, camera.zoom || 1)),
+        closeThreshold: CLOSE_THRESHOLD,
+      });
+      return action.kind === 'close';
     };
 
     const anchorHasHandles = (a: PenAnchor) =>
@@ -453,13 +603,16 @@ function PenDrawFeature({
     const onDown = (e: PointerEvent) => {
       if (e.button !== 0) return;
       e.preventDefault();
-      const p = toScene(e.clientX, e.clientY);
+      const raw = toScene(e.clientX, e.clientY);
+      // Hit-test with raw pointer; place new anchors on grid corners (Ctrl = free).
+      const skipGrid = e.ctrlKey || !gridSnapRef.current;
+      const p = snapPenAnchorPoint(raw.x, raw.y, gridSizeRef.current, skipGrid);
       const list = anchorsRef.current;
       const { anchor: anchorR, handle: handleR } = radii();
 
       // Prefer the anchor disc over nearby handle diamonds (click center ??corner).
-      const anchorIdx = hitAnchor(list, p, anchorR);
-      const handleHit = anchorIdx >= 0 ? null : hitHandle(list, p, handleR);
+      const anchorIdx = hitAnchor(list, raw, anchorR);
+      const handleHit = anchorIdx >= 0 ? null : hitHandle(list, raw, handleR);
 
       // Alt/Option + click handle ??delete that side (in = left, out = right).
       if (handleHit && (e.altKey || e.metaKey)) {
@@ -503,7 +656,37 @@ function PenDrawFeature({
       setHoverHandle(null);
       setPaperCursor(hitEl || paperEl, PEN_CURSOR);
 
-      if (nearClose(p)) {
+      // Empty draft: resume open stroke from its endpoint (same landing → link).
+      if (list.length === 0) {
+        const resume = findOpenPenEndpointResume(
+          document,
+          p.x,
+          p.y,
+          Math.max(CLOSE_THRESHOLD, radii().anchor)
+        );
+        if (resume) {
+          resumeNodeIdRef.current = resume.nodeId;
+          placingRef.current = null;
+          draggingRef.current = false;
+          dragKindRef.current = null;
+          lastAnchorTapRef.current = null;
+          setCloseHot(false);
+          setAnchors(resume.anchors);
+          setCursor(p);
+          setHoverAnchor(null);
+          return;
+        }
+      }
+
+      const action = resolvePenPlaceAction({
+        anchors: list,
+        snapped: p,
+        raw,
+        anchorHitRadius: radii().anchor,
+        closeThreshold: CLOSE_THRESHOLD,
+      });
+
+      if (action.kind === 'close') {
         closingRef.current = true;
         draggingRef.current = false;
         placingRef.current = null;
@@ -518,7 +701,8 @@ function PenDrawFeature({
       }
 
       // Click / double-click existing anchor: clear handles ??sharp corner.
-      if (anchorIdx >= 0) {
+      if (action.kind === 'anchor') {
+        const anchorIdx = action.index;
         const a = list[anchorIdx];
         const now = performance.now();
         const last = lastAnchorTapRef.current;
@@ -545,7 +729,7 @@ function PenDrawFeature({
       lastAnchorTapRef.current = null;
       setHoverAnchor(null);
 
-      const anchor: PenAnchor = { x: p.x, y: p.y };
+      const anchor: PenAnchor = { x: action.x, y: action.y };
       placingRef.current = anchor;
       draggingRef.current = false;
       dragKindRef.current = { kind: 'place' };
@@ -555,7 +739,9 @@ function PenDrawFeature({
     };
 
     const onMove = (e: PointerEvent) => {
-      const p = toScene(e.clientX, e.clientY);
+      const raw = toScene(e.clientX, e.clientY);
+      const skipGrid = e.ctrlKey || !gridSnapRef.current;
+      const p = snapPenAnchorPoint(raw.x, raw.y, gridSizeRef.current, skipGrid);
       const drag = dragKindRef.current;
       const { anchor: anchorR, handle: handleR } = radii();
 
@@ -565,11 +751,12 @@ function PenDrawFeature({
         setAnchors((prev) => {
           if (!prev[drag.index]) return prev;
           const next = [...prev];
+          // Handles stay free (curvature); only anchors snap to grid corners.
           next[drag.index] = setHandle(
             next[drag.index],
             drag.side,
-            p.x,
-            p.y,
+            raw.x,
+            raw.y,
             drag.mirror || e.shiftKey
           );
           return next;
@@ -580,14 +767,14 @@ function PenDrawFeature({
       if (closingRef.current || drag?.kind === 'close') {
         const first = anchorsRef.current[0];
         if (!first) return;
-        const dist = Math.hypot(p.x - first.x, p.y - first.y);
+        const dist = Math.hypot(raw.x - first.x, raw.y - first.y);
         if (dist > 3) draggingRef.current = true;
         if (draggingRef.current) {
           const updated = withMirroredHandles({
             x: first.x,
             y: first.y,
-            outX: p.x,
-            outY: p.y,
+            outX: raw.x,
+            outY: raw.y,
           });
           setAnchors((prev) => {
             if (!prev.length) return prev;
@@ -601,11 +788,11 @@ function PenDrawFeature({
 
       const placing = placingRef.current;
       if (placing) {
-        const dist = Math.hypot(p.x - placing.x, p.y - placing.y);
+        const dist = Math.hypot(raw.x - placing.x, raw.y - placing.y);
         if (dist > 3) draggingRef.current = true;
         if (draggingRef.current) {
-          placing.outX = p.x;
-          placing.outY = p.y;
+          placing.outX = raw.x;
+          placing.outY = raw.y;
           const mirrored = withMirroredHandles(placing);
           setAnchors((prev) => {
             if (!prev.length) return prev;
@@ -622,8 +809,9 @@ function PenDrawFeature({
         return;
       }
 
-      // Idle: prefer anchor hover, then handle diamonds.
-      const aIdx = hitAnchor(anchorsRef.current, p, anchorR);
+      // Idle: prefer anchor hover, then handle diamonds (raw hit). Tip always
+      // sticks to grid corners / edge mids so the CSS pen cursor tip ≠ place lattice.
+      const aIdx = hitAnchor(anchorsRef.current, raw, anchorR);
       if (aIdx >= 0) {
         setHoverAnchor(aIdx);
         setHoverHandle(null);
@@ -633,7 +821,7 @@ function PenDrawFeature({
         return;
       }
 
-      const hit = hitHandle(anchorsRef.current, p, handleR);
+      const hit = hitHandle(anchorsRef.current, raw, handleR);
       setHoverAnchor(null);
       setHoverHandle(hit);
       if (hit) {
@@ -644,6 +832,7 @@ function PenDrawFeature({
       }
 
       setPaperCursor(hitEl || paperEl, PEN_CURSOR);
+      // Rubber-band / snap tip sticks to grid corners + edge midpoints.
       setCursor(p);
       setCloseHot(nearClose(p));
     };
@@ -659,16 +848,18 @@ function PenDrawFeature({
         dragKindRef.current = null;
         draggingRef.current = false;
         // Back to drawing: restore rubber-band from current pointer.
-        const p = toScene(e.clientX, e.clientY);
+        const rawUp = toScene(e.clientX, e.clientY);
+        const skipUp = e.ctrlKey || !gridSnapRef.current;
+        const p = snapPenAnchorPoint(rawUp.x, rawUp.y, gridSizeRef.current, skipUp);
         const { anchor: anchorR, handle: handleR } = radii();
-        const aIdx = hitAnchor(anchorsRef.current, p, anchorR);
+        const aIdx = hitAnchor(anchorsRef.current, rawUp, anchorR);
         if (aIdx >= 0) {
           setHoverAnchor(aIdx);
           setHoverHandle(null);
           setPaperCursor(hitEl || paperEl, 'pointer');
           setCloseHot(false);
         } else {
-          const hit = hitHandle(anchorsRef.current, p, handleR);
+          const hit = hitHandle(anchorsRef.current, rawUp, handleR);
           setHoverAnchor(null);
           setHoverHandle(hit);
           setPaperCursor(hitEl || paperEl, hit ? 'grab' : PEN_CURSOR);
@@ -691,8 +882,9 @@ function PenDrawFeature({
       placingRef.current = null;
       draggingRef.current = false;
       dragKindRef.current = null;
-      const p = toScene(e.clientX, e.clientY);
-      setCursor(p);
+      const rawUp = toScene(e.clientX, e.clientY);
+      const skipUp = e.ctrlKey || !gridSnapRef.current;
+      setCursor(snapPenAnchorPoint(rawUp.x, rawUp.y, gridSizeRef.current, skipUp));
       setPaperCursor(hitEl || paperEl, PEN_CURSOR);
     };
 
@@ -820,18 +1012,24 @@ function PenDrawFeature({
       ? { x1: last.x, y1: last.y, x2: cursor.x, y2: cursor.y }
       : null;
 
+  // Snapped place tip (even before first click) — CSS pen cursor tip ≠ lattice.
+  const snapTip =
+    cursor && !hoverHandle && hoverAnchor == null && !placingRef.current
+      ? cursor
+      : null;
+
   return (
-    <PenInkPreviewCanvas
+    <PenInkPreviewSvg
       pathD={d}
       closePreviewD={showClosePreview ? closePreviewD : ''}
       rubberBand={rubberBand}
+      snapTip={snapTip}
       linkSegs={linkSegs}
       strokeColor={strokeColor || '#333333'}
       pathSw={pathSw}
       hairlineSw={stroke}
       linkSw={linkStroke}
       inv={inv}
-      anchors={anchors}
       anchorsDraw={anchorsDraw}
       handlesDraw={handlesDraw}
       knobStroke={stroke}
@@ -840,17 +1038,17 @@ function PenDrawFeature({
   );
 }
 
-function PenInkPreviewCanvas({
+function PenInkPreviewSvg({
   pathD,
   closePreviewD,
   rubberBand,
+  snapTip,
   linkSegs,
   strokeColor,
   pathSw,
   hairlineSw,
   linkSw,
   inv,
-  anchors,
   anchorsDraw,
   handlesDraw,
   knobStroke,
@@ -859,183 +1057,125 @@ function PenInkPreviewCanvas({
   pathD: string;
   closePreviewD: string;
   rubberBand: { x1: number; y1: number; x2: number; y2: number } | null;
+  snapTip: { x: number; y: number } | null;
   linkSegs: Array<{ x1: number; y1: number; x2: number; y2: number }>;
   strokeColor: string;
   pathSw: number;
   hairlineSw: number;
   linkSw: number;
   inv: number;
-  anchors: PenAnchor[];
   anchorsDraw: AnchorDraw[];
   handlesDraw: HandleDraw[];
   knobStroke: number;
   handleStroke: number;
 }) {
-  const overlayRef = useRef<RcbSceneOverlayCanvasHandle>(null);
-  /**
-   * Expand-only paint slot. Tight min-bbox every rubber-band move retargets
-   * canvas.style.left/top + bitmap → whole preview shakes (same as path-edit).
-   */
-  const slotBoxRef = useRef<{
-    left: number;
-    top: number;
-    width: number;
-    height: number;
-  } | null>(null);
-  const slotTopoKeyRef = useRef('');
+  // Remount when shared world SVG appears (portal target).
+  const [, setWorldEpoch] = useState(() => getSceneWorldEpoch());
+  useEffect(
+    () =>
+      subscribeShapeHosts(() => {
+        setWorldEpoch((prev) => {
+          const next = getSceneWorldEpoch();
+          return prev === next ? prev : next;
+        });
+      }),
+    []
+  );
+  const previewMount = getSceneDrawPreviewMount();
 
-  useLayoutEffect(() => {
-    const handle = overlayRef.current;
-    if (!handle) return;
-    const pts: Array<{ x: number; y: number }> = [];
-    for (const a of anchors) {
-      pts.push({ x: a.x, y: a.y });
-      if (a.inX != null && a.inY != null) pts.push({ x: a.inX, y: a.inY });
-      if (a.outX != null && a.outY != null) pts.push({ x: a.outX, y: a.outY });
-    }
-    for (const a of anchorsDraw) pts.push({ x: a.x, y: a.y });
-    for (const h of handlesDraw) pts.push({ x: h.x, y: h.y });
-    if (rubberBand) {
-      pts.push({ x: rubberBand.x1, y: rubberBand.y1 }, { x: rubberBand.x2, y: rubberBand.y2 });
-    }
-    if (!pts.length && !pathD && !closePreviewD) {
-      handle.clear();
-      slotBoxRef.current = null;
-      slotTopoKeyRef.current = '';
-      return;
-    }
-    let minX = Infinity;
-    let minY = Infinity;
-    let maxX = -Infinity;
-    let maxY = -Infinity;
-    for (const p of pts) {
-      minX = Math.min(minX, p.x);
-      minY = Math.min(minY, p.y);
-      maxX = Math.max(maxX, p.x);
-      maxY = Math.max(maxY, p.y);
-    }
-    if (!Number.isFinite(minX)) {
-      handle.clear();
-      slotBoxRef.current = null;
-      return;
-    }
-    const pad = Math.max(pathSw, hairlineSw, linkSw, knobStroke * 8, 12) * 2;
-    // Extra room so rubber-band motion does not grow the slot every pixel.
-    const slack = Math.max(64, pad * 2);
-    const needLeft = minX - pad;
-    const needTop = minY - pad;
-    const needRight = maxX + pad;
-    const needBottom = maxY + pad;
+  const tipR = Math.max(0.01, (3 * inv) / 2);
+  const tipArm = 4 * inv;
 
-    // New / cleared anchors: reset slot. Cursor-only moves expand.
-    const topoKey = String(anchors.length);
-    if (topoKey !== slotTopoKeyRef.current) {
-      slotTopoKeyRef.current = topoKey;
-      slotBoxRef.current = null;
-    }
+  const chrome: ReactNode = (
+    <g data-pen-draw-preview pointerEvents="none" aria-hidden>
+      {linkSegs.map((s, i) => (
+        <line
+          key={`link-${i}`}
+          x1={s.x1}
+          y1={s.y1}
+          x2={s.x2}
+          y2={s.y2}
+          stroke="#8b8b8b"
+          strokeWidth={linkSw}
+          strokeLinecap="butt"
+        />
+      ))}
+      {pathD ? (
+        <path
+          d={pathD}
+          fill="none"
+          stroke={strokeColor}
+          strokeWidth={pathSw}
+          strokeLinecap="butt"
+          strokeLinejoin="miter"
+        />
+      ) : null}
+      {closePreviewD ? (
+        <path
+          d={closePreviewD}
+          fill="none"
+          stroke={SEL_BASELINE}
+          strokeWidth={hairlineSw}
+          strokeLinecap="butt"
+          strokeLinejoin="miter"
+          strokeDasharray={`${4 * inv} ${3 * inv}`}
+          opacity={0.85}
+        />
+      ) : rubberBand ? (
+        <line
+          x1={rubberBand.x1}
+          y1={rubberBand.y1}
+          x2={rubberBand.x2}
+          y2={rubberBand.y2}
+          stroke="#8b8b8b"
+          strokeWidth={linkSw}
+          strokeDasharray={`${3 * inv} ${3 * inv}`}
+          opacity={0.55}
+          strokeLinecap="butt"
+        />
+      ) : null}
+      {snapTip ? (
+        <g data-pen-snap-tip="1">
+          {/* Fill-only + crisp: white stroke made the tip look ~0.5–1px off the lattice. */}
+          <circle
+            cx={snapTip.x}
+            cy={snapTip.y}
+            r={tipR}
+            fill={SEL_BASELINE}
+            stroke="none"
+            shapeRendering="geometricPrecision"
+          />
+          <path
+            d={`M ${snapTip.x - tipArm} ${snapTip.y} L ${snapTip.x + tipArm} ${snapTip.y} M ${snapTip.x} ${snapTip.y - tipArm} L ${snapTip.x} ${snapTip.y + tipArm}`}
+            fill="none"
+            stroke={SEL_BASELINE}
+            strokeWidth={hairlineSw}
+            strokeLinecap="butt"
+            shapeRendering="geometricPrecision"
+            opacity={0.9}
+          />
+        </g>
+      ) : null}
+      {handlesDraw.map((h, i) => (
+        <HandleDiamondSvg key={`h-${i}`} h={h} strokeW={handleStroke} />
+      ))}
+      {anchorsDraw.map((a, i) => (
+        <AnchorKnobSvg key={`a-${i}`} a={a} strokeW={knobStroke} />
+      ))}
+    </g>
+  );
 
-    let slot = slotBoxRef.current;
-    if (!slot) {
-      slot = {
-        left: needLeft - slack,
-        top: needTop - slack,
-        width: Math.max(1, needRight - needLeft + slack * 2),
-        height: Math.max(1, needBottom - needTop + slack * 2),
-      };
-      slotBoxRef.current = slot;
-    } else {
-      const slotRight = slot.left + slot.width;
-      const slotBottom = slot.top + slot.height;
-      const growL = needLeft < slot.left;
-      const growT = needTop < slot.top;
-      const growR = needRight > slotRight;
-      const growB = needBottom > slotBottom;
-      if (growL || growT || growR || growB) {
-        const left = growL ? needLeft - slack : slot.left;
-        const top = growT ? needTop - slack : slot.top;
-        const right = growR ? needRight + slack : slotRight;
-        const bottom = growB ? needBottom + slack : slotBottom;
-        slot = {
-          left,
-          top,
-          width: Math.max(1, right - left),
-          height: Math.max(1, bottom - top),
-        };
-        slotBoxRef.current = slot;
-      }
-    }
+  const hasInk =
+    Boolean(pathD) ||
+    Boolean(closePreviewD) ||
+    Boolean(rubberBand) ||
+    Boolean(snapTip) ||
+    anchorsDraw.length > 0 ||
+    handlesDraw.length > 0;
 
-    const ctx = handle.beginFrame(slot);
-    if (!ctx) return;
-    ctx.lineCap = 'butt';
-    ctx.lineJoin = 'miter';
+  if (!hasInk || !previewMount) return null;
 
-    for (const s of linkSegs) {
-      ctx.strokeStyle = '#8b8b8b';
-      ctx.lineWidth = linkSw;
-      ctx.setLineDash([]);
-      ctx.beginPath();
-      ctx.moveTo(s.x1, s.y1);
-      ctx.lineTo(s.x2, s.y2);
-      ctx.stroke();
-    }
-
-    if (pathD) {
-      ctx.setLineDash([]);
-      strokeCachedPath2D(ctx, pathD, {
-        strokeStyle: strokeColor,
-        lineWidth: pathSw,
-        lineCap: 'butt',
-        lineJoin: 'miter',
-      });
-    }
-
-    if (closePreviewD) {
-      ctx.globalAlpha = 0.85;
-      ctx.setLineDash([4 * inv, 3 * inv]);
-      strokeCachedPath2D(ctx, closePreviewD, {
-        strokeStyle: SEL_BASELINE,
-        lineWidth: hairlineSw,
-        lineCap: 'butt',
-        lineJoin: 'miter',
-      });
-      ctx.globalAlpha = 1;
-      ctx.setLineDash([]);
-    } else if (rubberBand) {
-      ctx.strokeStyle = '#8b8b8b';
-      ctx.lineWidth = linkSw;
-      ctx.globalAlpha = 0.55;
-      ctx.setLineDash([3 * inv, 3 * inv]);
-      ctx.beginPath();
-      ctx.moveTo(rubberBand.x1, rubberBand.y1);
-      ctx.lineTo(rubberBand.x2, rubberBand.y2);
-      ctx.stroke();
-      ctx.globalAlpha = 1;
-      ctx.setLineDash([]);
-    }
-
-    // Same canvas as ink — matches path-edit after outline (no DOM/canvas drift).
-    ctx.setLineDash([]);
-    for (const h of handlesDraw) paintHandleDiamond(ctx, h, handleStroke);
-    for (const a of anchorsDraw) paintAnchorKnob(ctx, a, knobStroke);
-  }, [
-    pathD,
-    closePreviewD,
-    rubberBand,
-    linkSegs,
-    strokeColor,
-    pathSw,
-    hairlineSw,
-    linkSw,
-    inv,
-    anchors,
-    anchorsDraw,
-    handlesDraw,
-    knobStroke,
-    handleStroke,
-  ]);
-
-  return <RcbSceneOverlayCanvas ref={overlayRef} zClass="z-20" />;
+  return createPortal(chrome, previewMount);
 }
 
 export default memo(PenDrawFeature);

--- a/apps/web/src/components/rcb/tools/PenPathEditFeature.tsx
+++ b/apps/web/src/components/rcb/tools/PenPathEditFeature.tsx
@@ -1,11 +1,11 @@
-﻿import { useEffect, useLayoutEffect, useRef, useState, memo } from 'react';
+﻿import { useEffect, useRef, useState, memo, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 import {
   useRcbCamera,
   useRcbScreenToScene,
 } from '../camera/context';
 import {
   boundsOfAnchors,
-  CLOSE_THRESHOLD,
   findClosestPathHit,
   localizeAnchors,
   offsetAnchors,
@@ -17,9 +17,12 @@ import {
 } from './penPath';
 import { nodeLeftTop } from '../scene/paint/sceneToSvg';
 import { normalizePathDForEdit } from '../scene/paint/outlineToPath';
-import RcbSceneOverlayCanvas, {
-  type RcbSceneOverlayCanvasHandle,
-} from '../canvas/RcbSceneOverlayCanvas';
+import { snapPenAnchorPoint } from './PenDrawFeature';
+import {
+  getSceneDrawPreviewMount,
+  getSceneWorldEpoch,
+  subscribeShapeHosts,
+} from '../shapes/shapeHostRegistry';
 
 type HandleSide = 'in' | 'out';
 type AnchorRef = { sub: number; index: number };
@@ -30,7 +33,7 @@ type PenSubpath = { anchors: PenAnchor[]; closed: boolean };
 type DragKind =
   | { kind: 'anchor'; sub: number; index: number; ox: number; oy: number; start: PenAnchor }
   | { kind: 'handle'; sub: number; index: number; side: HandleSide; mirror: boolean }
-  /** Alt/Option-drag on anchor 鈥?Adobe Convert Point: pull out mirrored handles. */
+  /** Alt-drag on an anchor: pull mirrored handles. */
   | { kind: 'convert'; sub: number; index: number; ax: number; ay: number; pulled: boolean };
 
 function anchorHasHandles(a: PenAnchor) {
@@ -59,6 +62,9 @@ type Props = {
   /** Stroke paint for newly drawn paths (path-edit Pen). */
   newStrokeColor?: string;
   newStrokeWidth?: number;
+  /** Snap anchors to grid corners (default on). Hold Ctrl to drag/place free. */
+  gridSnap?: boolean;
+  gridSize?: number;
   onCommitNewShape?: (payload: {
     pathD: string;
     box: { left: number; top: number; width: number; height: number };
@@ -194,36 +200,29 @@ type HandleDraw = {
   active: boolean;
 };
 
-function paintAnchorKnob(
-  ctx: CanvasRenderingContext2D,
-  a: AnchorDraw,
-  strokeW: number
-) {
-  ctx.beginPath();
-  ctx.arc(a.x, a.y, a.r, 0, Math.PI * 2);
-  ctx.fillStyle = a.fill;
-  ctx.fill();
-  ctx.strokeStyle = a.strokeColor;
-  ctx.lineWidth = strokeW;
-  ctx.stroke();
+function AnchorKnobSvg({ a, strokeW }: { a: AnchorDraw; strokeW: number }) {
+  return (
+    <circle
+      cx={a.x}
+      cy={a.y}
+      r={a.r}
+      fill={a.fill}
+      stroke={a.strokeColor}
+      strokeWidth={strokeW}
+    />
+  );
 }
 
-function paintHandleDiamond(
-  ctx: CanvasRenderingContext2D,
-  h: HandleDraw,
-  strokeW: number
-) {
-  ctx.beginPath();
-  ctx.moveTo(h.x, h.y - h.r);
-  ctx.lineTo(h.x + h.r, h.y);
-  ctx.lineTo(h.x, h.y + h.r);
-  ctx.lineTo(h.x - h.r, h.y);
-  ctx.closePath();
-  ctx.fillStyle = h.active ? SEL_BASELINE : '#fff';
-  ctx.fill();
-  ctx.strokeStyle = h.active ? SEL_BASELINE : '#383838';
-  ctx.lineWidth = strokeW;
-  ctx.stroke();
+function HandleDiamondSvg({ h, strokeW }: { h: HandleDraw; strokeW: number }) {
+  const d = `M ${h.x} ${h.y - h.r} L ${h.x + h.r} ${h.y} L ${h.x} ${h.y + h.r} L ${h.x - h.r} ${h.y} Z`;
+  return (
+    <path
+      d={d}
+      fill={h.active ? SEL_BASELINE : '#fff'}
+      stroke={h.active ? SEL_BASELINE : '#383838'}
+      strokeWidth={strokeW}
+    />
+  );
 }
 
 function hitHandle(
@@ -421,18 +420,16 @@ function loadSceneAnchors(document: any, nodeId: string) {
 }
 
 /**
- * Double-click pen path 鈫?edit anchors / Bezier handles.
- * Path-edit: Esc / ✓ finish. Empty-canvas click never auto-exits
- * (Pen subtool keeps adding draft points; Select subtool only clears handle chrome).
- * Path-edit toolbar Pen: hover path shows a preview dot; click draws a new
- * path in-place (does not activate the global Pen tool).
+ * Double-click pen path → edit anchors / Bezier handles.
+ * Exit via Esc / ✓ only. Empty-canvas click never auto-exits.
+ * Path-edit Pen: hover shows a preview dot; click adds a path in-place.
  *
- * Convert Point (same idea as PS / AI):
- * - Alt/Option + drag on an anchor → pull out mirrored handles (restore curve)
- * - Alt/Option + click on an anchor with handles → remove handles (corner)
+ * Convert point:
+ * - Alt + drag anchor → pull mirrored handles
+ * - Alt + click anchor with handles → remove handles (corner)
  * - Double-click anchor → remove handles
- * - Alt/Option + click a handle → delete that side's handle
- * - Path-edit Curve subtool → same convert behavior without holding Alt
+ * - Alt + click a handle → delete that side
+ * - Curve subtool → same convert without Alt
  */
 function PenPathEditFeature({
   enabled,
@@ -444,6 +441,8 @@ function PenPathEditFeature({
   convertPointMode = false,
   newStrokeColor = '#333333',
   newStrokeWidth = 2,
+  gridSnap = true,
+  gridSize = 1,
   onCommitNewShape,
   onCommit,
   onExit,
@@ -478,12 +477,16 @@ function PenPathEditFeature({
   const drawNewRef = useRef(drawNewShapeMode);
   const convertPointRef = useRef(convertPointMode);
   const newStrokeWidthRef = useRef(newStrokeWidth);
+  const gridSnapRef = useRef(gridSnap);
+  const gridSizeRef = useRef(gridSize);
   onCommitRef.current = onCommit;
   onExitRef.current = onExit;
   onCommitNewShapeRef.current = onCommitNewShape;
   drawNewRef.current = drawNewShapeMode;
   convertPointRef.current = convertPointMode;
   newStrokeWidthRef.current = newStrokeWidth;
+  gridSnapRef.current = gridSnap;
+  gridSizeRef.current = gridSize;
 
   subpathsRef.current = subpaths;
   strokeWidthRef.current = strokeWidth;
@@ -629,15 +632,31 @@ function PenPathEditFeature({
       // Path-edit Pen: draw a new path in-place (keep edge hover; never leave to Pen tool).
       if (drawNewRef.current) {
         const draft = draftAnchorsRef.current;
-        const hover = pathHoverRef.current;
-        const place =
-          hover && Math.hypot(hover.x - p.x, hover.y - p.y) < 24 / Math.max(0.05, camera.zoom || 1)
-            ? { x: hover.x, y: hover.y }
-            : p;
+        const skipGrid = e.ctrlKey || !gridSnapRef.current;
+        const place = snapPenAnchorPoint(p.x, p.y, gridSizeRef.current, skipGrid);
         if (draft.length >= 2) {
           const first = draft[0];
-          if (Math.hypot(place.x - first.x, place.y - first.y) <= CLOSE_THRESHOLD) {
+          const last = draft[draft.length - 1];
+          const onFirst =
+            Math.hypot(place.x - first.x, place.y - first.y) <= 0.75 ||
+            Math.hypot(p.x - first.x, p.y - first.y) <= radii().anchor;
+          const onLast =
+            Math.hypot(place.x - last.x, place.y - last.y) <= 0.75 ||
+            Math.hypot(p.x - last.x, p.y - last.y) <= radii().anchor;
+          // Same landing as last → keep stroke linked (do not close / split).
+          if (onLast && !onFirst) {
+            setDraftCursor(place);
+            return;
+          }
+          // Only close when tip hits the first anchor (not merely nearby).
+          if (onFirst) {
             commitDraftIfAny(true);
+            return;
+          }
+        } else if (draft.length === 1) {
+          const only = draft[0];
+          if (Math.hypot(place.x - only.x, place.y - only.y) <= 0.75) {
+            setDraftCursor(place);
             return;
           }
         }
@@ -684,7 +703,7 @@ function PenPathEditFeature({
       if (aRef) {
         const a = list[aRef.sub]?.anchors[aRef.index];
         if (!a) return;
-        // Adobe Convert Point: Alt/Option, or Curve subtool (no modifier).
+        // Convert point: Alt/Option, or Curve subtool (no modifier).
         if (convertMod && !e.metaKey) {
           dragRef.current = {
             kind: 'convert',
@@ -751,16 +770,16 @@ function PenPathEditFeature({
         const { anchor: anchorR, handle: handleR, path: pathR } = radii();
         const list = subpathsRef.current;
         if (drawNewRef.current) {
-          // Always show edge preview on the edited path 鈥?even mid-draw.
+          // Always show edge preview on the edited path — even mid-draw.
           const nearest = findClosestOnSubpaths(list, p.x, p.y);
           if (nearest && nearest.dist <= pathR) {
             setPathHover({ x: nearest.x, y: nearest.y });
           } else {
             setPathHover(null);
           }
-          if (draftAnchorsRef.current.length > 0) {
-            setDraftCursor(p);
-          }
+          const skipGrid = e.ctrlKey || !gridSnapRef.current;
+          // Snap tip even before the first draft click (CSS cursor ≠ lattice).
+          setDraftCursor(snapPenAnchorPoint(p.x, p.y, gridSizeRef.current, skipGrid));
           setHoverAnchor(null);
           setHoverHandle(null);
           return;
@@ -793,20 +812,29 @@ function PenPathEditFeature({
 
       if (drag.kind === 'anchor') {
         dirtyRef.current = true;
+        const skipGrid = e.ctrlKey || !gridSnapRef.current;
         const dx = p.x - drag.ox;
         const dy = p.y - drag.oy;
+        const snapped = snapPenAnchorPoint(
+          drag.start.x + dx,
+          drag.start.y + dy,
+          gridSizeRef.current,
+          skipGrid
+        );
+        const adx = snapped.x - drag.start.x;
+        const ady = snapped.y - drag.start.y;
         setSubpaths((prev) =>
           mapSubpathAnchor(prev, drag.sub, drag.index, () => {
             const s = drag.start;
             return {
               ...s,
-              x: s.x + dx,
-              y: s.y + dy,
+              x: snapped.x,
+              y: snapped.y,
               ...(s.inX != null && s.inY != null
-                ? { inX: s.inX + dx, inY: s.inY + dy }
+                ? { inX: s.inX + adx, inY: s.inY + ady }
                 : {}),
               ...(s.outX != null && s.outY != null
-                ? { outX: s.outX + dx, outY: s.outY + dy }
+                ? { outX: s.outX + adx, outY: s.outY + ady }
                 : {}),
             };
           })
@@ -961,7 +989,7 @@ function PenPathEditFeature({
   });
 
   return (
-    <PenPathEditInkCanvas
+    <PenPathEditInkSvg
       pathD={d}
       fillColor={fillColor}
       fillRule={fillRule === 'evenodd' ? 'evenodd' : 'nonzero'}
@@ -975,8 +1003,6 @@ function PenPathEditFeature({
       draftColor={newStrokeColor}
       draftSw={draftSw}
       inv={inv}
-      subpaths={subpaths}
-      draftAnchors={draftAnchors}
       draftCursor={draftCursor}
       anchorsDraw={anchorsDraw}
       handlesDraw={handlesDraw}
@@ -986,7 +1012,7 @@ function PenPathEditFeature({
   );
 }
 
-function PenPathEditInkCanvas({
+function PenPathEditInkSvg({
   pathD,
   fillColor,
   fillRule,
@@ -1000,8 +1026,6 @@ function PenPathEditInkCanvas({
   draftColor,
   draftSw,
   inv,
-  subpaths,
-  draftAnchors,
   draftCursor,
   anchorsDraw,
   handlesDraw,
@@ -1010,7 +1034,7 @@ function PenPathEditInkCanvas({
 }: {
   pathD: string;
   fillColor: string;
-  fillRule: CanvasFillRule;
+  fillRule: 'evenodd' | 'nonzero';
   editStrokeOn: boolean;
   editStrokeColor: string;
   pathSw: number;
@@ -1021,181 +1045,112 @@ function PenPathEditInkCanvas({
   draftColor: string;
   draftSw: number;
   inv: number;
-  subpaths: PenSubpath[];
-  draftAnchors: PenAnchor[];
   draftCursor: { x: number; y: number } | null;
   anchorsDraw: AnchorDraw[];
   handlesDraw: HandleDraw[];
   knobStroke: number;
   handleStroke: number;
 }) {
-  const overlayRef = useRef<RcbSceneOverlayCanvasHandle>(null);
-  /**
-   * Expand-only paint slot. Tight min-bbox every drag frame retargets
-   * canvas.style.left/top + bitmap size → whole ink shakes (same class of bug
-   * as SelectionChrome zoom-dependent shell).
-   */
-  const slotBoxRef = useRef<{
-    left: number;
-    top: number;
-    width: number;
-    height: number;
-  } | null>(null);
-  const slotPathKeyRef = useRef<string>('');
+  // Portal into shared world SVG — sibling sceneSurfaceSvgProps drifts under fractional DPR.
+  const [, setWorldEpoch] = useState(() => getSceneWorldEpoch());
+  useEffect(
+    () =>
+      subscribeShapeHosts(() => {
+        setWorldEpoch((prev) => {
+          const next = getSceneWorldEpoch();
+          return prev === next ? prev : next;
+        });
+      }),
+    []
+  );
+  const previewMount = getSceneDrawPreviewMount();
+  const tipArm = 4 * inv;
+  const tipR = Math.max(0.01, (3 * inv) / 2);
+  const dash = `${4 * inv} ${3 * inv}`;
 
-  useLayoutEffect(() => {
-    const handle = overlayRef.current;
-    if (!handle) return;
-    const pts: Array<{ x: number; y: number }> = [];
-    for (const sp of subpaths) {
-      for (const a of sp.anchors) {
-        pts.push({ x: a.x, y: a.y });
-        if (a.inX != null && a.inY != null) pts.push({ x: a.inX, y: a.inY });
-        if (a.outX != null && a.outY != null) pts.push({ x: a.outX, y: a.outY });
-      }
-    }
-    for (const a of draftAnchors) pts.push({ x: a.x, y: a.y });
-    if (draftCursor) pts.push(draftCursor);
-    for (const a of anchorsDraw) pts.push({ x: a.x, y: a.y });
-    for (const h of handlesDraw) pts.push({ x: h.x, y: h.y });
-    if (!pts.length && !pathD) {
-      handle.clear();
-      slotBoxRef.current = null;
-      slotPathKeyRef.current = '';
-      return;
-    }
-    let minX = Infinity;
-    let minY = Infinity;
-    let maxX = -Infinity;
-    let maxY = -Infinity;
-    for (const p of pts) {
-      minX = Math.min(minX, p.x);
-      minY = Math.min(minY, p.y);
-      maxX = Math.max(maxX, p.x);
-      maxY = Math.max(maxY, p.y);
-    }
-    if (!Number.isFinite(minX)) {
-      handle.clear();
-      return;
-    }
-    const pad = Math.max(pathSw, draftSw, linkSw, knobStroke * 8, 12) * 2;
-    // Extra room so small drags do not grow the slot every pixel.
-    const slack = Math.max(48, pad * 2);
-    const needLeft = minX - pad;
-    const needTop = minY - pad;
-    const needRight = maxX + pad;
-    const needBottom = maxY + pad;
+  const children: ReactNode = (
+    <g data-pen-path-edit-preview pointerEvents="none" aria-hidden>
+      {linkSegs.map((s, i) => (
+        <line
+          key={`link-${i}`}
+          x1={s.x1}
+          y1={s.y1}
+          x2={s.x2}
+          y2={s.y2}
+          stroke="#8b8b8b"
+          strokeWidth={linkSw}
+          strokeLinecap="round"
+        />
+      ))}
+      {pathD ? (
+        <path
+          d={pathD}
+          fill={fillColor !== 'none' ? fillColor : 'none'}
+          fillRule={fillRule}
+          stroke={editStrokeOn && pathSw > 0 ? editStrokeColor : 'none'}
+          strokeWidth={pathSw}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      ) : null}
+      {draftD ? (
+        <path
+          d={draftD}
+          fill="none"
+          stroke={draftColor}
+          strokeWidth={draftSw}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      ) : null}
+      {draftRubber ? (
+        <path
+          d={draftRubber}
+          fill="none"
+          stroke={draftColor}
+          strokeWidth={draftSw}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeDasharray={dash}
+          opacity={0.7}
+        />
+      ) : null}
+      {draftCursor ? (
+        <g data-pen-snap-tip="1">
+          <circle
+            cx={draftCursor.x}
+            cy={draftCursor.y}
+            r={tipR}
+            fill={SEL_BASELINE}
+            stroke="none"
+            shapeRendering="geometricPrecision"
+          />
+          <path
+            d={`M ${draftCursor.x - tipArm} ${draftCursor.y} L ${draftCursor.x + tipArm} ${draftCursor.y} M ${draftCursor.x} ${draftCursor.y - tipArm} L ${draftCursor.x} ${draftCursor.y + tipArm}`}
+            fill="none"
+            stroke={SEL_BASELINE}
+            strokeWidth={knobStroke}
+            strokeLinecap="butt"
+            shapeRendering="geometricPrecision"
+            opacity={0.9}
+          />
+        </g>
+      ) : null}
+      {handlesDraw.map((h, i) => (
+        <HandleDiamondSvg key={`h-${i}`} h={h} strokeW={handleStroke} />
+      ))}
+      {anchorsDraw.map((a, i) => (
+        <AnchorKnobSvg key={`a-${i}`} a={a} strokeW={knobStroke} />
+      ))}
+    </g>
+  );
 
-    // Topology change (load / add / delete verts): reset slot. Dragging only expands.
-    const pathKey = `${fillColor}:${subpaths.map((s) => `${s.anchors.length}:${s.closed ? 1 : 0}`).join('|')}`;
-    if (pathKey !== slotPathKeyRef.current) {
-      slotPathKeyRef.current = pathKey;
-      slotBoxRef.current = null;
-    }
+  if (!previewMount) return null;
+  if (!pathD && !draftD && !draftRubber && !anchorsDraw.length && !handlesDraw.length) {
+    return null;
+  }
 
-    let slot = slotBoxRef.current;
-    if (!slot) {
-      slot = {
-        left: needLeft - slack,
-        top: needTop - slack,
-        width: Math.max(1, needRight - needLeft + slack * 2),
-        height: Math.max(1, needBottom - needTop + slack * 2),
-      };
-      slotBoxRef.current = slot;
-    } else {
-      const slotRight = slot.left + slot.width;
-      const slotBottom = slot.top + slot.height;
-      const growL = needLeft < slot.left;
-      const growT = needTop < slot.top;
-      const growR = needRight > slotRight;
-      const growB = needBottom > slotBottom;
-      if (growL || growT || growR || growB) {
-        const left = growL ? needLeft - slack : slot.left;
-        const top = growT ? needTop - slack : slot.top;
-        const right = growR ? needRight + slack : slotRight;
-        const bottom = growB ? needBottom + slack : slotBottom;
-        slot = {
-          left,
-          top,
-          width: Math.max(1, right - left),
-          height: Math.max(1, bottom - top),
-        };
-        slotBoxRef.current = slot;
-      }
-    }
-
-    const ctx = handle.beginFrame(slot);
-    if (!ctx) return;
-    ctx.lineCap = 'round';
-    ctx.lineJoin = 'round';
-
-    for (const s of linkSegs) {
-      ctx.strokeStyle = '#8b8b8b';
-      ctx.lineWidth = linkSw;
-      ctx.setLineDash([]);
-      ctx.beginPath();
-      ctx.moveTo(s.x1, s.y1);
-      ctx.lineTo(s.x2, s.y2);
-      ctx.stroke();
-    }
-
-    if (pathD) {
-      const path = new Path2D(pathD);
-      if (fillColor !== 'none') {
-        ctx.fillStyle = fillColor;
-        ctx.fill(path, fillRule);
-      }
-      if (editStrokeOn && pathSw > 0) {
-        ctx.strokeStyle = editStrokeColor;
-        ctx.lineWidth = pathSw;
-        ctx.setLineDash([]);
-        ctx.stroke(path);
-      }
-    }
-
-    if (draftD) {
-      ctx.strokeStyle = draftColor;
-      ctx.lineWidth = draftSw;
-      ctx.setLineDash([]);
-      ctx.stroke(new Path2D(draftD));
-    }
-    if (draftRubber) {
-      ctx.strokeStyle = draftColor;
-      ctx.lineWidth = draftSw;
-      ctx.globalAlpha = 0.7;
-      ctx.setLineDash([4 * inv, 3 * inv]);
-      ctx.stroke(new Path2D(draftRubber));
-      ctx.globalAlpha = 1;
-      ctx.setLineDash([]);
-    }
-
-    ctx.setLineDash([]);
-    for (const h of handlesDraw) paintHandleDiamond(ctx, h, handleStroke);
-    for (const a of anchorsDraw) paintAnchorKnob(ctx, a, knobStroke);
-  }, [
-    pathD,
-    fillColor,
-    fillRule,
-    editStrokeOn,
-    editStrokeColor,
-    pathSw,
-    linkSegs,
-    linkSw,
-    draftD,
-    draftRubber,
-    draftColor,
-    draftSw,
-    inv,
-    subpaths,
-    draftAnchors,
-    draftCursor,
-    anchorsDraw,
-    handlesDraw,
-    knobStroke,
-    handleStroke,
-  ]);
-
-  return <RcbSceneOverlayCanvas ref={overlayRef} zClass="z-20" />;
+  return createPortal(children, previewMount);
 }
 
 export default memo(PenPathEditFeature);

--- a/apps/web/src/components/rcb/tools/PencilDrawFeature.tsx
+++ b/apps/web/src/components/rcb/tools/PencilDrawFeature.tsx
@@ -1,14 +1,16 @@
-import { useEffect, useRef, memo } from 'react';
+import { useEffect, useRef, useState, memo } from 'react';
 import {
   brushPad,
   brushSize,
   findPencilBrush,
   isStampBrush,
+  pencilSampleMinStep,
   polylinePathD,
   samplePolyline,
   serializePathPressures,
   stampSizeForBrush,
   stampSpacingForBrush,
+  streamlinePencilPoints,
   type PencilBrushId,
 } from './pencilBrushes';
 import { getTintedStampSrc } from './stampTint';
@@ -27,10 +29,38 @@ import {
 import {
   type RcbCamera as CanvasCamera,
 } from '../core/types';
-import RcbSceneOverlayCanvas, {
-  type RcbSceneOverlayCanvasHandle,
-  type SceneOverlayBox,
-} from '../canvas/RcbSceneOverlayCanvas';
+import { sceneSurfaceSvgProps } from '@/components/rcb/scene/paint/sceneToSvg';
+
+type SceneBox = { left: number; top: number; width: number; height: number };
+
+type PencilPreview =
+  | {
+      box: SceneBox;
+      mode: 'erase';
+      trailD: string;
+      tip: { x: number; y: number } | null;
+      tipR: number;
+      trailW: number;
+      tipStroke: number;
+      tipDash: string;
+    }
+  | {
+      box: SceneBox;
+      mode: 'stroke';
+      pathD: string;
+      color: string;
+      opacity: number;
+      lineWidth: number;
+    }
+  | {
+      box: SceneBox;
+      mode: 'stamp';
+      samples: Array<{ x: number; y: number }>;
+      size: number;
+      src: string;
+      opacity: number;
+    };
+
 import pencilCursorUrl from '@/assets/svg/editor/cursor_pencil.svg?url';
 import eraserCursorUrl from '@/assets/svg/editor/cursor_eraser.svg?url';
 import penCursorUrl from '@/assets/svg/editor/cursor_pen.svg?url';
@@ -39,7 +69,8 @@ import bucketCursorUrl from '@/assets/svg/editor/cursor_bucket.svg?url';
 /** CSS cursors — icons in `assets/svg/editor/cursor_*.svg` (hotspot = tip). */
 export const PENCIL_CURSOR = `url("${pencilCursorUrl}") 2 13, crosshair`;
 export const ERASER_CURSOR = `url("${eraserCursorUrl}") 3 15, crosshair`;
-export const PEN_CURSOR = `url("${penCursorUrl}") 2 2, crosshair`;
+/** Pen nib is at viewBox (2,2) on 24→18 CSS: hotspot ≈ (1.5,1.5) → use 2 2 was ~0.5px late; 1 1 tracks the tip. */
+export const PEN_CURSOR = `url("${penCursorUrl}") 1 1, crosshair`;
 export const BUCKET_CURSOR = `url("${bucketCursorUrl}") 15 18, cell`;
 
 function clientToPaperScene(
@@ -77,11 +108,11 @@ function clientToDrawScene(
   return clientToPaperScene(opts.paperEl, opts.artboard, clientX, clientY);
 }
 
-/** Stable scene rect covering the current viewport (for stroke preview — avoids per-point canvas resize jitter). */
+/** Stable scene rect covering the current viewport (for stroke preview — avoids per-point shell resize jitter). */
 function visibleSceneOverlayBox(
   camera: CanvasCamera,
   stageEl: HTMLElement | null
-): SceneOverlayBox | null {
+): SceneBox | null {
   const stage = rcbResolveViewportEl(stageEl);
   if (!stage) return null;
   const { clientWidth, clientHeight } = rcbViewportMetrics(stage);
@@ -97,7 +128,7 @@ function visibleSceneOverlayBox(
   };
 }
 
-function unionSceneOverlayBox(a: SceneOverlayBox, b: SceneOverlayBox): SceneOverlayBox {
+function unionSceneOverlayBox(a: SceneBox, b: SceneBox): SceneBox {
   const left = Math.min(a.left, b.left);
   const top = Math.min(a.top, b.top);
   const right = Math.max(a.left + a.width, b.left + b.width);
@@ -197,10 +228,9 @@ function PencilDrawFeature({
   const lastClientRef = useRef<{ x: number; y: number } | null>(null);
   const strokeScaleRef = useRef({ scaleX: 1, scaleY: 1 });
   const drawing = useRef(false);
-  /** Locked overlay viewport for the active stroke — stops per-point canvas resize jitter. */
-  const strokeViewBoxRef = useRef<SceneOverlayBox | null>(null);
-  const overlayRef = useRef<RcbSceneOverlayCanvasHandle>(null);
-  const stampImageRef = useRef<HTMLImageElement | null>(null);
+  /** Locked overlay viewport for the active stroke — stops per-point shell resize jitter. */
+  const strokeViewBoxRef = useRef<SceneBox | null>(null);
+  const [preview, setPreview] = useState<PencilPreview | null>(null);
   const lastTipPosRef = useRef<{ x: number; y: number } | null>(null);
   const brushRef = useRef(brushId);
   const widthRef = useRef(strokeWidth);
@@ -255,8 +285,6 @@ function PencilDrawFeature({
   };
 
   const redrawOverlay = () => {
-    const handle = overlayRef.current;
-    if (!handle) return;
     const zoom = Math.max(0.05, cameraRef.current.zoom || 1);
     const tip = lastTipPosRef.current;
     const points = pts.current;
@@ -270,7 +298,7 @@ function PencilDrawFeature({
     if (tip) all.push(tip);
     const contentBox = pointsBounds(all, pad);
     if (!contentBox) {
-      handle.clear();
+      setPreview(null);
       strokeViewBoxRef.current = null;
       return;
     }
@@ -298,72 +326,50 @@ function PencilDrawFeature({
       }
       box = view;
     }
-    const ctx = handle.beginFrame(box);
-    if (!ctx) return;
-    ctx.lineCap = 'round';
-    ctx.lineJoin = 'round';
 
     if (eraseModeRef.current) {
-      if (points.length >= 2) {
-        ctx.strokeStyle = 'rgba(20,20,20,0.28)';
-        ctx.lineWidth = eraseTipDiameter();
-        ctx.beginPath();
-        ctx.moveTo(points[0].x, points[0].y);
-        for (let i = 1; i < points.length; i += 1) ctx.lineTo(points[i].x, points[i].y);
-        ctx.stroke();
-      }
-      if (tip) {
-        const r = eraseTipRadius();
-        ctx.fillStyle = 'rgba(20,20,20,0.12)';
-        ctx.strokeStyle = 'rgba(20,20,20,0.85)';
-        ctx.lineWidth = 1.25 / zoom;
-        ctx.setLineDash([3 / zoom, 2 / zoom]);
-        ctx.beginPath();
-        ctx.arc(tip.x, tip.y, r, 0, Math.PI * 2);
-        ctx.fill();
-        ctx.stroke();
-        ctx.setLineDash([]);
-      }
+      setPreview({
+        box,
+        mode: 'erase',
+        trailD: points.length >= 2 ? polylinePathD(points) : '',
+        tip,
+        tipR: eraseTipRadius(),
+        trailW: eraseTipDiameter(),
+        tipStroke: 1.25 / zoom,
+        tipDash: `${3 / zoom} ${2 / zoom}`,
+      });
       return;
     }
 
-    if (points.length < 2) return;
+    if (points.length < 2) {
+      setPreview(null);
+      return;
+    }
     const brush = findPencilBrush(brushRef.current);
     if (isStampBrush(brush.id, brush.stampSrc) && brush.stampSrc) {
       const size = stampSizeForBrush(brush, widthRef.current);
       const spacing = stampSpacingForBrush(brush, widthRef.current);
       const samples = samplePolyline(points, spacing);
-      const tipSrc = getTintedStampSrc(brush.stampSrc, colorRef.current);
-      let img = stampImageRef.current;
-      if (!img || img.src !== tipSrc) {
-        img = new Image();
-        img.src = tipSrc;
-        stampImageRef.current = img;
-      }
-      ctx.globalAlpha = opacityRef.current;
-      for (const p of samples) {
-        try {
-          ctx.drawImage(img, p.x - size / 2, p.y - size / 2, size, size);
-        } catch {
-          /* decode pending */
-        }
-      }
-      ctx.globalAlpha = 1;
+      setPreview({
+        box,
+        mode: 'stamp',
+        samples,
+        size,
+        src: getTintedStampSrc(brush.stampSrc, colorRef.current),
+        opacity: opacityRef.current,
+      });
       return;
     }
 
-    // Match committed paint (sceneToSvg): centerline + stroke — same as pen.
     const inkW = brushSize(brush, widthRef.current);
-    ctx.strokeStyle = colorRef.current;
-    ctx.globalAlpha = opacityRef.current;
-    ctx.lineWidth = inkW;
-    ctx.lineCap = 'round';
-    ctx.lineJoin = 'round';
-    ctx.beginPath();
-    ctx.moveTo(points[0].x, points[0].y);
-    for (let i = 1; i < points.length; i += 1) ctx.lineTo(points[i].x, points[i].y);
-    ctx.stroke();
-    ctx.globalAlpha = 1;
+    setPreview({
+      box,
+      mode: 'stroke',
+      pathD: polylinePathD(points),
+      color: colorRef.current,
+      opacity: opacityRef.current,
+      lineWidth: inkW,
+    });
   };
 
   const paintTipCursor = (p: { x: number; y: number } | null) => {
@@ -443,34 +449,76 @@ function PencilDrawFeature({
       return toScene(e.clientX, e.clientY);
     };
 
+    const appendStrokePoint = (raw: {
+      x: number;
+      y: number;
+      pressure?: number;
+    }) => {
+      const brush = findPencilBrush(brushRef.current);
+      const minStep = pencilSampleMinStep(widthRef.current, brush);
+      const last = pts.current[pts.current.length - 1];
+      if (last && Math.hypot(raw.x - last.x, raw.y - last.y) < minStep) {
+        return false;
+      }
+      const streamline = Number(brush.options?.streamline) || 0;
+      if (last && streamline > 0) {
+        const a = Math.min(0.92, Math.max(0, streamline));
+        const smoothed = {
+          x: last.x + (raw.x - last.x) * (1 - a),
+          y: last.y + (raw.y - last.y) * (1 - a),
+          ...(raw.pressure != null ? { pressure: raw.pressure } : {}),
+        };
+        if (Math.hypot(smoothed.x - last.x, smoothed.y - last.y) < minStep * 0.5) {
+          return false;
+        }
+        pts.current.push(smoothed);
+      } else {
+        pts.current.push(raw);
+      }
+      return true;
+    };
+
     const onMove = (e: PointerEvent) => {
       if (!drawing.current) {
         paintTipCursor(toScene(e.clientX, e.clientY));
         return;
       }
-      const p = sampleScenePoint(e);
-      const pressure = pressureRef.current ? pointerPressure(e) : undefined;
-      const pt = pressure != null ? { ...p, pressure } : p;
-      if (eraseModeRef.current) {
-        const last = pts.current[pts.current.length - 1];
-        if (last && Math.hypot(p.x - last.x, p.y - last.y) < 0.5) {
-          paintTipCursor(p);
-          return;
+      const coalesced =
+        typeof e.getCoalescedEvents === 'function' ? e.getCoalescedEvents() : [];
+      const events = coalesced.length ? coalesced : [e];
+      let changed = false;
+      let tip = pts.current[pts.current.length - 1] || toScene(e.clientX, e.clientY);
+      for (const ev of events) {
+        const p = sampleScenePoint(ev);
+        tip = p;
+        const pressure = pressureRef.current ? pointerPressure(ev) : undefined;
+        const pt = pressure != null ? { ...p, pressure } : p;
+        if (eraseModeRef.current) {
+          const last = pts.current[pts.current.length - 1];
+          const minStep = Math.max(0.12, eraseTipRadius() * 0.15);
+          if (last && Math.hypot(p.x - last.x, p.y - last.y) < minStep) {
+            continue;
+          }
+          pts.current.push(pt);
+          changed = true;
+        } else if (appendStrokePoint(pt)) {
+          changed = true;
         }
-        pts.current.push(pt);
-        paintTipCursor(p);
-        paintEraseTrail(pts.current);
-        return;
       }
-      const last = pts.current[pts.current.length - 1];
-      // Skip near-duplicates to keep streamline stable.
-      if (last && Math.hypot(p.x - last.x, p.y - last.y) < 0.6) {
-        paintTipCursor(p);
-        return;
-      }
-      pts.current.push(pt);
-      paintTipCursor(p);
-      paintPreview(pts.current);
+      paintTipCursor(tip);
+      if (!changed) return;
+      if (eraseModeRef.current) paintEraseTrail(pts.current);
+      else paintPreview(pts.current);
+    };
+
+    const onMoveWhileDrawing = (e: PointerEvent) => {
+      if (!drawing.current) return;
+      onMove(e);
+    };
+
+    const onMoveIdle = (e: PointerEvent) => {
+      if (drawing.current) return;
+      paintTipCursor(toScene(e.clientX, e.clientY));
     };
 
     const finishStroke = (e: PointerEvent, commit: boolean) => {
@@ -483,8 +531,30 @@ function PencilDrawFeature({
       } catch {
         /* ignore */
       }
-      overlayRef.current?.clear();
+      setPreview(null);
       const wasErase = eraseModeRef.current;
+      // Pin the last sample to the real tip, then optional full-path polish.
+      if (!wasErase && pts.current.length >= 1) {
+        const tip = toScene(e.clientX, e.clientY);
+        const pressure = pressureRef.current ? pointerPressure(e) : undefined;
+        const last = pts.current[pts.current.length - 1];
+        if (Math.hypot(tip.x - last.x, tip.y - last.y) > 0.05) {
+          pts.current.push(
+            pressure != null ? { ...tip, pressure } : tip
+          );
+        } else {
+          pts.current[pts.current.length - 1] = {
+            x: tip.x,
+            y: tip.y,
+            ...(pressure != null ? { pressure } : {}),
+          };
+        }
+        const brush = findPencilBrush(brushRef.current);
+        const streamline = Number(brush.options?.streamline) || 0;
+        if (streamline > 0 && pts.current.length >= 3) {
+          pts.current = streamlinePencilPoints(pts.current, streamline * 0.45);
+        }
+      }
       const points = pts.current;
       pts.current = [];
       if (!wasErase) paintTipCursor(null);
@@ -545,18 +615,20 @@ function PencilDrawFeature({
     };
 
     hitEl.addEventListener('pointerdown', onDown, true);
-    hitEl.addEventListener('pointermove', onMove);
-    hitEl.addEventListener('pointerup', onUp);
-    hitEl.addEventListener('pointercancel', onCancel);
-    hitEl.addEventListener('pointerleave', onLeave);
+    hitEl.addEventListener('pointermove', onMoveIdle);
+    // Window move/up while drawing — stage-only move drops samples when the
+    // pointer briefly leaves / is coalesced away (feels choppy / broken).
+    window.addEventListener('pointermove', onMoveWhileDrawing);
+    window.addEventListener('pointerup', onUp);
     window.addEventListener('pointercancel', onCancel);
+    hitEl.addEventListener('pointerleave', onLeave);
     return () => {
       hitEl.removeEventListener('pointerdown', onDown, true);
-      hitEl.removeEventListener('pointermove', onMove);
-      hitEl.removeEventListener('pointerup', onUp);
-      hitEl.removeEventListener('pointercancel', onCancel);
-      hitEl.removeEventListener('pointerleave', onLeave);
+      hitEl.removeEventListener('pointermove', onMoveIdle);
+      window.removeEventListener('pointermove', onMoveWhileDrawing);
+      window.removeEventListener('pointerup', onUp);
       window.removeEventListener('pointercancel', onCancel);
+      hitEl.removeEventListener('pointerleave', onLeave);
       paintTipCursor(null);
     };
   }, [enabled, stageEl, paperEl, viewportEl, artboard, onCommit, liveStage]);
@@ -576,7 +648,72 @@ function PencilDrawFeature({
 
   if (!enabled) return null;
 
-  return <RcbSceneOverlayCanvas ref={overlayRef} zClass="z-20" />;
+  if (!preview) return null;
+  const surf = sceneSurfaceSvgProps(preview.box, camera);
+  return (
+    <svg
+      data-pencil-draw-preview
+      data-rcb-infinite="1"
+      className="pointer-events-none absolute z-20 overflow-visible"
+      width={surf.width}
+      height={surf.height}
+      viewBox={surf.viewBox}
+      preserveAspectRatio="none"
+      style={surf.style}
+      aria-hidden
+    >
+      {preview.mode === 'erase' ? (
+        <>
+          {preview.trailD ? (
+            <path
+              d={preview.trailD}
+              fill="none"
+              stroke="rgba(20,20,20,0.28)"
+              strokeWidth={preview.trailW}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          ) : null}
+          {preview.tip ? (
+            <circle
+              cx={preview.tip.x}
+              cy={preview.tip.y}
+              r={preview.tipR}
+              fill="rgba(20,20,20,0.12)"
+              stroke="rgba(20,20,20,0.85)"
+              strokeWidth={preview.tipStroke}
+              strokeDasharray={preview.tipDash}
+            />
+          ) : null}
+        </>
+      ) : null}
+      {preview.mode === 'stroke' ? (
+        <path
+          d={preview.pathD}
+          fill="none"
+          stroke={preview.color}
+          strokeOpacity={preview.opacity}
+          strokeWidth={preview.lineWidth}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      ) : null}
+      {preview.mode === 'stamp'
+        ? preview.samples.map((pt, i) => (
+            <image
+              key={i}
+              href={preview.src}
+              x={pt.x - preview.size / 2}
+              y={pt.y - preview.size / 2}
+              width={preview.size}
+              height={preview.size}
+              opacity={preview.opacity}
+              preserveAspectRatio="xMidYMid meet"
+            />
+          ))
+        : null}
+    </svg>
+  );
 }
 
 export default memo(PencilDrawFeature);

--- a/apps/web/src/components/rcb/tools/ShapeDrawFeature.tsx
+++ b/apps/web/src/components/rcb/tools/ShapeDrawFeature.tsx
@@ -7,17 +7,12 @@ import {
   rcbResolveViewportEl,
   rcbViewportMetrics,
 } from '../core/math';
-import { useEffect, useLayoutEffect, useRef, useState, memo } from 'react';
-import {
-  ARROW_HEAD,
-  fillCachedPath2D,
-  strokeCachedPath2D,
-} from '@/components/rcb/scene/document/sceneShapes';
+import { createPortal } from 'react-dom';
+import { useEffect, useRef, useState, memo, type ReactNode } from 'react';
+import { ARROW_HEAD } from '@/components/rcb/scene/document/sceneShapes';
 import { getShapeBaselineD } from '@/components/rcb/core/geometry';
 import { snapBoxEdgesToGrid, snapCoordToGrid } from '../selection/alignGuides';
-import RcbSceneOverlayCanvas, {
-  type RcbSceneOverlayCanvasHandle,
-} from '../canvas/RcbSceneOverlayCanvas';
+import { getSceneDrawPreviewMount } from '../shapes/shapeHostRegistry';
 
 function normalizeBox(x0: number, y0: number, x1: number, y1: number) {
   const left = Math.min(x0, x1);
@@ -77,7 +72,8 @@ function locksSquareAspect(kind: string) {
 }
 
 function squareLockedBox(box: { left: number; top: number; width: number; height: number }) {
-  const size = Math.max(3, Math.max(box.width, box.height));
+  // No hardcoded min size — visual min is enforced after grid snap (minSide).
+  const size = Math.max(box.width, box.height);
   return {
     left: box.left + (box.width - size) / 2,
     top: box.top + (box.height - size) / 2,
@@ -104,8 +100,9 @@ type DrawBox = { left: number; top: number; width: number; height: number };
 
 /**
  * Rubber-band → integer visual outer → inset stroke/2 → path geom.
+ * Preview and commit must both use this (do not re-inflate geom on create).
  */
-function resolveClosedDrawBoxes(
+export function resolveClosedDrawBoxes(
   raw: DrawBox,
   useGrid: boolean,
   gridSize: number,
@@ -180,7 +177,7 @@ type PreviewState =
   | { mode: 'box'; geom: DrawBox; visual: DrawBox }
   | { mode: 'stroke'; x0: number; y0: number; x1: number; y1: number };
 
-/** Drag-to-create shapes — Path2D overlay preview (same stack as pen/pencil). */
+/** Drag-to-create shapes — preview paints into shared scene SVG (same lattice as grid). */
 function ShapeDrawFeature({
   enabled,
   shapeKind,
@@ -205,13 +202,11 @@ function ShapeDrawFeature({
   gridSizeRef.current = gridSize;
   const session = useRef<ShapeDrawSession | null>(null);
   const [preview, setPreview] = useState<PreviewState | null>(null);
-  const overlayRef = useRef<RcbSceneOverlayCanvasHandle>(null);
 
   useEffect(() => {
     if (!enabled) {
       session.current = null;
       setPreview(null);
-      overlayRef.current?.clear();
     }
   }, [enabled]);
 
@@ -324,7 +319,6 @@ function ShapeDrawFeature({
       if (!s || e.pointerId !== s.pointerId) return;
       session.current = null;
       setPreview(null);
-      overlayRef.current?.clear();
       try {
         hitEl.releasePointerCapture?.(e.pointerId);
       } catch {
@@ -383,7 +377,6 @@ function ShapeDrawFeature({
       window.removeEventListener('pointercancel', finishSession);
       window.removeEventListener('keydown', onKey);
       window.removeEventListener('keyup', onKey);
-      overlayRef.current?.clear();
     };
   }, [enabled, paperEl, stageEl, viewportEl]);
 
@@ -391,113 +384,17 @@ function ShapeDrawFeature({
   const z = Math.max(0.05, camera.zoom || 1);
   const inv = 1 / z;
   const kind = shapeKind || 'rect';
-
-  useLayoutEffect(() => {
-    const handle = overlayRef.current;
-    if (!enabled || !preview || !handle) {
-      handle?.clear();
-      return;
-    }
-
-    const isStroke = kind === 'line' || kind === 'arrow';
-    const strokeW = defaultShapeBorderWidth(kind);
-    const pad = Math.ceil(strokeW * 2) + (kind === 'arrow' ? Math.ceil(ARROW_HEAD) : 2);
-
-    let drawLeft: number;
-    let drawTop: number;
-    let drawW: number;
-    let drawH: number;
-    let pathLeft = 0;
-    let pathTop = 0;
-    let pathW = 1;
-    let pathH = 1;
-    let x0 = 0;
-    let y0 = 0;
-    let x1 = 0;
-    let y1 = 0;
-
-    if (preview.mode === 'stroke') {
-      x0 = preview.x0;
-      y0 = preview.y0;
-      x1 = preview.x1;
-      y1 = preview.y1;
-      drawLeft = Math.min(x0, x1);
-      drawTop = Math.min(y0, y1);
-      drawW = Math.max(1, Math.abs(x1 - x0));
-      drawH = Math.max(1, Math.abs(y1 - y0));
-    } else {
-      const { geom, visual } = preview;
-      drawLeft = visual.left;
-      drawTop = visual.top;
-      drawW = visual.width;
-      drawH = visual.height;
-      pathLeft = geom.left;
-      pathTop = geom.top;
-      pathW = geom.width;
-      pathH = geom.height;
-    }
-
-    const ctx = handle.beginFrame({
-      left: drawLeft - pad,
-      top: drawTop - pad,
-      width: Math.max(1, drawW + pad * 2),
-      height: Math.max(1, drawH + pad * 2),
-    });
-    if (!ctx) return;
-
-    ctx.lineCap = 'butt';
-    ctx.lineJoin = 'miter';
-    ctx.miterLimit = 10;
-
-    if (isStroke) {
-      ctx.strokeStyle = '#333333';
-      ctx.lineWidth = strokeW;
-      ctx.beginPath();
-      ctx.moveTo(x0, y0);
-      ctx.lineTo(x1, y1);
-      ctx.stroke();
-      if (kind === 'arrow') {
-        const len = Math.hypot(x1 - x0, y1 - y0);
-        if (len >= 3) {
-          const ux = (x1 - x0) / len;
-          const uy = (y1 - y0) / len;
-          const head = Math.min(ARROW_HEAD, len * 0.45);
-          const bx = x1 - ux * head;
-          const by = y1 - uy * head;
-          const nx = -uy;
-          const ny = ux;
-          const wing = head * 0.55;
-          ctx.beginPath();
-          ctx.moveTo(bx + nx * wing, by + ny * wing);
-          ctx.lineTo(x1, y1);
-          ctx.lineTo(bx - nx * wing, by - ny * wing);
-          ctx.stroke();
-        }
-      }
-    } else {
-      const pathD =
-        getShapeBaselineD(
-          { key: 'shape', width: pathW, height: pathH, attrs: { shapeType: kind } },
-          { width: pathW, height: pathH }
-        ) || `M 0 0 H ${Math.max(1, pathW)} V ${Math.max(1, pathH)} H 0 Z`;
-      ctx.save();
-      ctx.translate(pathLeft, pathTop);
-      fillCachedPath2D(ctx, pathD, { fillStyle: 'rgba(255,255,255,0.85)' });
-      strokeCachedPath2D(ctx, pathD, {
-        strokeStyle: '#333333',
-        lineWidth: strokeW,
-        lineCap: 'butt',
-        lineJoin: 'miter',
-      });
-      ctx.restore();
-    }
-  }, [enabled, preview, kind, z]);
+  const strokeW = defaultShapeBorderWidth(kind);
 
   if (!enabled) return null;
 
   let sizeLabel: string | null = null;
   let labelX = 0;
   let labelY = 0;
+  let previewSvg: ReactNode = null;
+
+  const previewMount = getSceneDrawPreviewMount();
+
   if (preview?.mode === 'stroke') {
     const len = Math.hypot(preview.x1 - preview.x0, preview.y1 - preview.y0);
     if (len >= 3) {
@@ -505,13 +402,69 @@ function ShapeDrawFeature({
       labelX = (preview.x0 + preview.x1) / 2;
       labelY = Math.min(preview.y0, preview.y1);
     }
+    let arrowHead: ReactNode = null;
+    if (kind === 'arrow' && len >= 3) {
+      const ux = (preview.x1 - preview.x0) / len;
+      const uy = (preview.y1 - preview.y0) / len;
+      const head = Math.min(ARROW_HEAD, len * 0.45);
+      const bx = preview.x1 - ux * head;
+      const by = preview.y1 - uy * head;
+      const nx = -uy;
+      const ny = ux;
+      const wing = head * 0.55;
+      arrowHead = (
+        <path
+          d={`M ${bx + nx * wing} ${by + ny * wing} L ${preview.x1} ${preview.y1} L ${bx - nx * wing} ${by - ny * wing}`}
+          fill="none"
+          stroke="#333333"
+          strokeWidth={strokeW}
+          strokeLinecap="butt"
+          strokeLinejoin="miter"
+        />
+      );
+    }
+    const strokePreview = (
+      <g data-shape-draw-preview pointerEvents="none" aria-hidden>
+        <line
+          x1={preview.x0}
+          y1={preview.y0}
+          x2={preview.x1}
+          y2={preview.y1}
+          stroke="#333333"
+          strokeWidth={strokeW}
+          strokeLinecap="butt"
+        />
+        {arrowHead}
+      </g>
+    );
+    previewSvg = previewMount ? createPortal(strokePreview, previewMount) : null;
   } else if (preview?.mode === 'box') {
-    const { visual } = preview;
+    const { visual, geom } = preview;
     if (visual.width >= 3 || visual.height >= 3) {
       sizeLabel = `${Math.round(visual.width)} × ${Math.round(visual.height)}`;
       labelX = visual.left + visual.width / 2;
       labelY = visual.top;
     }
+    const pathD =
+      getShapeBaselineD(
+        { key: 'shape', width: geom.width, height: geom.height, attrs: { shapeType: kind } },
+        { width: geom.width, height: geom.height }
+      ) || `M 0 0 H ${Math.max(1, geom.width)} V ${Math.max(1, geom.height)} H 0 Z`;
+    const boxPreview = (
+      <g data-shape-draw-preview pointerEvents="none" aria-hidden>
+        <g transform={`translate(${geom.left} ${geom.top})`}>
+          <path
+            d={pathD}
+            fill="rgba(255,255,255,0.85)"
+            stroke="#333333"
+            strokeWidth={strokeW}
+            strokeLinecap="butt"
+            strokeLinejoin="miter"
+          />
+        </g>
+      </g>
+    );
+    previewSvg = previewMount ? createPortal(boxPreview, previewMount) : null;
   }
 
   const labelFont = 10 * inv;
@@ -519,7 +472,7 @@ function ShapeDrawFeature({
 
   return (
     <>
-      <RcbSceneOverlayCanvas ref={overlayRef} zClass="z-20" />
+      {previewSvg}
       {sizeLabel ? (
         <div
           data-shape-draw-preview-label

--- a/apps/web/src/components/rcb/tools/TextPlaceFeature.tsx
+++ b/apps/web/src/components/rcb/tools/TextPlaceFeature.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, memo } from 'react';
 import { useRcbCamera, useRcbScreenToScene } from '../camera/context';
+import { rcbDefaultPlaceFontSize } from '../core/layout';
 
 /** `dragDistanceSquared` default = 16 → 4px; fixed-width needs ~6× that. */
 const BASE_DRAG_PX = 4;
@@ -108,7 +109,14 @@ function TextPlaceFeature({
       }
       const left = Math.min(pt.originX, p.x);
       const width = Math.max(1, Math.abs(p.x - pt.originX));
-      setPreview({ left, top: pt.originY, width, height: 24 });
+      const zoom = Math.max(0.05, camera.zoom || 1);
+      const fs = rcbDefaultPlaceFontSize(zoom, 14);
+      setPreview({
+        left,
+        top: pt.originY,
+        width,
+        height: Math.max(1, Math.ceil(fs * 1.4)),
+      });
     };
 
     const finish = (e: PointerEvent, commit: boolean) => {

--- a/apps/web/src/components/rcb/tools/__tests__/penAnchorGridSnap.test.ts
+++ b/apps/web/src/components/rcb/tools/__tests__/penAnchorGridSnap.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import { snapPenAnchorPoint } from '../PenDrawFeature';
+import { snapCoordToGrid } from '../../selection/alignGuides';
+import { penAnchorsToD, boundsOfAnchors, type PenAnchor } from '../penPath';
+
+/**
+ * Mirrors PenDrawFeature place path (without DOM):
+ * raw pointer → snapPenAnchorPoint → anchor list → commit bounds.
+ */
+function simulatePenClicks(
+  rawPoints: Array<{ x: number; y: number }>,
+  gridSize = 1,
+  skipGrid = false
+): PenAnchor[] {
+  return rawPoints.map((raw) => {
+    const p = snapPenAnchorPoint(raw.x, raw.y, gridSize, skipGrid);
+    return { x: p.x, y: p.y };
+  });
+}
+
+/** Corner or edge-mid on the 1px lattice (not free floats / not cell centers). */
+function assertOnPenGridLattice(anchors: PenAnchor[], gridSize: number) {
+  const g = gridSize;
+  const half = g / 2;
+  for (const a of anchors) {
+    const onX =
+      Math.abs(a.x - snapCoordToGrid(a.x, g)) < 1e-9 ||
+      Math.abs(a.x - (Math.floor(a.x / g) * g + half)) < 1e-9;
+    const onY =
+      Math.abs(a.y - snapCoordToGrid(a.y, g)) < 1e-9 ||
+      Math.abs(a.y - (Math.floor(a.y / g) * g + half)) < 1e-9;
+    const corner =
+      Math.abs(a.x - snapCoordToGrid(a.x, g)) < 1e-9 &&
+      Math.abs(a.y - snapCoordToGrid(a.y, g)) < 1e-9;
+    const edgeMid =
+      (Math.abs(a.x - snapCoordToGrid(a.x, g)) < 1e-9 &&
+        Math.abs(a.y - (Math.floor(a.y / g) * g + half)) < 1e-9) ||
+      (Math.abs(a.y - snapCoordToGrid(a.y, g)) < 1e-9 &&
+        Math.abs(a.x - (Math.floor(a.x / g) * g + half)) < 1e-9);
+    expect(onX && onY).toBe(true);
+    expect(corner || edgeMid).toBe(true);
+    // Cell center is not a snap target.
+    expect(
+      Math.abs(a.x - (Math.floor(a.x / g) * g + half)) < 1e-9 &&
+        Math.abs(a.y - (Math.floor(a.y / g) * g + half)) < 1e-9
+    ).toBe(false);
+  }
+}
+
+describe('snapPenAnchorPoint (corners + edge mids)', () => {
+  it('snaps to nearest grid cell corner when closer than edge mid', () => {
+    const p = snapPenAnchorPoint(10.15, 20.85, 1, false);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-snap:corner]', p);
+    expect(p).toEqual({ x: 10, y: 21 });
+  });
+
+  it('snaps to vertical edge midpoint (网格边缘线中间)', () => {
+    // Near mid of vertical line x=14 between y=11 and y=12.
+    const raw = { x: 14.12, y: 11.48 };
+    const tip = snapPenAnchorPoint(raw.x, raw.y, 1, false);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-snap:v-edge-mid]', { raw, tip });
+    expect(tip).toEqual({ x: 14, y: 11.5 });
+  });
+
+  it('snaps to horizontal edge midpoint', () => {
+    const raw = { x: 20.47, y: 30.08 };
+    const tip = snapPenAnchorPoint(raw.x, raw.y, 1, false);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-snap:h-edge-mid]', { raw, tip });
+    expect(tip).toEqual({ x: 20.5, y: 30 });
+  });
+
+  it('cell center prefers nearest edge mid (not stay at ½,½)', () => {
+    const p = snapPenAnchorPoint(3.5, 7.5, 1, false);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-snap:cell-center]', p);
+    // Four edge mids tie at dist 0.5 — stable pick prefers lower x then y among ties,
+    // after corner preference (corners farther). Expect an edge mid.
+    expect(p.x === 3.5 || p.y === 7.5).toBe(true);
+    expect(p.x === 3.5 && p.y === 7.5).toBe(false);
+  });
+
+  it('Ctrl / skip leaves the raw point (free place)', () => {
+    const p = snapPenAnchorPoint(3.5, 7.5, 1, true);
+    expect(p.x).toBe(3.5);
+    expect(p.y).toBe(7.5);
+  });
+
+  it('gridSize 0 is a no-op', () => {
+    const p = snapPenAnchorPoint(1.2, 3.4, 0, false);
+    expect(p).toEqual({ x: 1.2, y: 3.4 });
+  });
+});
+
+describe('pen draw full flow (click → snap → path)', () => {
+  it('user clicks → all anchors land on corner or edge-mid lattice', () => {
+    const rawClicks = [
+      { x: 12.3, y: 8.7 },
+      { x: 40.1, y: 9.4 },
+      { x: 55.6, y: 30.2 },
+      { x: 38.9, y: 48.5 },
+      { x: 10.2, y: 45.8 },
+    ];
+    const anchors = simulatePenClicks(rawClicks, 1, false);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-flow:clicks]', {
+      raw: rawClicks,
+      snapped: anchors,
+    });
+    expect(anchors).toHaveLength(5);
+    assertOnPenGridLattice(anchors, 1);
+  });
+
+  it('rubber-band tip follows snapped cursor (edge mid when nearer)', () => {
+    const tip = snapPenAnchorPoint(22.37, 18.61, 1, false);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-flow:cursor]', tip);
+    expect(tip).toEqual({ x: 22, y: 18.5 });
+  });
+
+  it('closed path from snapped anchors keeps vertices on lattice after localize', () => {
+    const anchors = simulatePenClicks(
+      [
+        { x: 0.4, y: 0.4 },
+        { x: 10.6, y: 0.3 },
+        { x: 10.2, y: 8.7 },
+        { x: 0.1, y: 8.4 },
+      ],
+      1,
+      false
+    );
+    assertOnPenGridLattice(anchors, 1);
+    const bounds = boundsOfAnchors(anchors, true);
+    const d = penAnchorsToD(anchors, true);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-flow:commit]', { anchors, bounds, d });
+    expect(d.length).toBeGreaterThan(0);
+  });
+
+  it('edit-drag: start off-grid legacy + move → ends on lattice', () => {
+    const start = { x: 14.3, y: 11.7 };
+    const pointer = { x: 20.2, y: 15.1 };
+    const dx = pointer.x - 14.3;
+    const dy = pointer.y - 11.7;
+    const next = snapPenAnchorPoint(start.x + dx, start.y + dy, 1, false);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-flow:edit-drag]', { start, pointer, next });
+    assertOnPenGridLattice([next], 1);
+  });
+
+  it('screenshot: hover near vertical edge mid snaps there (not forced to corner)', () => {
+    // User arrow: mid of vertical grid line should get a snap tip.
+    const raw = { x: 14.08, y: 11.52 };
+    const tip = snapPenAnchorPoint(raw.x, raw.y, 1, false);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-flow:edge-mid-tip]', { raw, tip });
+    expect(tip).toEqual({ x: 14, y: 11.5 });
+  });
+
+  it('final place never stores free mid-cell floats off the lattice', () => {
+    const raw = [
+      { x: 18.4, y: 22.7 },
+      { x: 31.2, y: 35.6 },
+    ];
+    const placed = simulatePenClicks(raw, 1, false);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-flow:final-land]', { raw, placed });
+    assertOnPenGridLattice(placed, 1);
+  });
+});

--- a/apps/web/src/components/rcb/tools/__tests__/penContinueLink.test.ts
+++ b/apps/web/src/components/rcb/tools/__tests__/penContinueLink.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolvePenPlaceAction,
+  reversePenAnchors,
+  type PenAnchor,
+} from '../penPath';
+import { findOpenPenEndpointResume } from '../PenDrawFeature';
+
+/**
+ * Regression: re-clicking the same landing (esp. last≈first) used to close and
+ * commit — next clicks started an unlinked path. Hit last/anchor before close.
+ */
+describe('pen place action (same landing must not break stroke)', () => {
+  const anchors: PenAnchor[] = [
+    { x: 10, y: 10 },
+    { x: 40, y: 12 },
+    { x: 12, y: 14 }, // last near first (within CLOSE_THRESHOLD=10)
+  ];
+
+  it('re-click last landing → anchor (keep linked), not close', () => {
+    const action = resolvePenPlaceAction({
+      anchors,
+      snapped: { x: 12, y: 14 },
+      raw: { x: 12.2, y: 14.1 },
+      anchorHitRadius: 2,
+      closeThreshold: 10,
+    });
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-place:reclick-last]', action);
+    expect(action).toEqual({ kind: 'anchor', index: 2 });
+  });
+
+  it('click first landing with ≥2 points → close', () => {
+    const action = resolvePenPlaceAction({
+      anchors,
+      snapped: { x: 10, y: 10 },
+      raw: { x: 10.1, y: 9.9 },
+      anchorHitRadius: 2,
+      closeThreshold: 10,
+    });
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-place:click-first]', action);
+    expect(action).toEqual({ kind: 'close' });
+  });
+
+  it('empty near first (not on first disc) still places — keeps stroke linked', () => {
+    const action = resolvePenPlaceAction({
+      anchors,
+      snapped: { x: 9, y: 9 },
+      raw: { x: 9, y: 9 },
+      anchorHitRadius: 0.5,
+      closeThreshold: 10,
+    });
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-place:near-first]', action);
+    expect(action).toEqual({ kind: 'place', x: 9, y: 9 });
+  });
+
+  it('new cell far from ends → place', () => {
+    const action = resolvePenPlaceAction({
+      anchors,
+      snapped: { x: 80, y: 80 },
+      raw: { x: 80.2, y: 79.7 },
+      anchorHitRadius: 2,
+      closeThreshold: 10,
+    });
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-place:new]', action);
+    expect(action).toEqual({ kind: 'place', x: 80, y: 80 });
+  });
+
+  it('full flow: A→B→C(near A)→reclick C stays open; only click A closes', () => {
+    let list: PenAnchor[] = [];
+    const clicks = [
+      { x: 10, y: 10 },
+      { x: 40, y: 10 },
+      { x: 12, y: 12 },
+      { x: 12, y: 12 }, // re-click last
+    ];
+    const kinds: string[] = [];
+    for (const c of clicks) {
+      const action = resolvePenPlaceAction({
+        anchors: list,
+        snapped: c,
+        raw: c,
+        anchorHitRadius: 2,
+        closeThreshold: 10,
+      });
+      kinds.push(action.kind);
+      if (action.kind === 'place') list = [...list, { x: action.x, y: action.y }];
+      if (action.kind === 'close') break;
+    }
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-place:flow]', { kinds, list });
+    expect(kinds).toEqual(['place', 'place', 'place', 'anchor']);
+    expect(list).toHaveLength(3);
+
+    const close = resolvePenPlaceAction({
+      anchors: list,
+      snapped: { x: 10, y: 10 },
+      raw: { x: 10, y: 10 },
+      anchorHitRadius: 2,
+      closeThreshold: 10,
+    });
+    expect(close.kind).toBe('close');
+  });
+});
+
+describe('resume open pen from endpoint (link later stroke)', () => {
+  it('click near open end loads that stroke (not a fresh path)', () => {
+    const document = {
+      deltaSetLike: {
+        pen1: {
+          key: 'shape',
+          x: 0,
+          y: 0,
+          width: 50,
+          height: 20,
+          attrs: {
+            shapeType: 'pen',
+            path: 'M 0 0 L 40 0 L 40 10',
+            closed: 'false',
+            'stroke-enabled': 'true',
+            'border-width': 1,
+          },
+        },
+      },
+    };
+    const hit = findOpenPenEndpointResume(document, 40, 10, 10);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-resume:end]', hit);
+    expect(hit?.nodeId).toBe('pen1');
+    expect(hit?.anchors.at(-1)).toEqual({ x: 40, y: 10 });
+    expect(hit?.anchors).toHaveLength(3);
+  });
+
+  it('click near open start reverses so append continues from that end', () => {
+    const document = {
+      deltaSetLike: {
+        pen1: {
+          key: 'shape',
+          x: 5,
+          y: 5,
+          width: 50,
+          height: 20,
+          attrs: {
+            shapeType: 'pen',
+            path: 'M 0 0 L 30 0',
+            closed: 'false',
+          },
+        },
+      },
+    };
+    // nodeLeftTop uses x/y → scene anchors at (5,5)-(35,5)
+    const hit = findOpenPenEndpointResume(document, 5, 5, 8);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-resume:start]', hit);
+    expect(hit?.nodeId).toBe('pen1');
+    expect(hit?.anchors.at(-1)).toEqual({ x: 5, y: 5 });
+    expect(hit?.anchors[0]).toEqual({ x: 35, y: 5 });
+  });
+
+  it('closed path is not resumed', () => {
+    const document = {
+      deltaSetLike: {
+        pen1: {
+          key: 'shape',
+          x: 0,
+          y: 0,
+          width: 20,
+          height: 20,
+          attrs: {
+            shapeType: 'pen',
+            path: 'M 0 0 L 10 0 L 10 10 Z',
+            closed: 'true',
+          },
+        },
+      },
+    };
+    const hit = findOpenPenEndpointResume(document, 10, 10, 10);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-resume:closed]', hit);
+    expect(hit).toBeNull();
+  });
+
+  it('reversePenAnchors swaps in/out handles', () => {
+    const rev = reversePenAnchors([
+      { x: 0, y: 0, outX: 2, outY: 0 },
+      { x: 10, y: 0, inX: 8, inY: 0 },
+    ]);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-reverse]', rev);
+    expect(rev[0]).toEqual({ x: 10, y: 0, outX: 8, outY: 0 });
+    expect(rev[1]).toEqual({ x: 0, y: 0, inX: 2, inY: 0 });
+  });
+});

--- a/apps/web/src/components/rcb/tools/__tests__/pencilSmoothness.test.ts
+++ b/apps/web/src/components/rcb/tools/__tests__/pencilSmoothness.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import {
+  findPencilBrush,
+  pencilSampleMinStep,
+  samplePolyline,
+  stampSpacing,
+  stampSpacingForBrush,
+  streamlinePencilPoints,
+  type Pt,
+} from '../pencilBrushes';
+
+/**
+ * Pencil smoothness regressions:
+ * - stamp spacing must not floor at 2 scene-px (disconnected sausages at high zoom)
+ * - sample step stays dense vs stroke size
+ * - streamline reduces path jitter while keeping endpoints
+ */
+describe('pencil stroke smoothness', () => {
+  it('stamp spacing tracks brush size (no Math.max(2) gap)', () => {
+    const solid = findPencilBrush('solid');
+    const stampLike = {
+      ...solid,
+      kind: 'stamp' as const,
+      sizeFactor: 1,
+      spacingFactor: 0.45,
+      stampSrc: 'data:image/png;base64,xx',
+    };
+    const sw = 1;
+    const spacing = stampSpacing(stampLike, sw);
+    // eslint-disable-next-line no-console
+    console.log('[test:pencil-spacing]', {
+      strokeWidth: sw,
+      spacing,
+      legacyFloor2: 2,
+    });
+    expect(spacing).toBeLessThan(2);
+    expect(spacing).toBeCloseTo(0.45, 5);
+    expect(stampSpacingForBrush(stampLike, sw)).toBe(spacing);
+  });
+
+  it('dense diagonal path keeps overlapping stamps (no sausage gaps)', () => {
+    const brush = {
+      ...findPencilBrush('solid'),
+      kind: 'stamp' as const,
+      sizeFactor: 1,
+      spacingFactor: 0.4,
+      stampSrc: 'data:image/png;base64,xx',
+    };
+    const size = 1 * brush.sizeFactor;
+    const spacing = stampSpacing(brush, 1);
+    // Simulate a short diagonal stroke across ~6 cells.
+    const raw: Pt[] = [];
+    for (let i = 0; i <= 20; i += 1) {
+      raw.push({ x: 10 + i * 0.3, y: 10 + i * 0.25 });
+    }
+    const samples = samplePolyline(raw, spacing);
+    // eslint-disable-next-line no-console
+    console.log('[test:pencil-stamp-density]', {
+      spacing,
+      size,
+      rawN: raw.length,
+      sampleN: samples.length,
+      gap: spacing,
+      overlap: size - spacing,
+    });
+    expect(samples.length).toBeGreaterThan(8);
+    // Consecutive stamps must overlap (spacing < size) so ink looks continuous.
+    expect(spacing).toBeLessThan(size);
+    for (let i = 1; i < samples.length; i += 1) {
+      const d = Math.hypot(
+        samples[i].x - samples[i - 1].x,
+        samples[i].y - samples[i - 1].y
+      );
+      expect(d).toBeLessThanOrEqual(spacing * 1.05 + 1e-6);
+    }
+  });
+
+  it('sample min step is dense at 1px stroke (not fixed 0.6)', () => {
+    const brush = findPencilBrush('solid');
+    const step = pencilSampleMinStep(1, brush);
+    // eslint-disable-next-line no-console
+    console.log('[test:pencil-min-step]', { step, legacy: 0.6 });
+    expect(step).toBeLessThan(0.6);
+    expect(step).toBeGreaterThanOrEqual(0.12);
+  });
+
+  it('streamline reduces mid-path jitter, keeps endpoints', () => {
+    const jagged: Pt[] = [
+      { x: 0, y: 0 },
+      { x: 1, y: 0.8 },
+      { x: 2, y: -0.6 },
+      { x: 3, y: 0.7 },
+      { x: 4, y: 0 },
+    ];
+    const smooth = streamlinePencilPoints(jagged, 0.55);
+    // eslint-disable-next-line no-console
+    console.log('[test:pencil-streamline]', { jagged, smooth });
+    expect(smooth[0]).toEqual(jagged[0]);
+    expect(smooth[smooth.length - 1]).toEqual(jagged[jagged.length - 1]);
+    // Mid points should move toward a calmer path (smaller |y| swing).
+    const jaggedAmp = Math.max(...jagged.map((p) => Math.abs(p.y)));
+    const smoothAmp = Math.max(...smooth.slice(1, -1).map((p) => Math.abs(p.y)));
+    expect(smoothAmp).toBeLessThan(jaggedAmp);
+  });
+
+  it('full flow: raw moves → dense samples → continuous stamp chain', () => {
+    const brush = {
+      ...findPencilBrush('solid'),
+      kind: 'stamp' as const,
+      sizeFactor: 1.2,
+      spacingFactor: 0.35,
+      stampSrc: 'data:image/png;base64,xx',
+    };
+    const strokeWidth = 1;
+    const minStep = pencilSampleMinStep(strokeWidth, brush);
+    const rawMoves: Pt[] = [];
+    for (let i = 0; i < 40; i += 1) {
+      rawMoves.push({
+        x: 5 + i * 0.22 + (i % 3 === 0 ? 0.05 : 0),
+        y: 8 + i * 0.18 + (i % 2 === 0 ? -0.04 : 0.04),
+      });
+    }
+    // Mimic capture: min-step filter then streamline.
+    const captured: Pt[] = [rawMoves[0]];
+    for (let i = 1; i < rawMoves.length; i += 1) {
+      const last = captured[captured.length - 1];
+      const p = rawMoves[i];
+      if (Math.hypot(p.x - last.x, p.y - last.y) < minStep) continue;
+      captured.push(p);
+    }
+    const polished = streamlinePencilPoints(captured, 0.35);
+    const spacing = stampSpacing(brush, strokeWidth);
+    const stamps = samplePolyline(polished, spacing);
+    // eslint-disable-next-line no-console
+    console.log('[test:pencil-flow]', {
+      rawN: rawMoves.length,
+      capturedN: captured.length,
+      polishedN: polished.length,
+      stampN: stamps.length,
+      minStep,
+      spacing,
+    });
+    expect(captured.length).toBeGreaterThan(15);
+    expect(stamps.length).toBeGreaterThan(10);
+    expect(spacing).toBeLessThan(brush.sizeFactor * strokeWidth);
+  });
+});

--- a/apps/web/src/components/rcb/tools/__tests__/shapeDrawPreviewLattice.test.ts
+++ b/apps/web/src/components/rcb/tools/__tests__/shapeDrawPreviewLattice.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { snapBoxEdgesToGrid, snapCoordToGrid } from '../../selection/alignGuides';
+import { sceneSurfaceSvgProps, worldCameraViewport } from '../../scene/paint/sceneToSvg';
+import type { RcbCamera } from '../../core/types';
+import { resolveClosedDrawBoxes } from '../ShapeDrawFeature';
+
+/**
+ * Preview used to paint on a per-drag `sceneSurfaceSvgProps` SVG.
+ * At fractional DPR that surface origin snaps independently from the shared
+ * world viewport → preview drifts vs grid; commit (shared SVG) looks correct.
+ * Preview must share the world lattice (portal into data-rcb-draw-preview-mount).
+ *
+ * Pen draw / path-edit chrome had the same sibling-SVG drift — anchors looked
+ * mid-cell even when snap math stored integers. Same portal target.
+ */
+describe('shape draw preview lattice', () => {
+  const camera: RcbCamera = { x: 12.3, y: 45.6, zoom: 1 };
+
+  it('at dpr 0.9, per-box preview surface snaps origin independently of world viewport', () => {
+    const dpr = 0.9;
+    const world = worldCameraViewport(camera, dpr, 800, 600);
+    expect(world).not.toBeNull();
+    const rawLeft = 100.4;
+    const rawTop = 200.7;
+    const surf = sceneSurfaceSvgProps(
+      { left: rawLeft, top: rawTop, width: 60, height: 50 },
+      camera,
+      dpr
+    );
+    // Fractional DPR snaps the preview SVG origin away from the raw scene box.
+    expect(surf.style.left !== rawLeft || surf.style.top !== rawTop).toBe(true);
+    // That origin is not the shared world surface — two lattices.
+    expect(surf.style.left).not.toBe(world!.left);
+    expect(surf.style.top).not.toBe(world!.top);
+    // eslint-disable-next-line no-console
+    console.log('[test:pen-chrome-lattice:legacy]', {
+      world: { left: world!.left, top: world!.top },
+      penSurf: { left: surf.style.left, top: surf.style.top },
+    });
+  });
+
+  it('closed draw visual edges land on grid (same math preview + commit)', () => {
+    const gridSize = 1;
+    const raw = { left: 10.4, top: 20.6, width: 5.7, height: 4.2 };
+    const visual = snapBoxEdgesToGrid(raw, gridSize, 1);
+    expect(visual.left).toBe(snapCoordToGrid(visual.left, gridSize));
+    expect(visual.top).toBe(snapCoordToGrid(visual.top, gridSize));
+    expect(visual.left + visual.width).toBe(snapCoordToGrid(visual.left + visual.width, gridSize));
+    expect(visual.top + visual.height).toBe(snapCoordToGrid(visual.top + visual.height, gridSize));
+  });
+
+  it('circle visual 3×3 → geom 2×2; commit must keep geom (not Math.max 3)', () => {
+    const { visual, geom, outset } = resolveClosedDrawBoxes(
+      { left: 10, top: 10, width: 3, height: 3 },
+      true,
+      1,
+      'circle'
+    );
+    expect(visual.width).toBe(3);
+    expect(visual.height).toBe(3);
+    expect(outset).toBe(0.5);
+    expect(geom.width).toBe(2);
+    expect(geom.height).toBe(2);
+    // Old onCreateShape did Math.max(3, geom) → path 3 + stroke → visual 4. Forbidden.
+    expect(Math.max(3, geom.width)).not.toBe(geom.width);
+  });
+});

--- a/apps/web/src/components/rcb/tools/penPath.ts
+++ b/apps/web/src/components/rcb/tools/penPath.ts
@@ -432,6 +432,82 @@ export function penSubpathsToD(
 
 export const CLOSE_THRESHOLD = 10;
 
+export type PenPlaceAction =
+  | { kind: 'close' }
+  | { kind: 'anchor'; index: number }
+  | { kind: 'place'; x: number; y: number };
+
+/**
+ * Pen click decision (pure — used by PenDrawFeature + tests).
+ *
+ * Order matters: hit an existing landing (esp. last) BEFORE close-to-first.
+ * Close only when the tip hits the **first anchor** (idx===0). Empty cells near
+ * the start still place — otherwise “almost back to start” commits and the next
+ * stroke becomes an unlinked path (user: 同落点再次点击就断了).
+ */
+export function resolvePenPlaceAction(opts: {
+  anchors: PenAnchor[];
+  snapped: { x: number; y: number };
+  raw: { x: number; y: number };
+  anchorHitRadius: number;
+  closeThreshold?: number;
+}): PenPlaceAction {
+  const { anchors, snapped, raw, anchorHitRadius } = opts;
+  void opts.closeThreshold;
+  if (!anchors.length) {
+    return { kind: 'place', x: snapped.x, y: snapped.y };
+  }
+
+  const hitNear = (
+    p: { x: number; y: number },
+    radius: number
+  ): number => {
+    let best = -1;
+    let bestD = radius;
+    for (let i = 0; i < anchors.length; i += 1) {
+      const a = anchors[i];
+      const d = Math.hypot(p.x - a.x, p.y - a.y);
+      if (d <= bestD) {
+        bestD = d;
+        best = i;
+      }
+    }
+    return best;
+  };
+
+  // Prefer snapped lattice (same drop cell) so re-clicking the tip hits the node.
+  let idx = hitNear(snapped, Math.max(anchorHitRadius, 0.75));
+  if (idx < 0) idx = hitNear(raw, anchorHitRadius);
+
+  if (idx === 0 && anchors.length >= 2) {
+    return { kind: 'close' };
+  }
+  if (idx >= 0) {
+    return { kind: 'anchor', index: idx };
+  }
+
+  return { kind: 'place', x: snapped.x, y: snapped.y };
+}
+
+/** Reverse open stroke so continuing from the former start appends at the end. */
+export function reversePenAnchors(anchors: PenAnchor[]): PenAnchor[] {
+  return anchors
+    .slice()
+    .reverse()
+    .map((a) => {
+      const next: PenAnchor = { x: a.x, y: a.y };
+      if (a.outX != null && a.outY != null) {
+        next.inX = a.outX;
+        next.inY = a.outY;
+      }
+      if (a.inX != null && a.inY != null) {
+        next.outX = a.inX;
+        next.outY = a.inY;
+      }
+      return next;
+    });
+}
+
 type SegHit = {
   segIndex: number;
   t: number;
@@ -575,7 +651,7 @@ function splitCubicAt(
 }
 
 /**
- * Insert an anchor on the closest path segment (Illustrator-style “add anchor”).
+ * Insert an anchor on the closest path segment.
  * Returns null when farther than `maxDist` from the path.
  */
 export function insertAnchorOnPath(

--- a/apps/web/src/components/rcb/tools/pencilBrushes.ts
+++ b/apps/web/src/components/rcb/tools/pencilBrushes.ts
@@ -338,7 +338,9 @@ export function stampSpacing(brush: PencilBrushDef, strokeWidth: number) {
   const size = brushSize(brush, strokeWidth);
   const factor = Number(brush.spacingFactor);
   const f = Number.isFinite(factor) && factor > 0 ? factor : 0.45;
-  return Math.max(2, size * f);
+  // Scene units — never floor at 2 (that left huge gaps under 1px grid / high zoom,
+  // so stamp strokes looked like disconnected sausages).
+  return Math.max(size * 0.12, size * f);
 }
 
 /** Convert input points to perfect-freehand input (real pressure or speed simulation). */
@@ -643,6 +645,42 @@ export function samplePolyline(points: Pt[], spacing: number): Pt[] {
     out[out.length - 1] = last;
   }
   return out;
+}
+
+/**
+ * EMA streamline for live pencil capture (brush.options.streamline).
+ * `amount` 0 = raw, ~0.35–0.7 = smoother. Last point stays on the tip.
+ */
+export function streamlinePencilPoints(points: Pt[], amount: number): Pt[] {
+  if (points.length < 2) return points.slice();
+  const a = Math.min(0.92, Math.max(0, Number(amount) || 0));
+  if (!(a > 0)) return points.map((p) => ({ ...p }));
+  const out: Pt[] = [{ ...points[0] }];
+  let px = points[0].x;
+  let py = points[0].y;
+  for (let i = 1; i < points.length; i += 1) {
+    const p = points[i];
+    px = px + (p.x - px) * (1 - a);
+    py = py + (p.y - py) * (1 - a);
+    out.push({
+      x: px,
+      y: py,
+      ...(p.pressure != null ? { pressure: p.pressure } : {}),
+    });
+  }
+  const last = points[points.length - 1];
+  out[out.length - 1] = {
+    x: last.x,
+    y: last.y,
+    ...(last.pressure != null ? { pressure: last.pressure } : {}),
+  };
+  return out;
+}
+
+/** Min scene step between stored samples — scales with ink size, stays dense at high zoom. */
+export function pencilSampleMinStep(strokeWidth: number, brush?: PencilBrushDef | null): number {
+  const size = brush ? brushSize(brush, strokeWidth) : Math.max(1, strokeWidth);
+  return Math.max(0.12, Math.min(0.4, size * 0.1));
 }
 
 export function stampSizeForBrush(brush: PencilBrushDef, strokeWidth: number) {


### PR DESCRIPTION
## Summary
- Keep selection chrome, titles, and toolbars on the shared world SVG lattice so ink stays aligned under canvas zoom and browser zoom.
- Title/toolbar gaps stay screen-constant (10px / 20px); title edit uses overlay portal like inline text.
- Add lattice / gap / grid-snap regression tests; trim third-party and redundant comments; ignore Alembic lock sidecars.

## Test plan
- [ ] Select frame / image / shape at 100% and ~8000% canvas zoom — blue box sticks to ink; title 10px above; toolbar clears title
- [ ] Browser zoom 75% / 125% — chrome and grid stay on the same lattice
- [ ] Rename title inline — caret stays on the SVG text line
- [ ] Pen / pencil / path-edit / smart guides still paint on world surface
- [ ] `pnpm --filter web test` (or relevant vitest files under `rcb/selection` / `rcb/tools`)

Made with [Cursor](https://cursor.com)