### PR TITLE
Public plaza feed, canvas bg theme reset, venv-aware API

### DIFF
--- a/apps/api/app/api/routes/plaza.py
+++ b/apps/api/app/api/routes/plaza.py
@@ -101,7 +101,6 @@ def _require_public_plaza_item(submission_id: str) -> dict[str, Any]:
 
 @router.get("/feed")
 def plaza_feed(
-    current_user: CurrentUser,
     page: int = 1,
     pageSize: int | None = None,
     limit: int | None = None,
@@ -110,7 +109,7 @@ def plaza_feed(
     authorIds: str | None = None,
 ) -> dict[str, Any]:
     """
-    Public plaza feed.
+    Public plaza feed (no login required).
     tab=recommended|latest (following deprecated — use authorIds to filter by creator)
     category=optional category filter (website|mobile|image|poster|video)
     authorIds=comma-separated user ids to filter works by creator.

--- a/apps/web/src/components/editor/chrome/CanvasBgPicker.tsx
+++ b/apps/web/src/components/editor/chrome/CanvasBgPicker.tsx
@@ -10,6 +10,8 @@ import { cn } from '@/utils/classnames';
 type Props = {
   value: FillPanelValue;
   onChange: (next: FillPanelValue) => void;
+  /** Clear saved canvas color → follow theme `--canvas`. */
+  onReset?: () => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   meshSelectedIndex?: number;
@@ -22,6 +24,7 @@ type Props = {
 function CanvasBgPicker({
   value,
   onChange,
+  onReset,
   open,
   onOpenChange,
   meshSelectedIndex,
@@ -33,6 +36,7 @@ function CanvasBgPicker({
     <FillPanelPopover
       value={value}
       onChange={onChange}
+      onReset={onReset}
       title={'画布背景色'}
       placement="top-start"
       shiftMainAxis={false}

--- a/apps/web/src/components/editor/page/EditorBottomHud.tsx
+++ b/apps/web/src/components/editor/page/EditorBottomHud.tsx
@@ -130,6 +130,9 @@ const THEME_FOLLOW_CANVAS_BGS = new Set([
   '#f3f3f3',
   '#f5f5f5',
   '#fafafa',
+  // Dark theme `--canvas` / near-canvas neutrals
+  '#1e1e1e',
+  '#141414',
 ]);
 
 export function isThemeFollowCanvasBg(raw: string) {
@@ -146,6 +149,17 @@ export function canvasFillToDocumentMeta(next: FillPanelValue, followTheme: bool
     backgroundImageFit: next.fillImageFit,
     backgroundImageRotate: next.fillImageRotate,
     backgroundImageAdjust: next.fillImageAdjust,
+  };
+}
+
+/** Clear user-saved canvas fill so the stage follows theme `--canvas` again. */
+export function themeDefaultCanvasMeta() {
+  return {
+    backgroundColor: '',
+    backgroundFillType: 'solid',
+    backgroundOpacity: 100,
+    backgroundGradient: '',
+    backgroundImageSrc: '',
   };
 }
 
@@ -403,6 +417,7 @@ function EditorBottomHud({
                       next.fillType === 'solid' && isThemeFollowCanvasBg(next.fillColor);
                     dispatch(setCanvasMeta(canvasFillToDocumentMeta(next, follow)));
                   }}
+                  onReset={() => dispatch(setCanvasMeta(themeDefaultCanvasMeta()))}
                 />
                 <HudBtn tip={t('editor.layers')} active={layersOpen} onClick={() => setLayersOpen((v) => !v)}>
                   <HiOutlineSquare3Stack3D className={HUD_ICON} strokeWidth={HUD_ICON_STROKE} />

--- a/apps/web/src/components/editor/panels/FillPanel.tsx
+++ b/apps/web/src/components/editor/panels/FillPanel.tsx
@@ -487,6 +487,7 @@ function FillPanel({
   onLayerVisibleChange,
   activeStopIndex,
   onActiveStopIndexChange,
+  onReset,
 }: {
   value: FillPanelValue;
   onChange: (next: FillPanelValue) => void;
@@ -504,6 +505,8 @@ function FillPanel({
   /** Sync gradient stop selection with on-canvas handles. */
   activeStopIndex?: number;
   onActiveStopIndexChange?: (index: number) => void;
+  /** Optional header reset (e.g. canvas bg → clear saved color / follow theme). */
+  onReset?: () => void;
 }) {
   const fillType = parseFillType(value.fillType);
   const panelType = (FILL_PANEL_TYPES.includes(fillType) ? fillType : 'solid') as FillType;
@@ -630,6 +633,20 @@ function FillPanel({
       onLayerVisibleChange={onLayerVisibleChange}
       layerVisibleTipShow="显示填充"
       layerVisibleTipHide="隐藏填充"
+      headerActions={
+        onReset ? (
+          <Tooltip tip="恢复默认" placement="bottom">
+            <button
+              type="button"
+              aria-label="恢复默认"
+              onClick={onReset}
+              className="inline-flex h-8 w-8 items-center justify-center rounded text-[var(--muted)] hover:bg-[var(--accent-soft)] hover:text-[var(--ink)]"
+            >
+              <HiOutlineArrowPath className="h-[18px] w-[18px]" />
+            </button>
+          </Tooltip>
+        ) : null
+      }
     >
         <SegmentedControl
           size="sm"
@@ -827,6 +844,7 @@ export type FillPanelPopoverProps = {
   onMeshSelectedIndexChange?: (index: number) => void;
   meshShowGuides?: boolean;
   onMeshShowGuidesChange?: (show: boolean) => void;
+  onReset?: () => void;
 };
 
 /** Floating fill panel (type tabs + solid / gradients / image). */
@@ -848,6 +866,7 @@ function FillPanelPopover({
   onMeshSelectedIndexChange,
   meshShowGuides,
   onMeshShowGuidesChange,
+  onReset,
 }: FillPanelPopoverProps) {
   const [localOpen, setLocalOpen] = useState(false);
   const open = controlledOpen ?? localOpen;
@@ -939,6 +958,7 @@ function FillPanelPopover({
               onChange={onChange}
               title={title}
               onClose={() => setOpen(false)}
+              onReset={onReset}
               meshSelectedIndex={meshSelectedIndex}
               onMeshSelectedIndexChange={onMeshSelectedIndexChange}
               meshShowGuides={meshShowGuides}

--- a/apps/web/src/components/editor/panels/StylePanelChrome.tsx
+++ b/apps/web/src/components/editor/panels/StylePanelChrome.tsx
@@ -163,6 +163,8 @@ function StylePanelShell({
   bodyClassName,
   width,
   dataAttr,
+  /** Extra header controls (e.g. reset) rendered before eye / exit. */
+  headerActions,
   /** Layer visibility (eye) — fill / stroke hide toggles live in the panel header. */
   layerVisible,
   onLayerVisibleChange,
@@ -177,6 +179,7 @@ function StylePanelShell({
   bodyClassName?: string;
   width?: number;
   dataAttr?: string;
+  headerActions?: ReactNode;
   layerVisible?: boolean;
   onLayerVisibleChange?: (visible: boolean) => void;
   layerVisibleTipShow?: string;
@@ -197,6 +200,7 @@ function StylePanelShell({
       <div className="flex h-11 items-center justify-between px-3">
         <span className="text-[13px] font-medium text-[var(--ink)]">{title}</span>
         <div className="flex items-center gap-0.5">
+          {headerActions}
           {showLayerToggle ? (
             <Tooltip
               tip={layerVisible ? layerVisibleTipHide : layerVisibleTipShow}

--- a/apps/web/src/theme/dark.css
+++ b/apps/web/src/theme/dark.css
@@ -1,9 +1,10 @@
 /* Dark theme — Figma-like charcoal stack (not near-black) */
 html[data-theme='dark'] {
-  /* Chrome / panels sit above the canvas, matching Figma home + editor. */
+  /* Chrome / panels sit above the canvas, matching Figma home + editor.
+     --rail must differ from --surface so inset tracks / size fields read on panels. */
   --surface: #2c2c2c;
   --canvas: #1e1e1e;
-  --rail: #2c2c2c;
+  --rail: #242424;
   --account-rail: #2c2c2c;
   --account-main: #1e1e1e;
   --account-card: #2c2c2c;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev:docs": "npm run dev --workspace=apps/docs",
     "dev:collab": "npm run dev --workspace=apps/collab",
     "build:docs": "npm run build --workspace=apps/docs",
-    "dev:api": "cd apps/api && python -m uvicorn app.main:app --reload --host 127.0.0.1 --port 8000",
+    "dev:api": "node scripts/dev-api.mjs",
     "build": "npm run build --workspace=apps/web",
     "test": "npm run test:web && npm run test:api",
     "test:web": "npm run test --workspace=apps/web",

--- a/scripts/dev-api.mjs
+++ b/scripts/dev-api.mjs
@@ -1,0 +1,25 @@
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const apiRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../apps/api');
+const win = process.platform === 'win32';
+const venvPy = path.join(apiRoot, '.venv', win ? 'Scripts/python.exe' : 'bin/python');
+const py = existsSync(venvPy) ? venvPy : 'python';
+
+if (!existsSync(venvPy)) {
+  console.warn(
+    `[dev:api] apps/api/.venv not found — using "${py}". Prefer: cd apps/api && python -m venv .venv && pip install -e ".[dev]"`
+  );
+}
+
+const child = spawn(
+  py,
+  ['-m', 'uvicorn', 'app.main:app', '--reload', '--host', '127.0.0.1', '--port', '8000'],
+  { cwd: apiRoot, stdio: 'inherit', env: process.env }
+);
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  process.exit(code ?? 1);
+});


### PR DESCRIPTION
## Summary
- Make `/api/v1/plaza/feed` public (no login) so inspiration cases load for guests.
- Add canvas background 「恢复默认」 to clear saved color and follow theme `--canvas`.
- Point `npm run dev:api` at `apps/api/.venv` via `scripts/dev-api.mjs`.
- Dark theme: separate `--rail` from `--surface` so inset fields remain readable.

## Test plan
- [ ] Open home logged out — inspiration feed loads (no 401 / casesLoadFailed)
- [ ] Customize canvas bg, click 恢复默认 — stage follows light/dark `--canvas`
- [ ] `npm run dev:api` starts with venv (sqlmodel resolves)
