### PR TITLE
Fix web selection chrome: titles, live radius, undo

### DIFF
--- a/apps/web/src/components/editor/canvas/SvgCanvas.tsx
+++ b/apps/web/src/components/editor/canvas/SvgCanvas.tsx
@@ -297,8 +297,18 @@ function SvgCanvas({
   const reduxCanUndo = useSelector((s: any) => (s.editor.historyPast?.length || 0) > 0);
   const reduxCanRedo = useSelector((s: any) => (s.editor.historyFuture?.length || 0) > 0);
   useSyncExternalStore(subscribeCollabUndo, getCollabUndoEpoch, getCollabUndoEpoch);
-  const canUndo = isCollabActive() ? canCollabUndo() : reduxCanUndo;
-  const canRedo = isCollabActive() ? canCollabRedo() : reduxCanRedo;
+  // Collab prefers Yjs undo; if that stack is empty (pre-seed / sync lag), fall
+  // back to Redux so the menu and Ctrl+Z stay usable. View-only never undoes.
+  const canUndo = isCollabViewOnly()
+    ? false
+    : isCollabActive()
+      ? canCollabUndo() || reduxCanUndo
+      : reduxCanUndo;
+  const canRedo = isCollabViewOnly()
+    ? false
+    : isCollabActive()
+      ? canCollabRedo() || reduxCanRedo
+      : reduxCanRedo;
   const imageToolPanelKind = useSelector((s: any) => s.editor.imageToolPanel?.kind as string | undefined);
   const shapeStylePanel = useSelector((s: any) => s.editor.shapeStylePanel as null | { kind: string });
   const shapeStylePanelOpen = Boolean(shapeStylePanel);

--- a/apps/web/src/components/editor/collab/collabRuntime.ts
+++ b/apps/web/src/components/editor/collab/collabRuntime.ts
@@ -103,7 +103,7 @@ export function clearCollabUndoStack() {
 /** @returns true when collab handled the gesture (caller should skip Redux history). */
 export function collabUndo(): boolean {
   if (!active || viewOnly || !undoManager) return false;
-  if (!undoManager.canUndo()) return true;
+  if (!undoManager.canUndo()) return false;
   undoManager.undo();
   return true;
 }
@@ -111,7 +111,7 @@ export function collabUndo(): boolean {
 /** @returns true when collab handled the gesture. */
 export function collabRedo(): boolean {
   if (!active || viewOnly || !undoManager) return false;
-  if (!undoManager.canRedo()) return true;
+  if (!undoManager.canRedo()) return false;
   undoManager.redo();
   return true;
 }

--- a/apps/web/src/components/editor/nodes/ShapeNode/ShapeSelectionToolbar.tsx
+++ b/apps/web/src/components/editor/nodes/ShapeNode/ShapeSelectionToolbar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, memo } from 'react';
+import { useMemo, useState, useSyncExternalStore, memo } from 'react';
 import { useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import {
@@ -39,7 +39,11 @@ import {
   supportsShapeSides,
   supportsStroke,
 } from '@/components/rcb/scene/document/sceneDocument';
-import { isRadiusLinked, maxRadius, radiiFromAttrs } from '@/components/rcb/scene/document/sceneRadii';
+import {
+  cornerRadiusToolbarDisplay,
+  getLiveCornerRadiusPreview,
+  subscribeLiveCornerRadiusPreview,
+} from '@/components/rcb/scene/document/sceneRadii';
 import {
   clampShapeSides,
   DEFAULT_SHAPE_SIDES,
@@ -65,9 +69,7 @@ function readAspectLocked(attrs: Record<string, unknown> | undefined): boolean {
 
 /** Compact toolbar R: linked → any corner; unlinked → max so mixed corners stay visible. */
 function toolbarCornerRadius(attrs: Record<string, unknown> | undefined): number {
-  const r = radiiFromAttrs(attrs);
-  if (isRadiusLinked(attrs)) return Math.round(r.tl);
-  return Math.round(maxRadius(r));
+  return cornerRadiusToolbarDisplay(attrs);
 }
 
 type SceneBox = { left: number; top: number; width: number; height: number };
@@ -124,7 +126,12 @@ function ShapeSelectionToolbar({
     boolEffectAttr(node?.attrs?.['stroke-enabled'], true) &&
     boolEffectAttr(node?.attrs?.['stroke-visible'], true);
   const strokeColor = String(node?.attrs?.['border-color'] || node?.attrs?.stroke || '#333333');
-  const radius = toolbarCornerRadius(node?.attrs);
+  const liveCornerRadius = useSyncExternalStore(
+    subscribeLiveCornerRadiusPreview,
+    () => getLiveCornerRadiusPreview(nodeId),
+    () => null
+  );
+  const radius = liveCornerRadius ?? toolbarCornerRadius(node?.attrs);
 
   const patchAttrs = (attrs: Record<string, unknown>) => {
     const shapeType = node?.attrs?.shapeType;

--- a/apps/web/src/components/rcb/scene/document/sceneRadii.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneRadii.ts
@@ -604,3 +604,45 @@ export function polygonRadiiFromCorners(
   const u = (c.tl + c.tr + c.br + c.bl) / 4;
   return Array.from({ length: pointCount }, () => u);
 }
+
+/**
+ * Live corner-radius while knob-dragging (DOM preview only — Redux stays idle
+ * mid-drag to avoid remount ghosts). Toolbars subscribe for the compact R label.
+ */
+type LiveCornerRadiusPreview = { nodeId: string; display: number };
+
+let liveCornerRadiusPreview: LiveCornerRadiusPreview | null = null;
+const liveCornerRadiusListeners = new Set<() => void>();
+
+export function cornerRadiusToolbarDisplay(
+  attrs: Record<string, unknown> | null | undefined
+): number {
+  const r = radiiFromAttrs(attrs);
+  if (isRadiusLinked(attrs)) return Math.round(r.tl);
+  return Math.round(maxRadius(r));
+}
+
+export function cornerRadiusDisplayFromRadii(radii: CornerRadii, linked: boolean): number {
+  if (linked) return Math.round(radii.tl);
+  return Math.round(maxRadius(radii));
+}
+
+export function setLiveCornerRadiusPreview(next: LiveCornerRadiusPreview | null) {
+  const prev = liveCornerRadiusPreview;
+  if (prev?.nodeId === next?.nodeId && prev?.display === next?.display) return;
+  if (prev == null && next == null) return;
+  liveCornerRadiusPreview = next;
+  liveCornerRadiusListeners.forEach((l) => l());
+}
+
+export function getLiveCornerRadiusPreview(nodeId: string): number | null {
+  if (!nodeId || liveCornerRadiusPreview?.nodeId !== nodeId) return null;
+  return liveCornerRadiusPreview.display;
+}
+
+export function subscribeLiveCornerRadiusPreview(onStoreChange: () => void): () => void {
+  liveCornerRadiusListeners.add(onStoreChange);
+  return () => {
+    liveCornerRadiusListeners.delete(onStoreChange);
+  };
+}

--- a/apps/web/src/components/rcb/scene/paint/sceneToSvg.ts
+++ b/apps/web/src/components/rcb/scene/paint/sceneToSvg.ts
@@ -2783,14 +2783,32 @@ export function previewSvgNodeCornerRadii(
 
   rememberSceneCornerRadii(el, r);
 
+  let ok = false;
   if (el.tagName.toLowerCase() === 'path') {
-    return setPathD(el, d);
+    ok = setPathD(el, d);
+  } else {
+    const body =
+      el.querySelector(':scope > [data-baseline="1"]') ||
+      el.querySelector(':scope > [data-radius-body="1"]:not([data-stroke-under])') ||
+      el.querySelector(':scope > path:not([data-stroke-under])');
+    ok = setPathD(body, d);
   }
-  const body =
-    el.querySelector(':scope > [data-baseline="1"]') ||
-    el.querySelector(':scope > [data-radius-body="1"]:not([data-stroke-under])') ||
-    el.querySelector(':scope > path:not([data-stroke-under])');
-  return setPathD(body, d);
+
+  // Image / video: visible rounding is a <clipPath> in defs (baseline path is pe:none).
+  const clipId = String(el.getAttribute('data-radius-clip-id') || '').trim();
+  if (clipId) {
+    const root = el.ownerSVGElement;
+    let clipPathEl: Element | null = null;
+    try {
+      const clip = root?.getElementById(clipId);
+      clipPathEl = clip?.querySelector('[data-radius-clip="1"]') || clip?.querySelector('path') || null;
+    } catch {
+      clipPathEl = null;
+    }
+    if (setPathD(clipPathEl, d)) ok = true;
+  }
+
+  return ok;
 }
 
 function removeSceneNodesById(layer: SVGElement, nodeId: string) {

--- a/apps/web/src/components/rcb/selection/SelectionChrome.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionChrome.tsx
@@ -114,8 +114,15 @@ export function radiusHandleParkScreenPx(): number {
 
 /**
  * Scene park for radius seats at any zoom.
- * Ideal park is screen-constant; on-screen budget keeps the seat near the
- * corner so low zoom cannot park/hit near the center and steal move.
+ *
+ * Control-box local model (same space as HostPathChrome resize/rotate):
+ * - box corners at (0,0) / (w,0) / (w,h) / (0,h)
+ * - radius seat at axis inset `(inset, inset)` from that corner
+ * - rotate hotzone = corner ± `rotateHotzoneOutward(...)` in scene units
+ *
+ * Park is screen-constant (`parkPx / zoom`), only clamped so it cannot cross
+ * the box center. Do not scale park with box size — that made seats jump
+ * while resizing.
  */
 export function radiusParkSceneForBox(
   boxW: number,
@@ -125,11 +132,7 @@ export function radiusParkSceneForBox(
 ): number {
   const z = Math.max(0.05, Number(zoom) || 1);
   const half = Math.min(Math.max(1, boxW), Math.max(1, boxH)) / 2;
-  const minScreen = Math.min(Math.max(1, boxW), Math.max(1, boxH)) * z;
-  // Keep park ≤ ~22% of on-screen min side so the seat stays near the corner.
-  const screenBudget = Math.max(0, minScreen * 0.22);
-  const px = Math.min(Math.max(0, parkPx), screenBudget);
-  return Math.min(px / z, half * 0.45);
+  return Math.min(Math.max(0, parkPx) / z, half * 0.45);
 }
 
 /**

--- a/apps/web/src/components/rcb/selection/__tests__/lowZoomSnap.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/lowZoomSnap.test.ts
@@ -141,7 +141,12 @@ describe('radius park + chrome hits @ all canvas zooms', () => {
       const half = Math.min(box.w, box.h) / 2;
       expect(park).toBeGreaterThanOrEqual(0);
       expect(park).toBeLessThanOrEqual(half * 0.45 + 1e-9);
-      expect(park * zoom).toBeLessThanOrEqual(Math.min(box.w, box.h) * zoom * 0.22 + 1e-6);
+      // Screen-constant: park * zoom == parkPx unless clamped by half-side.
+      const parkPx = radiusHandleParkScreenPx();
+      const unclamped = parkPx / zoom;
+      if (unclamped <= half * 0.45) {
+        expect(park * zoom).toBeCloseTo(parkPx, 5);
+      }
     }
   );
 
@@ -150,16 +155,16 @@ describe('radius park + chrome hits @ all canvas zooms', () => {
     (zoom) => {
       if (!radiusHandlesFitOnScreen(box.w, box.h, zoom)) return;
       const parkPx = radiusHandleParkScreenPx();
-      const minScreen = Math.min(box.w, box.h) * zoom;
       const parkScene = radiusParkSceneForBox(box.w, box.h, zoom, parkPx);
-      const expectedPx = Math.min(parkPx, minScreen * 0.22);
-      expect(parkScene * zoom).toBeCloseTo(expectedPx, 5);
+      const half = Math.min(box.w, box.h) / 2;
+      const expectedScene = Math.min(parkPx / zoom, half * 0.45);
+      expect(parkScene).toBeCloseTo(expectedScene, 5);
       const hitScale = chromeHitScaleForBox(box.w, box.h, zoom);
       // Both hits are icon-centered — park clears halfHit + halfRadius + gap.
       const resizeHalf = (CHROME_HANDLE_HIT_PX * hitScale) / 2 / zoom;
       const radiusHalf = (CHROME_RADIUS_HIT_PX * hitScale) / 2 / zoom;
       const clearance = parkScene - resizeHalf - radiusHalf;
-      if (expectedPx >= parkPx - 1e-6) {
+      if (expectedScene >= parkPx / zoom - 1e-6) {
         expect(clearance * zoom).toBeGreaterThanOrEqual(CHROME_RADIUS_PARK_GAP_PX - 0.05);
       } else {
         expect(clearance).toBeGreaterThanOrEqual(0);

--- a/apps/web/src/components/rcb/selection/__tests__/nodeTitleAbove.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/nodeTitleAbove.test.ts
@@ -26,7 +26,7 @@ import { rcbScreenPxToScene } from '../../core/math';
 const CANVAS_ZOOMS = [0.5, 1, 2.247, 10, 71.61, 80, 100] as const;
 const VIEWPORT_SCALES = [0.75, 0.9, 1, 1.1, 1.25] as const;
 
-describe('nodeTitleLabelWorldPlacement — SVG knob contract', () => {
+describe('nodeTitleLabelWorldPlacement — title layout contract', () => {
   it('clips the name so it cannot overlap the size column on a narrow plate', () => {
     const box = { left: 0, top: 10, width: 32, height: 32 };
     const zoom = 12.84;
@@ -61,7 +61,7 @@ describe('nodeTitleLabelWorldPlacement — SVG knob contract', () => {
     // Title lives fully above the plate.
     expect(place.labelTopScene + place.lineScene).toBeCloseTo(place.labelBottomScene, 10);
     // eslint-disable-next-line no-console
-    console.log('[test:title-svg@8000%]', {
+    console.log('[test:title-layout@8000%]', {
       zoom,
       fontSize: place.fontSize,
       handleVisLike: 8 * inv,

--- a/apps/web/src/components/rcb/selection/__tests__/resizeRadiusHitOverlap.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/resizeRadiusHitOverlap.test.ts
@@ -199,6 +199,17 @@ describe('resize vs radius hit pads (icon-centered)', () => {
     expect(layout.axisClearanceScreen).toBeGreaterThanOrEqual(CHROME_RADIUS_PARK_GAP_PX - 0.05);
   });
 
+  it('park scene distance is stable across box sizes at fixed zoom (no resize jump)', () => {
+    const zoom = 1;
+    const parkPx = radiusHandleParkScreenPx();
+    const a = radiusParkSceneForBox(80, 80, zoom, parkPx);
+    const b = radiusParkSceneForBox(400, 300, zoom, parkPx);
+    const c = radiusParkSceneForBox(1200, 900, zoom, parkPx);
+    expect(a).toBeCloseTo(parkPx / zoom, 5);
+    expect(b).toBeCloseTo(a, 5);
+    expect(c).toBeCloseTo(a, 5);
+  });
+
   it('bisector park matches axis park on 45° corners', () => {
     const park = 13;
     const along = radiusParkAlongBisector(park, -Math.SQRT1_2, -Math.SQRT1_2);

--- a/apps/web/src/components/rcb/selection/chrome/CornerRadiusHandlesOverlay.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/CornerRadiusHandlesOverlay.tsx
@@ -17,10 +17,12 @@ import {
 import { useRcbCamera } from '@/components/rcb/camera/context';
 import {
   clampCornerRadii,
+  cornerRadiusDisplayFromRadii,
   cornerVertexCount,
   isRadiusLinked,
   radiiFromAttrs,
   serializeRadiusVertices,
+  setLiveCornerRadiusPreview,
   sharpCornerSitesForNode,
   parseRadiusVertices,
   vertexRadiiFromAttrs,
@@ -378,8 +380,9 @@ function CornerRadiusHandlesOverlay({
     ? resolvePathVertexRadii(node?.attrs, pathVertexCount, baseRadii)
     : [];
 
-  // Seat tracks R (scene). Park when R≈0 so radius hit clears the resize hit.
-  // Screen budget keeps seats near corners at every zoom (not only one %).
+  // Seat = max(R, park) in control-box local space — TL at (inset,inset), etc.
+  // Park is screen-constant scene units (see radiusParkSceneForBox); resize /
+  // rotate knobs use the same box corners in HostPathChrome.
   const hitScale = chromeHitScaleForBox(w, h, z);
   const hitPx = CHROME_RADIUS_HIT_PX * hitScale;
   const k = 1 / z;
@@ -392,6 +395,7 @@ function CornerRadiusHandlesOverlay({
 
   const radiusHandleInset = (r: number) => radiusSeatInset(r, halfSide, parkScene);
 
+  /** Control-box local: corner (cx,cy) → seat at axis inset from that corner. */
   const boxHandleLocalPos = (corner: (typeof RADIUS_CORNERS)[number], r: number) => {
     const inset = radiusHandleInset(r);
     return {
@@ -506,13 +510,16 @@ function CornerRadiusHandlesOverlay({
           : d.startVertices.map(() => rounded);
         setDragValue(rounded);
         // DOM preview only — Redux remount mid-drag leaves ghost shadows.
+        // Publish live display so the toolbar R label tracks the drag.
         const u = next[0] ?? rounded;
-        previewRadiiOnHost(
-          d.solo
-            ? { tl: u, tr: u, br: u, bl: u }
-            : { tl: rounded, tr: rounded, br: rounded, bl: rounded },
-          next
-        );
+        const previewRadii: CornerRadii = d.solo
+          ? { tl: u, tr: u, br: u, bl: u }
+          : { tl: rounded, tr: rounded, br: rounded, bl: rounded };
+        setLiveCornerRadiusPreview({
+          nodeId,
+          display: cornerRadiusDisplayFromRadii(previewRadii, !d.solo && d.linked),
+        });
+        previewRadiiOnHost(previewRadii, next);
         return;
       }
       const corner = RADIUS_CORNERS.find((c) => c.key === d.corner);
@@ -522,6 +529,10 @@ function CornerRadiusHandlesOverlay({
         ? { ...d.startRadii, [d.corner]: rounded }
         : { tl: rounded, tr: rounded, br: rounded, bl: rounded };
       setDragValue(rounded);
+      setLiveCornerRadiusPreview({
+        nodeId,
+        display: cornerRadiusDisplayFromRadii(next, !d.solo && d.linked),
+      });
       previewRadiiOnHost(next);
     };
     const onUp = (e: PointerEvent) => {
@@ -531,6 +542,7 @@ function CornerRadiusHandlesOverlay({
       dragRef.current = null;
       setActiveKey(null);
       setDragValue(null);
+      setLiveCornerRadiusPreview(null);
       if (softClick) {
         // Restore any mid-frame preview (none on soft click) and bail.
         if (d.mode === 'path') {
@@ -579,6 +591,7 @@ function CornerRadiusHandlesOverlay({
       dragRef.current = null;
       setActiveKey(null);
       setDragValue(null);
+      setLiveCornerRadiusPreview(null);
       if (d.mode === 'path') {
         previewRadiiOnHost(
           {
@@ -602,6 +615,7 @@ function CornerRadiusHandlesOverlay({
       window.removeEventListener('pointerup', onUp);
       window.removeEventListener('pointercancel', onUp);
       window.removeEventListener('keydown', onKey);
+      setLiveCornerRadiusPreview(null);
     };
   }, [dispatch, node, nodeId, box, angle, w, h, maxR, toScene, radiusInteractive, linked]);
 

--- a/apps/web/src/components/rcb/selection/chrome/NodeTitleLabel.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/NodeTitleLabel.tsx
@@ -1,26 +1,22 @@
+/**
+ * Frame / image / video title row above the control box.
+ * HTML under camera scale (same contract as SelectionToolbarShell) — not world SVG.
+ */
 import {
   useEffect,
-  useId,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
   type PointerEvent as ReactPointerEvent,
   type ReactNode,
   memo,
 } from 'react';
-import {
-  useRcbCamera,
-  useRcbDevicePixelRatio,
-  rcbCameraCssZoom,
-  rcbSceneToScreen,
-  RcbOverlayPortal,
-} from '@/components/rcb';
+import { useRcbCamera, rcbCameraCssZoom } from '@/components/rcb';
 import {
   NODE_TITLE_LABEL_GAP_PX,
   NODE_TITLE_LABEL_LINE_PX,
 } from './SelectionToolbarShell';
-import { selectionChromeSurfaceProps } from '../SelectionChrome';
+import { cn } from '@/utils/classnames';
 
 type NodeTitleLabelBox = {
   left: number;
@@ -55,33 +51,13 @@ type Props = {
 };
 
 const MUTED = 'var(--muted)';
-/** Edit overlay font (matches idle SVG 11px after camera scale). */
-const TITLE_EDIT_FONT_PX = 11;
-
-function rotateLocalToScene(
-  lx: number,
-  ly: number,
-  box: NodeTitleLabelBox,
-  angleDeg: number
-): { x: number; y: number } {
-  if (Math.abs(angleDeg) < 0.001) {
-    return { x: box.left + lx, y: box.top + ly };
-  }
-  const rad = (angleDeg * Math.PI) / 180;
-  const cos = Math.cos(rad);
-  const sin = Math.sin(rad);
-  const cx = box.width / 2;
-  const cy = box.height / 2;
-  const dx = lx - cx;
-  const dy = ly - cy;
-  return {
-    x: box.left + cx + dx * cos - dy * sin,
-    y: box.top + cy + dx * sin + dy * cos,
-  };
-}
+/** Idle + edit font (screen px; parent counter-scales under camera zoom). */
+const TITLE_FONT_PX = 11;
+const TITLE_ICON_PX = 12;
 
 /**
- * Scene-space title layout: `scene = screenPx / zoom` under camera scale.
+ * Scene-space title layout: used by toolbar clearance math / tests.
+ * Paint is HTML (`scale(1/zoom)`); these numbers stay `screenPx / zoom`.
  */
 export function nodeTitleLabelWorldPlacement(
   box: NodeTitleLabelBox,
@@ -112,8 +88,8 @@ export function nodeTitleLabelWorldPlacement(
   const inv = 1 / z;
   const gapScene = NODE_TITLE_LABEL_GAP_PX * inv;
   const lineScene = NODE_TITLE_LABEL_LINE_PX * inv;
-  const fontSize = 11 * inv;
-  const iconSize = 12 * inv;
+  const fontSize = TITLE_FONT_PX * inv;
+  const iconSize = TITLE_ICON_PX * inv;
   const labelBottomScene = box.top - gapScene;
   const labelTopScene = labelBottomScene - lineScene;
   const textY = labelTopScene + lineScene * 0.5;
@@ -158,19 +134,8 @@ export function nodeTitleScreenGapPx(
   return (boxTop - place.labelBottomScene) * z * sx;
 }
 
-/** 24×24 stroke icons, scaled into scene via `size`. */
-function TitleIconSvg({
-  kind,
-  x,
-  y,
-  size,
-}: {
-  kind: NodeTitleIcon;
-  x: number;
-  y: number;
-  size: number;
-}) {
-  const s = size / 24;
+/** 24×24 stroke icons at fixed screen size. */
+function TitleIcon({ kind }: { kind: NodeTitleIcon }): ReactNode {
   const common = {
     fill: 'none' as const,
     stroke: MUTED,
@@ -221,11 +186,21 @@ function TitleIconSvg({
       </>
     );
   }
-  return <g transform={`translate(${x} ${y}) scale(${s})`}>{path}</g>;
+  return (
+    <svg
+      width={TITLE_ICON_PX}
+      height={TITLE_ICON_PX}
+      viewBox="0 0 24 24"
+      className="shrink-0"
+      aria-hidden
+    >
+      {path}
+    </svg>
+  );
 }
 
 /**
- * Title row above frames / images / generators (world SVG, `px/zoom`).
+ * Title row above frames / images / generators — HTML chrome, screen-constant type.
  */
 function NodeTitleLabel({
   box,
@@ -258,10 +233,9 @@ function NodeTitleLabel({
     started: boolean;
   } | null>(null);
   const camera = useRcbCamera();
-  const dpr = useRcbDevicePixelRatio();
   const z = rcbCameraCssZoom(camera);
+  const inv = 1 / Math.max(0.05, z);
   const rotated = Math.abs(angle) > 0.001;
-  const clipUid = useId().replace(/:/g, '');
   const sizeText = `${Math.round(sizeWidth)} × ${Math.round(sizeHeight)}`;
 
   useEffect(() => {
@@ -293,75 +267,8 @@ function NodeTitleLabel({
     return () => window.removeEventListener('pointerdown', onPointerDown, true);
   }, [editing, name, onRename]);
 
-  const place = useMemo(
-    () => nodeTitleLabelWorldPlacement(box, z, { sizeText }),
-    [box.left, box.top, box.width, box.height, z, sizeText]
-  );
-
-  // Prefer shared world lattice; pad includes title strip so glyphs are not clipped.
-  const surf = useMemo(
-    () =>
-      selectionChromeSurfaceProps(
-        box,
-        angle,
-        place.gapScene + place.lineScene,
-        camera,
-        dpr
-      ),
-    [
-      box.left,
-      box.top,
-      box.width,
-      box.height,
-      angle,
-      place.gapScene,
-      place.lineScene,
-      camera,
-      dpr,
-    ]
-  );
-
   const iconKind: NodeTitleIcon =
     icon || (dataAttr === 'frame-label' ? 'frame' : 'image');
-
-  const bodyTransform = rotated
-    ? `translate(${box.left} ${box.top}) rotate(${angle} ${box.width / 2} ${box.height / 2})`
-    : null;
-
-  /** Local coords when rotated; else absolute scene. */
-  const local = rotated
-    ? {
-        iconX: 0,
-        iconY: -(place.gapScene + place.lineScene) + (place.lineScene - place.iconSize) * 0.5,
-        nameX: place.iconSize + 4 * place.inv,
-        sizeX: Math.max(1, box.width),
-        textY: -(place.gapScene + place.lineScene * 0.5),
-        hitX: 0,
-        hitY: -(place.gapScene + place.lineScene),
-        hitW: Math.max(1, box.width),
-        hitH: place.lineScene,
-        nameMaxWidth: Math.max(
-          0,
-          Math.max(1, box.width) -
-            (place.iconSize + 4 * place.inv) -
-            8 * place.inv -
-            place.sizeReserve
-        ),
-      }
-    : {
-        iconX: place.iconX,
-        iconY: place.iconY,
-        nameX: place.nameX,
-        sizeX: place.sizeX,
-        textY: place.textY,
-        hitX: place.hitLeft,
-        hitY: place.hitTop,
-        hitW: place.hitWidth,
-        hitH: place.hitHeight,
-        nameMaxWidth: place.nameMaxWidth,
-      };
-
-  const nameClipId = `rcb-title-name-${clipUid}`;
 
   const commit = () => {
     const next = draft.trim() || name;
@@ -377,7 +284,7 @@ function NodeTitleLabel({
       ? { 'data-frame-label': true as const }
       : { 'data-image-label': true as const };
 
-  const onLabelPointerDown = (e: ReactPointerEvent<SVGRectElement>) => {
+  const onLabelPointerDown = (e: ReactPointerEvent<HTMLElement>) => {
     e.stopPropagation();
     if (editing) return;
     onSelect?.();
@@ -416,27 +323,42 @@ function NodeTitleLabel({
     window.addEventListener('pointerup', onUpWin);
   };
 
-  const labelBody = (
-    <>
-      <defs>
-        <clipPath id={nameClipId}>
-          <rect
-            x={local.nameX}
-            y={local.hitY}
-            width={Math.max(0, local.nameMaxWidth)}
-            height={local.hitH}
-          />
-        </clipPath>
-      </defs>
-      <rect
+  // Anchor at box center (scene). Counter-scale so children use screen px.
+  // Title row sits above the top edge: gap + line, left-aligned to the plate.
+  const screenW = Math.max(1, box.width) / inv;
+  const halfH = Math.max(1, box.height) / (2 * inv);
+
+  return (
+    <div
+      data-rcb-node-title="1"
+      className="pointer-events-none absolute z-[999990] overflow-visible"
+      style={{
+        left: box.left + box.width / 2,
+        top: box.top + box.height / 2,
+        width: 0,
+        height: 0,
+        transform: rotated ? `rotate(${angle}deg) scale(${inv})` : `scale(${inv})`,
+        transformOrigin: '0 0',
+        pointerEvents: 'none',
+      }}
+    >
+      <div
         {...attrProps}
         {...dataProps}
-        x={local.hitX}
-        y={local.hitY}
-        width={local.hitW}
-        height={local.hitH}
-        fill="transparent"
-        style={{ pointerEvents: 'all', cursor: onMove ? 'grab' : 'default' }}
+        className={cn(
+          'pointer-events-auto absolute flex min-w-0 items-center gap-1 overflow-hidden font-medium select-none',
+          onMove ? 'cursor-grab' : 'cursor-default'
+        )}
+        style={{
+          left: -screenW / 2,
+          top: -halfH - NODE_TITLE_LABEL_GAP_PX,
+          width: screenW,
+          height: NODE_TITLE_LABEL_LINE_PX,
+          transform: 'translateY(-100%)',
+          color: MUTED,
+          fontSize: TITLE_FONT_PX,
+          lineHeight: `${NODE_TITLE_LABEL_LINE_PX}px`,
+        }}
         onPointerDown={onLabelPointerDown}
         onDoubleClick={(e) => {
           if (!onRename) return;
@@ -446,79 +368,22 @@ function NodeTitleLabel({
           setDraft(name);
           setEditing(true);
         }}
-      />
-      <TitleIconSvg kind={iconKind} x={local.iconX} y={local.iconY} size={place.iconSize} />
-      {!editing ? (
-        <text
-          x={local.nameX}
-          y={local.textY}
-          fill={MUTED}
-          fontSize={place.fontSize}
-          fontWeight={500}
-          fontFamily="ui-sans-serif, system-ui, sans-serif"
-          textAnchor="start"
-          dominantBaseline="central"
-          clipPath={`url(#${nameClipId})`}
-          style={{ pointerEvents: 'none' }}
-        >
-          {name}
-        </text>
-      ) : null}
-      <text
-        x={local.sizeX}
-        y={local.textY}
-        fill={MUTED}
-        fontSize={place.fontSize}
-        fontWeight={500}
-        fontFamily="ui-sans-serif, system-ui, sans-serif"
-        textAnchor="end"
-        dominantBaseline="central"
-        opacity={0.8}
-        style={{ pointerEvents: 'none' }}
       >
-        {sizeText}
-      </text>
-    </>
-  );
-
-  // Unscaled overlay + scene→screen; anchor at text center then translateY(-50%).
-  const editLocalX = rotated ? local.nameX : place.nameX - box.left;
-  const editLocalY = rotated ? local.textY : place.textY - box.top;
-  const editScene = rotateLocalToScene(editLocalX, editLocalY, box, angle);
-  const editScreen = rcbSceneToScreen(camera, editScene.x, editScene.y, dpr);
-  const editScreenW = Math.max(44, local.nameMaxWidth * z);
-
-  const editInput =
-    editing && onRename ? (
-      <RcbOverlayPortal>
-        <div
-          data-rcb-title-edit="1"
-          data-text-inline-editor
-          className="pointer-events-auto absolute z-[40] overflow-hidden"
-          style={{
-            left: editScreen.x,
-            top: editScreen.y,
-            width: editScreenW,
-            height: NODE_TITLE_LABEL_LINE_PX,
-            transform: 'translateY(-50%)',
-          }}
-          onPointerDown={(e) => e.stopPropagation()}
-        >
+        <TitleIcon kind={iconKind} />
+        {editing && onRename ? (
           <input
             ref={inputRef}
+            data-rcb-title-edit="1"
+            data-text-inline-editor
             value={draft}
             aria-label={renameAriaLabel || name}
-            className="block w-full appearance-none border-0 bg-transparent p-0 font-medium leading-none text-[var(--ink)] shadow-none outline-none ring-0"
+            className="min-w-0 flex-1 appearance-none overflow-hidden text-ellipsis whitespace-nowrap border-0 bg-transparent p-0 font-medium leading-none text-[var(--ink)] shadow-none outline-none ring-0"
             style={{
-              fontSize: TITLE_EDIT_FONT_PX,
+              fontSize: TITLE_FONT_PX,
               lineHeight: `${NODE_TITLE_LABEL_LINE_PX}px`,
               height: NODE_TITLE_LABEL_LINE_PX,
-              margin: 0,
-              padding: 0,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
             }}
+            onPointerDown={(e) => e.stopPropagation()}
             onChange={(e) => setDraft(e.target.value)}
             onBlur={commit}
             onKeyDown={(e) => {
@@ -534,30 +399,14 @@ function NodeTitleLabel({
               e.stopPropagation();
             }}
           />
-        </div>
-      </RcbOverlayPortal>
-    ) : null;
-
-  return (
-    <>
-      <svg
-        data-rcb-infinite="1"
-        data-rcb-node-title="1"
-        className="absolute z-[999990] overflow-visible"
-        width={surf.width}
-        height={surf.height}
-        viewBox={surf.viewBox}
-        preserveAspectRatio="none"
-        style={{
-          ...surf.style,
-          pointerEvents: 'none',
-        }}
-        aria-hidden={false}
-      >
-        {bodyTransform ? <g transform={bodyTransform}>{labelBody}</g> : labelBody}
-      </svg>
-      {editInput}
-    </>
+        ) : (
+          <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+            {name}
+          </span>
+        )}
+        <span className="shrink-0 opacity-80 tabular-nums">{sizeText}</span>
+      </div>
+    </div>
   );
 }
 

--- a/apps/web/src/components/rcb/selection/chrome/PolygonShapeHandlesOverlay.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/PolygonShapeHandlesOverlay.tsx
@@ -15,6 +15,7 @@ import {
   isRadiusLinked,
   radiiFromAttrs,
   serializeRadiusVertices,
+  setLiveCornerRadiusPreview,
   type CornerRadii,
 } from '@/components/rcb/scene/document/sceneRadii';
 import {
@@ -332,6 +333,7 @@ function PolygonShapeHandlesOverlay({
       const local = scenePointToLocal(sc.x, sc.y, box, angle);
       const rounded = Math.round(radiusAlongSite(d.site, local));
       setDragValue(rounded);
+      setLiveCornerRadiusPreview({ nodeId, display: rounded });
       previewRadii(rounded, sides);
     };
 
@@ -343,6 +345,7 @@ function PolygonShapeHandlesOverlay({
       setActiveKey(null);
       setDragValue(null);
       setLiveSides(null);
+      setLiveCornerRadiusPreview(null);
 
       if (soft) {
         previewRadii(baseR, baseSides);
@@ -368,6 +371,7 @@ function PolygonShapeHandlesOverlay({
       setActiveKey(null);
       setDragValue(null);
       setLiveSides(null);
+      setLiveCornerRadiusPreview(null);
       previewRadii(baseR, baseSides);
     };
 
@@ -380,6 +384,7 @@ function PolygonShapeHandlesOverlay({
       window.removeEventListener('pointerup', onUp);
       window.removeEventListener('pointercancel', onUp);
       window.removeEventListener('keydown', onKey);
+      setLiveCornerRadiusPreview(null);
     };
   }, [
     interactive,

--- a/apps/web/src/components/rcb/selection/chrome/SelectionContextToolbar.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/SelectionContextToolbar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode, memo } from 'react';
+import { useEffect, useMemo, useState, useSyncExternalStore, type ReactNode, memo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import {
@@ -69,7 +69,11 @@ import {
 } from '@/components/editor/nodes/VideoNode';
 import ShapeSelectionToolbar from '@/components/editor/nodes/ShapeNode/ShapeSelectionToolbar';
 import { SelectionToolbarShell } from './SelectionToolbarShell';
-import { isRadiusLinked, maxRadius, radiiFromAttrs } from '@/components/rcb/scene/document/sceneRadii';
+import {
+  cornerRadiusToolbarDisplay,
+  getLiveCornerRadiusPreview,
+  subscribeLiveCornerRadiusPreview,
+} from '@/components/rcb/scene/document/sceneRadii';
 import { supportsCornerRadius } from '@/components/rcb/scene/document/sceneDocument';
 import {
   buildOutlinePathAsync,
@@ -168,6 +172,13 @@ function SelectionContextToolbar(props: Props): ReactNode {
     () => (kind === 'text' ? parseNodeTextStyle(node?.attrs || {}) : null),
     [kind, node?.attrs]
   );
+  const liveCornerRadius = useSyncExternalStore(
+    subscribeLiveCornerRadiusPreview,
+    () => getLiveCornerRadiusPreview(nodeId),
+    () => null
+  );
+  const toolbarCornerRadius =
+    liveCornerRadius ?? cornerRadiusToolbarDisplay(node?.attrs);
 
   useEffect(() => {
     let cancelled = false;
@@ -614,11 +625,7 @@ function SelectionContextToolbar(props: Props): ReactNode {
                               }
                             >
                               <IconCornerRadius className="h-4 w-4" />
-                              <span className="tabular-nums">
-                                {isRadiusLinked(node.attrs)
-                                  ? Math.round(radiiFromAttrs(node.attrs).tl)
-                                  : Math.round(maxRadius(radiiFromAttrs(node.attrs)))}
-                              </span>
+                              <span className="tabular-nums">{toolbarCornerRadius}</span>
                             </button>
                           </Tooltip>
                         ) : null

--- a/apps/web/src/components/rcb/selection/chrome/StarShapeHandlesOverlay.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/StarShapeHandlesOverlay.tsx
@@ -13,6 +13,7 @@ import {
   isRadiusLinked,
   radiiFromAttrs,
   serializeRadiusVertices,
+  setLiveCornerRadiusPreview,
   type CornerRadii,
 } from '@/components/rcb/scene/document/sceneRadii';
 import {
@@ -335,6 +336,7 @@ function StarShapeHandlesOverlay({
       const along = (local.x - d.site.x) * d.site.ix + (local.y - d.site.y) * d.site.iy;
       const rounded = Math.max(0, Math.min(maxR, Math.round(along)));
       setDragValue(rounded);
+      setLiveCornerRadiusPreview({ nodeId, display: rounded });
       preview({ r: rounded });
     };
 
@@ -347,6 +349,7 @@ function StarShapeHandlesOverlay({
       setDragValue(null);
       setLiveSides(null);
       setLiveInner(null);
+      setLiveCornerRadiusPreview(null);
 
       if (soft) {
         preview({ r: baseR, sides: baseSides, inner: baseInner });
@@ -383,6 +386,7 @@ function StarShapeHandlesOverlay({
       setDragValue(null);
       setLiveSides(null);
       setLiveInner(null);
+      setLiveCornerRadiusPreview(null);
       preview({ r: baseR, sides: baseSides, inner: baseInner });
     };
 
@@ -395,6 +399,7 @@ function StarShapeHandlesOverlay({
       window.removeEventListener('pointerup', onUp);
       window.removeEventListener('pointercancel', onUp);
       window.removeEventListener('keydown', onKey);
+      setLiveCornerRadiusPreview(null);
     };
   }, [
     interactive,


### PR DESCRIPTION
## Summary
- Move Frame/image titles to HTML (same chrome contract as toolbars) with overflow ellipsis.
- Keep corner-radius park screen-constant so seats do not jump while resizing.
- Live-update image/video `clipPath` and toolbar R while dragging radius knobs.
- Collab undo: empty Yjs stack falls back to Redux so Undo/Redo stay usable.

## Test plan
- [ ] Select a Frame — title is HTML, long names ellipsize, toolbar still clears the title
- [ ] Drag image corner-radius knobs — photo rounds live; toolbar number tracks
- [ ] Resize a rounded rect — radius dots stay near corners (no jump)
- [ ] Edit in collab room, then Undo/Redo from context menu and Ctrl+Z/Y