### PR TITLE
Fix project cover collage sync for homepage and Publish

### DIFF
--- a/apps/web/src/components/editor/useProjectCloudSync.ts
+++ b/apps/web/src/components/editor/useProjectCloudSync.ts
@@ -226,8 +226,8 @@ export async function patchProjectToCloud(payload: {
   if (import.meta.env.DEV) {
     console.info('[project-sync] PATCH thumb', {
       id: payload.id,
-      hasThumb: Boolean(thumb),
-      thumbBytes: thumb ? Math.round(thumb.length / 1024) : 0,
+      urls: payload.thumb?.thumbnailUrls?.length || 0,
+      dataUrls: payload.thumb?.thumbnailDataUrls?.length || 0,
     });
   }
   const res = await withProjectConflict(() =>
@@ -456,22 +456,7 @@ export function useProjectCloudSync() {
         keepBaseDocument: true,
       });
 
-      // Logged out: local draft is enough — clear dirty.
-      if (!getToken()) {
-        const after = store.getState().editor as { document: unknown };
-        if (after.document === pushedDoc) dispatch(clearEditorDirty());
-        return;
-      }
-
-      // Live Yjs room owns cloud document writes (debounced PUT in CollabRoomProvider).
-      // Still keep local draft + allow force leave-flush.
-      if (isCollabActive() && !force) {
-        const after = store.getState().editor as { document: unknown };
-        if (after.document === pushedDoc) dispatch(clearEditorDirty());
-        return;
-      }
-
-      // Skip cloud when content + name already ACKed — unless leave-force (refresh cover).
+      // Skip cloud when content + name already ACKed — unless leave-force.
       if (
         !force &&
         draft?.syncedAt &&
@@ -483,9 +468,9 @@ export function useProjectCloudSync() {
         return;
       }
 
+      // Data changed → rebuild cover, then persist (local / thumb-only / full).
       let thumb: ThumbUpload = {};
       try {
-        // Up to 4 per-element snapshots (never skip for thumbnailCustom).
         const tiles = await buildProjectCoverTiles(pushedDoc);
         thumb = thumbPayloadFromTiles(tiles);
         const localPreview =
@@ -513,6 +498,49 @@ export function useProjectCloudSync() {
       } catch (err) {
         if (import.meta.env.DEV) console.warn('[project-sync] cover tiles failed', err);
         /* thumb is best-effort — still upload the document */
+      }
+
+      // Logged out: local draft + in-memory cover is enough.
+      if (!getToken()) {
+        const after = store.getState().editor as { document: unknown };
+        if (after.document === pushedDoc) dispatch(clearEditorDirty());
+        return;
+      }
+
+      // Live Yjs owns document writes — still push cover (thumbnail-only PATCH).
+      if (isCollabActive() && !force) {
+        const baseRevision =
+          draft?.cloudRevision != null && Number(draft.cloudRevision) >= 1
+            ? Number(draft.cloudRevision)
+            : null;
+        if (baseRevision != null && (thumb.thumbnailDataUrls || thumb.thumbnailDataUrl || thumb.thumbnailUrls)) {
+          try {
+            const acked = await patchProjectToCloud({
+              id,
+              name,
+              baseRevision,
+              patch: {},
+              thumb,
+            });
+            const nextThumb = ackThumbnail(acked?.thumbnailUrl);
+            if (nextThumb) {
+              dispatch(
+                setTemplateThumbnail({
+                  id,
+                  thumbnail: nextThumb,
+                  custom: false,
+                })
+              );
+            }
+          } catch (err) {
+            if (import.meta.env.DEV) {
+              console.warn('[project-sync] collab cover patch failed', err);
+            }
+          }
+        }
+        const after = store.getState().editor as { document: unknown };
+        if (after.document === pushedDoc) dispatch(clearEditorDirty());
+        return;
       }
 
       const baseRevision =

--- a/apps/web/src/components/templates/PlazaPublishDialog.tsx
+++ b/apps/web/src/components/templates/PlazaPublishDialog.tsx
@@ -5,7 +5,10 @@ import { Button, Dialog, message } from '@/components/base';
 import ProjectCoverCollage from '@/components/home/ProjectCoverCollage';
 import { checkPlazaCoverForPublish, coverDocumentHasContent } from '@/utils/plazaCover';
 import { normalizeProjectThumbnailUrls } from '@/utils/projectThumb';
-import { buildProjectCoverTiles } from '@/utils/renderProjectThumbnail';
+import { buildProjectCoverTiles, PREVIEW_PNG_MAX_EDGE } from '@/utils/renderProjectThumbnail';
+
+/** Publish modal preview — sharper than list-card 360px JPEG thumbs. */
+const PUBLISH_PREVIEW_TILE_EDGE = Math.max(960, Math.round(PREVIEW_PNG_MAX_EDGE / 2));
 
 /** `<img src>` cannot send Bearer — skip auth-only upload routes. */
 function canUseAsImgSrc(url: string): boolean {
@@ -72,7 +75,9 @@ function PlazaPublishForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId]);
 
-  // Enter Publish tab: use rewritten public collage URLs, else build homepage tiles.
+  // Same source as Share / homepage: prefer saved collage URLs.
+  // Only live-raster when nothing is stored yet (or regenerate failed to
+  // load). Live element crops of white frames look blank in a 2×2 grid.
   useEffect(() => {
     let cancelled = false;
 
@@ -93,7 +98,12 @@ function PlazaPublishForm({
       }
       if (!cancelled) setResolvingCover(true);
       try {
-        const tiles = await buildProjectCoverTiles(document);
+        const tiles = await buildProjectCoverTiles(document, {
+          maxEdge: PUBLISH_PREVIEW_TILE_EDGE,
+          fullBoardMaxEdge: PREVIEW_PNG_MAX_EDGE,
+          format: 'png',
+          compress: false,
+        });
         if (cancelled) return;
         const next = (tiles.dataUrls || tiles.urls || [])
           .map((u) => String(u || '').trim())

--- a/apps/web/src/utils/renderProjectThumbnail.ts
+++ b/apps/web/src/utils/renderProjectThumbnail.ts
@@ -11,8 +11,10 @@ import {
 } from '@/components/rcb/scene/document/sceneDocument';
 import {
   coverDocumentHasContent,
+  extractFrameDocument,
   extractPlazaCoverDocument,
   findPlazaCoverFrame,
+  listArtboardFrames,
   type PlazaCoverFrame,
 } from '@/utils/plazaCover';
 
@@ -142,14 +144,21 @@ export function pickCoverElementIds(document: unknown): string[] {
 /** Rasterize one element (cropped to its bbox) for a collage tile. */
 async function rasterizeElementTile(
   document: unknown,
-  nodeId: string
+  nodeId: string,
+  opts?: { maxEdge?: number; format?: 'webp' | 'png' | 'jpeg'; compress?: boolean }
 ): Promise<string | null> {
   const dsl = (document as { deltaSetLike?: Record<string, unknown> })?.deltaSetLike;
   const node = dsl?.[nodeId];
   if (!node || typeof node !== 'object') return null;
   const w = Math.max(1, num((node as Record<string, unknown>).width, 1));
   const h = Math.max(1, num((node as Record<string, unknown>).height, 1));
-  const multiplier = Math.max(0.25, Math.min(1, TILE_MAX_EDGE / Math.max(w, h)));
+  const maxEdge = Math.max(64, Math.round(opts?.maxEdge || TILE_MAX_EDGE));
+  // Allow >1× so small scene boxes still fill the tile sharply on retina.
+  const multiplier = Math.max(0.25, Math.min(2, maxEdge / Math.max(w, h)));
+  const format = opts?.format || 'jpeg';
+  // renderExport only accepts png|jpeg|svg — map webp tiles to png.
+  const exportFormat = format === 'webp' ? 'png' : format;
+  const compress = opts?.compress ?? exportFormat === 'jpeg';
 
   try {
     const result = await renderExport({
@@ -157,8 +166,8 @@ async function rasterizeElementTile(
       selectionOnly: true,
       nodeIds: [nodeId],
       multiplier,
-      format: 'jpeg',
-      compress: true,
+      format: exportFormat,
+      compress,
       backgroundColor: '#ffffff',
     });
     if (result?.kind === 'raster' && result.dataUrl) return result.dataUrl;
@@ -209,24 +218,81 @@ export type ProjectCoverTiles = {
   dataUrls?: string[];
 };
 
+export type ProjectCoverTileOptions = {
+  /** Longest edge for each tile (default list-card 360). Publish modal should pass ~960+. */
+  maxEdge?: number;
+  format?: 'webp' | 'png' | 'jpeg';
+  /** JPEG only — list cards compress; HD previews should pass false. */
+  compress?: boolean;
+  /** Full-board fallback max edge (default 480 list / use PREVIEW_PNG_MAX_EDGE for modal). */
+  fullBoardMaxEdge?: number;
+};
+
+/** List thumbs use webp; jpeg callers map to webp. PNG kept for HD publish preview. */
+function resolveCoverTileRasterOpts(opts?: ProjectCoverTileOptions) {
+  let format: 'webp' | 'png' = 'webp';
+  if (opts?.format === 'png') format = 'png';
+
+  const tileMax = opts?.maxEdge ?? TILE_MAX_EDGE;
+
+  let fullMax = MAX_EDGE;
+  if (opts?.fullBoardMaxEdge != null) fullMax = opts.fullBoardMaxEdge;
+  else if (opts?.maxEdge != null) fullMax = opts.maxEdge;
+
+  return { format, tileMax, fullMax };
+}
+
 /**
- * Up to 4 per-element snapshots for 最近打开 / 我的项目 collage.
- * Falls back to one full-artboard cover only when no element tile succeeds.
+ * Up to 4 cover tiles for 最近打开 / 我的项目 / Publish.
+ * Prefer one snapshot per artboard when there are 2+ boards (matches Share collage);
+ * else per-element crops; else one full-board cover.
  */
-export async function buildProjectCoverTiles(document: unknown): Promise<ProjectCoverTiles> {
+export async function buildProjectCoverTiles(
+  document: unknown,
+  opts?: ProjectCoverTileOptions
+): Promise<ProjectCoverTiles> {
   if (!document || typeof document !== 'object') return {};
 
-  const ids = pickCoverElementIds(document);
-  if (ids.length) {
+  const { format: thumbFormat, tileMax, fullMax } = resolveCoverTileRasterOpts(opts);
+
+  const frames = listArtboardFrames(document).slice(0, MAX_TILES);
+  if (frames.length >= 2) {
     const dataUrls: string[] = [];
-    for (const id of ids) {
-      const data = await rasterizeElementTile(document, id);
+    for (const frame of frames) {
+      const slice = extractFrameDocument(document, frame, { contentFit: true });
+      if (!slice) continue;
+      const data = await renderDocumentThumbnail(slice, {
+        allowEmpty: true,
+        format: thumbFormat,
+        maxEdge: tileMax,
+      });
       if (data) dataUrls.push(data);
     }
     if (dataUrls.length) return { dataUrls };
   }
 
-  const one = await renderProjectThumbnail(document);
+  const ids = pickCoverElementIds(document);
+  if (ids.length) {
+    const dataUrls: string[] = [];
+    for (const id of ids) {
+      const data = await rasterizeElementTile(document, id, {
+        maxEdge: opts?.maxEdge,
+        format: opts?.format,
+        compress: opts?.compress,
+      });
+      if (data) dataUrls.push(data);
+    }
+    if (dataUrls.length) return { dataUrls };
+  }
+
+  const one = await renderDocumentThumbnail(
+    extractPlazaCoverDocument(document, { contentFit: true }) || document,
+    {
+      allowEmpty: true,
+      format: thumbFormat,
+      maxEdge: fullMax,
+    }
+  );
   return one ? { dataUrls: [one] } : {};
 }
 


### PR DESCRIPTION
## Summary
- Rebuild and save cover tiles whenever document content changes, including collab sessions via thumbnail-only PATCH (covers were previously skipped).
- Prefer one snapshot per artboard when there are 2+ boards so homepage / Publish match Share instead of blank element crops.
- Publish preview uses sharper PNG tile edges when live-rasterizing, and still prefers already-saved collage URLs.

## Test plan
- [ ] Edit a multi-artboard project, wait for autosave, confirm homepage card shows up to 4 artboard tiles
- [ ] Open Share → Publish and confirm preview matches the homepage collage (not white/purple element blanks)
- [ ] In a collab room, edit content and confirm cover updates without a full leave-force flush
- [ ] Single-artboard projects still get element tiles / full-board fallback