### PR TITLE
Fix RCB selection chrome hit-testing (resize vs toolbar)

### DIFF
--- a/apps/web/src/components/editor/nodes/ImageNode/ImageReplaceCornerButton.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageReplaceCornerButton.tsx
@@ -113,7 +113,7 @@ function ImageReplaceCornerButton({
           className={
             visible
               ? 'pointer-events-auto absolute opacity-100 transition-opacity duration-150'
-              : 'pointer-events-auto absolute opacity-0 transition-opacity duration-150'
+              : 'pointer-events-none absolute opacity-0 transition-opacity duration-150'
           }
           style={btnWrapStyle}
           onPointerDown={(e) => e.stopPropagation()}

--- a/apps/web/src/components/editor/nodes/ImageNode/ImageVariantsOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageVariantsOverlay.tsx
@@ -178,15 +178,22 @@ function ImageVariantsOverlay({
 
   return (
     <RcbOverlayPortal>
-      <div data-image-variants data-sel-toolbar data-scene-node-id={nodeId}>
+      <div
+        data-image-variants
+        data-sel-toolbar
+        data-scene-node-id={nodeId}
+        className="pointer-events-none"
+      >
         {/* One corner bar: replace + count — shared position, hover-visible */}
         <div className="pointer-events-none absolute z-[36]" style={frameStyle}>
           <div
             data-image-replace
             data-image-node-id={nodeId}
             className={cn(
-              'pointer-events-auto absolute flex items-center gap-1 transition-opacity duration-150',
-              visible ? 'opacity-100' : 'opacity-0'
+              'absolute flex items-center gap-1 transition-opacity duration-150',
+              visible
+                ? 'pointer-events-auto opacity-100'
+                : 'pointer-events-none opacity-0'
             )}
             style={{ right: EDGE_PAD, top: EDGE_PAD }}
             onPointerDown={(e) => e.stopPropagation()}

--- a/apps/web/src/components/editor/nodes/VideoNode/VideoReplaceCornerButton.tsx
+++ b/apps/web/src/components/editor/nodes/VideoNode/VideoReplaceCornerButton.tsx
@@ -296,7 +296,7 @@ function VideoReplaceCornerButton({
           className={
             visible
               ? 'pointer-events-auto absolute opacity-100 transition-opacity duration-150'
-              : 'pointer-events-auto absolute opacity-0 transition-opacity duration-150'
+              : 'pointer-events-none absolute opacity-0 transition-opacity duration-150'
           }
           style={btnWrapStyle}
           onPointerDown={(e) => e.stopPropagation()}

--- a/apps/web/src/components/editor/page/EditorStageWorld.tsx
+++ b/apps/web/src/components/editor/page/EditorStageWorld.tsx
@@ -1,4 +1,10 @@
-import { memo, useCallback, useState, type RefObject } from 'react';
+import {
+  memo,
+  useCallback,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+} from 'react';
 import { useDispatch } from 'react-redux';
 import {
   RcbCanvas,
@@ -22,6 +28,7 @@ import { stackZIndex } from '@/components/rcb/scene/document/sceneDocument';
 import {
   parseFillGradient,
   serializeFillGradient,
+  type FillGradient,
 } from '@/components/rcb/scene/document/sceneFill';
 import {
   addArtboardFrame,
@@ -55,6 +62,72 @@ const EDITOR_PAN_BLOCK_SELECTOR = [
   '[data-video-playback-bar]',
   '[data-video-trim-toolbar]',
 ].join(',');
+
+function isEditableFocusTarget(el: HTMLElement | null | undefined): boolean {
+  if (!el) return false;
+  return (
+    el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || Boolean(el.isContentEditable)
+  );
+}
+
+/** Blur stage inputs when pointer lands on the canvas chrome (not the field itself). */
+function blurStageEditableOnPointerDown(e: ReactPointerEvent<HTMLDivElement>) {
+  const active = window.document.activeElement as HTMLElement | null;
+  if (
+    !active ||
+    active === e.currentTarget ||
+    !e.currentTarget.contains(active) ||
+    !isEditableFocusTarget(active)
+  ) {
+    return;
+  }
+  active.blur();
+}
+
+function canvasDiffuseMeshGradient(
+  fill: FillPanelValue
+): FillGradient & { type: 'diffuse' } {
+  return {
+    ...parseFillGradient(fill.fillGradient, 'diffuse', fill.fillColor),
+    type: 'diffuse',
+  };
+}
+
+/** Per-frame label handlers — undefined in inspect/dev so chrome stays inert. */
+function frameLabelInteractionProps(
+  frameId: string,
+  isDevMode: boolean,
+  handlers: {
+    onSelectFrame: (id: string) => void;
+    onRenameFrame: (id: string, name: string) => void;
+    onMoveFrame: (
+      id: string,
+      x: number,
+      y: number,
+      opts?: { skipGrid?: boolean }
+    ) => void;
+    onFrameMoveStart: (id: string) => void;
+    onFrameMoveEnd: () => void;
+  }
+) {
+  if (isDevMode) {
+    return {
+      onSelect: undefined as undefined,
+      onRename: undefined as undefined,
+      onMove: undefined as undefined,
+      onMoveStart: undefined as undefined,
+      onMoveEnd: undefined as undefined,
+    };
+  }
+  return {
+    onSelect: () => handlers.onSelectFrame(frameId),
+    onRename: (name: string) => handlers.onRenameFrame(frameId, name),
+    onMove: (x: number, y: number, opts?: { skipGrid?: boolean }) =>
+      handlers.onMoveFrame(frameId, x, y, opts),
+    onMoveStart: () => handlers.onFrameMoveStart(frameId),
+    onMoveEnd: handlers.onFrameMoveEnd,
+  };
+}
 
 type Props = {
   document: any;
@@ -194,24 +267,47 @@ function EditorStageWorld({
     dispatch(setMixedSelection({ nodeIds: [], frameIds: [] }));
   }, [dispatch]);
 
+  const onRenameFrame = useCallback(
+    (id: string, name: string) => {
+      dispatch(renameArtboardFrame({ id, name }));
+    },
+    [dispatch]
+  );
+
+  const onCanvasDiffuseMeshChange = useCallback(
+    (next: FillGradient) => {
+      dispatch(
+        setCanvasMeta(
+          canvasFillToDocumentMeta(
+            {
+              ...canvasFillValue,
+              fillType: 'diffuse',
+              fillGradient: serializeFillGradient(next),
+              fillColor: next.meshPoints?.[0]?.color || canvasFillValue.fillColor,
+            },
+            false
+          )
+        )
+      );
+    },
+    [canvasFillValue, dispatch]
+  );
+
   if (isMobileViewport || !document) return null;
+
+  const showCanvasDiffuseMesh =
+    canvasBgOpen && canvasFillValue.fillType === 'diffuse';
+  const showFrameToolbar =
+    !isDevMode &&
+    selectedFrames.length >= 1 &&
+    selectedNodeIds.length === 0 &&
+    Boolean(activeFrame) &&
+    movingFrameId !== activeFrame?.id;
 
   return (
     <div
       className="relative min-h-0 flex-1"
-      onPointerDown={(e) => {
-        const active = window.document.activeElement as HTMLElement | null;
-        if (
-          active &&
-          active !== e.currentTarget &&
-          e.currentTarget.contains(active) &&
-          (active.tagName === 'INPUT' ||
-            active.tagName === 'TEXTAREA' ||
-            active.isContentEditable)
-        ) {
-          active.blur();
-        }
-      }}
+      onPointerDown={blurStageEditableOnPointerDown}
     >
       <RcbCanvas
         artboard={worldBounds}
@@ -261,7 +357,7 @@ function EditorStageWorld({
         <CropExpandSessionHost document={document} />
         <VideoTrimSessionHost document={document} />
 
-        {canvasBgOpen && canvasFillValue.fillType === 'diffuse' ? (
+        {showCanvasDiffuseMesh ? (
           <MeshHandlesOverlay
             box={{
               left: 0,
@@ -269,33 +365,11 @@ function EditorStageWorld({
               width: worldSurface.width,
               height: worldSurface.height,
             }}
-            gradient={{
-              ...parseFillGradient(
-                canvasFillValue.fillGradient,
-                'diffuse',
-                canvasFillValue.fillColor
-              ),
-              type: 'diffuse',
-            }}
+            gradient={canvasDiffuseMeshGradient(canvasFillValue)}
             selectedIndex={canvasMeshSelectedIndex}
             showGuides={canvasMeshShowGuides}
             onActivePointChange={setCanvasMeshSelectedIndex}
-            onChange={(next) => {
-              dispatch(
-                setCanvasMeta(
-                  canvasFillToDocumentMeta(
-                    {
-                      ...canvasFillValue,
-                      fillType: 'diffuse',
-                      fillGradient: serializeFillGradient(next),
-                      fillColor:
-                        next.meshPoints?.[0]?.color || canvasFillValue.fillColor,
-                    },
-                    false
-                  )
-                )
-              );
-            }}
+            onChange={onCanvasDiffuseMeshChange}
           />
         ) : null}
 
@@ -306,27 +380,19 @@ function EditorStageWorld({
               frame={frame}
               selected={!isDevMode && selectedFrameIds.includes(frame.id)}
               hideTitle={isDevMode || movingFrameId === frame.id}
-              onSelect={isDevMode ? undefined : () => onSelectFrame(frame.id)}
-              onRename={
-                isDevMode
-                  ? undefined
-                  : (name) => dispatch(renameArtboardFrame({ id: frame.id, name }))
-              }
-              onMove={
-                isDevMode ? undefined : (x, y, opts) => onMoveFrame(frame.id, x, y, opts)
-              }
-              onMoveStart={isDevMode ? undefined : () => onFrameMoveStart(frame.id)}
-              onMoveEnd={isDevMode ? undefined : onFrameMoveEnd}
+              {...frameLabelInteractionProps(frame.id, isDevMode, {
+                onSelectFrame,
+                onRenameFrame,
+                onMoveFrame,
+                onFrameMoveStart,
+                onFrameMoveEnd,
+              })}
               layer="label"
             />
           )
         )}
 
-        {!isDevMode &&
-        selectedFrames.length >= 1 &&
-        selectedNodeIds.length === 0 &&
-        activeFrame &&
-        movingFrameId !== activeFrame.id ? (
+        {showFrameToolbar && activeFrame ? (
           <FrameContextToolbar frame={activeFrame} />
         ) : null}
 

--- a/apps/web/src/components/rcb/selection/HostPathChrome.tsx
+++ b/apps/web/src/components/rcb/selection/HostPathChrome.tsx
@@ -28,6 +28,8 @@ import {
   CHROME_ROTATE_GAP_PX,
   CHROME_ROTATE_HIT_PX,
   CHROME_STROKE_PX,
+  chromeHitScaleForBox,
+  chromeOutsideHitPadScene,
   cursorForResize,
   rotateHotzoneOutward,
 } from './SelectionChrome';
@@ -102,6 +104,28 @@ const SEL_BADGE_ATTR = 'data-rcb-sel-badge';
 const SEL_CHROME_LAYER_ATTR = 'data-rcb-sel-chrome-layer';
 const SEL_EP_HOVER_STYLE = 'g.sel-hit:hover > .sel-ep-halo { opacity: 1; }';
 
+/**
+ * World chrome layer hit-shell — must stay `0×0` + overflow visible (same as
+ * SelectionFeature / SvgCanvas overlay wrappers). Never full-bleed `inset-0`:
+ * that keeps paint visible but drops `data-sel-handle` out of hit-testing under
+ * world `[&>*]:pointer-events-auto`.
+ */
+export function selChromeLayerShell(): {
+  className: string;
+  width: string;
+  height: string;
+  zIndex: string;
+  pointerEvents: 'none';
+} {
+  return {
+    className: 'pointer-events-none absolute left-0 top-0 overflow-visible',
+    width: '0',
+    height: '0',
+    zIndex: '1000000',
+    pointerEvents: 'none',
+  };
+}
+
 function ensureSelEpHoverStyle(root: SVGSVGElement) {
   if (root.querySelector('style[data-rcb-sel-ep-style]')) return;
   const style = document.createElementNS(SVG_NS, 'style');
@@ -156,6 +180,10 @@ function boxFromLocalAnchor(
   return { left: centerX - cx, top: centerY - cy, width: w, height: h };
 }
 
+/**
+ * Host selection chrome mount. Applies {@link selChromeLayerShell}; inline
+ * pe:none beats world auto so only pe:all kids receive hits.
+ */
 function ensureSelChromeLayer(): HTMLElement | null {
   if (typeof document === 'undefined') return null;
   const world = document.querySelector('[data-rcb-world="1"]') as HTMLElement | null;
@@ -166,14 +194,68 @@ function ensureSelChromeLayer(): HTMLElement | null {
   if (!layer) {
     layer = document.createElement('div');
     layer.setAttribute(SEL_CHROME_LAYER_ATTR, '1');
-    layer.className = 'pointer-events-none absolute left-0 top-0 overflow-visible';
-    layer.style.zIndex = '1000000';
-    layer.style.width = '0';
-    layer.style.height = '0';
     world.appendChild(layer);
   }
-  if (world.lastElementChild !== layer) world.appendChild(layer);
+  const shell = selChromeLayerShell();
+  layer.className = shell.className;
+  layer.style.width = shell.width;
+  layer.style.height = shell.height;
+  layer.style.zIndex = shell.zIndex;
+  layer.style.pointerEvents = shell.pointerEvents;
+  // Do not re-append every sync — z-index already stacks above hosts.
   return layer;
+}
+
+/** Fingerprint for resize/rotate DOM — skip tear-down when only camera pan updates. */
+function hostSelHandlesKey(
+  o: ShapeOutlineItem,
+  stroke: number,
+  inv: number,
+  outlineD: string
+): string {
+  const b = o.box;
+  return [
+    o.withHandles ? 1 : 0,
+    o.showRotate ? 1 : 0,
+    o.lineMode ? 1 : 0,
+    o.shaftEndpoints ? 1 : 0,
+    o.cornerHandlesOnly ? 1 : 0,
+    o.edgeHandles || 'all',
+    o.color || '',
+    stroke.toFixed(5),
+    inv.toFixed(6),
+    b.left.toFixed(2),
+    b.top.toFixed(2),
+    b.width.toFixed(2),
+    b.height.toFixed(2),
+    (Number(o.angle) || 0).toFixed(3),
+    Number(o.chromeOutset) || 0,
+    outlineD.length,
+    outlineD.slice(0, 32),
+    outlineD.slice(-32),
+  ].join('|');
+}
+
+function syncHostSelHandlesIfNeeded(
+  chrome: SVGGElement,
+  o: ShapeOutlineItem,
+  stroke: number,
+  inv: number,
+  outlineD: string
+) {
+  const key = hostSelHandlesKey(o, stroke, inv, outlineD);
+  if (!o.withHandles) {
+    if (chrome.getAttribute('data-rcb-handles-key')) {
+      chrome
+        .querySelectorAll(`g.sel-hit,[data-sel-handle],[data-rcb-sel-knob],[${SEL_BOX_ATTR}]`)
+        .forEach((n) => n.remove());
+      chrome.removeAttribute('data-rcb-handles-key');
+    }
+    return;
+  }
+  if (chrome.getAttribute('data-rcb-handles-key') === key) return;
+  syncHostSelHandles(chrome, o, stroke, inv, outlineD);
+  chrome.setAttribute('data-rcb-handles-key', key);
 }
 
 function clearHostSelOutline(nodeId: string) {
@@ -232,11 +314,7 @@ function silhouettePathD(d: string): string {
 }
 
 /** Path chrome `d` — prefer live host baseline, else attrs path; single contour. */
-function readHostOutlinePathD(
-  _el: SVGElement | null | undefined,
-  baseline: SVGElement | null,
-  o: ShapeOutlineItem
-): string {
+function readHostOutlinePathD(baseline: SVGElement | null, o: ShapeOutlineItem): string {
   return silhouettePathD(readBaselinePathD(baseline, o.pathD));
 }
 
@@ -277,6 +355,42 @@ function nodeUsesOpenStrokeEndpoints(node: any): boolean {
   const t = String(node.attrs?.shapeType || '');
   return t === 'line' || t === 'arrow';}
 
+type BoxResizeKnob = ['n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw', number, number];
+
+/** Control-box resize seats for the given edge/corner policy. */
+function boxResizeKnobs(
+  bx: number,
+  by: number,
+  bw: number,
+  bh: number,
+  opts: { cornerHandlesOnly?: boolean; edgeHandles?: 'all' | 'horizontal' | 'none' }
+): BoxResizeKnob[] {
+  if (opts.cornerHandlesOnly) {
+    return [
+      ['nw', bx, by],
+      ['ne', bx + bw, by],
+      ['se', bx + bw, by + bh],
+      ['sw', bx, by + bh],
+    ];
+  }
+  if (opts.edgeHandles === 'horizontal') {
+    return [
+      ['w', bx, by + bh / 2],
+      ['e', bx + bw, by + bh / 2],
+    ];
+  }
+  return [
+    ['nw', bx, by],
+    ['n', bx + bw / 2, by],
+    ['ne', bx + bw, by],
+    ['e', bx + bw, by + bh / 2],
+    ['se', bx + bw, by + bh],
+    ['s', bx + bw / 2, by + bh],
+    ['sw', bx, by + bh],
+    ['w', bx, by + bh / 2],
+  ];
+}
+
 function syncHostSelHandles(
   chrome: SVGGElement,
   o: ShapeOutlineItem,
@@ -287,13 +401,14 @@ function syncHostSelHandles(
   const w = Math.max(1, o.box.width);
   const h = Math.max(1, o.box.height);
   const color = o.color || '#3388ff';
+  const hitScale = chromeHitScaleForBox(w, h, 1 / Math.max(0.05, inv));
   const handleVis = CHROME_HANDLE_VIS_PX * inv;
-  const handleHit = CHROME_HANDLE_HIT_PX * inv;
+  const handleHit = CHROME_HANDLE_HIT_PX * inv * hitScale;
   const halfVis = handleVis / 2;
   const halfHit = handleHit / 2;
   const lineEpVis = CHROME_LINE_ENDPOINT_VIS_PX * inv;
-  const lineEpHit = CHROME_LINE_ENDPOINT_HIT_PX * inv;
-  const rotateHit = CHROME_ROTATE_HIT_PX * inv;
+  const lineEpHit = CHROME_LINE_ENDPOINT_HIT_PX * inv * hitScale;
+  const rotateHit = CHROME_ROTATE_HIT_PX * inv * hitScale;
   const rotateGap = CHROME_ROTATE_GAP_PX * inv;
 
   // Drop previous handle/rotate/box children (keep path silhouette outline).
@@ -380,33 +495,55 @@ function syncHostSelHandles(
   const edgeMode = o.edgeHandles || 'all';
   if (edgeMode === 'none') return;
 
-  const knobs: Array<
-    ['n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw', number, number]
-  > = o.cornerHandlesOnly
-    ? [
-        ['nw', bx, by],
-        ['ne', bx + bw, by],
-        ['se', bx + bw, by + bh],
-        ['sw', bx, by + bh],
-      ]
-    : edgeMode === 'horizontal'
-      ? [
-          ['w', bx, by + bh / 2],
-          ['e', bx + bw, by + bh / 2],
-        ]
-      : [
-          ['nw', bx, by],
-          ['n', bx + bw / 2, by],
-          ['ne', bx + bw, by],
-          ['e', bx + bw, by + bh / 2],
-          ['se', bx + bw, by + bh],
-          ['s', bx + bw / 2, by + bh],
-          ['sw', bx, by + bh],
-          ['w', bx, by + bh / 2],
-        ];
+  const knobs = boxResizeKnobs(bx, by, bw, bh, {
+    cornerHandlesOnly: o.cornerHandlesOnly,
+    edgeHandles: edgeMode,
+  });
 
   const angle = Number(o.angle) || 0;
-  for (const [dir, lx, ly] of knobs) {
+  // Rotate first, then resize on top — corner / control-box clicks prefer scale.
+  if (o.showRotate) {
+    const corners: Array<['nw' | 'ne' | 'se' | 'sw', number, number, number, number, number]> = [
+      ['nw', bx, by, -1, -1, 0],
+      ['ne', bx + bw, by, 1, -1, 90],
+      ['se', bx + bw, by + bh, 1, 1, 180],
+      ['sw', bx, by + bh, -1, 1, 270],
+    ];
+    const out = rotateHotzoneOutward(handleHit, rotateGap, rotateHit);
+    for (const [corner, lx, ly, signX, signY, iconDeg] of corners) {
+      // Axis-aligned outer quadrant from the control-box corner (same center as resize).
+      const g = document.createElementNS(SVG_NS, 'g');
+      g.setAttribute('class', 'sel-hit');
+      g.setAttribute('pointer-events', 'all');
+      g.setAttribute('transform', `translate(${lx + signX * out} ${ly + signY * out})`);
+      const hit = document.createElementNS(SVG_NS, 'rect');
+      hit.setAttribute('data-sel-handle', 'rotate');
+      hit.setAttribute('data-rotate-corner', corner);
+      hit.setAttribute('role', 'button');
+      hit.setAttribute('aria-label', 'Rotate');
+      hit.setAttribute('x', String(-rotateHit / 2));
+      hit.setAttribute('y', String(-rotateHit / 2));
+      hit.setAttribute('width', String(rotateHit));
+      hit.setAttribute('height', String(rotateHit));
+      hit.setAttribute('fill', 'transparent');
+      hit.setAttribute('pointer-events', 'all');
+      hit.style.cursor = cursorForRotate(iconDeg, angle);
+      g.appendChild(hit);
+      chrome.appendChild(g);
+    }
+  }
+
+  // Edges first, corners last — on tiny boxes edge hits otherwise cover corners
+  // (e paints after ne → TR white square becomes east-resize / feels broken).
+  const isCorner = (d: string) => d === 'nw' || d === 'ne' || d === 'se' || d === 'sw';
+  const orderedKnobs = [
+    ...knobs.filter(([d]) => !isCorner(d)),
+    ...knobs.filter(([d]) => isCorner(d)),
+  ];
+
+  // Direct chrome children (absolute local x/y) — same as pre-regression HEAD.
+  // A wrapping pe:none <g> under chrome pe:none dropped pe:all hits in practice.
+  for (const [dir, lx, ly] of orderedKnobs) {
     const visFill = document.createElementNS(SVG_NS, 'rect');
     visFill.setAttribute('data-rcb-sel-knob', '1');
     visFill.setAttribute('x', String(lx - halfVis));
@@ -441,35 +578,6 @@ function syncHostSelHandles(
     hit.style.cursor = cursorForResize(dir, angle);
     chrome.appendChild(hit);
   }
-
-  if (o.showRotate) {
-    // Transparent corner hotzones only — rotate icon appears as the cursor, not on canvas.
-    // Axis-aligned outer quadrant so rotate AABB never overlaps resize hits.
-    const corners: Array<['nw' | 'ne' | 'se' | 'sw', number, number, number, number, number]> = [
-      ['nw', bx, by, -1, -1, 0],
-      ['ne', bx + bw, by, 1, -1, 90],
-      ['se', bx + bw, by + bh, 1, 1, 180],
-      ['sw', bx, by + bh, -1, 1, 270],
-    ];
-    const out = rotateHotzoneOutward(handleHit, rotateGap, rotateHit);
-    for (const [corner, lx, ly, signX, signY, iconDeg] of corners) {
-      const hx = lx + signX * out;
-      const hy = ly + signY * out;
-      const hit = document.createElementNS(SVG_NS, 'rect');
-      hit.setAttribute('data-sel-handle', 'rotate');
-      hit.setAttribute('data-rotate-corner', corner);
-      hit.setAttribute('role', 'button');
-      hit.setAttribute('aria-label', 'Rotate');
-      hit.setAttribute('x', String(hx - rotateHit / 2));
-      hit.setAttribute('y', String(hy - rotateHit / 2));
-      hit.setAttribute('width', String(rotateHit));
-      hit.setAttribute('height', String(rotateHit));
-      hit.setAttribute('fill', 'transparent');
-      hit.setAttribute('pointer-events', 'all');
-      hit.style.cursor = cursorForRotate(iconDeg, angle);
-      chrome.appendChild(hit);
-    }
-  }
 }
 
 /** Multi-select union AABB; twin member host viewport. */
@@ -488,11 +596,8 @@ function syncHostSelUnionChrome(
 
   const w = Math.max(1, o.box.width);
   const h = Math.max(1, o.box.height);
-  const pad = Math.max(
-    stroke * 8,
-    CHROME_HANDLE_HIT_PX * inv,
-    CHROME_ROTATE_HIT_PX * inv + CHROME_ROTATE_GAP_PX * inv
-  );
+  const outset = Math.max(0, Number(o.chromeOutset) || 0);
+  const pad = chromeOutsideHitPadScene(inv, outset, stroke * 8);
 
   let root = layer.querySelector(
     `:scope > svg[${SEL_CHROME_ATTR}="${CSS.escape(o.id)}"]`
@@ -508,6 +613,7 @@ function syncHostSelUnionChrome(
     root.style.display = 'block';
     layer.appendChild(root);
   }
+  root.style.pointerEvents = 'none';
 
   const mirrored = Boolean(hostRoot && mirrorHostSurface(root, hostRoot));
   if (mirrored) {
@@ -537,7 +643,7 @@ function syncHostSelUnionChrome(
   }
   // Scene-absolute union box — translate to union origin for local handle math.
   chrome.setAttribute('transform', `translate(${o.box.left} ${o.box.top})`);
-  syncHostSelHandles(chrome, { ...o, showRotate: false }, stroke, inv, '');
+  syncHostSelHandlesIfNeeded(chrome, { ...o, showRotate: false }, stroke, inv, '');
   return mirrored;
 }
 
@@ -568,7 +674,7 @@ function syncHostSelOutline(
       (el.querySelector?.('[data-baseline="1"]') as SVGElement | null)
     : null;
 
-  const d = readHostOutlinePathD(el, baseline, o);
+  const d = readHostOutlinePathD(baseline, o);
   if (!d) {
     clearHostSelOutline(o.id);
     return false;
@@ -595,11 +701,8 @@ function syncHostSelOutline(
   const w = Math.max(1, o.box.width);
   const h = Math.max(1, o.box.height);
   const angle = Number(o.angle) || 0;
-  const pad = Math.max(
-    stroke * 8,
-    CHROME_HANDLE_HIT_PX * inv,
-    CHROME_ROTATE_HIT_PX * inv + CHROME_ROTATE_GAP_PX * inv
-  );
+  const outset = Math.max(0, Number(o.chromeOutset) || 0);
+  const pad = chromeOutsideHitPadScene(inv, outset, stroke * 8);
   const left = o.box.left;
   const top = o.box.top;
 
@@ -617,6 +720,7 @@ function syncHostSelOutline(
     root.style.display = 'block';
     layer.appendChild(root);
   }
+  root.style.pointerEvents = 'none';
 
   // Host-mirrored surface; fallback: scene surface.
   // World hosts already cover the viewport — do not expandInfiniteSvgPad
@@ -671,12 +775,8 @@ function syncHostSelOutline(
   outline.setAttribute('stroke-linejoin', roundStroke ? 'round' : 'miter');
   outline.setAttribute('stroke-linecap', roundStroke ? 'round' : 'butt');
 
-  if (o.withHandles) syncHostSelHandles(chrome, o, stroke, inv, d);
-  else {
-    chrome
-      .querySelectorAll(`g.sel-hit,[data-sel-handle],[data-rcb-sel-knob],[${SEL_BOX_ATTR}]`)
-      .forEach((n) => n.remove());
-  }
+  if (o.withHandles) syncHostSelHandlesIfNeeded(chrome, o, stroke, inv, d);
+  else syncHostSelHandlesIfNeeded(chrome, { ...o, withHandles: false }, stroke, inv, d);
 
   return true;
 }
@@ -770,5 +870,6 @@ export {
   pathLocalEndpoints,
   localPointToWorld,
   boxFromLocalAnchor,
+  hostSelHandlesKey,
   ShapeOutlineSvg,
 };

--- a/apps/web/src/components/rcb/selection/SelectionChrome.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionChrome.tsx
@@ -51,10 +51,19 @@ type SelectionChromeProps = {
  */
 export const CHROME_STROKE_PX = 1.5;
 export const CHROME_HANDLE_VIS_PX = 8;
-export const CHROME_HANDLE_HIT_PX = 18;
+/**
+ * Resize hit — barely larger than the 8px knob. Hits follow the icon; do not
+ * inflate into a big magnet that swallows radius seats inside the box.
+ */
+export const CHROME_HANDLE_HIT_PX = 10;
+/** Corner-radius hit — icon-sized, slightly under resize so corner prefers scale. */
+export const CHROME_RADIUS_HIT_PX = 8;
+/** Air between resize hit edge and radius hit edge (screen px). */
+export const CHROME_RADIUS_PARK_GAP_PX = 6;
 /** Transparent rotate hotzone (screen px) — shared with HostPathChrome. */
-export const CHROME_ROTATE_HIT_PX = 22;
-export const CHROME_ROTATE_GAP_PX = 2;
+export const CHROME_ROTATE_HIT_PX = 14;
+/** Air between resize hit outer edge and rotate hit inner edge (screen px). */
+export const CHROME_ROTATE_GAP_PX = 8;
 /** Line / arrow endpoint chrome (screen px). */
 export const CHROME_LINE_ENDPOINT_VIS_PX = 8;
 export const CHROME_LINE_ENDPOINT_HALO_PX = 22;
@@ -74,6 +83,83 @@ export function rotateHotzoneOutward(
   rotateHit: number
 ): number {
   return handleHit / 2 + rotateGap + rotateHit / 2;
+}
+
+/**
+ * Scene pad so resize + rotate hits outside the geom (and chromeOutset) still
+ * receive pointer events when the chrome SVG is tight to the box.
+ */
+export function chromeOutsideHitPadScene(
+  inv: number,
+  chromeOutset = 0,
+  strokePad = 0
+): number {
+  const outset = Math.max(0, chromeOutset);
+  const handleHit = CHROME_HANDLE_HIT_PX * inv;
+  const rotateHit = CHROME_ROTATE_HIT_PX * inv;
+  const rotateGap = CHROME_ROTATE_GAP_PX * inv;
+  const rotateOuter =
+    rotateHotzoneOutward(handleHit, rotateGap, rotateHit) + rotateHit / 2;
+  return Math.max(strokePad, outset + handleHit / 2, outset + rotateOuter);
+}
+
+/**
+ * Screen px from corner (resize / control-box icon center) → radius seat when R≈0.
+ * Both hits are centered on their icons; axis park `(inset, inset)` clears
+ * `halfResizeHit + halfRadiusHit + gap` along each axis.
+ */
+export function radiusHandleParkScreenPx(): number {
+  return CHROME_HANDLE_HIT_PX / 2 + CHROME_RADIUS_HIT_PX / 2 + CHROME_RADIUS_PARK_GAP_PX;
+}
+
+/**
+ * Scene park for radius seats at any zoom.
+ * Ideal park is screen-constant; on-screen budget keeps the seat near the
+ * corner so low zoom cannot park/hit near the center and steal move.
+ */
+export function radiusParkSceneForBox(
+  boxW: number,
+  boxH: number,
+  zoom: number,
+  parkPx = radiusHandleParkScreenPx()
+): number {
+  const z = Math.max(0.05, Number(zoom) || 1);
+  const half = Math.min(Math.max(1, boxW), Math.max(1, boxH)) / 2;
+  const minScreen = Math.min(Math.max(1, boxW), Math.max(1, boxH)) * z;
+  // Keep park ≤ ~22% of on-screen min side so the seat stays near the corner.
+  const screenBudget = Math.max(0, minScreen * 0.22);
+  const px = Math.min(Math.max(0, parkPx), screenBudget);
+  return Math.min(px / z, half * 0.45);
+}
+
+/**
+ * True when the box is large enough on screen for radius hits without covering move.
+ */
+export function radiusHandlesFitOnScreen(
+  boxW: number,
+  boxH: number,
+  zoom: number,
+  parkPx = radiusHandleParkScreenPx()
+): boolean {
+  const z = Math.max(0.05, Number(zoom) || 1);
+  const minScreen = Math.min(Math.max(1, boxW), Math.max(1, boxH)) * z;
+  return minScreen >= parkPx * 2 + CHROME_HANDLE_HIT_PX;
+}
+
+/**
+ * Scale chrome hit pads down when the box is tiny on screen so move stays reachable.
+ * Driven by on-screen size (any zoom), not a single zoom value.
+ */
+export function chromeHitScaleForBox(
+  boxW: number,
+  boxH: number,
+  zoom: number,
+  minScreenPx = 56
+): number {
+  const z = Math.max(0.05, Number(zoom) || 1);
+  const minScreen = Math.min(Math.max(1, boxW), Math.max(1, boxH)) * z;
+  if (minScreen >= minScreenPx) return 1;
+  return Math.max(0.35, minScreen / minScreenPx);
 }
 
 /** Scene AABB that covers a (possibly rotated) box plus chrome pad. */
@@ -373,11 +459,18 @@ function selectResizeKnobs(opts: {
   const { lineMode, cornerHandlesOnly, edgeHandles, w, h } = opts;
   if (lineMode) return [['w', 0, h / 2], ['e', w, h / 2]];
   const all = buildAllKnobs(w, h);
-  if (cornerHandlesOnly) return all.filter(([dir]) => isCornerHandle(dir));
-  if (edgeHandles === 'horizontal') {
-    return all.filter(([dir]) => isCornerHandle(dir) || dir === 'e' || dir === 'w');
+  let picked: Knob[];
+  if (cornerHandlesOnly) picked = all.filter(([dir]) => isCornerHandle(dir));
+  else if (edgeHandles === 'horizontal') {
+    picked = all.filter(([dir]) => isCornerHandle(dir) || dir === 'e' || dir === 'w');
+  } else {
+    picked = all;
   }
-  return all;
+  // Edges first, corners last — corner hits must win when AABBs overlap on tiny boxes.
+  return [
+    ...picked.filter(([dir]) => isEdgeHandle(dir)),
+    ...picked.filter(([dir]) => isCornerHandle(dir)),
+  ];
 }
 
 function selectVisualKnobs(
@@ -429,13 +522,14 @@ function SelectionChrome({
   const lineMode = variant === 'line';
 
   const stroke = CHROME_STROKE_PX * inv;
+  const hitScale = chromeHitScaleForBox(w, h, z);
   const handleVis = CHROME_HANDLE_VIS_PX * inv;
-  const handleHit = CHROME_HANDLE_HIT_PX * inv;
+  const handleHit = CHROME_HANDLE_HIT_PX * inv * hitScale;
   const lineEpVis = CHROME_LINE_ENDPOINT_VIS_PX * inv;
   const lineEpHalo = CHROME_LINE_ENDPOINT_HALO_PX * inv;
-  const lineEpHit = CHROME_LINE_ENDPOINT_HIT_PX * inv;
-  const lineShaftHit = CHROME_LINE_SHAFT_HIT_PX * inv;
-  const rotateHit = CHROME_ROTATE_HIT_PX * inv;
+  const lineEpHit = CHROME_LINE_ENDPOINT_HIT_PX * inv * hitScale;
+  const lineShaftHit = CHROME_LINE_SHAFT_HIT_PX * inv * hitScale;
+  const rotateHit = CHROME_ROTATE_HIT_PX * inv * hitScale;
   const rotateGap = CHROME_ROTATE_GAP_PX * inv;
   const metaOffset = 16 * inv;
   const metaFont = 10 * inv;
@@ -470,16 +564,6 @@ function SelectionChrome({
   const lineLen = Math.hypot(lineEnd.x - lineStart.x, lineEnd.y - lineStart.y) || 1;
   const lineAngleDeg =
     (Math.atan2(lineEnd.y - lineStart.y, lineEnd.x - lineStart.x) * 180) / Math.PI;
-
-  const edgeHits: Array<[ResizeHandle, number, number]> =
-    !lineMode && !cornerHandlesOnly && edgeHandles === 'all'
-      ? [
-          ['n', w / 2, 0],
-          ['s', w / 2, h],
-          ['e', w, h / 2],
-          ['w', 0, h / 2],
-        ]
-      : [];
 
   // World root when available (hits + lattice). Fallback: box outline only —
   // never include 1/zoom handle pads (that desynced chrome from ink).
@@ -516,6 +600,40 @@ function SelectionChrome({
           {metaLabel}
         </text>
       ) : null}
+
+      {showRotate && !lineMode
+        ? ROTATE_CORNERS.map(({ corner, localX, localY, iconDeg, label }) => {
+            // Under resize hits in paint order — control-box / corner prefer scale.
+            const signX = localX === 0 ? -1 : 1;
+            const signY = localY === 0 ? -1 : 1;
+            const out = rotateHotzoneOutward(handleHit, rotateGap, rotateHit);
+            // Rotate measures from the control-box / resize icon center (same as hit).
+            const cornerPt = toScene(localX * w, localY * h);
+            const cx = cornerPt.x + signX * out;
+            const cy = cornerPt.y + signY * out;
+            return (
+              <g key={`rot-${corner}`} className="sel-hit" transform={`translate(${cx} ${cy})`}>
+                <title>{label}</title>
+                <rect
+                  data-sel-handle="rotate"
+                  data-rotate-corner={corner}
+                  data-testid={`selection.rotate.${corner}`}
+                  role="button"
+                  aria-label={label}
+                  x={-rotateHit / 2}
+                  y={-rotateHit / 2}
+                  width={rotateHit}
+                  height={rotateHit}
+                  fill="transparent"
+                  style={{
+                    pointerEvents: 'all',
+                    cursor: cursorForRotate(iconDeg, angle),
+                  }}
+                />
+              </g>
+            );
+          })
+        : null}
 
       {lineMode ? (
         <g transform={`translate(${lineStart.x} ${lineStart.y}) rotate(${lineAngleDeg})`}>
@@ -558,18 +676,18 @@ function SelectionChrome({
           ) : null}
           {showHandles
             ? visualKnobs.map(([dir, lx, ly]) => (
-                <g key={`knob-${dir}`} style={{ pointerEvents: 'none' }}>
+                <g key={`knob-${dir}`} transform={`translate(${lx} ${ly})`} style={{ pointerEvents: 'none' }}>
                   <rect
-                    x={lx - halfVis}
-                    y={ly - halfVis}
+                    x={-halfVis}
+                    y={-halfVis}
                     width={handleVis}
                     height={handleVis}
                     fill="#ffffff"
                     stroke="none"
                   />
                   <rect
-                    x={lx - halfVis}
-                    y={ly - halfVis}
+                    x={-halfVis}
+                    y={-halfVis}
                     width={handleVis}
                     height={handleVis}
                     fill="none"
@@ -580,37 +698,21 @@ function SelectionChrome({
               ))
             : null}
           {showHandles
-            ? edgeHits.map(([dir, lx, ly]) => (
-                <rect
-                  key={`edge-hit-${dir}`}
-                  {...{ [handleDataAttr]: handleDataValue }}
-                  data-resize={dir}
-                  role="button"
-                  aria-label={`resize-${dir}`}
-                  x={lx - halfHit}
-                  y={ly - halfHit}
-                  width={handleHit}
-                  height={handleHit}
-                  fill="transparent"
-                  style={{ pointerEvents: 'all', cursor: cursorForResize(dir, angle) }}
-                />
-              ))
-            : null}
-          {showHandles
             ? knobs.map(([dir, lx, ly]) => (
-                <rect
-                  key={`hit-${dir}`}
-                  {...{ [handleDataAttr]: handleDataValue }}
-                  data-resize={dir}
-                  role="button"
-                  aria-label={`resize-${dir}`}
-                  x={lx - halfHit}
-                  y={ly - halfHit}
-                  width={handleHit}
-                  height={handleHit}
-                  fill="transparent"
-                  style={{ pointerEvents: 'all', cursor: cursorForResize(dir, angle) }}
-                />
+                <g key={`hit-${dir}`} transform={`translate(${lx} ${ly})`}>
+                  <rect
+                    {...{ [handleDataAttr]: handleDataValue }}
+                    data-resize={dir}
+                    role="button"
+                    aria-label={`resize-${dir}`}
+                    x={-halfHit}
+                    y={-halfHit}
+                    width={handleHit}
+                    height={handleHit}
+                    fill="transparent"
+                    style={{ pointerEvents: 'all', cursor: cursorForResize(dir, angle) }}
+                  />
+                </g>
               ))
             : null}
         </g>
@@ -646,39 +748,6 @@ function SelectionChrome({
                   height={lineEpHit}
                   fill="transparent"
                   style={{ pointerEvents: 'all', cursor: 'grab' }}
-                />
-              </g>
-            );
-          })
-        : null}
-
-      {showRotate && !lineMode
-        ? ROTATE_CORNERS.map(({ corner, localX, localY, iconDeg, label }) => {
-            // Axis-aligned outer quadrant — same lattice as resize knobs.
-            const signX = localX === 0 ? -1 : 1;
-            const signY = localY === 0 ? -1 : 1;
-            const out = rotateHotzoneOutward(handleHit, rotateGap, rotateHit);
-            const cornerPt = toScene(localX * w, localY * h);
-            const cx = cornerPt.x + signX * out;
-            const cy = cornerPt.y + signY * out;
-            return (
-              <g key={`rot-${corner}`} className="sel-hit" transform={`translate(${cx} ${cy})`}>
-                <title>{label}</title>
-                <rect
-                  data-sel-handle="rotate"
-                  data-rotate-corner={corner}
-                  data-testid={`selection.rotate.${corner}`}
-                  role="button"
-                  aria-label={label}
-                  x={-rotateHit / 2}
-                  y={-rotateHit / 2}
-                  width={rotateHit}
-                  height={rotateHit}
-                  fill="transparent"
-                  style={{
-                    pointerEvents: 'all',
-                    cursor: cursorForRotate(iconDeg, angle),
-                  }}
                 />
               </g>
             );

--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -25,6 +25,7 @@ import {
   snapMoveToSmartGuides,
   snapResizeToSmartGuides,
   smartSnapThreshold,
+  collectSmartGuidesAt,
   type SceneBox,
   type SmartGuideLine,
 } from './alignGuides';
@@ -802,31 +803,27 @@ function computeMovedUnion(ctx: MoveSnapContext): {
   };
   let guides: SmartGuideLine[] = [];
   if (!ctx.disableSnap) {
-    if (ctx.gridSize > 0) {
-      // Pixel grid owns translation. Smart guides used to nudge first (and old
-      // code skipped grid on snapped axes) → ink floated between cells while
-      // gap badges still showed "4". Guides are display-only after grid snap.
-      nextVisual = snapBoxToGrid(nextVisual, ctx.gridSize);
-      const shown = snapMoveToSmartGuides({
-        box: nextVisual,
-        targets: ctx.targets,
-        threshold: 0.51,
-        gridSize: ctx.gridSize,
-      });
-      const stillAligned =
-        Math.abs(shown.box.left - nextVisual.left) < 1e-9 &&
-        Math.abs(shown.box.top - nextVisual.top) < 1e-9;
-      guides = stillAligned ? shown.guides : [];
-    } else {
+    // Smart align (capped screen feel) then pin ink to the pixel grid.
+    // Old "guides display-only" path hid align lines whenever near-snap would
+    // have moved the box — low zoom only showed gap numbers, no orange lines.
+    if (ctx.threshold > 0 && ctx.targets.length) {
       const smart = snapMoveToSmartGuides({
         box: nextVisual,
         targets: ctx.targets,
         threshold: ctx.threshold,
-        gridSize: 0,
+        gridSize: ctx.gridSize > 0 ? ctx.gridSize : 0,
       });
       nextVisual = smart.box;
-      guides = smart.guides;
     }
+    if (ctx.gridSize > 0) {
+      nextVisual = snapBoxToGrid(nextVisual, ctx.gridSize);
+    }
+    // Paint from the settled box: gaps always; align strokes when edges match.
+    guides = collectSmartGuidesAt(
+      nextVisual,
+      ctx.targets,
+      Math.max(0.51, ctx.threshold)
+    );
   }
   const sdx = nextVisual.left - visualUnion.left;
   const sdy = nextVisual.top - visualUnion.top;
@@ -888,71 +885,56 @@ function computeResizedUnion(ctx: ResizeSnapContext): {
   const singleNode = singleId ? ctx.document?.deltaSetLike?.[singleId] : null;
   const snapAsPath = Boolean(singleId && !parseFrameSelId(singleId));
   if (!ctx.disableSnap) {
-    // Resize the painted outer ink onto the grid, then write path = visual − outset.
+    // Resize painted outer ink: smart align (capped) then grid — same as move.
+    // Guides always reflect the settled box (gaps + coincides), never cleared
+    // by a "would have snapped" display probe.
     if (snapAsPath && singleNode) {
       const path0 = deflateSelectionBox({ ...next }, singleNode);
       const visual0 = inflateBoxByVisualOutset(path0, singleNode);
-      const smart = snapResizeToSmartGuides({
-        box: visual0,
-        handle,
-        targets: ctx.targets,
-        threshold: ctx.threshold,
-        min: Math.max(8, Math.ceil(strokeVisualOutset(singleNode) * 2) + 1),
-        gridSize: ctx.gridSize,
-      });
-      const gridVisual = snapResizeToGrid(smart.box, handle, ctx.gridSize, 8, {
-        lockAspect,
-        aspectRatio: ctx.drag.aspectRatio,
-      });
+      let visualNext = visual0;
+      if (ctx.threshold > 0 && ctx.targets.length) {
+        visualNext = snapResizeToSmartGuides({
+          box: visualNext,
+          handle,
+          targets: ctx.targets,
+          threshold: ctx.threshold,
+          min: Math.max(8, Math.ceil(strokeVisualOutset(singleNode) * 2) + 1),
+          gridSize: ctx.gridSize > 0 ? ctx.gridSize : 0,
+        }).box;
+      }
+      if (ctx.gridSize > 0) {
+        visualNext = snapResizeToGrid(visualNext, handle, ctx.gridSize, 8, {
+          lockAspect,
+          aspectRatio: ctx.drag.aspectRatio,
+        });
+      }
       const outset = Math.max(0, strokeVisualOutset(singleNode));
       const pathNext = {
-        left: gridVisual.left + outset,
-        top: gridVisual.top + outset,
-        width: Math.max(1, gridVisual.width - outset * 2),
-        height: Math.max(1, gridVisual.height - outset * 2),
+        left: visualNext.left + outset,
+        top: visualNext.top + outset,
+        width: Math.max(1, visualNext.width - outset * 2),
+        height: Math.max(1, visualNext.height - outset * 2),
       };
-      const shown = snapResizeToSmartGuides({
-        box: gridVisual,
-        handle,
-        targets: ctx.targets,
-        threshold: 0.51,
-        min: 8,
-        gridSize: ctx.gridSize,
-      });
-      const stillAligned =
-        Math.abs(shown.box.left - gridVisual.left) < 1e-9 &&
-        Math.abs(shown.box.top - gridVisual.top) < 1e-9 &&
-        Math.abs(shown.box.width - gridVisual.width) < 1e-9 &&
-        Math.abs(shown.box.height - gridVisual.height) < 1e-9;
-      guides = stillAligned ? shown.guides : [];
+      guides = collectSmartGuidesAt(visualNext, ctx.targets, Math.max(0.51, ctx.threshold));
       next = inflateSelectionBox(pathNext, singleNode);
     } else {
-      const smart = snapResizeToSmartGuides({
-        box: next,
-        handle,
-        targets: ctx.targets,
-        threshold: ctx.threshold,
-        min: 8,
-        gridSize: ctx.gridSize,
-      });
-      next = snapResizeToGrid(smart.box, handle, ctx.gridSize, 8, {
-        lockAspect,
-        aspectRatio: ctx.drag.aspectRatio,
-      });
-      const shown = snapResizeToSmartGuides({
-        box: next,
-        handle,
-        targets: ctx.targets,
-        threshold: 0.51,
-        min: 8,
-        gridSize: ctx.gridSize,
-      });
-      const stillAligned =
-        Math.abs(shown.box.left - next.left) < 1e-9 &&
-        Math.abs(shown.box.top - next.top) < 1e-9 &&
-        Math.abs(shown.box.width - next.width) < 1e-9 &&
-        Math.abs(shown.box.height - next.height) < 1e-9;
-      guides = stillAligned ? shown.guides : [];
+      if (ctx.threshold > 0 && ctx.targets.length) {
+        next = snapResizeToSmartGuides({
+          box: next,
+          handle,
+          targets: ctx.targets,
+          threshold: ctx.threshold,
+          min: 8,
+          gridSize: ctx.gridSize > 0 ? ctx.gridSize : 0,
+        }).box;
+      }
+      if (ctx.gridSize > 0) {
+        next = snapResizeToGrid(next, handle, ctx.gridSize, 8, {
+          lockAspect,
+          aspectRatio: ctx.drag.aspectRatio,
+        });
+      }
+      guides = collectSmartGuidesAt(next, ctx.targets, Math.max(0.51, ctx.threshold));
     }
   }
   next = {
@@ -1853,7 +1835,8 @@ function SelectionFeature({
     if (!enabled || !hitEl) return undefined;
 
     const getPointerCtx = () => ({
-      document: documentRef.current,
+      // Scene model — never shadow DOM Document (elementsFromPoint / querySelector).
+      sceneDoc: documentRef.current,
       toScene: toSceneRef.current,
       zoom: zoomRef.current,
       gridSize: gridSizeRef.current,
@@ -1883,9 +1866,9 @@ function SelectionFeature({
      * Must not run on pointerdown ??otherwise one click (down+up) looks like a double-tap.
      */
     const tryOpenTextEdit = (id: string) => {
-      const { document, onEditText, onSelect, readOnly } = getPointerCtx();
+      const { sceneDoc, onEditText, onSelect, readOnly } = getPointerCtx();
       if (readOnly) return false;
-      const node = document?.deltaSetLike?.[id];
+      const node = sceneDoc?.deltaSetLike?.[id];
       if (node?.key !== 'text' || !onEditText) {
         lastTextClickRef.current = null;
         return false;
@@ -1911,7 +1894,7 @@ function SelectionFeature({
       // New gesture — drop any brush left stuck after a lost pointerup.
       setMarquee(null);
       const {
-        document,
+        sceneDoc,
         toScene,
         readOnly,
         attachPickActive,
@@ -1922,9 +1905,24 @@ function SelectionFeature({
         onSelectFrame,
       } = getPointerCtx();
       const target = e.target as HTMLElement;
+      // Prefer sceneDoc for scene; DOM APIs use globalThis.document.
+      const underPointer =
+        typeof globalThis.document?.elementsFromPoint === 'function'
+          ? globalThis.document.elementsFromPoint(e.clientX, e.clientY)
+          : [];
+      const resizeUnderPointer = () =>
+        underPointer.some(
+          (n) => n instanceof Element && n.getAttribute('data-sel-handle') === 'resize'
+        );
+      // Overlays handle their own pointers — unless a resize hit also sits under
+      // the cursor (corner / control-box must prefer scale).
+      const onOverlayKnob = target.closest(
+        '[data-radius-handle],[data-star-handle],[data-poly-handle],[data-circle-handle],[data-sel-toolbar],[data-frame-toolbar]'
+      );
+      if (onOverlayKnob && !resizeUnderPointer()) return;
       if (
         target.closest(
-          '[data-ctx-menu],[data-sel-toolbar],[data-frame-toolbar],[data-export-panel],[data-image-label],[data-frame-label],[data-crop-expand-overlay],[data-crop-expand-toolbar],[data-image-tool-panel],[data-image-variants],[data-image-quick-edit],[data-shape-style-panel],[data-gradient-handles],[data-mesh-handles],[data-color-panel],[data-text-inline-editor],[data-frame-handle],[data-image-generator],[data-video-generator],[data-video-playback-bar],[data-video-trim-toolbar],[data-radius-handle],[data-star-handle],[data-poly-handle],[data-circle-handle]'
+          '[data-ctx-menu],[data-export-panel],[data-image-label],[data-frame-label],[data-crop-expand-overlay],[data-crop-expand-toolbar],[data-image-tool-panel],[data-image-variants],[data-image-quick-edit],[data-shape-style-panel],[data-gradient-handles],[data-mesh-handles],[data-color-panel],[data-text-inline-editor],[data-frame-handle],[data-image-generator],[data-video-generator],[data-video-playback-bar],[data-video-trim-toolbar]'
         )
       )
         return;
@@ -1940,9 +1938,20 @@ function SelectionFeature({
       const liveUnionNow = liveUnionRef.current;
       const liveOriginsNow = liveOriginsRef.current;
       const liveAngleNow = liveAngleRef.current;
-      const lockedSelection = isSelectionOriginsLocked(document, liveOriginsNow);
+      const lockedSelection = isSelectionOriginsLocked(sceneDoc, liveOriginsNow);
 
-      const rotateEl = target.closest('[data-sel-handle="rotate"]') as HTMLElement | null;
+      // Prefer resize over rotate when both are under the pointer (same corner).
+      const resizeEl = underPointer.find(
+        (n) => n instanceof Element && n.getAttribute('data-sel-handle') === 'resize'
+      ) as HTMLElement | undefined;
+      const rotateEl =
+        resizeEl
+          ? null
+          : (underPointer.find(
+              (n) => n instanceof Element && n.getAttribute('data-sel-handle') === 'rotate'
+            ) as HTMLElement | undefined) ||
+            (target.closest('[data-sel-handle="rotate"]') as HTMLElement | null);
+
       if (rotateEl && liveUnionNow && liveOriginsNow?.length) {
         if (readOnly || lockedSelection) return;
         e.preventDefault();
@@ -1954,14 +1963,14 @@ function SelectionFeature({
         const angle0 =
           liveAngleNow ||
           (liveOriginsNow.length === 1
-            ? readNodeAngle(document, liveOriginsNow[0].nodeId)
+            ? readNodeAngle(sceneDoc, liveOriginsNow[0].nodeId)
             : 0);
         const pointerAngle0 = (Math.atan2(p.y - center.y, p.x - center.x) * 180) / Math.PI;
         dragRef.current = seed('rotate', e, p, {
           origins: liveOriginsNow.map((o) => ({
             nodeId: o.nodeId,
             box: { ...o.box },
-            angle0: readNodeAngle(document, o.nodeId),
+            angle0: readNodeAngle(sceneDoc, o.nodeId),
           })),
           union: { ...liveUnionNow },
           angle0,
@@ -1973,18 +1982,20 @@ function SelectionFeature({
         return;
       }
 
-      const resizeEl = target.closest('[data-sel-handle="resize"]') as HTMLElement | null;
-      if (resizeEl && liveUnionNow && liveOriginsNow?.length) {
+      const resizeHandleEl =
+        resizeEl ||
+        (target.closest('[data-sel-handle="resize"]') as HTMLElement | null);
+      if (resizeHandleEl && liveUnionNow && liveOriginsNow?.length) {
         if (readOnly || lockedSelection) return;
         e.preventDefault();
         e.stopPropagation();
-        const handle = (resizeEl.getAttribute('data-resize') || 'se') as ResizeHandle;
+        const handle = (resizeHandleEl.getAttribute('data-resize') || 'se') as ResizeHandle;
         const singleId = liveOriginsNow.length === 1 ? liveOriginsNow[0].nodeId : '';
-        const singleNode = singleId ? document?.deltaSetLike?.[singleId] : null;
+        const singleNode = singleId ? sceneDoc?.deltaSetLike?.[singleId] : null;
         const shapeType = singleNode ? String(singleNode.attrs?.shapeType || '') : '';
         const angle0 =
           liveOriginsNow.length === 1 && !parseFrameSelId(liveOriginsNow[0].nodeId)
-            ? liveAngleNow || readNodeAngle(document, liveOriginsNow[0].nodeId)
+            ? liveAngleNow || readNodeAngle(sceneDoc, liveOriginsNow[0].nodeId)
             : 0;
         let pathEpLocal0: [number, number] | undefined;
         let pathEpLocal1: [number, number] | undefined;
@@ -2051,7 +2062,7 @@ function SelectionFeature({
       // Hit-test scene nodes (selection chrome is non-blocking so empty clicks pass through).
       const hitId = hitTest(p.x, p.y, { clientX: e.clientX, clientY: e.clientY });
       const selectedIds = liveOriginsNow?.map((o) => o.nodeId) ?? [];
-      const plateFrameId = hitId ? frameForFullBleedPlate(document, hitId) : null;
+      const plateFrameId = hitId ? frameForFullBleedPlate(sceneDoc, hitId) : null;
 
       // Composer pick: attach node or artboard; never move / never treat frame as blank cancel.
       if (attachPickActive) {
@@ -2067,7 +2078,7 @@ function SelectionFeature({
             : null);
         if (hitId && !plateFrameId) {
           // Do NOT call onSelectFrame(null) here ??during pick that clears pick mode.
-          onSelect(expandSelectionWithGroups(document, [hitId]));
+          onSelect(expandSelectionWithGroups(sceneDoc, [hitId]));
         } else if (frameUnder) {
           onSelectFrame?.(frameUnder);
         } else {
@@ -2114,7 +2125,7 @@ function SelectionFeature({
         e.preventDefault();
         e.stopPropagation();
         const additive = e.shiftKey;
-        const expandedHit = expandSelectionWithGroups(document, [hitId]);
+        const expandedHit = expandSelectionWithGroups(sceneDoc, [hitId]);
 
         if (readOnly) {
           // Preview / Dev inspect: select only (no move).
@@ -2141,7 +2152,7 @@ function SelectionFeature({
         }
 
         const { origins, union } = buildMoveOriginsForHit({
-          document,
+          document: sceneDoc,
           hitId,
           selectedIds,
           expandedHit,
@@ -2162,10 +2173,10 @@ function SelectionFeature({
 
         // Keep chrome rotation in sync ??transforming flips chromeAngle onto liveAngle.
         if (origins.length === 1 && !parseFrameSelId(origins[0].nodeId)) {
-          setLiveAngle(readNodeAngle(document, origins[0].nodeId));
+          setLiveAngle(readNodeAngle(sceneDoc, origins[0].nodeId));
         }
         // Locked layers stay selectable but cannot start a drag.
-        if (isSelectionOriginsLocked(document, origins)) {
+        if (isSelectionOriginsLocked(sceneDoc, origins)) {
           dragRef.current = seed('blank', e, p);
           capture(e.pointerId);
           return;
@@ -2197,7 +2208,7 @@ function SelectionFeature({
       const drag = dragRef.current;
       if (!drag) return;
       const {
-        document,
+        sceneDoc,
         toScene,
         zoom,
         gridSize,
@@ -2293,12 +2304,12 @@ function SelectionFeature({
         const { nextUnion, sdx, sdy, guides } = computeMovedUnion({
           union: drag.union,
           origins: drag.origins,
-          document,
+          document: sceneDoc,
           dx,
           dy,
           disableSnap: e.ctrlKey || e.metaKey,
           gridSize,
-          targets: collectSmartGuideTargets(document, listNodeIds, getNodeBox, exclude),
+          targets: collectSmartGuideTargets(sceneDoc, listNodeIds, getNodeBox, exclude),
           threshold: smartSnapThreshold(zoom),
         });
         const nextOrigins = drag.origins.map((o) => ({
@@ -2324,7 +2335,7 @@ function SelectionFeature({
         // Soft-click on a handle must not resize: at 3% zoom, 2px jitter ??60+
         // scene units and snap threshold is huge (8/zoom), so the box jumps.
         if (screenDistSq <= DRAG_DISTANCE_SQUARED) return;
-        const stroke = strokeEndpointBox(drag, document, p.x, p.y);
+        const stroke = strokeEndpointBox(drag, sceneDoc, p.x, p.y);
         if (stroke) {
           setLiveUnion(stroke.next);
           setLiveOrigins([{ nodeId: stroke.strokeId, box: stroke.next }]);
@@ -2344,14 +2355,14 @@ function SelectionFeature({
         }
         const exclude = new Set(drag.origins.map((o) => o.nodeId));
         const { next, textMode, guides } = computeResizedUnion({
-          document,
+          document: sceneDoc,
           drag,
           dx,
           dy,
           shiftKey: e.shiftKey,
           disableSnap: e.ctrlKey || e.metaKey,
           gridSize,
-          targets: collectSmartGuideTargets(document, listNodeIds, getNodeBox, exclude),
+          targets: collectSmartGuideTargets(sceneDoc, listNodeIds, getNodeBox, exclude),
           threshold: smartSnapThreshold(zoom),
         });
         setSmartGuides(guides);
@@ -2403,7 +2414,7 @@ function SelectionFeature({
       if (!drag) return;
       dragRef.current = null;
       const {
-        document,
+        sceneDoc,
         toScene,
         zoom,
         gridSize,
@@ -2487,11 +2498,11 @@ function SelectionFeature({
         }
         const candidates = queryNodeIdsInRect?.(box) ?? listNodeIds();
         const rawHits = candidates.filter((id) =>
-          nodeHitsMarquee(document, id, box, getNodeBox, toScene)
+          nodeHitsMarquee(sceneDoc, id, box, getNodeBox, toScene)
         );
-        const frameHits = framesHittingMarquee(document, box).map((f) => f.id);
+        const frameHits = framesHittingMarquee(sceneDoc, box).map((f) => f.id);
         // Full-bleed plate: keep when artboard brushed, or other non-plate content hit.
-        const contentHits = filterMarqueeContentHits(document, rawHits, new Set(frameHits));
+        const contentHits = filterMarqueeContentHits(sceneDoc, rawHits, new Set(frameHits));
         commitMarqueeSelection({
           contentHits,
           frameHits,
@@ -2588,12 +2599,12 @@ function SelectionFeature({
         const { nextUnion, sdx, sdy } = computeMovedUnion({
           union: drag.union,
           origins: drag.origins,
-          document,
+          document: sceneDoc,
           dx,
           dy,
           disableSnap: e.ctrlKey || e.metaKey,
           gridSize,
-          targets: collectSmartGuideTargets(document, listNodeIds, getNodeBox, exclude),
+          targets: collectSmartGuideTargets(sceneDoc, listNodeIds, getNodeBox, exclude),
           threshold: smartSnapThreshold(zoom),
         });
         const patches = drag.origins.map((o) => ({
@@ -2620,7 +2631,7 @@ function SelectionFeature({
           endTransform();
           return;
         }
-        const stroke = strokeEndpointBox(drag, document, p.x, p.y);
+        const stroke = strokeEndpointBox(drag, sceneDoc, p.x, p.y);
         if (stroke) {
           setLiveUnion(stroke.next);
           setLiveOrigins([{ nodeId: stroke.strokeId, box: stroke.next }]);
@@ -2643,14 +2654,14 @@ function SelectionFeature({
         }
         const excludeUp = new Set(drag.origins.map((o) => o.nodeId));
         const { next, textMode } = computeResizedUnion({
-          document,
+          document: sceneDoc,
           drag,
           dx,
           dy,
           shiftKey,
           disableSnap: e.ctrlKey || e.metaKey,
           gridSize,
-          targets: collectSmartGuideTargets(document, listNodeIds, getNodeBox, excludeUp),
+          targets: collectSmartGuideTargets(sceneDoc, listNodeIds, getNodeBox, excludeUp),
           threshold: smartSnapThreshold(zoom),
         });
         if (drag.origins.length === 1) {
@@ -2692,7 +2703,7 @@ function SelectionFeature({
 
     const onDblClick = (e: MouseEvent) => {
       const {
-        document,
+        sceneDoc,
         toScene,
         readOnly,
         hitTest,
@@ -2714,7 +2725,7 @@ function SelectionFeature({
         if (ids.length === 1) hit = ids[0];
       }
       if (!hit) return;
-      const node = document?.deltaSetLike?.[hit];
+      const node = sceneDoc?.deltaSetLike?.[hit];
       if (node?.key === 'text') {
         e.preventDefault();
         e.stopPropagation();

--- a/apps/web/src/components/rcb/selection/__tests__/hostSelHandlesKey.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/hostSelHandlesKey.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Pan/zoom must not tear down resize knobs when box/flags are unchanged.
+ */
+import { describe, expect, it } from 'vitest';
+import { hostSelHandlesKey, type ShapeOutlineItem } from '../HostPathChrome';
+
+function item(partial: Partial<ShapeOutlineItem> = {}): ShapeOutlineItem {
+  return {
+    id: 'n1',
+    pathD: 'M0 0 H10 V8 Z',
+    box: { left: 1, top: 2, width: 10, height: 8 },
+    angle: 0,
+    withHandles: true,
+    showRotate: true,
+    ...partial,
+  };
+}
+
+describe('hostSelHandlesKey', () => {
+  it('is stable for identical outline + stroke/inv', () => {
+    const o = item();
+    expect(hostSelHandlesKey(o, 0.1, 1, o.pathD)).toBe(
+      hostSelHandlesKey(o, 0.1, 1, o.pathD)
+    );
+  });
+
+  it('changes when box or zoom (inv) changes, not merely by identity', () => {
+    const o = item();
+    const a = hostSelHandlesKey(o, 0.1, 1, o.pathD);
+    const b = hostSelHandlesKey(
+      item({ box: { ...o.box, width: 11 } }),
+      0.1,
+      1,
+      o.pathD
+    );
+    const c = hostSelHandlesKey(o, 0.1, 0.5, o.pathD);
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(c);
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/lowZoomSnap.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/lowZoomSnap.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SMART_SNAP_PX,
+  SMART_SNAP_SCENE_MAX,
+  smartSnapThreshold,
+  snapMoveToSmartGuides,
+  snapBoxToGrid,
+  collectSmartGuidesAt,
+} from '../alignGuides';
+import {
+  CHROME_HANDLE_HIT_PX,
+  CHROME_RADIUS_HIT_PX,
+  CHROME_RADIUS_PARK_GAP_PX,
+  chromeHitScaleForBox,
+  radiusHandleParkScreenPx,
+  radiusHandlesFitOnScreen,
+  radiusParkSceneForBox,
+} from '../SelectionChrome';
+
+/** Canvas zooms from floor → extreme (not a single repro %). */
+const CANVAS_ZOOMS = [0.05, 0.13, 0.25, 0.5, 0.8, 1, 2, 8, 20, 40, 80] as const;
+
+/** Production move settle: smart (capped) → grid → paint guides. */
+function settleMove(opts: {
+  box: { left: number; top: number; width: number; height: number };
+  targets: Array<{ left: number; top: number; width: number; height: number }>;
+  zoom: number;
+  gridSize?: number;
+}) {
+  const gridSize = opts.gridSize ?? 1;
+  const threshold = smartSnapThreshold(opts.zoom);
+  let next = { ...opts.box };
+  if (threshold > 0 && opts.targets.length) {
+    next = snapMoveToSmartGuides({
+      box: next,
+      targets: opts.targets,
+      threshold,
+      gridSize,
+    }).box;
+  }
+  if (gridSize > 0) next = snapBoxToGrid(next, gridSize);
+  const guides = collectSmartGuidesAt(next, opts.targets, Math.max(0.51, threshold));
+  return { box: next, guides, threshold };
+}
+
+describe('smartSnapThreshold @ all canvas zooms', () => {
+  it.each([...CANVAS_ZOOMS])('never exceeds scene cap at zoom %s', (zoom) => {
+    const threshold = smartSnapThreshold(zoom);
+    expect(threshold).toBeLessThanOrEqual(SMART_SNAP_SCENE_MAX + 1e-9);
+    expect(threshold).toBeCloseTo(Math.min(SMART_SNAP_PX / zoom, SMART_SNAP_SCENE_MAX), 6);
+  });
+
+  it.each([...CANVAS_ZOOMS])(
+    'does not yank across a 67-cell gap at zoom %s',
+    (zoom) => {
+      const left = { left: 0, top: 0, width: 120, height: 90 };
+      const gap = 67;
+      const right = {
+        left: left.left + left.width + gap,
+        top: 0,
+        width: 120,
+        height: 90,
+      };
+      const nudged = { ...right, left: right.left - 2 };
+      const { box, threshold } = settleMove({ box: nudged, targets: [left], zoom });
+      // eslint-disable-next-line no-console
+      console.log('[test:smart-snap@zoom]', {
+        zoom,
+        threshold,
+        remainingGap: box.left - (left.left + left.width),
+      });
+      expect(box.left).toBe(nudged.left);
+      expect(box.left - (left.left + left.width)).toBe(gap - 2);
+    }
+  );
+
+  it.each([...CANVAS_ZOOMS])(
+    'snaps flush when gap is within the capped threshold at zoom %s',
+    (zoom) => {
+      const left = { left: 0, top: 0, width: 100, height: 80 };
+      const threshold = smartSnapThreshold(zoom);
+      // Stay inside the magnet; at extreme zoom threshold can be < 1.
+      const gap = Math.min(threshold, Math.max(threshold * 0.5, 0.25));
+      const right = {
+        left: left.left + left.width + gap,
+        top: 0,
+        width: 100,
+        height: 80,
+      };
+      const settled = settleMove({ box: right, targets: [left], zoom, gridSize: 0 });
+      // eslint-disable-next-line no-console
+      console.log('[test:smart-snap-flush@zoom]', {
+        zoom,
+        threshold,
+        gap,
+        nextGap: settled.box.left - (left.left + left.width),
+        alignCount: settled.guides.filter((g) => g.kind === 'align').length,
+      });
+      expect(settled.box.left).toBeCloseTo(left.left + left.width, 6);
+      expect(settled.guides.some((g) => g.kind === 'align' && g.axis === 'x')).toBe(true);
+    }
+  );
+
+  it.each([0.13, 0.25, 0.5, 1])(
+    'shows gap badge beside a sibling even when not edge-aligned at zoom %s',
+    (zoom) => {
+      const left = { left: 0, top: 0, width: 100, height: 80 };
+      const right = { left: 140, top: 10, width: 100, height: 80 };
+      const { guides } = settleMove({ box: right, targets: [left], zoom });
+      const gaps = guides.filter((g) => g.kind === 'gap');
+      // eslint-disable-next-line no-console
+      console.log('[test:gap-badge@zoom]', { zoom, gaps });
+      expect(gaps.length).toBeGreaterThan(0);
+      expect(gaps.some((g) => g.kind === 'gap' && g.dist === 40)).toBe(true);
+    }
+  );
+
+  it('near-align probe must not clear guides (old stillAligned bug)', () => {
+    const left = { left: 0, top: 0, width: 100, height: 80 };
+    const right = { left: 100.3, top: 0, width: 100, height: 80 };
+    const guides = collectSmartGuidesAt(snapBoxToGrid(right, 1), [left], 8);
+    expect(guides.some((g) => g.kind === 'gap' || g.kind === 'align')).toBe(true);
+  });
+
+  it('uses full screen-px feel when 5/zoom is under the scene cap', () => {
+    const edge = SMART_SNAP_PX / SMART_SNAP_SCENE_MAX;
+    expect(smartSnapThreshold(edge)).toBeCloseTo(SMART_SNAP_SCENE_MAX, 6);
+    expect(smartSnapThreshold(1)).toBe(SMART_SNAP_PX);
+    expect(smartSnapThreshold(2)).toBeCloseTo(SMART_SNAP_PX / 2, 6);
+    expect(smartSnapThreshold(40)).toBeCloseTo(SMART_SNAP_PX / 40, 6);
+  });
+});
+
+describe('radius park + chrome hits @ all canvas zooms', () => {
+  const box = { w: 200, h: 150 };
+
+  it.each([...CANVAS_ZOOMS])(
+    'keeps park near the corner (≤45% half-side) at zoom %s',
+    (zoom) => {
+      const park = radiusParkSceneForBox(box.w, box.h, zoom);
+      const half = Math.min(box.w, box.h) / 2;
+      expect(park).toBeGreaterThanOrEqual(0);
+      expect(park).toBeLessThanOrEqual(half * 0.45 + 1e-9);
+      expect(park * zoom).toBeLessThanOrEqual(Math.min(box.w, box.h) * zoom * 0.22 + 1e-6);
+    }
+  );
+
+  it.each([...CANVAS_ZOOMS])(
+    'park clears scaled resize/radius hits when radius is interactive at zoom %s',
+    (zoom) => {
+      if (!radiusHandlesFitOnScreen(box.w, box.h, zoom)) return;
+      const parkPx = radiusHandleParkScreenPx();
+      const minScreen = Math.min(box.w, box.h) * zoom;
+      const parkScene = radiusParkSceneForBox(box.w, box.h, zoom, parkPx);
+      const expectedPx = Math.min(parkPx, minScreen * 0.22);
+      expect(parkScene * zoom).toBeCloseTo(expectedPx, 5);
+      const hitScale = chromeHitScaleForBox(box.w, box.h, zoom);
+      // Both hits are icon-centered — park clears halfHit + halfRadius + gap.
+      const resizeHalf = (CHROME_HANDLE_HIT_PX * hitScale) / 2 / zoom;
+      const radiusHalf = (CHROME_RADIUS_HIT_PX * hitScale) / 2 / zoom;
+      const clearance = parkScene - resizeHalf - radiusHalf;
+      if (expectedPx >= parkPx - 1e-6) {
+        expect(clearance * zoom).toBeGreaterThanOrEqual(CHROME_RADIUS_PARK_GAP_PX - 0.05);
+      } else {
+        expect(clearance).toBeGreaterThanOrEqual(0);
+      }
+    }
+  );
+
+  it.each([...CANVAS_ZOOMS])(
+    'hit scale follows on-screen size at zoom %s',
+    (zoom) => {
+      const scale = chromeHitScaleForBox(box.w, box.h, zoom);
+      const minScreen = Math.min(box.w, box.h) * zoom;
+      if (minScreen >= 56) expect(scale).toBe(1);
+      else {
+        expect(scale).toBeLessThan(1);
+        expect(scale).toBeGreaterThanOrEqual(0.35);
+      }
+    }
+  );
+
+  it('disables radius hits only when on-screen box is too small (any zoom)', () => {
+    expect(radiusHandlesFitOnScreen(200, 150, 0.13)).toBe(false);
+    expect(radiusHandlesFitOnScreen(26, 20, 1)).toBe(false);
+    expect(radiusHandlesFitOnScreen(200, 150, 1)).toBe(true);
+    expect(radiusHandlesFitOnScreen(200, 150, 20)).toBe(true);
+    expect(radiusHandlesFitOnScreen(40, 40, 80)).toBe(true);
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/moveSnapGrid.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/moveSnapGrid.test.ts
@@ -15,8 +15,7 @@ import { resolveClosedDrawBoxes } from '../../tools/ShapeDrawFeature';
 
 /**
  * Production move policy when gridSize > 0:
- *   nextVisual = snapBoxToGrid(visual0 + delta)   // smart does NOT nudge
- *   path += (nextVisual - visual0)
+ *   smart align (capped threshold, grid-compatible) → snapBoxToGrid → guides
  * Path may stay on *.5; ink outer stays on integer cells.
  */
 function moveSnapVisualOnly(opts: {

--- a/apps/web/src/components/rcb/selection/__tests__/radiusHandlePark.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/radiusHandlePark.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CHROME_HANDLE_HIT_PX,
+  CHROME_RADIUS_HIT_PX,
+  CHROME_RADIUS_PARK_GAP_PX,
+  radiusHandleParkScreenPx,
+} from '../SelectionChrome';
+import { radiusSeatInset } from '../chrome/CornerRadiusHandlesOverlay';
+
+describe('radiusHandleParkScreenPx', () => {
+  it('parks past half-resize + half-radius when both hits are icon-centered', () => {
+    const park = radiusHandleParkScreenPx();
+    const resizeHalf = CHROME_HANDLE_HIT_PX / 2;
+    const radiusHalf = CHROME_RADIUS_HIT_PX / 2;
+    expect(park).toBe(resizeHalf + radiusHalf + CHROME_RADIUS_PARK_GAP_PX);
+    expect(park - radiusHalf - resizeHalf).toBe(CHROME_RADIUS_PARK_GAP_PX);
+  });
+
+  it.each([0.5, 1, 2.247, 10, 80, 90])(
+    'keeps non-overlapping hits at canvas zoom %s',
+    (zoom) => {
+      const parkScene = radiusHandleParkScreenPx() / zoom;
+      const resizeHalf = CHROME_HANDLE_HIT_PX / 2 / zoom;
+      const radiusHalf = CHROME_RADIUS_HIT_PX / 2 / zoom;
+      expect((parkScene - radiusHalf - resizeHalf) * zoom).toBeCloseTo(
+        CHROME_RADIUS_PARK_GAP_PX,
+        5
+      );
+    }
+  );
+});
+
+describe('radiusSeatInset', () => {
+  it('parks at park when R≈0 and tracks R once past park', () => {
+    const park = radiusHandleParkScreenPx();
+    expect(radiusSeatInset(0, 100, park)).toBe(park);
+    expect(radiusSeatInset(10, 100, park)).toBe(park);
+    expect(radiusSeatInset(park + 8, 100, park)).toBe(park + 8);
+  });
+
+  it('clamps park on tiny boxes so the seat stays inside', () => {
+    const half = 20;
+    const seat = radiusSeatInset(0, half, 40);
+    expect(seat).toBeLessThanOrEqual(half * 0.45);
+    expect(seat).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/resizeRadiusHitOverlap.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/resizeRadiusHitOverlap.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Executable checks: resize vs corner-radius hit pads at any canvas zoom.
+ * Hits are centered on their icons (control-box corner / radius dot).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  CHROME_HANDLE_HIT_PX,
+  CHROME_HANDLE_VIS_PX,
+  CHROME_RADIUS_HIT_PX,
+  CHROME_RADIUS_PARK_GAP_PX,
+  chromeHitScaleForBox,
+  radiusHandleParkScreenPx,
+  radiusHandlesFitOnScreen,
+  radiusParkSceneForBox,
+} from '../SelectionChrome';
+import {
+  radiusParkAlongBisector,
+  radiusSeatInset,
+} from '../chrome/CornerRadiusHandlesOverlay';
+
+type Aabb = { left: number; top: number; right: number; bottom: number };
+
+function aabbFixed(cx: number, cy: number, half: number): Aabb {
+  return {
+    left: cx - half,
+    top: cy - half,
+    right: cx + half,
+    bottom: cy + half,
+  };
+}
+
+function aabbsOverlap(a: Aabb, b: Aabb): boolean {
+  return !(a.right <= b.left || b.right <= a.left || a.bottom <= b.top || b.bottom <= a.top);
+}
+
+function pointInAabb(x: number, y: number, box: Aabb): boolean {
+  return x >= box.left && x <= box.right && y >= box.top && y <= box.bottom;
+}
+
+/** Box-mode: SE resize hit (icon center) + BR radius seat (R≈0). */
+function seCornerHitLayout(boxW: number, boxH: number, zoom: number, r = 0) {
+  const z = Math.max(0.05, zoom);
+  const inv = 1 / z;
+  const hitScale = chromeHitScaleForBox(boxW, boxH, z);
+  const parkScene = radiusParkSceneForBox(boxW, boxH, z);
+  const halfSide = Math.min(boxW, boxH) / 2;
+  const inset = radiusSeatInset(r, halfSide, parkScene);
+
+  const halfHit = (CHROME_HANDLE_HIT_PX * hitScale * inv) / 2;
+  const resizeCx = boxW;
+  const resizeCy = boxH;
+  const radiusCx = boxW - inset;
+  const radiusCy = boxH - inset;
+
+  const radiusHalfScene = (CHROME_RADIUS_HIT_PX * hitScale * inv) / 2;
+  const resizeHit = aabbFixed(resizeCx, resizeCy, halfHit);
+  const radiusHit = aabbFixed(radiusCx, radiusCy, radiusHalfScene);
+
+  const axisClearanceScene = Math.min(
+    resizeHit.left - radiusHit.right,
+    resizeHit.top - radiusHit.bottom
+  );
+
+  return {
+    z,
+    parkScene,
+    resizeCx,
+    resizeCy,
+    radiusCx,
+    radiusCy,
+    resizeHit,
+    radiusHit,
+    overlap: aabbsOverlap(resizeHit, radiusHit),
+    axisClearanceScreen: axisClearanceScene * z,
+    resizeHitScreen: CHROME_HANDLE_HIT_PX * hitScale,
+    radiusHitScreen: CHROME_RADIUS_HIT_PX * hitScale,
+    radiusInteractive: radiusHandlesFitOnScreen(boxW, boxH, z),
+  };
+}
+
+/** Path-mode: seat along inward 45° bisector. */
+function sePathHitLayout(boxW: number, boxH: number, zoom: number, r = 0) {
+  const z = Math.max(0.05, zoom);
+  const inv = 1 / z;
+  const hitScale = chromeHitScaleForBox(boxW, boxH, z);
+  const parkScene = radiusParkSceneForBox(boxW, boxH, z);
+  const halfSide = Math.min(boxW, boxH) / 2;
+  const inset = radiusSeatInset(r, halfSide, parkScene);
+  const ix = -Math.SQRT1_2;
+  const iy = -Math.SQRT1_2;
+  const along = radiusParkAlongBisector(inset, ix, iy);
+
+  const halfHit = (CHROME_HANDLE_HIT_PX * hitScale * inv) / 2;
+  const resizeHit = aabbFixed(boxW, boxH, halfHit);
+  const radiusCx = boxW + ix * along;
+  const radiusCy = boxH + iy * along;
+  const radiusHit = aabbFixed(radiusCx, radiusCy, (CHROME_RADIUS_HIT_PX * hitScale * inv) / 2);
+  const axisClearanceScene = Math.min(
+    resizeHit.left - radiusHit.right,
+    resizeHit.top - radiusHit.bottom
+  );
+
+  return {
+    overlap: aabbsOverlap(resizeHit, radiusHit),
+    axisClearanceScreen: axisClearanceScene * z,
+    radiusCx,
+    radiusCy,
+    resizeHit,
+    radiusInteractive: radiusHandlesFitOnScreen(boxW, boxH, z),
+  };
+}
+
+const ZOOMS = [0.05, 0.13, 0.25, 0.5, 1, 2, 8, 20, 49.9, 80, 90] as const;
+const BOX = { w: 200, h: 150 };
+
+describe('resize vs radius hit pads (icon-centered)', () => {
+  it('hits stay near icon size (not oversized magnets)', () => {
+    expect(CHROME_HANDLE_HIT_PX).toBeLessThanOrEqual(CHROME_HANDLE_VIS_PX + 4);
+    expect(CHROME_RADIUS_HIT_PX).toBeLessThanOrEqual(CHROME_HANDLE_VIS_PX + 4);
+    expect(radiusHandleParkScreenPx()).toBe(
+      CHROME_HANDLE_HIT_PX / 2 + CHROME_RADIUS_HIT_PX / 2 + CHROME_RADIUS_PARK_GAP_PX
+    );
+  });
+
+  it.each([...ZOOMS])(
+    'hit scene size scales as screenPx/zoom at canvas zoom %s',
+    (zoom) => {
+      const layout = seCornerHitLayout(BOX.w, BOX.h, zoom);
+      const resizeScene = layout.resizeHit.right - layout.resizeHit.left;
+      expect(resizeScene * zoom).toBeCloseTo(layout.resizeHitScreen, 5);
+      if (zoom >= 2) {
+        expect(resizeScene).toBeLessThan(CHROME_HANDLE_HIT_PX);
+      }
+    }
+  );
+
+  it.each([...ZOOMS])(
+    'box-mode SE resize hit does not overlap BR radius at zoom %s when interactive',
+    (zoom) => {
+      const layout = seCornerHitLayout(BOX.w, BOX.h, zoom, 0);
+      if (!layout.radiusInteractive) {
+        expect(layout.radiusInteractive).toBe(false);
+        return;
+      }
+      expect(layout.overlap).toBe(false);
+      expect(pointInAabb(layout.resizeCx, layout.resizeCy, layout.resizeHit)).toBe(true);
+      expect(pointInAabb(layout.radiusCx, layout.radiusCy, layout.resizeHit)).toBe(false);
+      expect(pointInAabb(layout.resizeCx, layout.resizeCy, layout.radiusHit)).toBe(false);
+      const fullPark =
+        Math.abs(layout.parkScene * layout.z - radiusHandleParkScreenPx()) < 0.05;
+      if (fullPark) {
+        expect(layout.axisClearanceScreen).toBeGreaterThanOrEqual(
+          CHROME_RADIUS_PARK_GAP_PX - 0.05
+        );
+      } else {
+        expect(layout.axisClearanceScreen).toBeGreaterThanOrEqual(-0.05);
+      }
+    }
+  );
+
+  it.each([...ZOOMS])(
+    'path-mode bisector seat clears SE resize hit at zoom %s when interactive',
+    (zoom) => {
+      const layout = sePathHitLayout(BOX.w, BOX.h, zoom, 0);
+      if (!layout.radiusInteractive) {
+        expect(layout.radiusInteractive).toBe(false);
+        return;
+      }
+      expect(layout.overlap).toBe(false);
+      expect(layout.axisClearanceScreen).toBeGreaterThanOrEqual(-0.05);
+      expect(pointInAabb(layout.radiusCx, layout.radiusCy, layout.resizeHit)).toBe(false);
+    }
+  );
+
+  it('at 9000% (90×), 1 scene px of park is enough on screen', () => {
+    const zoom = 90;
+    const layout = seCornerHitLayout(BOX.w, BOX.h, zoom, 0);
+    expect(layout.radiusInteractive).toBe(true);
+    expect(layout.overlap).toBe(false);
+    expect(layout.parkScene).toBeLessThan(1);
+    expect(layout.parkScene * zoom).toBeCloseTo(radiusHandleParkScreenPx(), 5);
+    expect(layout.axisClearanceScreen).toBeGreaterThanOrEqual(CHROME_RADIUS_PARK_GAP_PX - 0.05);
+  });
+
+  it('at 100%, hits clear with icon-sized pads', () => {
+    const layout = seCornerHitLayout(BOX.w, BOX.h, 1, 0);
+    expect(layout.overlap).toBe(false);
+    expect(layout.resizeHitScreen).toBe(10);
+    expect(layout.radiusHitScreen).toBe(8);
+  });
+
+  it('at 8019% on 4×4 box, corner icon is resize territory; radius center is free of resize', () => {
+    const layout = seCornerHitLayout(4, 4, 80.19, 0);
+    expect(layout.radiusInteractive).toBe(true);
+    expect(layout.overlap).toBe(false);
+    expect(pointInAabb(layout.resizeCx, layout.resizeCy, layout.radiusHit)).toBe(false);
+    expect(pointInAabb(layout.resizeCx, layout.resizeCy, layout.resizeHit)).toBe(true);
+    expect(pointInAabb(layout.radiusCx, layout.radiusCy, layout.resizeHit)).toBe(false);
+    expect(layout.axisClearanceScreen).toBeGreaterThanOrEqual(CHROME_RADIUS_PARK_GAP_PX - 0.05);
+  });
+
+  it('bisector park matches axis park on 45° corners', () => {
+    const park = 13;
+    const along = radiusParkAlongBisector(park, -Math.SQRT1_2, -Math.SQRT1_2);
+    expect(along * Math.SQRT1_2).toBeCloseTo(park, 10);
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/resizeRotateHitOverlap.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/resizeRotateHitOverlap.test.ts
@@ -1,0 +1,108 @@
+/**
+ * At ~8000% zoom, rotate must not steal control-box / resize clicks.
+ * Repro: 4×4 box @ zoom 80.19 (screenshot 8019%).
+ * Resize hit is centered on the control-box corner icon.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  CHROME_HANDLE_HIT_PX,
+  CHROME_ROTATE_GAP_PX,
+  CHROME_ROTATE_HIT_PX,
+  chromeHitScaleForBox,
+  rotateHotzoneOutward,
+} from '../SelectionChrome';
+
+type Aabb = { left: number; top: number; right: number; bottom: number };
+
+function aabb(cx: number, cy: number, half: number): Aabb {
+  return {
+    left: cx - half,
+    top: cy - half,
+    right: cx + half,
+    bottom: cy + half,
+  };
+}
+
+function overlap(a: Aabb, b: Aabb): boolean {
+  return !(a.right <= b.left || b.right <= a.left || a.bottom <= b.top || b.bottom <= a.top);
+}
+
+function contains(box: Aabb, x: number, y: number): boolean {
+  return x >= box.left && x <= box.right && y >= box.top && y <= box.bottom;
+}
+
+/** Production SE corner layout (local geom). */
+function seResizeRotateLayout(boxW: number, boxH: number, zoom: number) {
+  const z = Math.max(0.05, zoom);
+  const inv = 1 / z;
+  const hitScale = chromeHitScaleForBox(boxW, boxH, z);
+  const handleHit = CHROME_HANDLE_HIT_PX * inv * hitScale;
+  const halfHit = handleHit / 2;
+  const rotateHit = CHROME_ROTATE_HIT_PX * inv * hitScale;
+  const rotateGap = CHROME_ROTATE_GAP_PX * inv;
+  const out = rotateHotzoneOutward(handleHit, rotateGap, rotateHit);
+
+  const resizeC = { x: boxW, y: boxH };
+  const rotateC = { x: resizeC.x + out, y: resizeC.y + out };
+  const resizeHit = aabb(resizeC.x, resizeC.y, halfHit);
+  const rotateHitBox = aabb(rotateC.x, rotateC.y, rotateHit / 2);
+
+  return {
+    resizeC,
+    rotateC,
+    resizeHit,
+    rotateHitBox,
+    overlap: overlap(resizeHit, rotateHitBox),
+    axisGapScreen: (rotateHitBox.left - resizeHit.right) * z,
+  };
+}
+
+function ownerAt(
+  layout: ReturnType<typeof seResizeRotateLayout>,
+  x: number,
+  y: number
+): 'resize' | 'rotate' | 'none' {
+  if (contains(layout.resizeHit, x, y)) return 'resize';
+  if (contains(layout.rotateHitBox, x, y)) return 'rotate';
+  return 'none';
+}
+
+describe('resize vs rotate @ high zoom (control box clicks)', () => {
+  it('rotate hit stays modest (not a 22px magnet on the corner)', () => {
+    expect(CHROME_ROTATE_HIT_PX).toBeLessThanOrEqual(16);
+    expect(CHROME_ROTATE_GAP_PX).toBeGreaterThanOrEqual(6);
+  });
+
+  it.each([1, 8, 20, 49.9, 80.19, 90] as const)(
+    'SE resize and rotate AABBs do not overlap at zoom %s (4×4 box)',
+    (zoom) => {
+      const layout = seResizeRotateLayout(4, 4, zoom);
+      expect(layout.overlap).toBe(false);
+      expect(layout.axisGapScreen).toBeGreaterThanOrEqual(CHROME_ROTATE_GAP_PX - 0.05);
+    }
+  );
+
+  it('at 8019%, control-box corner / resize icon is resize — not rotate', () => {
+    const layout = seResizeRotateLayout(4, 4, 80.19);
+    expect(ownerAt(layout, layout.resizeC.x, layout.resizeC.y)).toBe('resize');
+    expect(ownerAt(layout, 4, 4)).toBe('resize');
+    expect(ownerAt(layout, 3.95, 3.95)).not.toBe('rotate');
+    expect(ownerAt(layout, 2, 4)).not.toBe('rotate');
+    expect(ownerAt(layout, 4, 2)).not.toBe('rotate');
+    expect(ownerAt(layout, layout.rotateC.x, layout.rotateC.y)).toBe('rotate');
+  });
+
+  it('approach corridor: screen px 0–6 resize, then air, then rotate', () => {
+    const zoom = 80.19;
+    const layout = seResizeRotateLayout(4, 4, zoom);
+    const samples: Array<{ d: number; owner: string }> = [];
+    for (let d = 0; d <= 36; d += 2) {
+      const s = d / zoom;
+      const owner = ownerAt(layout, 4 + s, 4 + s);
+      if (owner !== 'none') samples.push({ d, owner });
+    }
+    expect(samples.filter((s) => s.owner === 'resize').every((s) => s.d <= 8)).toBe(true);
+    expect(samples.filter((s) => s.owner === 'rotate').every((s) => s.d >= 12)).toBe(true);
+    expect(layout.overlap).toBe(false);
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/selChromeLayerShell.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/selChromeLayerShell.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Regression: full-bleed inset-0 chrome layer painted knobs but dropped resize hits.
+ * Keep the same 0×0 + overflow-visible shell as SelectionFeature / SvgCanvas overlays.
+ */
+import { describe, expect, it } from 'vitest';
+import { selChromeLayerShell } from '../HostPathChrome';
+
+describe('selChromeLayerShell', () => {
+  it('is a 0×0 left-top overflow shell (not full-bleed inset-0)', () => {
+    const shell = selChromeLayerShell();
+    expect(shell.width).toBe('0');
+    expect(shell.height).toBe('0');
+    expect(shell.pointerEvents).toBe('none');
+    expect(shell.className).toContain('left-0');
+    expect(shell.className).toContain('top-0');
+    expect(shell.className).toContain('overflow-visible');
+    expect(shell.className).toContain('pointer-events-none');
+    expect(shell.className).not.toContain('inset-0');
+  });
+
+  it('stays under SelectionFeature overlay z (1e6 < 1000001)', () => {
+    expect(Number(selChromeLayerShell().zIndex)).toBe(1_000_000);
+  });
+});

--- a/apps/web/src/components/rcb/selection/alignGuides.ts
+++ b/apps/web/src/components/rcb/selection/alignGuides.ts
@@ -8,6 +8,12 @@ export const DEFAULT_GRID_SIZE = 1;
 
 /** Screen-px threshold for object-to-object smart guides. */
 export const SMART_SNAP_PX = 5;
+/**
+ * Cap scene-space snap for every zoom. Uncapped `SMART_SNAP_PX/zoom` stays
+ * screen-constant, but at low zoom that is dozens of document cells and feels
+ * like a distant magnet. High zoom is unchanged (5/zoom already &lt; this cap).
+ */
+export const SMART_SNAP_SCENE_MAX = 8;
 
 /** Alignment + spacing guide color. */
 export const SMART_GUIDE_COLOR = '#FF6B35';
@@ -36,8 +42,12 @@ export type SmartGuideGap = {
 
 export type SmartGuideLine = SmartGuideAlign | SmartGuideGap;
 
+/**
+ * Scene snap radius for guides — `min(screenPx/zoom, sceneCap)` at every zoom.
+ */
 export function smartSnapThreshold(zoom: number): number {
-  return SMART_SNAP_PX / Math.max(0.05, Number(zoom) || 1);
+  const z = Math.max(0.05, Number(zoom) || 1);
+  return Math.min(SMART_SNAP_PX / z, SMART_SNAP_SCENE_MAX);
 }
 
 type AxisMark = { value: number; role: 'min' | 'mid' | 'max' };
@@ -340,6 +350,25 @@ function finishSmartGuides(
   }
   const gaps = collectGapGuides(box, targets);
   return [...aligns, ...gaps];
+}
+
+/**
+ * Paint-only guides for the current box — gaps always; aligns when edges
+ * coincide within `eps` (does not move the box).
+ */
+export function collectSmartGuidesAt(
+  box: SceneBox,
+  targets: SceneBox[],
+  eps: number = GUIDE_COINCIDE_EPS
+): SmartGuideLine[] {
+  const coincide = Math.max(GUIDE_COINCIDE_EPS, Number(eps) || 0);
+  const aligns = collectAlignGuides(box, targets, coincide).map((g) => ({
+    ...g,
+    marks: g.marks?.length
+      ? g.marks
+      : marksAlongGuide(box, targets, g.axis, g.at, GUIDE_COINCIDE_EPS),
+  }));
+  return [...aligns, ...collectGapGuides(box, targets)];
 }
 
 /** Snap a moving AABB to sibling path edges / centers. */

--- a/apps/web/src/components/rcb/selection/chrome/CornerRadiusHandlesOverlay.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/CornerRadiusHandlesOverlay.tsx
@@ -37,28 +37,21 @@ import {
 } from '@/components/rcb/shapes/shapeHostRegistry';
 import type { SceneBox } from '../alignGuides';
 import {
-  CHROME_HANDLE_HIT_PX,
   CHROME_HANDLE_VIS_PX,
+  CHROME_RADIUS_HIT_PX,
   CHROME_STROKE_PX,
+  chromeHitScaleForBox,
+  radiusHandleParkScreenPx,
+  radiusHandlesFitOnScreen,
+  radiusParkSceneForBox,
   WorldScreenBadge,
 } from '../SelectionChrome';
 
 /** Soft-click threshold (screen px²) — match SelectionFeature. */
 const DRAG_DISTANCE_SQUARED = 16;
 
-/**
- * Screen-constant sizes under world CSS camera scale(z) — same contract as
- * SelectionChrome / path chrome knobs (scene = screenPx / zoom).
- */
-const RADIUS_VIS_PX = CHROME_HANDLE_VIS_PX;
-const RADIUS_HIT_PX = CHROME_HANDLE_HIT_PX;
-const RADIUS_STROKE_PX = CHROME_STROKE_PX;
-const RADIUS_REVEAL_DIST_PX = 56;
-/**
- * When R≈0 (or R is still small), seat this many screen px inside the corner
- * so the radius dot clears the resize knob (~8px) with ~10px spacing.
- */
-const RADIUS_PARK_PX = 10;
+/** Ideal park when the box is large enough on screen (icon-centered hits). */
+const RADIUS_PARK_PX = radiusHandleParkScreenPx();
 
 function liveNodeEl(nodeId: string): Element | null {
   return (
@@ -105,7 +98,7 @@ function HostMirroredKnobSvg({
     return (
       <svg
         data-rcb-infinite="1"
-        className="absolute z-[28] overflow-visible"
+        className="absolute z-[16] overflow-visible"
         preserveAspectRatio="none"
         viewBox={mirror.viewBox}
         width={mirror.width}
@@ -137,7 +130,7 @@ function HostMirroredKnobSvg({
   return (
     <svg
       data-rcb-infinite="1"
-      className="absolute z-[28] overflow-visible"
+      className="absolute z-[16] overflow-visible"
       preserveAspectRatio="none"
       width={surf.width}
       height={surf.height}
@@ -216,12 +209,30 @@ function localPointToScene(
 
 /**
  * Seat inset from the corner: tracks R. When R is below the park distance,
- * keep a screen-constant inset so the dot stays ~10px clear of the resize
- * knob under any zoom.
+ * keep a screen-constant inset so the radius hit clears the resize hit under any zoom.
+ * Park is clamped on tiny boxes so the seat cannot cross the center.
  */
-function radiusSeatInset(r: number, halfSide: number, parkScene: number): number {
-  const capped = Math.max(0, Math.min(Number(r) || 0, Math.max(0, halfSide - parkScene)));
-  return Math.max(parkScene, capped);
+export function radiusSeatInset(r: number, halfSide: number, parkScene: number): number {
+  const park = Math.min(Math.max(0, parkScene), Math.max(0, halfSide * 0.45));
+  const capped = Math.max(0, Math.min(Number(r) || 0, Math.max(0, halfSide - park)));
+  return Math.max(park, capped);
+}
+
+/**
+ * Path seats travel along the inward bisector. Axis AABB clearance needs the
+ * same park on both axes as box-mode `(inset, inset)` — so along ≥ park / min(|ix|,|iy|).
+ */
+export function radiusParkAlongBisector(
+  parkScene: number,
+  ix: number,
+  iy: number
+): number {
+  const park = Math.max(0, parkScene);
+  const ax = Math.abs(Number(ix) || 0);
+  const ay = Math.abs(Number(iy) || 0);
+  const m = Math.min(ax, ay);
+  if (!(m > 1e-9)) return park;
+  return park / m;
 }
 
 /** Path sharp-corner radii list — stored vertices, or uniform fallback from box radii. */
@@ -325,7 +336,7 @@ function CornerRadiusHandlesOverlay({
   nodeId,
   node,
   toScene,
-  stageEl,
+  stageEl: _stageEl,
   interactive = true,
 }: {
   box: SceneBox;
@@ -333,6 +344,7 @@ function CornerRadiusHandlesOverlay({
   nodeId: string;
   node: any;
   toScene: (clientX: number, clientY: number) => { x: number; y: number };
+  /** Kept for call-site parity with other shape overlays (unused — seats always show). */
   stageEl: HTMLElement | null;
   /** False while moving/resizing so dots follow chrome without stealing pointers. */
   interactive?: boolean;
@@ -350,7 +362,6 @@ function CornerRadiusHandlesOverlay({
   const dispatch = useDispatch();
   const camera = useRcbCamera();
   const z = Math.max(0.05, camera.zoom || 1);
-  const [nearCorners, setNearCorners] = useState(false);
   const [activeKey, setActiveKey] = useState<string | null>(null);
   const [dragValue, setDragValue] = useState<number | null>(null);
   const dragRef = useRef<RadiusHandleDrag | null>(null);
@@ -367,15 +378,16 @@ function CornerRadiusHandlesOverlay({
     ? resolvePathVertexRadii(node?.attrs, pathVertexCount, baseRadii)
     : [];
 
-  // Seat tracks R (scene). Tiny screen-constant park when R≈0 so it stays off the resize knob.
-  const visualPx = RADIUS_VIS_PX;
-  const hitPx = RADIUS_HIT_PX;
-  const revealDist = RADIUS_REVEAL_DIST_PX;
+  // Seat tracks R (scene). Park when R≈0 so radius hit clears the resize hit.
+  // Screen budget keeps seats near corners at every zoom (not only one %).
+  const hitScale = chromeHitScaleForBox(w, h, z);
+  const hitPx = CHROME_RADIUS_HIT_PX * hitScale;
   const k = 1 / z;
-  const parkScene = RADIUS_PARK_PX * k;
+  const parkScene = radiusParkSceneForBox(w, h, z, RADIUS_PARK_PX);
+  const radiusInteractive =
+    interactive && radiusHandlesFitOnScreen(w, h, z, RADIUS_PARK_PX);
   // `box` prop is path geom (caller deflates visual chrome). Host-mirrored
   // local space is also geom — path sites need no chrome pad.
-  const geomOutset = 0;
   const halfSide = Math.min(w, h) / 2;
 
   const radiusHandleInset = (r: number) => radiusSeatInset(r, halfSide, parkScene);
@@ -394,10 +406,10 @@ function CornerRadiusHandlesOverlay({
   };
 
   const pathHandleLocalPos = (site: SharpCornerSite, r: number) => {
-    const along = radiusHandleInset(r);
+    const along = radiusParkAlongBisector(radiusHandleInset(r), site.ix, site.iy);
     return {
-      lx: geomOutset + site.x + site.ix * along,
-      ly: geomOutset + site.y + site.iy * along,
+      lx: site.x + site.ix * along,
+      ly: site.y + site.iy * along,
     };
   };
 
@@ -420,10 +432,11 @@ function CornerRadiusHandlesOverlay({
   };
 
   const radiusAlongPathSite = (site: SharpCornerSite, local: { x: number; y: number }) => {
-    const sx = geomOutset + site.x;
-    const sy = geomOutset + site.y;
-    const along = (local.x - sx) * site.ix + (local.y - sy) * site.iy;
-    return Math.max(0, Math.min(maxR, along));
+    const along = (local.x - site.x) * site.ix + (local.y - site.y) * site.iy;
+    // Inverse of radiusParkAlongBisector: axis park ↔ R (same as box inset).
+    const m = Math.min(Math.abs(site.ix), Math.abs(site.iy));
+    const axis = m > 1e-9 ? along * m : along;
+    return Math.max(0, Math.min(maxR, axis));
   };
 
   const previewRadiiOnHost = (radii: CornerRadii, vertices?: number[]) => {
@@ -457,69 +470,7 @@ function CornerRadiusHandlesOverlay({
   };
 
   useEffect(() => {
-    if (!stageEl || !interactive) return undefined;
-    const onMove = (e: PointerEvent) => {
-      if (dragRef.current) return;
-      const target = e.target as HTMLElement | null;
-      if (target?.closest?.('[data-radius-handle]')) {
-        setNearCorners(true);
-        return;
-      }
-      const sc = toScene(e.clientX, e.clientY);
-      const local = scenePointToLocal(sc.x, sc.y, box, angle);
-      let best = Infinity;
-      if (usePath && pathSites) {
-        for (const site of pathSites) {
-          const r = pathVertices[site.sharpIndex] ?? 0;
-          const seat = pathHandleScenePos(site, r);
-          const lx = geomOutset + site.x;
-          const ly = geomOutset + site.y;
-          best = Math.min(
-            best,
-            Math.hypot((sc.x - seat.x) * z, (sc.y - seat.y) * z),
-            Math.hypot((local.x - lx) * z, (local.y - ly) * z)
-          );
-        }
-      } else {
-        for (const c of RADIUS_CORNERS) {
-          const r = baseRadii[c.key] ?? 0;
-          const { lx: seatLx, ly: seatLy } = boxHandleLocalPos(c, r);
-          best = Math.min(
-            best,
-            Math.hypot((local.x - c.cx * w) * z, (local.y - c.cy * h) * z),
-            Math.hypot((local.x - seatLx) * z, (local.y - seatLy) * z)
-          );
-        }
-      }
-      setNearCorners(best <= revealDist);
-    };
-    const onLeave = () => {
-      if (!dragRef.current) setNearCorners(false);
-    };
-    window.addEventListener('pointermove', onMove, { passive: true });
-    stageEl.addEventListener('pointerleave', onLeave);
-    return () => {
-      window.removeEventListener('pointermove', onMove);
-      stageEl.removeEventListener('pointerleave', onLeave);
-    };
-  }, [
-    stageEl,
-    interactive,
-    box,
-    angle,
-    w,
-    h,
-    z,
-    toScene,
-    revealDist,
-    usePath,
-    pathSites,
-    pathVertices,
-    baseRadii,
-  ]);
-
-  useEffect(() => {
-    if (!interactive) return undefined;
+    if (!radiusInteractive) return undefined;
 
     const commitPathRadii = (
       vertices: number[],
@@ -652,7 +603,7 @@ function CornerRadiusHandlesOverlay({
       window.removeEventListener('pointercancel', onUp);
       window.removeEventListener('keydown', onKey);
     };
-  }, [dispatch, node, nodeId, box, angle, w, h, maxR, toScene, interactive, linked]);
+  }, [dispatch, node, nodeId, box, angle, w, h, maxR, toScene, radiusInteractive, linked]);
 
   // Always show while selected — seats track R (park only when R≈0).
   let badgeVal = Math.round(baseRadii.tl);
@@ -681,8 +632,8 @@ function CornerRadiusHandlesOverlay({
   }
 
   const hitSize = hitPx * k;
-  const visualSize = visualPx * k;
-  const stroke = RADIUS_STROKE_PX * k;
+  const visualSize = CHROME_HANDLE_VIS_PX * k;
+  const stroke = CHROME_STROKE_PX * k;
   const halfVis = visualSize / 2;
   const halfHit = hitSize / 2;
 
@@ -720,7 +671,6 @@ function CornerRadiusHandlesOverlay({
               };
               setActiveKey(String(site.sharpIndex));
               setDragValue(Math.round(pathVertices[site.sharpIndex] ?? 0));
-              setNearCorners(true);
             },
           };
         })
@@ -748,7 +698,6 @@ function CornerRadiusHandlesOverlay({
               };
               setActiveKey(corner.key);
               setDragValue(Math.round(baseRadii[corner.key]));
-              setNearCorners(true);
             },
           };
         });
@@ -782,10 +731,10 @@ function CornerRadiusHandlesOverlay({
             data-radius-handle={h.key}
             transform={`translate(${h.lx} ${h.ly})`}
             style={{
-              pointerEvents: interactive ? 'all' : 'none',
-              cursor: interactive ? 'default' : undefined,
+              pointerEvents: radiusInteractive ? 'all' : 'none',
+              cursor: radiusInteractive ? 'default' : undefined,
             }}
-            onPointerDown={interactive ? h.onDown : undefined}
+            onPointerDown={radiusInteractive ? h.onDown : undefined}
           >
             <rect x={-halfHit} y={-halfHit} width={hitSize} height={hitSize} fill="transparent" />
             <circle

--- a/apps/web/src/components/rcb/selection/chrome/NodeTitleLabel.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/NodeTitleLabel.tsx
@@ -543,7 +543,7 @@ function NodeTitleLabel({
       <svg
         data-rcb-infinite="1"
         data-rcb-node-title="1"
-        className="absolute z-[1000002] overflow-visible"
+        className="absolute z-[999990] overflow-visible"
         width={surf.width}
         height={surf.height}
         viewBox={surf.viewBox}

--- a/apps/web/src/components/rcb/selection/chrome/PolygonShapeHandlesOverlay.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/PolygonShapeHandlesOverlay.tsx
@@ -31,9 +31,11 @@ import {
 } from '@/components/rcb/shapes/shapeHostRegistry';
 import type { SceneBox } from '../alignGuides';
 import {
-  CHROME_HANDLE_HIT_PX,
   CHROME_HANDLE_VIS_PX,
+  CHROME_RADIUS_HIT_PX,
   CHROME_STROKE_PX,
+  radiusHandleParkScreenPx,
+  radiusParkSceneForBox,
   WorldSvgFrame,
   WorldScreenBadge,
 } from '../SelectionChrome';
@@ -41,10 +43,9 @@ import {
 const DRAG_DISTANCE_SQUARED = 16;
 const SIDES_DRAG_STEP_PX = 14;
 const KNOB_VIS_PX = CHROME_HANDLE_VIS_PX;
-const KNOB_HIT_PX = CHROME_HANDLE_HIT_PX;
+const KNOB_HIT_PX = CHROME_RADIUS_HIT_PX;
 const KNOB_STROKE_PX = CHROME_STROKE_PX;
-/** Min inward seat when R=0 so the knob clears the vertex / resize chrome. */
-const RADIUS_MIN_INSET_PX = 18;
+const RADIUS_MIN_INSET_PX = radiusHandleParkScreenPx();
 
 function liveNodeEl(nodeId: string): Element | null {
   return (
@@ -259,7 +260,7 @@ function PolygonShapeHandlesOverlay({
 
   // Seat tracks R along the top-vertex inward normal (same as rect R-dots).
   const insetFor = (r: number) => {
-    const park = RADIUS_MIN_INSET_PX * k;
+    const park = radiusParkSceneForBox(w, h, z, RADIUS_MIN_INSET_PX);
     const maxAlong = Math.max(park, maxR - 1);
     return Math.max(park, Math.min(Math.max(0, Number(r) || 0), maxAlong));
   };

--- a/apps/web/src/components/rcb/selection/chrome/SelectionToolbarShell.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/SelectionToolbarShell.tsx
@@ -87,8 +87,8 @@ export const SELECTION_TOOLBAR_ABOVE_BOX_GAP_PX = 20;
 /** Gap between box bottom and toolbar top (below dock). */
 export const SELECTION_TOOLBAR_BELOW_BOX_GAP_PX = 20;
 
-/** Half knob + air outside the chrome edge. */
-export const SELECTION_HANDLE_CLEARANCE_PX = 6;
+/** Half knob + air outside the chrome edge (must clear 10px resize hit). */
+export const SELECTION_HANDLE_CLEARANCE_PX = 14;
 
 export type SelectionToolbarBox = {
   left: number;
@@ -144,7 +144,12 @@ export function toolbarAboveScreenGapPx(
 
 /**
  * World-layer HTML chrome under camera `scale(zoom)`.
- * Nested: outer `scale(1/zoom)` at the scene anchor, inner %-translate.
+ *
+ * Why DevTools shows a “phantom” strip on the box while the pill sits above:
+ * anchor is at the selection edge; `translate(-50%,-100%)` only moves paint.
+ * If the wrapper keeps the toolbar’s layout size + `pointer-events:auto`, that
+ * untransformed box covers the top edge / NE resize knob. Same fix as
+ * SelectionFeature overlays: outer `0×0` shell, absolute pe:auto content.
  */
 export function WorldScreenChromeRoot({
   left,
@@ -166,23 +171,28 @@ export function WorldScreenChromeRoot({
   const inv = 1 / rcbCameraCssZoom(camera);
   return (
     <div
-      className={className}
+      className={cn('pointer-events-none absolute overflow-visible', className)}
       style={{
         position: 'absolute',
         left,
         top,
+        width: 0,
+        height: 0,
         transform: `scale(${inv})`,
         transformOrigin: '0 0',
+        // Inline beats world `[&>*]:pointer-events-auto` if mounted there.
+        pointerEvents: 'none',
         ...style,
       }}
-      {...rest}
     >
       <div
+        className="pointer-events-auto absolute left-0 top-0"
         style={{
           transform:
             anchor === 'bottom' ? 'translate(-50%, -100%)' : 'translate(-50%, 0)',
           width: 'max-content',
         }}
+        {...rest}
       >
         {children}
       </div>
@@ -269,7 +279,7 @@ function SelectionToolbarShell({
       anchor={anchor}
       data-sel-toolbar
       {...(isFrameToolbar ? { 'data-frame-toolbar': true } : {})}
-      className={cn('pointer-events-auto overflow-visible', zIndexClassName)}
+      className={zIndexClassName}
       {...chromePointer}
     >
       <FloatingToolbar bare={bare} className={className}>

--- a/apps/web/src/components/rcb/selection/chrome/StarShapeHandlesOverlay.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/StarShapeHandlesOverlay.tsx
@@ -30,9 +30,11 @@ import {
 } from '@/components/rcb/shapes/shapeHostRegistry';
 import type { SceneBox } from '../alignGuides';
 import {
-  CHROME_HANDLE_HIT_PX,
   CHROME_HANDLE_VIS_PX,
+  CHROME_RADIUS_HIT_PX,
   CHROME_STROKE_PX,
+  radiusHandleParkScreenPx,
+  radiusParkSceneForBox,
   WorldSvgFrame,
   WorldScreenBadge,
 } from '../SelectionChrome';
@@ -40,9 +42,9 @@ import {
 const DRAG_DISTANCE_SQUARED = 16;
 const SIDES_DRAG_STEP_PX = 14;
 const KNOB_VIS_PX = CHROME_HANDLE_VIS_PX;
-const KNOB_HIT_PX = CHROME_HANDLE_HIT_PX;
+const KNOB_HIT_PX = CHROME_RADIUS_HIT_PX;
 const KNOB_STROKE_PX = CHROME_STROKE_PX;
-const RADIUS_MIN_INSET_PX = 18;
+const RADIUS_MIN_INSET_PX = radiusHandleParkScreenPx();
 
 function liveNodeEl(nodeId: string): Element | null {
   return (
@@ -245,7 +247,7 @@ function StarShapeHandlesOverlay({
   // A fixed park inset left the knob glued to the sharp tip while the rounded
   // silhouette pulled inward — looked like “controls stuck at the old place”.
   const insetFor = (r: number) => {
-    const park = RADIUS_MIN_INSET_PX * k;
+    const park = radiusParkSceneForBox(w, h, z, RADIUS_MIN_INSET_PX);
     const maxAlong = Math.max(park, maxR - 1);
     return Math.max(park, Math.min(Math.max(0, Number(r) || 0), maxAlong));
   };


### PR DESCRIPTION
## Summary
- Restore 0x0 HostPath chrome and toolbar hit shells so painted knobs/toolbars no longer leave full-bleed pe:auto phantoms over NE resize.
- Prefer resize over radius/toolbar overlays via DOM elementsFromPoint (sceneDoc rename), park radius seats, and skip handle tear-down on camera pan.
- Keep invisible replace/variants controls pointer-events-none; refactor EditorStageWorld inline handlers into named helpers.

## Test plan
- [ ] Select a rect: drag white corner/edge knobs to resize; cursor shows resize on hover
- [ ] Toolbar sits above the box; DevTools highlight does not cover TR resize
- [ ] Drag corner radius dots without stealing resize at the white square
- [ ] Pan/zoom with selection: handles stay usable without flicker rebuild issues
- [ ] Image/video replace button: hidden state does not block NE corner