### PR TITLE
Fix half-pixel fill after hiding center stroke

### DIFF
--- a/apps/web/src/components/editor/nodes/ShapeNode/ShapeStylePanelHost.tsx
+++ b/apps/web/src/components/editor/nodes/ShapeNode/ShapeStylePanelHost.tsx
@@ -40,6 +40,7 @@ import {
   boolEffectAttr,
   inflateBoxByVisualOutset,
   inflateBoxByTextSelectionPad,
+  geometryPatchForStrokeVisibilityToggle,
 } from '@/components/rcb/scene/document/sceneEffects';
 import { supportsFill, supportsCornerRadius } from '@/components/rcb/scene/document/sceneDocument';
 import {
@@ -443,10 +444,12 @@ function ShapeStylePanelHost({ document }: { document: any }): ReactNode {
       const node = document?.deltaSetLike?.[id];
       if (!node) continue;
       const shapeType = node?.attrs?.shapeType;
+      const geom = geometryPatchForStrokeVisibilityToggle(node, visible);
       dispatch(
         patchDocumentNode({
           nodeId: id,
           patch: {
+            ...(geom || {}),
             attrs: {
               ...(shapeType != null ? { shapeType } : {}),
               'stroke-enabled': visible ? 'true' : 'false',

--- a/apps/web/src/components/rcb/scene/document/sceneEffects.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneEffects.ts
@@ -195,6 +195,95 @@ export function inflateBoxByVisualOutset<
   return padBox(box, strokeVisualOutset(node));
 }
 
+/** Half-pixel quantize — same as createShapeNode (odd center strokes). */
+function quantizeHalfPx(n: number) {
+  return Math.round(n * 2) / 2;
+}
+
+/**
+ * Outset as if stroke were painted (ignore current stroke-visible/enabled).
+ * Used when turning stroke back on to inset geom again.
+ */
+function strokeVisualOutsetAssumingPainted(node: any): number {
+  if (!node) return 0;
+  return strokeVisualOutset({
+    ...node,
+    attrs: {
+      ...(node.attrs || {}),
+      'stroke-enabled': 'true',
+      'stroke-visible': 'true',
+    },
+  });
+}
+
+/**
+ * Closed shapes drawn with center stroke store path geom inset by sw/2 so outer
+ * ink sits on the integer grid. Hiding stroke without expanding leaves the fill
+ * on half-pixels. Expand/inset AABB to keep the visible edge stable.
+ *
+ * Skips open strokes / freehand / custom path `d` (AABB alone would not offset the curve).
+ */
+export function geometryPatchForStrokeVisibilityToggle(
+  node: any,
+  nextVisible: boolean
+): { x: number; y: number; width: number; height: number } | null {
+  if (!node) return null;
+  const shapeType = String(node.attrs?.shapeType || '');
+  if (
+    shapeType === 'line' ||
+    shapeType === 'arrow' ||
+    shapeType === 'pencil' ||
+    shapeType === 'pen' ||
+    shapeType === 'path'
+  ) {
+    return null;
+  }
+  if (node.key === 'text' || node.key === 'frame' || node.key === 'image' || node.key === 'video') {
+    return null;
+  }
+  // Boolean / pasted outlines keep absolute local `path` — resizing the box alone
+  // would not grow the fill to the old outer ink.
+  if (typeof node.attrs?.path === 'string' && String(node.attrs.path).trim()) {
+    return null;
+  }
+
+  const attrs = node.attrs || {};
+  const currentlyVisible =
+    boolEffectAttr(attrs['stroke-enabled'], true) && boolEffectAttr(attrs['stroke-visible'], true);
+  if (currentlyVisible === nextVisible) return null;
+
+  const outset = nextVisible
+    ? strokeVisualOutsetAssumingPainted(node)
+    : strokeVisualOutset(node);
+  if (!(outset > 0)) return null;
+
+  const x = Number(node.x) || 0;
+  const y = Number(node.y) || 0;
+  const width = Math.max(1, Number(node.width) || 1);
+  const height = Math.max(1, Number(node.height) || 1);
+
+  if (nextVisible) {
+    // Show stroke → inset path so outer ink matches current fill edge.
+    const nextW = Math.max(1, width - outset * 2);
+    const nextH = Math.max(1, height - outset * 2);
+    if (nextW >= width && nextH >= height) return null;
+    return {
+      x: quantizeHalfPx(x + outset),
+      y: quantizeHalfPx(y + outset),
+      width: quantizeHalfPx(nextW),
+      height: quantizeHalfPx(nextH),
+    };
+  }
+
+  // Hide stroke → expand fill to previous outer ink.
+  return {
+    x: quantizeHalfPx(x - outset),
+    y: quantizeHalfPx(y - outset),
+    width: quantizeHalfPx(width + outset * 2),
+    height: quantizeHalfPx(height + outset * 2),
+  };
+}
+
 /** Scene-space air between text glyphs and selection chrome (flush / ~0). */
 export const TEXT_SELECTION_PAD = 0;
 

--- a/apps/web/src/components/rcb/selection/__tests__/chromeStrokeOutset.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/chromeStrokeOutset.test.ts
@@ -5,6 +5,7 @@ import {
   inflateBoxByVisualOutset,
   strokeChromeOutset,
   strokeVisualOutset,
+  geometryPatchForStrokeVisibilityToggle,
 } from '../../scene/document/sceneEffects';
 
 /**
@@ -116,5 +117,66 @@ describe('selection chrome vs stroke (AABB on path)', () => {
     });
     expect(geomForPolygonKnobs).toEqual(path);
     expect(chrome).toEqual(path);
+  });
+});
+
+describe('geometryPatchForStrokeVisibilityToggle', () => {
+  const rectCenter1 = {
+    key: 'shape',
+    x: 10.5,
+    y: 8.5,
+    width: 42,
+    height: 31,
+    attrs: {
+      shapeType: 'rect',
+      'border-width': 1,
+      'border-color': '#333',
+      strokeAlign: 'center',
+      'stroke-enabled': 'true',
+      'stroke-visible': 'true',
+      'fill-color': '#fff',
+    },
+  };
+
+  it('hide 1px center stroke expands fill to prior outer ink (on grid)', () => {
+    const patch = geometryPatchForStrokeVisibilityToggle(rectCenter1, false);
+    expect(patch).toEqual({ x: 10, y: 8, width: 43, height: 32 });
+    const hidden = {
+      ...rectCenter1,
+      ...patch,
+      attrs: { ...rectCenter1.attrs, 'stroke-enabled': 'false', 'stroke-visible': 'false' },
+    };
+    expect(strokeVisualOutset(hidden)).toBe(0);
+    expect(hidden.x).toBe(10);
+    expect(hidden.y).toBe(8);
+  });
+
+  it('show stroke again insets back to path *.5', () => {
+    const expanded = {
+      ...rectCenter1,
+      x: 10,
+      y: 8,
+      width: 43,
+      height: 32,
+      attrs: { ...rectCenter1.attrs, 'stroke-enabled': 'false', 'stroke-visible': 'false' },
+    };
+    const patch = geometryPatchForStrokeVisibilityToggle(expanded, true);
+    expect(patch).toEqual({ x: 10.5, y: 8.5, width: 42, height: 31 });
+  });
+
+  it('inside stroke: no geom change (outset 0)', () => {
+    const node = {
+      ...rectCenter1,
+      attrs: { ...rectCenter1.attrs, strokeAlign: 'inside', 'stroke-align': 'inside' },
+    };
+    expect(geometryPatchForStrokeVisibilityToggle(node, false)).toBeNull();
+  });
+
+  it('custom path d: skip (AABB alone cannot offset the curve)', () => {
+    const node = {
+      ...rectCenter1,
+      attrs: { ...rectCenter1.attrs, shapeType: 'path', path: 'M0 0 L10 0 L10 10 Z', closed: 'true' },
+    };
+    expect(geometryPatchForStrokeVisibilityToggle(node, false)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- When hiding a center stroke, expand shape geometry by the visual outset so fill stays on the integer grid (path was stored inset by sw/2).
- Re-showing stroke insets geometry back; skips freehand / custom path `d`.
- Adds unit coverage for expand / inset / skip cases.

## Test plan
- [ ] Draw a rect on grid with default 1px center stroke — outer ink on grid
- [ ] Hide stroke in the style panel — fill edges stay on grid (no half-pixel gap)
- [ ] Show stroke again — geometry returns; outer ink still on grid
- [ ] Inside-align stroke: hide does not change W/H
- [ ] `npx vitest run src/components/rcb/selection/__tests__/chromeStrokeOutset.test.ts`
