### PR TITLE
Fix web snap, save, and preview inspect measure

### DIFF
--- a/apps/api/app/api/routes/shares.py
+++ b/apps/api/app/api/routes/shares.py
@@ -85,7 +85,7 @@ def shares_get(
     current_user: OptionalUser,
     share_id: str,
 ) -> dict[str, Any]:
-    share = get_share(share_id, actor_user_id=current_user.id if user else None)
+    share = get_share(share_id, actor_user_id=current_user.id if current_user else None)
     if not share:
         raise HTTPException(status_code=404, detail="Not found")
     return {"share": share}
@@ -123,7 +123,7 @@ def shares_update_document(
         share = update_share_document(
             share_id,
             body.document,
-            actor_user_id=current_user.id if user else None,
+            actor_user_id=current_user.id if current_user else None,
         )
     except ShareError as err:
         raise _share_http(err) from err

--- a/apps/api/app/services/projects.py
+++ b/apps/api/app/services/projects.py
@@ -239,11 +239,19 @@ def _next_thumbnail(
             data_list = [one]
 
     if data_list:
+        from concurrent.futures import ThreadPoolExecutor
+
+        batch = list(enumerate(data_list[:4]))
+
+        def _one(item: tuple[int, str]) -> str | None:
+            i, data_url = item
+            return _thumb_key_from_data_url(user_id, project_id, data_url, index=i)
+
         uploaded: list[str] = []
-        for i, data_url in enumerate(data_list[:4]):
-            key = _thumb_key_from_data_url(user_id, project_id, data_url, index=i)
-            if key:
-                uploaded.append(key)
+        with ThreadPoolExecutor(max_workers=min(4, len(batch))) as pool:
+            for key in pool.map(_one, batch):
+                if key:
+                    uploaded.append(key)
         if uploaded:
             _delete_thumb_entries(existing_key)
             custom = True if mark_custom is True else False
@@ -463,6 +471,16 @@ def patch_project(
 
     if old_key and old_key != doc_key:
         delete_object(old_key)
+
+    # Keep linked share snapshots warm (same as upsert) — PATCH used to skip this.
+    try:
+        from app.services.shares.store import sync_project_share_documents
+
+        sync_project_share_documents(
+            owner_id=user_id, project_id=pid, document=merged
+        )
+    except Exception:
+        pass
 
     return {
         "id": pid,

--- a/apps/web/src/components/editor/collab/CollabRoomProvider.tsx
+++ b/apps/web/src/components/editor/collab/CollabRoomProvider.tsx
@@ -1,6 +1,6 @@
 /**
  * Yjs room lifecycle: mint token → IndexedDB (offline) + WebsocketProvider → bridge scene ↔ Redux.
- * Presence (selection / cursors) via Awareness. Persist via debounced cloud PUT.
+ * Presence (selection / cursors) via Awareness. Persist via debounced cloud PATCH (or PUT).
  * Offline: y-indexeddb keeps the room locally; reconnect merges with peers / server.
  * @see https://docs.yjs.dev/getting-started/allowing-offline-editing
  */
@@ -23,15 +23,20 @@ import { IndexeddbPersistence } from 'y-indexeddb';
 import { WebsocketProvider } from 'y-websocket';
 import { Awareness } from 'y-protocols/awareness';
 import { mintCollabRoomTokenApi } from '@/apis/collab';
-import { upsertProjectApi } from '@/apis/projects';
 import { updateShareDocumentApi } from '@/apis/shares';
 import { rcbSceneToScreen, rcbScreenToScene } from '@/components/rcb/core/math';
 import type { RcbCamera } from '@/components/rcb/core/types';
 import {
+  buildProjectDocumentPatch,
   getProjectDraft,
   hashDocument,
   markProjectDraftSynced,
 } from '@/components/editor/projectDraftStore';
+import {
+  patchProjectToCloud,
+  ProjectRevisionConflictError,
+  pushProjectToCloud,
+} from '@/components/editor/useProjectCloudSync';
 import store from '@/store';
 import { applyCollabDocument, applyCollabScenePatch, EMPTY_ID_LIST } from '@/store/modules/editor';
 import { getToken } from '@/utils/token';
@@ -39,6 +44,7 @@ import {
   bindCollabUndoManager,
   clearCollabUndoStack,
   setCollabActive,
+  setCollabCloudPersistOwned,
   setCollabViewOnly,
 } from './collabRuntime';
 import type { CollabPeer, CollabRole, CollabStatus } from './collabTypes';
@@ -97,7 +103,7 @@ const PERSIST_DEBOUNCE_MS = 2000;
 const PEER_COLORS = ['#E4572E', '#29335C', '#F3A712', '#A8C256', '#669BBC', '#6A4C93'];
 const CAMERA_AWARENESS_MS = 80;
 
-/** Debounced cloud PUT of the collab Y scene (owner/editor only). */
+/** Debounced cloud persist of the collab Y scene (owner/editor only) — PATCH when possible. */
 async function persistCloudSnapshot(opts: {
   id: string;
   name: string;
@@ -109,30 +115,49 @@ async function persistCloudSnapshot(opts: {
     draft?.cloudRevision != null && Number(draft.cloudRevision) >= 1
       ? Number(draft.cloudRevision)
       : null;
+  const baseDoc = draft?.baseDocument ?? null;
   const contentHash = hashDocument(scene);
+  const delta =
+    baseDoc && baseRevision != null ? buildProjectDocumentPatch(baseDoc, scene) : null;
+
   try {
-    const res = await upsertProjectApi({
-      id,
-      name,
-      document: scene,
-      ...(baseRevision != null ? { baseRevision } : {}),
-    });
-    const revision = Number(res?.project?.revision);
-    await markProjectDraftSynced(
-      id,
-      contentHash,
-      Number.isFinite(revision) && revision >= 1 ? revision : null
-    );
+    let acked: { revision: number } | undefined;
+    if (delta && !delta.preferFull && baseRevision != null) {
+      try {
+        acked = await patchProjectToCloud({
+          id,
+          name,
+          baseRevision,
+          patch: delta.patch,
+        });
+      } catch (err) {
+        if (err instanceof ProjectRevisionConflictError) throw err;
+        acked = await pushProjectToCloud({
+          id,
+          name,
+          document: scene,
+          baseRevision,
+        });
+      }
+    } else {
+      acked = await pushProjectToCloud({
+        id,
+        name,
+        document: scene,
+        baseRevision,
+      });
+    }
+    await markProjectDraftSynced(id, contentHash, acked?.revision ?? null);
   } catch {
     // Revision conflict / flake — last-writer full PUT without If-Match.
     try {
-      const res = await upsertProjectApi({ id, name, document: scene });
-      const revision = Number(res?.project?.revision);
-      await markProjectDraftSynced(
+      const acked = await pushProjectToCloud({
         id,
-        contentHash,
-        Number.isFinite(revision) && revision >= 1 ? revision : null
-      );
+        name,
+        document: scene,
+        baseRevision: null,
+      });
+      await markProjectDraftSynced(id, contentHash, acked?.revision ?? null);
     } catch {
       /* keep local Y truth; retry on next edit */
     }
@@ -575,6 +600,7 @@ export function CollabRoomProvider({
   useEffect(() => {
     if (!enabled || !currentId || !user?.id || !getToken()) {
       setCollabActive(false);
+      setCollabCloudPersistOwned(false);
       setStatus('idle');
       setRole(null);
       setPeers([]);
@@ -589,6 +615,11 @@ export function CollabRoomProvider({
     setStatus('connecting');
     setError(null);
     setCollabActive(true);
+    setCollabCloudPersistOwned(false);
+
+    const refreshCloudPersistOwned = () => {
+      setCollabCloudPersistOwned(roleRef.current === 'edit' && seededRef.current);
+    };
 
     // Track only local scene writes — seed / remote / undo replay stay out of the stack.
     const undoManager = new Y.UndoManager(
@@ -740,6 +771,7 @@ export function CollabRoomProvider({
         setRole(tokenRes.role);
         roleRef.current = tokenRes.role;
         setCollabViewOnly(tokenRes.role === 'view');
+        refreshCloudPersistOwned();
 
         // Local offline replica (same room id as WS). Meshable with WebsocketProvider.
         const persistence = new IndexeddbPersistence(tokenRes.roomId, ydoc);
@@ -751,6 +783,7 @@ export function CollabRoomProvider({
         if (!isYDocEmpty(ydoc)) {
           hydrateFromY();
           seededRef.current = true;
+          refreshCloudPersistOwned();
         }
 
         const awareness = new Awareness(ydoc);
@@ -784,8 +817,12 @@ export function CollabRoomProvider({
         provider.on('sync', (isSynced: boolean) => {
           if (cancelled || !isSynced) return;
           setStatus('synced');
-          if (seededRef.current) return;
+          if (seededRef.current) {
+            refreshCloudPersistOwned();
+            return;
+          }
           seededRef.current = true;
+          refreshCloudPersistOwned();
           resolveInitialRoomContent(awareness);
         });
       } catch (err) {
@@ -794,6 +831,7 @@ export function CollabRoomProvider({
         setStatus('error');
         setError(err instanceof Error ? err.message : 'collab_connect_failed');
         setCollabActive(false);
+        setCollabCloudPersistOwned(false);
       }
     };
 

--- a/apps/web/src/components/editor/collab/collabRuntime.ts
+++ b/apps/web/src/components/editor/collab/collabRuntime.ts
@@ -6,6 +6,8 @@
 import type * as Y from 'yjs';
 
 let active = false;
+/** True when Y room is seeded and this client may debounce-PUT the project doc. */
+let cloudPersistOwned = false;
 let viewOnly = false;
 let undoManager: Y.UndoManager | null = null;
 let undoEpoch = 0;
@@ -38,6 +40,7 @@ function bumpUndoListeners() {
 export function setCollabActive(next: boolean) {
   active = Boolean(next);
   if (!active) {
+    cloudPersistOwned = false;
     bindCollabUndoManager(null);
     setCollabViewOnly(false);
   }
@@ -45,6 +48,19 @@ export function setCollabActive(next: boolean) {
 
 export function isCollabActive() {
   return active;
+}
+
+/**
+ * When true, CollabRoomProvider owns cloud document writes — useProjectCloudSync
+ * must not also PATCH/PUT the scene (cover-only is still ok).
+ * False while connecting / seed pending / view-only / connect failed.
+ */
+export function setCollabCloudPersistOwned(next: boolean) {
+  cloudPersistOwned = Boolean(next) && active;
+}
+
+export function isCollabCloudPersistOwned() {
+  return Boolean(active && cloudPersistOwned);
 }
 
 export function setCollabViewOnly(next: boolean) {

--- a/apps/web/src/components/editor/projectDraftStore.ts
+++ b/apps/web/src/components/editor/projectDraftStore.ts
@@ -165,6 +165,8 @@ export function buildProjectDocumentPatch(
     if (id === 'ROOT') continue;
     const a = baseDelta[id];
     const c = nextDelta[id];
+    // Same Immer ref ⇒ unchanged (skip stringify).
+    if (a === c) continue;
     if (a === undefined || stableJson(a) !== stableJson(c)) {
       upsertNodes[id] = c;
     }
@@ -248,9 +250,9 @@ export async function putProjectDraft(input: {
 
   try {
     const db = await openDb();
-    const prev = (await idbReq(
-      db.transaction(STORE_DRAFTS, 'readonly').objectStore(STORE_DRAFTS).get(persistenceKey)
-    )) as ProjectDraftRecord | undefined;
+    const tx = db.transaction(STORE_DRAFTS, 'readwrite');
+    const store = tx.objectStore(STORE_DRAFTS);
+    const prev = (await idbReq(store.get(persistenceKey))) as ProjectDraftRecord | undefined;
 
     let syncedAt: number | null =
       input.syncedAt !== undefined ? input.syncedAt : null;
@@ -299,9 +301,7 @@ export async function putProjectDraft(input: {
       baseDocument: baseDocument ?? null,
     };
 
-    await idbReq(
-      db.transaction(STORE_DRAFTS, 'readwrite').objectStore(STORE_DRAFTS).put(record)
-    );
+    await idbReq(store.put(record));
     db.close();
     return record;
   } catch {
@@ -334,35 +334,32 @@ export async function markProjectDraftSynced(
   contentHash: string,
   cloudRevision?: number | null
 ): Promise<void> {
-  const draft = await getProjectDraft(projectId);
-  if (!draft || draft.contentHash !== contentHash) return;
-  await putProjectDraft({
-    projectId: draft.projectId,
-    name: draft.name,
-    document: draft.document,
-    updatedAt: draft.updatedAt,
-    syncedAt: Date.now(),
-    cloudRevision:
-      cloudRevision !== undefined ? cloudRevision : draft.cloudRevision ?? null,
-    // After ACK, live document is the new diff base.
-    baseDocument: draft.document,
-  });
-}
-
-export async function setProjectDraftCloudRevision(
-  projectId: string,
-  cloudRevision: number | null
-): Promise<void> {
-  const draft = await getProjectDraft(projectId);
-  if (!draft) return;
-  await putProjectDraft({
-    projectId: draft.projectId,
-    name: draft.name,
-    document: draft.document,
-    updatedAt: draft.updatedAt,
-    syncedAt: draft.syncedAt,
-    cloudRevision,
-  });
+  const id = String(projectId || '').trim();
+  if (!id || !contentHash) return;
+  try {
+    const db = await openDb();
+    const tx = db.transaction(STORE_DRAFTS, 'readwrite');
+    const store = tx.objectStore(STORE_DRAFTS);
+    const draft = (await idbReq(
+      store.get(projectPersistenceKey(id))
+    )) as ProjectDraftRecord | undefined;
+    if (!draft || draft.contentHash !== contentHash) {
+      db.close();
+      return;
+    }
+    const record: ProjectDraftRecord = {
+      ...draft,
+      syncedAt: Date.now(),
+      cloudRevision:
+        cloudRevision !== undefined ? cloudRevision : draft.cloudRevision ?? null,
+      // After ACK, live document is the new diff base.
+      baseDocument: draft.document,
+    };
+    await idbReq(store.put(record));
+    db.close();
+  } catch {
+    /* ignore */
+  }
 }
 
 export async function deleteProjectDraft(projectId: string): Promise<void> {
@@ -384,9 +381,7 @@ export async function deleteProjectDraft(projectId: string): Promise<void> {
 }
 
 export async function deleteProjectDrafts(projectIds: string[]): Promise<void> {
-  for (const id of projectIds) {
-    await deleteProjectDraft(id);
-  }
+  await Promise.all(projectIds.map((id) => deleteProjectDraft(id)));
 }
 
 /** Wipe every local draft + editor session (logout). */

--- a/apps/web/src/components/editor/useProjectCloudSync.ts
+++ b/apps/web/src/components/editor/useProjectCloudSync.ts
@@ -1,7 +1,7 @@
 /**
- * Debounced project sync: IndexedDB draft then PATCH (node delta) or PUT (full doc).
- * Local draft survives refresh / flaky network; cloud remains source of truth when newer.
- * Camera / selection live in a separate local session store — never uploaded.
+ * Debounced project sync: IndexedDB draft → incremental PATCH (or PUT) for document.
+ * Cover tiles rebuild only on force leave / first save — existing thumbnailUrl is reused
+ * so edits do not re-fetch scene PNGs or re-upload COS thumbs every debounce.
  */
 
 import { useCallback, useEffect, useRef } from 'react';
@@ -34,7 +34,7 @@ import {
   markProjectDraftSynced,
   putProjectDraft,
 } from '@/components/editor/projectDraftStore';
-import { isCollabActive } from '@/components/editor/collab/collabRuntime';
+import { isCollabCloudPersistOwned } from '@/components/editor/collab/collabRuntime';
 
 const DEBOUNCE_MS = 800;
 /** Coalesce rapid Ctrl/⌘+S into one flush. */
@@ -119,14 +119,16 @@ function thumbPayloadFromTiles(tiles: {
   dataUrls?: string[];
   urls?: string[];
 }): ThumbUpload {
+  // Up to 4 tiles in one projects request (not separate cover PATCHes).
   if (tiles.urls?.length) return { thumbnailUrls: tiles.urls.slice(0, 4) };
-  if (tiles.dataUrls?.length) {
-    const dataUrls = tiles.dataUrls.slice(0, 4);
-    return dataUrls.length === 1
-      ? { thumbnailDataUrl: dataUrls[0], thumbnailDataUrls: dataUrls }
-      : { thumbnailDataUrls: dataUrls };
-  }
-  return {};
+  const dataUrls = (tiles.dataUrls || [])
+    .map((u) => String(u || '').trim())
+    .filter((u) => u.startsWith('data:image/'))
+    .slice(0, 4);
+  if (!dataUrls.length) return {};
+  return dataUrls.length === 1
+    ? { thumbnailDataUrl: dataUrls[0], thumbnailDataUrls: dataUrls }
+    : { thumbnailDataUrls: dataUrls };
 }
 
 function applyThumbUpload(
@@ -142,6 +144,69 @@ function ackThumbnail(url: string | string[] | null | undefined, version?: numbe
   const list = normalizeProjectThumbnailUrls(url, version);
   if (!list.length) return null;
   return list.length === 1 ? list[0] : list;
+}
+
+async function buildSyncCoverThumb(
+  document: unknown,
+  dispatch: ReturnType<typeof useDispatch>,
+  projectId: string
+): Promise<ThumbUpload> {
+  try {
+    const tiles = await buildProjectCoverTiles(document);
+    const thumb = thumbPayloadFromTiles(tiles);
+    const localPreview =
+      tiles.urls?.length ? tiles.urls : tiles.dataUrls?.length ? tiles.dataUrls : null;
+    if (import.meta.env.DEV) {
+      console.info('[project-sync] cover tiles', {
+        id: projectId,
+        urls: tiles.urls?.length || 0,
+        dataUrls: tiles.dataUrls?.length || 0,
+      });
+    }
+    if (localPreview) {
+      dispatch(
+        setTemplateThumbnail({
+          id: projectId,
+          thumbnail: localPreview.length === 1 ? localPreview[0] : localPreview,
+          custom: false,
+        })
+      );
+    }
+    return thumb;
+  } catch (err) {
+    if (import.meta.env.DEV) console.warn('[project-sync] cover tiles failed', err);
+    return {};
+  }
+}
+
+/** Prefer already-hosted cover URLs — skip raster + scene image fetches. */
+function existingCoverThumb(template: { thumbnail?: unknown } | null | undefined): ThumbUpload {
+  const urls = normalizeProjectThumbnailUrls(template?.thumbnail as string | string[] | null);
+  return urls.length ? { thumbnailUrls: urls.slice(0, 4) } : {};
+}
+
+/**
+ * Rebuild covers only when forced (leave / Ctrl+S force) or the project has no cover yet.
+ * Incremental edits keep server thumbnailUrl as-is (omit thumb payload).
+ */
+async function resolveSyncCoverThumb(opts: {
+  force: boolean;
+  document: unknown;
+  template: { thumbnail?: unknown } | null | undefined;
+  dispatch: ReturnType<typeof useDispatch>;
+  projectId: string;
+}): Promise<ThumbUpload> {
+  const existing = existingCoverThumb(opts.template);
+  if (!opts.force && existing.thumbnailUrls?.length) {
+    if (import.meta.env.DEV) {
+      console.info('[project-sync] reuse thumbnailUrl', {
+        id: opts.projectId,
+        n: existing.thumbnailUrls.length,
+      });
+    }
+    return {};
+  }
+  return buildSyncCoverThumb(opts.document, opts.dispatch, opts.projectId);
 }
 
 /** Push one owned project to the API (no-op when logged out). */
@@ -274,10 +339,12 @@ export async function removeProjectsFromCloud(ids: string[]): Promise<void> {
 /** Ask the open editor to flush the project to the cloud immediately. */
 export function requestProjectFlush() {
   try {
+    // Clears debounce timers when useProjectCloudSync is mounted.
     window.dispatchEvent(new CustomEvent(FLUSH_NOW_EVENT));
   } catch {
     /* ignore */
   }
+  // Single flush — event only clears timers (does not enqueue a second flush).
   void flushCurrentProjectNow();
 }
 
@@ -316,7 +383,7 @@ export async function renameProjectOnCloud(id: string, name: string): Promise<vo
       });
       await markProjectDraftSynced(
         projectId,
-        hashDocument(draft.document),
+        draft.contentHash,
         acked?.revision ?? rev
       );
       return;
@@ -402,9 +469,8 @@ export function useProjectCloudSync() {
   const flushingRef = useRef(false);
   /** Delete/edit while a flush is in-flight — run again after current finishes. */
   const pendingFlushRef = useRef(false);
-  const flushRef = useRef<(opts?: FlushProjectOptions) => Promise<void>>(async () => {});
-  const latestRef = useRef({ document, currentId, template, dirty });
-  latestRef.current = { document, currentId, template, dirty };
+  const dirtyRef = useRef(dirty);
+  dirtyRef.current = dirty;
 
   const scheduleFlush = useCallback((delayMs: number) => {
     if (timerRef.current) clearTimeout(timerRef.current);
@@ -415,8 +481,7 @@ export function useProjectCloudSync() {
   }, []);
 
   const flush = useCallback(async (opts?: FlushProjectOptions) => {
-    // Read Redux directly — requestProjectFlush may fire before this hook re-renders,
-    // so latestRef can still hold the pre-delete document.
+    // Read Redux directly — requestProjectFlush may fire before this hook re-renders.
     const force = Boolean(opts?.force);
     const ed = store.getState().editor as {
       dirty: boolean;
@@ -443,9 +508,9 @@ export function useProjectCloudSync() {
       dispatch(persistCurrent({ keepDirty: true }));
       const pushedDoc = (store.getState().editor as { document: unknown }).document;
       const name = String(tpl.name || 'Untitled');
-      const contentHash = hashDocument(pushedDoc);
 
       // 1) Local persistenceKey draft first (durable before cloud).
+      // putProjectDraft hashes once — reuse draft.contentHash (do not stringify again).
       const draft = await putProjectDraft({
         projectId: id,
         name,
@@ -455,6 +520,7 @@ export function useProjectCloudSync() {
         keepCloudRevision: true,
         keepBaseDocument: true,
       });
+      const contentHash = draft?.contentHash || hashDocument(pushedDoc);
 
       // Skip cloud when content + name already ACKed — unless leave-force.
       if (
@@ -468,51 +534,29 @@ export function useProjectCloudSync() {
         return;
       }
 
-      // Data changed → rebuild cover, then persist (local / thumb-only / full).
-      let thumb: ThumbUpload = {};
-      try {
-        const tiles = await buildProjectCoverTiles(pushedDoc);
-        thumb = thumbPayloadFromTiles(tiles);
-        const localPreview =
-          tiles.urls?.length
-            ? tiles.urls
-            : tiles.dataUrls?.length
-              ? tiles.dataUrls
-              : null;
-        if (import.meta.env.DEV) {
-          console.info('[project-sync] cover tiles', {
-            id,
-            urls: tiles.urls?.length || 0,
-            dataUrls: tiles.dataUrls?.length || 0,
-          });
-        }
-        if (localPreview) {
-          dispatch(
-            setTemplateThumbnail({
-              id,
-              thumbnail: localPreview.length === 1 ? localPreview[0] : localPreview,
-              custom: false,
-            })
-          );
-        }
-      } catch (err) {
-        if (import.meta.env.DEV) console.warn('[project-sync] cover tiles failed', err);
-        /* thumb is best-effort — still upload the document */
-      }
+      // Cover: reuse stored thumbnailUrl on normal debounce; rebuild ≤4 only on force / first save.
+      const thumb = await resolveSyncCoverThumb({
+        force,
+        document: pushedDoc,
+        template: tpl,
+        dispatch,
+        projectId: id,
+      });
 
-      // Logged out: local draft + in-memory cover is enough.
+      // Logged out: local draft (+ optional in-memory cover on first/force) is enough.
       if (!getToken()) {
         const after = store.getState().editor as { document: unknown };
         if (after.document === pushedDoc) dispatch(clearEditorDirty());
         return;
       }
 
-      // Live Yjs owns document writes — still push cover (thumbnail-only PATCH).
-      if (isCollabActive() && !force) {
-        const baseRevision =
-          draft?.cloudRevision != null && Number(draft.cloudRevision) >= 1
-            ? Number(draft.cloudRevision)
-            : null;
+      const baseRevision =
+        draft?.cloudRevision != null && Number(draft.cloudRevision) >= 1
+          ? Number(draft.cloudRevision)
+          : null;
+
+      // Y room owns cloud document writes only after seed + edit role.
+      if (isCollabCloudPersistOwned() && !force) {
         if (baseRevision != null && (thumb.thumbnailDataUrls || thumb.thumbnailDataUrl || thumb.thumbnailUrls)) {
           try {
             const acked = await patchProjectToCloud({
@@ -543,10 +587,6 @@ export function useProjectCloudSync() {
         return;
       }
 
-      const baseRevision =
-        draft?.cloudRevision != null && Number(draft.cloudRevision) >= 1
-          ? Number(draft.cloudRevision)
-          : null;
       const baseDoc = draft?.baseDocument ?? null;
       const delta =
         baseDoc && baseRevision != null
@@ -558,7 +598,6 @@ export function useProjectCloudSync() {
           | { revision: number; thumbnailUrl?: string | string[] | null }
           | undefined;
         if (delta && !delta.preferFull && baseRevision != null) {
-          // 2a) Incremental node PATCH when the delta is small enough.
           try {
             acked = await patchProjectToCloud({
               id,
@@ -568,7 +607,6 @@ export function useProjectCloudSync() {
               thumb,
             });
           } catch (err) {
-            // Revision conflict must surface; any other patch failure → full PUT.
             if (err instanceof ProjectRevisionConflictError) throw err;
             acked = await pushProjectToCloud({
               id,
@@ -579,7 +617,6 @@ export function useProjectCloudSync() {
             });
           }
         } else {
-          // 2b) Full-document PUT (create, large delta, missing base, or untracked fields).
           acked = await pushProjectToCloud({
             id,
             name,
@@ -589,7 +626,6 @@ export function useProjectCloudSync() {
           });
         }
         const nextThumb = ackThumbnail(acked?.thumbnailUrl, acked?.revision ?? Date.now());
-        // Always mirror server cover URL into the card (source of truth after ACK).
         if (nextThumb) {
           dispatch(
             setTemplateThumbnail({
@@ -600,15 +636,12 @@ export function useProjectCloudSync() {
           );
         }
         await markProjectDraftSynced(id, contentHash, acked?.revision ?? null);
-        // Another edit landed while uploading — leave dirty so the next flush runs.
         const after = store.getState().editor as { document: unknown };
         if (after.document === pushedDoc) {
           dispatch(clearEditorDirty());
         }
       } catch (err) {
         if (err instanceof ProjectRevisionConflictError) {
-          // If our unsynced local draft is newer than the conflicting cloud row,
-          // force a full PUT (no If-Match) instead of adopting and wiping edits.
           const local = await getProjectDraft(id).catch(() => null);
           const localNewer =
             Boolean(local?.document) &&
@@ -662,7 +695,6 @@ export function useProjectCloudSync() {
     }
   }, [dispatch, scheduleFlush]);
 
-  flushRef.current = flush;
   flushRunner = flush;
 
   useEffect(() => {
@@ -675,18 +707,17 @@ export function useProjectCloudSync() {
     };
   }, [dirty, document, currentId, template, scheduleFlush]);
 
-  // Immediate flush after delete / other structural edits.
+  // Clear debounce timers only — requestProjectFlush owns the single flush enqueue.
   useEffect(() => {
     const onFlushNow = () => {
       if (timerRef.current) clearTimeout(timerRef.current);
       timerRef.current = null;
       if (manualSaveTimerRef.current) clearTimeout(manualSaveTimerRef.current);
       manualSaveTimerRef.current = null;
-      void flushCurrentProjectNow();
     };
     window.addEventListener(FLUSH_NOW_EVENT, onFlushNow);
     return () => window.removeEventListener(FLUSH_NOW_EVENT, onFlushNow);
-  }, [flush]);
+  }, []);
 
   // Ctrl/⌘+S — manual save (debounced so key-repeat / rapid presses don't spam).
   useEffect(() => {
@@ -713,7 +744,7 @@ export function useProjectCloudSync() {
   // Flush when tab hides (if dirty); unmount always force-saves doc + cover.
   useEffect(() => {
     const onHide = () => {
-      if (!latestRef.current.dirty) return;
+      if (!dirtyRef.current) return;
       void flushCurrentProjectNow();
     };
     const onVisibility = () => {
@@ -726,5 +757,5 @@ export function useProjectCloudSync() {
       window.document.removeEventListener('visibilitychange', onVisibility);
       void flushCurrentProjectNow({ force: true });
     };
-  }, [flush]);
+  }, []);
 }

--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -26,6 +26,9 @@ import {
   snapResizeToSmartGuides,
   smartSnapThreshold,
   collectSmartGuidesAt,
+  collectPairSpacingGuides,
+  GUIDE_COINCIDE_EPS,
+  SMART_GUIDE_COLOR,
   type SceneBox,
   type SmartGuideLine,
 } from './alignGuides';
@@ -539,6 +542,8 @@ type DragState = {
   currentClientX: number;
   currentClientY: number;
   currentShift?: boolean;
+  /** Last move-snap guide `at` values — hysteresis across pointer frames. */
+  stickySnapAt?: { x?: number; y?: number };
 };
 
 /** Shared seed for blank / pointing_canvas / move / resize / rotate drags. */
@@ -745,6 +750,7 @@ type MoveSnapContext = {
   gridSize: number;
   targets: SceneBox[];
   threshold: number;
+  stickyAt?: { x?: number; y?: number } | null;
 };
 
 /**
@@ -779,6 +785,7 @@ function computeMovedUnion(ctx: MoveSnapContext): {
   sdx: number;
   sdy: number;
   guides: SmartGuideLine[];
+  stickyAt: { x?: number; y?: number };
 } {
   // Snap **painted outer ink** in 1px steps, then apply the same delta to path.
   // Never fall back to path/chrome as "visual" — that reintroduces half-cell drift.
@@ -794,6 +801,7 @@ function computeMovedUnion(ctx: MoveSnapContext): {
       sdx: ctx.dx,
       sdy: ctx.dy,
       guides: [],
+      stickyAt: {},
     };
   }
   let nextVisual = {
@@ -802,28 +810,29 @@ function computeMovedUnion(ctx: MoveSnapContext): {
     top: visualUnion.top + ctx.dy,
   };
   let guides: SmartGuideLine[] = [];
+  let stickyAt: { x?: number; y?: number } = {};
   if (!ctx.disableSnap) {
-    // Smart align (capped screen feel) then pin ink to the pixel grid.
-    // Old "guides display-only" path hid align lines whenever near-snap would
-    // have moved the box — low zoom only showed gap numbers, no orange lines.
+    // Grid first so smart only chooses among lattice positions, then pin again.
+    if (ctx.gridSize > 0) {
+      nextVisual = snapBoxToGrid(nextVisual, ctx.gridSize);
+    }
     if (ctx.threshold > 0 && ctx.targets.length) {
       const smart = snapMoveToSmartGuides({
         box: nextVisual,
         targets: ctx.targets,
         threshold: ctx.threshold,
         gridSize: ctx.gridSize > 0 ? ctx.gridSize : 0,
+        stickyAt: ctx.stickyAt,
       });
       nextVisual = smart.box;
+      stickyAt = smart.stickyAt;
     }
     if (ctx.gridSize > 0) {
       nextVisual = snapBoxToGrid(nextVisual, ctx.gridSize);
     }
-    // Paint from the settled box: gaps always; align strokes when edges match.
-    guides = collectSmartGuidesAt(
-      nextVisual,
-      ctx.targets,
-      Math.max(0.51, ctx.threshold)
-    );
+    // Paint only when edges truly coincide — never use snap threshold as paint
+    // eps (at 31% zoom that painted "aligned" across ~25 scene cells and felt blocked).
+    guides = collectSmartGuidesAt(nextVisual, ctx.targets, GUIDE_COINCIDE_EPS);
   }
   const sdx = nextVisual.left - visualUnion.left;
   const sdy = nextVisual.top - visualUnion.top;
@@ -853,6 +862,7 @@ function computeMovedUnion(ctx: MoveSnapContext): {
     sdx,
     sdy,
     guides,
+    stickyAt,
   };
 }
 
@@ -915,7 +925,7 @@ function computeResizedUnion(ctx: ResizeSnapContext): {
         width: Math.max(1, visualNext.width - outset * 2),
         height: Math.max(1, visualNext.height - outset * 2),
       };
-      guides = collectSmartGuidesAt(visualNext, ctx.targets, Math.max(0.51, ctx.threshold));
+      guides = collectSmartGuidesAt(visualNext, ctx.targets, GUIDE_COINCIDE_EPS);
       next = inflateSelectionBox(pathNext, singleNode);
     } else {
       if (ctx.threshold > 0 && ctx.targets.length) {
@@ -934,7 +944,7 @@ function computeResizedUnion(ctx: ResizeSnapContext): {
           aspectRatio: ctx.drag.aspectRatio,
         });
       }
-      guides = collectSmartGuidesAt(next, ctx.targets, Math.max(0.51, ctx.threshold));
+      guides = collectSmartGuidesAt(next, ctx.targets, GUIDE_COINCIDE_EPS);
     }
   }
   next = {
@@ -1104,8 +1114,8 @@ function resolveChromeAngle(opts: {
   return fromDoc;
 }
 
-/** Inspect spacing pair: hover first, then sticky pair node. */
-function resolveInspectPairNodeId(opts: {
+/** Share / Dev inspect spacing pair: live hover first, then sticky prior selection. */
+function resolveMeasurePairNodeId(opts: {
   inspectDev: boolean;
   transforming: boolean;
   hoverNodeId: string | null;
@@ -1113,24 +1123,44 @@ function resolveInspectPairNodeId(opts: {
   inspectPrimaryId: string | null;
   selectedNodeIds: string[];
 }): string | null {
-  if (!opts.inspectDev || opts.transforming) return null;
+  // Design edit: no preview-style select↔hover measure / orange pair chrome.
+  if (!opts.inspectDev || opts.transforming || !opts.inspectPrimaryId) return null;
   if (
     opts.hoverNodeId &&
     opts.hoverNodeId !== opts.inspectPrimaryId &&
-    !opts.selectedNodeIds.includes(opts.hoverNodeId) &&
-    !parseFrameSelId(opts.hoverNodeId)
+    !opts.selectedNodeIds.includes(opts.hoverNodeId)
   ) {
     return opts.hoverNodeId;
   }
   if (
     opts.inspectPairNodeId &&
     opts.inspectPairNodeId !== opts.inspectPrimaryId &&
-    !opts.selectedNodeIds.includes(opts.inspectPairNodeId) &&
-    !parseFrameSelId(opts.inspectPairNodeId)
+    !opts.selectedNodeIds.includes(opts.inspectPairNodeId)
   ) {
     return opts.inspectPairNodeId;
   }
   return null;
+}
+
+/** Resolve node or `__frame__:` synthetic id to a scene AABB. */
+function resolveMeasureBox(
+  selId: string | null | undefined,
+  document: any,
+  getNodeBox: (id: string) => SceneBox | null
+): SceneBox | null {
+  if (!selId) return null;
+  const frameId = parseFrameSelId(selId);
+  if (frameId) {
+    const frames = Array.isArray(document?.frames) ? document.frames : [];
+    const frame = frames.find((f: any) => f && String(f.id) === String(frameId));
+    if (!frame) return null;
+    const left = Number(frame.x) || 0;
+    const top = Number(frame.y) || 0;
+    const width = Math.max(1, Number(frame.width) || 1);
+    const height = Math.max(1, Number(frame.height) || 1);
+    return { left, top, width, height };
+  }
+  return getNodeBox(selId);
 }
 
 function deflateChromeBox(chrome: SceneBox | null | undefined, node: any): SceneBox | null {
@@ -1214,7 +1244,7 @@ function buildShapeOutlines(opts: {
     ids.push(id);
   };
 
-  const inspectPairId = resolveInspectPairNodeId({
+  const measurePairId = resolveMeasurePairNodeId({
     inspectDev: opts.inspectDev,
     transforming: opts.transforming,
     hoverNodeId: opts.hoverNodeId,
@@ -1223,17 +1253,20 @@ function buildShapeOutlines(opts: {
     selectedNodeIds: opts.selectedNodeIds,
   });
 
-  // Hover path silhouette — edit + inspect (same algorithm).
-  if (!opts.transforming && opts.hoverNodeId && !opts.selectedNodeIds.includes(opts.hoverNodeId)) {
+  // Inspect measure-pair silhouette (orange + spacing).
+  if (!opts.transforming && measurePairId) {
+    pushId(measurePairId);
+  } else if (
+    // Edit: light blue hover outline only — no spacing pair chrome.
+    !opts.inspectDev &&
+    !opts.transforming &&
+    opts.hoverNodeId &&
+    !opts.selectedNodeIds.includes(opts.hoverNodeId)
+  ) {
     pushId(opts.hoverNodeId);
   }
 
-  // Inspect click-pair silhouette when not hovering.
-  if (opts.inspectDev && !opts.transforming && inspectPairId) {
-    pushId(inspectPairId);
-  }
-
-  // Inspect select: path silhouette only (spacing/size badges removed — reimplement later).
+  // Inspect select: path silhouette only (spacing drawn via SmartGuidesOverlay).
   if (
     opts.inspectDev &&
     !opts.transforming &&
@@ -1304,12 +1337,14 @@ function buildShapeOutlines(opts: {
       : nodeKey === 'video'
         ? 'horizontal'
         : 'all';
+    const isMeasurePair =
+      Boolean(measurePairId) && id === measurePairId && !opts.selectedNodeIds.includes(id);
     out.push({
       id,
       pathD,
       box: geomBox,
       angle,
-      color: '#3388ff',
+      color: isMeasurePair ? SMART_GUIDE_COLOR : '#3388ff',
       withHandles,
       // Selected with handles: control box only (no blue path silhouette).
       // Hover / inspect / generator (box via handles+edge none) still show path when no knobs path.
@@ -1562,7 +1597,7 @@ function SelectionFeature({
   );
   /** Radius panel keeps chrome (rounded outline) but hides floating toolbars. */
   const suppressToolbars = suppressChrome || shapeStylePanel?.kind === 'radius';
-  /** Share preview / Dev: no edit chrome (spacing annotations removed). */
+  /** Share preview / Dev: select↔hover spacing + orange pair chrome. */
   const inspectDev = workspaceMode === 'dev' || readOnly;
   const dragRef = useRef<DragState | null>(null);
   const liveUnionRef = useRef<SceneBox | null>(null);
@@ -2301,7 +2336,7 @@ function SelectionFeature({
         // Ignore pointer jitter until the pointer actually moves (protects dblclick).
         if (screenDistSq <= DRAG_DISTANCE_SQUARED) return;
         const exclude = new Set(drag.origins.map((o) => o.nodeId));
-        const { nextUnion, sdx, sdy, guides } = computeMovedUnion({
+        const { nextUnion, sdx, sdy, guides, stickyAt } = computeMovedUnion({
           union: drag.union,
           origins: drag.origins,
           document: sceneDoc,
@@ -2311,7 +2346,9 @@ function SelectionFeature({
           gridSize,
           targets: collectSmartGuideTargets(sceneDoc, listNodeIds, getNodeBox, exclude),
           threshold: smartSnapThreshold(zoom),
+          stickyAt: drag.stickySnapAt,
         });
+        drag.stickySnapAt = stickyAt;
         const nextOrigins = drag.origins.map((o) => ({
           nodeId: o.nodeId,
           box: { ...o.box, left: o.box.left + sdx, top: o.box.top + sdy },
@@ -2606,6 +2643,7 @@ function SelectionFeature({
           gridSize,
           targets: collectSmartGuideTargets(sceneDoc, listNodeIds, getNodeBox, exclude),
           threshold: smartSnapThreshold(zoom),
+          stickyAt: drag.stickySnapAt,
         });
         const patches = drag.origins.map((o) => ({
           nodeId: o.nodeId,
@@ -2865,8 +2903,42 @@ function SelectionFeature({
     liveAngle,
   });
 
-  /** Single node or single frame — both get size badge + hover spacing. */
+  /** Single node or single frame — inspect size badge + hover spacing. */
   const inspectPrimaryId = resolveInspectPrimaryId(selectedNodeIds, selectedFrameIds);
+
+  const measurePairId = resolveMeasurePairNodeId({
+    inspectDev,
+    transforming,
+    hoverNodeId,
+    inspectPairNodeId,
+    inspectPrimaryId,
+    selectedNodeIds,
+  });
+
+  const measurePrimaryBox = useMemo(
+    () => resolveMeasureBox(inspectPrimaryId, document, getNodeBox),
+    [inspectPrimaryId, document, getNodeBox]
+  );
+  const measurePairBox = useMemo(
+    () => resolveMeasureBox(measurePairId, document, getNodeBox),
+    [measurePairId, document, getNodeBox]
+  );
+
+  const idleMeasureGuides = useMemo(() => {
+    if (!inspectDev || transforming || !measurePrimaryBox || !measurePairBox) {
+      return [] as SmartGuideLine[];
+    }
+    return collectPairSpacingGuides(measurePrimaryBox, measurePairBox);
+  }, [inspectDev, transforming, measurePrimaryBox, measurePairBox]);
+
+  const displayGuides = transforming ? smartGuides : idleMeasureGuides;
+  // WxH under the box: inspect/preview only — edit already has the title size label.
+  const measureSizeBox =
+    inspectDev && inspectPrimaryId && !suppressChrome
+      ? transforming && liveUnion
+        ? liveUnion
+        : measurePrimaryBox
+      : null;
 
   const shapeOutlines = buildShapeOutlines({
     enabled,
@@ -2975,8 +3047,9 @@ function SelectionFeature({
       <ShapeOutlineSvg outlines={shapeOutlines} />
       <BrushOverlay box={marquee} />
       <SmartGuidesOverlay
-        guides={smartGuides}
+        guides={displayGuides}
         mirrorNodeId={liveOrigins?.[0]?.nodeId ?? selectedNodeIds[0] ?? null}
+        sizeBox={measureSizeBox}
       />
 
       {/* World SelectionChrome when idle — path single/multi use host-mirrored chrome. */}

--- a/apps/web/src/components/rcb/selection/__tests__/lowZoomSnap.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/lowZoomSnap.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   SMART_SNAP_PX,
-  SMART_SNAP_SCENE_MAX,
+  GUIDE_COINCIDE_EPS,
   smartSnapThreshold,
   snapMoveToSmartGuides,
   snapBoxToGrid,
@@ -17,10 +17,10 @@ import {
   radiusParkSceneForBox,
 } from '../SelectionChrome';
 
-/** Canvas zooms from floor → extreme (not a single repro %). */
-const CANVAS_ZOOMS = [0.05, 0.13, 0.25, 0.5, 0.8, 1, 2, 8, 20, 40, 80] as const;
+/** Canvas zooms from floor → extreme (includes user repro ~31%). */
+const CANVAS_ZOOMS = [0.05, 0.13, 0.25, 0.31, 0.5, 0.8, 1, 2, 8, 20, 40, 80] as const;
 
-/** Production move settle: smart (capped) → grid → paint guides. */
+/** Production move settle: grid → smart → grid → paint guides. */
 function settleMove(opts: {
   box: { left: number; top: number; width: number; height: number };
   targets: Array<{ left: number; top: number; width: number; height: number }>;
@@ -30,6 +30,7 @@ function settleMove(opts: {
   const gridSize = opts.gridSize ?? 1;
   const threshold = smartSnapThreshold(opts.zoom);
   let next = { ...opts.box };
+  if (gridSize > 0) next = snapBoxToGrid(next, gridSize);
   if (threshold > 0 && opts.targets.length) {
     next = snapMoveToSmartGuides({
       box: next,
@@ -39,22 +40,25 @@ function settleMove(opts: {
     }).box;
   }
   if (gridSize > 0) next = snapBoxToGrid(next, gridSize);
-  const guides = collectSmartGuidesAt(next, opts.targets, Math.max(0.51, threshold));
+  // Paint coincide only — never threshold (at 31% that painted ~25 cells as "aligned").
+  const guides = collectSmartGuidesAt(next, opts.targets, GUIDE_COINCIDE_EPS);
   return { box: next, guides, threshold };
 }
 
 describe('smartSnapThreshold @ all canvas zooms', () => {
-  it.each([...CANVAS_ZOOMS])('never exceeds scene cap at zoom %s', (zoom) => {
+  it.each([...CANVAS_ZOOMS])('is screen-constant (px/zoom) at zoom %s', (zoom) => {
     const threshold = smartSnapThreshold(zoom);
-    expect(threshold).toBeLessThanOrEqual(SMART_SNAP_SCENE_MAX + 1e-9);
-    expect(threshold).toBeCloseTo(Math.min(SMART_SNAP_PX / zoom, SMART_SNAP_SCENE_MAX), 6);
+    expect(threshold).toBeCloseTo(SMART_SNAP_PX / zoom, 6);
+    expect(threshold * zoom).toBeCloseTo(SMART_SNAP_PX, 6);
   });
 
   it.each([...CANVAS_ZOOMS])(
-    'does not yank across a 67-cell gap at zoom %s',
+    'does not yank across a gap beyond the screen-px magnet at zoom %s',
     (zoom) => {
       const left = { left: 0, top: 0, width: 120, height: 90 };
-      const gap = 67;
+      const threshold = smartSnapThreshold(zoom);
+      // Stay clearly outside the magnet in scene space.
+      const gap = threshold + 10;
       const right = {
         left: left.left + left.width + gap,
         top: 0,
@@ -62,25 +66,24 @@ describe('smartSnapThreshold @ all canvas zooms', () => {
         height: 90,
       };
       const nudged = { ...right, left: right.left - 2 };
-      const { box, threshold } = settleMove({ box: nudged, targets: [left], zoom });
-      // eslint-disable-next-line no-console
-      console.log('[test:smart-snap@zoom]', {
+      const { box } = settleMove({
+        box: nudged,
+        targets: [left],
         zoom,
-        threshold,
-        remainingGap: box.left - (left.left + left.width),
+        gridSize: 0,
       });
-      expect(box.left).toBe(nudged.left);
-      expect(box.left - (left.left + left.width)).toBe(gap - 2);
+      expect(box.left).toBeCloseTo(nudged.left, 9);
+      expect(box.left - (left.left + left.width)).toBeCloseTo(gap - 2, 9);
     }
   );
 
   it.each([...CANVAS_ZOOMS])(
-    'snaps flush when gap is within the capped threshold at zoom %s',
+    'snaps flush when gap is within the screen-px threshold at zoom %s',
     (zoom) => {
       const left = { left: 0, top: 0, width: 100, height: 80 };
       const threshold = smartSnapThreshold(zoom);
-      // Stay inside the magnet; at extreme zoom threshold can be < 1.
-      const gap = Math.min(threshold, Math.max(threshold * 0.5, 0.25));
+      // Stay strictly inside the magnet (avoid equality / float edge).
+      const gap = Math.max(1e-6, threshold * 0.5);
       const right = {
         left: left.left + left.width + gap,
         top: 0,
@@ -88,46 +91,81 @@ describe('smartSnapThreshold @ all canvas zooms', () => {
         height: 80,
       };
       const settled = settleMove({ box: right, targets: [left], zoom, gridSize: 0 });
-      // eslint-disable-next-line no-console
-      console.log('[test:smart-snap-flush@zoom]', {
-        zoom,
-        threshold,
-        gap,
-        nextGap: settled.box.left - (left.left + left.width),
-        alignCount: settled.guides.filter((g) => g.kind === 'align').length,
-      });
       expect(settled.box.left).toBeCloseTo(left.left + left.width, 6);
       expect(settled.guides.some((g) => g.kind === 'align' && g.axis === 'x')).toBe(true);
     }
   );
 
-  it.each([0.13, 0.25, 0.5, 1])(
+  it('at 5% zoom a 67-scene gap is still within ~8 screen px and snaps', () => {
+    const zoom = 0.05;
+    const left = { left: 0, top: 0, width: 120, height: 90 };
+    const gap = 67;
+    expect(gap * zoom).toBeLessThan(SMART_SNAP_PX);
+    const right = {
+      left: left.left + left.width + gap,
+      top: 0,
+      width: 120,
+      height: 90,
+    };
+    const settled = settleMove({ box: right, targets: [left], zoom, gridSize: 0 });
+    expect(settled.threshold).toBeCloseTo(SMART_SNAP_PX / zoom, 6);
+    expect(settled.box.left).toBeCloseTo(left.left + left.width, 6);
+  });
+
+  it.each([0.13, 0.25, 0.31, 0.5, 1])(
     'shows gap badge beside a sibling even when not edge-aligned at zoom %s',
     (zoom) => {
       const left = { left: 0, top: 0, width: 100, height: 80 };
       const right = { left: 140, top: 10, width: 100, height: 80 };
-      const { guides } = settleMove({ box: right, targets: [left], zoom });
+      // Paint-only — do not settle/snap first (low zoom would close the 40 gap).
+      const guides = collectSmartGuidesAt(right, [left], GUIDE_COINCIDE_EPS);
       const gaps = guides.filter((g) => g.kind === 'gap');
-      // eslint-disable-next-line no-console
-      console.log('[test:gap-badge@zoom]', { zoom, gaps });
       expect(gaps.length).toBeGreaterThan(0);
       expect(gaps.some((g) => g.kind === 'gap' && g.dist === 40)).toBe(true);
+      // Must not paint false align strokes for a 40-scene gap.
+      expect(guides.some((g) => g.kind === 'align')).toBe(false);
     }
   );
+
+  it('at 31% zoom does not paint distant edges as aligned (old threshold-as-eps)', () => {
+    const zoom = 0.31;
+    const threshold = smartSnapThreshold(zoom);
+    // ~25.8 scene units — old paint used this as coincide and looked "stuck".
+    expect(threshold).toBeGreaterThan(20);
+    const left = { left: 0, top: 0, width: 100, height: 80 };
+    const gap = 10;
+    // Offset Y so tops/mids/bottoms do not coincide — only the false X paint matters.
+    const right = {
+      left: left.left + left.width + gap,
+      top: 6,
+      width: 100,
+      height: 80,
+    };
+
+    const paintOnly = collectSmartGuidesAt(right, [left], GUIDE_COINCIDE_EPS);
+    expect(paintOnly.some((g) => g.kind === 'align')).toBe(false);
+    expect(paintOnly.some((g) => g.kind === 'gap' && g.dist === gap)).toBe(true);
+
+    // Wrong paint (threshold as eps) would falsely claim X alignment:
+    const falsePaint = collectSmartGuidesAt(right, [left], Math.max(0.51, threshold));
+    expect(falsePaint.some((g) => g.kind === 'align' && g.axis === 'x')).toBe(true);
+
+    // Settle still snaps flush within the screen-px magnet, then paints real align.
+    const settled = settleMove({
+      box: { ...right, top: 0 },
+      targets: [left],
+      zoom,
+      gridSize: 0,
+    });
+    expect(settled.box.left).toBeCloseTo(left.left + left.width, 6);
+    expect(settled.guides.some((g) => g.kind === 'align' && g.axis === 'x')).toBe(true);
+  });
 
   it('near-align probe must not clear guides (old stillAligned bug)', () => {
     const left = { left: 0, top: 0, width: 100, height: 80 };
     const right = { left: 100.3, top: 0, width: 100, height: 80 };
     const guides = collectSmartGuidesAt(snapBoxToGrid(right, 1), [left], 8);
     expect(guides.some((g) => g.kind === 'gap' || g.kind === 'align')).toBe(true);
-  });
-
-  it('uses full screen-px feel when 5/zoom is under the scene cap', () => {
-    const edge = SMART_SNAP_PX / SMART_SNAP_SCENE_MAX;
-    expect(smartSnapThreshold(edge)).toBeCloseTo(SMART_SNAP_SCENE_MAX, 6);
-    expect(smartSnapThreshold(1)).toBe(SMART_SNAP_PX);
-    expect(smartSnapThreshold(2)).toBeCloseTo(SMART_SNAP_PX / 2, 6);
-    expect(smartSnapThreshold(40)).toBeCloseTo(SMART_SNAP_PX / 40, 6);
   });
 });
 
@@ -141,7 +179,6 @@ describe('radius park + chrome hits @ all canvas zooms', () => {
       const half = Math.min(box.w, box.h) / 2;
       expect(park).toBeGreaterThanOrEqual(0);
       expect(park).toBeLessThanOrEqual(half * 0.45 + 1e-9);
-      // Screen-constant: park * zoom == parkPx unless clamped by half-side.
       const parkPx = radiusHandleParkScreenPx();
       const unclamped = parkPx / zoom;
       if (unclamped <= half * 0.45) {
@@ -160,7 +197,6 @@ describe('radius park + chrome hits @ all canvas zooms', () => {
       const expectedScene = Math.min(parkPx / zoom, half * 0.45);
       expect(parkScene).toBeCloseTo(expectedScene, 5);
       const hitScale = chromeHitScaleForBox(box.w, box.h, zoom);
-      // Both hits are icon-centered — park clears halfHit + halfRadius + gap.
       const resizeHalf = (CHROME_HANDLE_HIT_PX * hitScale) / 2 / zoom;
       const radiusHalf = (CHROME_RADIUS_HIT_PX * hitScale) / 2 / zoom;
       const clearance = parkScene - resizeHalf - radiusHalf;

--- a/apps/web/src/components/rcb/selection/__tests__/moveSnapStickiness.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/moveSnapStickiness.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import {
+  smartSnapThreshold,
+  snapBoxToGrid,
+  snapMoveToSmartGuides,
+  snapCoordToGrid,
+} from '../alignGuides';
+import { inflateBoxByVisualOutset } from '../../scene/document/sceneEffects';
+
+/** Same settle order as computeMovedUnion (grid → smart → grid). */
+function productionMoveSettle(opts: {
+  box: { left: number; top: number; width: number; height: number };
+  targets: Array<{ left: number; top: number; width: number; height: number }>;
+  zoom: number;
+  gridSize?: number;
+  stickyAt?: { x?: number; y?: number } | null;
+}) {
+  const gridSize = opts.gridSize ?? 1;
+  const threshold = smartSnapThreshold(opts.zoom);
+  let next = { ...opts.box };
+  let stickyAt = opts.stickyAt || {};
+  if (gridSize > 0) next = snapBoxToGrid(next, gridSize);
+  if (threshold > 0 && opts.targets.length) {
+    const smart = snapMoveToSmartGuides({
+      box: next,
+      targets: opts.targets,
+      threshold,
+      gridSize,
+      stickyAt,
+    });
+    next = smart.box;
+    stickyAt = smart.stickyAt;
+  }
+  if (gridSize > 0) next = snapBoxToGrid(next, gridSize);
+  return { box: next, threshold, stickyAt };
+}
+
+function assertBoxOnGrid(
+  box: { left: number; top: number; width: number; height: number },
+  gridSize: number
+) {
+  expect(box.left).toBe(snapCoordToGrid(box.left, gridSize));
+  expect(box.top).toBe(snapCoordToGrid(box.top, gridSize));
+}
+
+describe('move snap stickiness + grid integrity', () => {
+  const sibling = { left: 0, top: 0, width: 135, height: 292 };
+
+  it('oscillating near a sibling never leaves the grid at any zoom', () => {
+    for (const zoom of [0.05, 0.25, 0.5, 1, 2, 8]) {
+      for (let i = 0; i < 40; i += 1) {
+        // Pointer wanders around flush / gap-4 / gap-12 like a user hunting the magnet.
+        const intended =
+          sibling.left + sibling.width + 4 + Math.sin(i * 0.9) * 10 + (i % 3) * 0.17;
+        const top = Math.cos(i * 0.6) * 5.3;
+        const { box } = productionMoveSettle({
+          box: { left: intended, top, width: 135, height: 292 },
+          targets: [sibling],
+          zoom,
+        });
+        assertBoxOnGrid(box, 1);
+      }
+    }
+  });
+
+  it('grid-first settle follows pointer by whole cells once past the magnet', () => {
+    // After escaping flush, each grid step of the pointer should move the box.
+    const zoom = 1;
+    const threshold = smartSnapThreshold(zoom);
+    const escaped = sibling.left + sibling.width + threshold + 3;
+    const a = productionMoveSettle({
+      box: { left: escaped, top: 0, width: 135, height: 292 },
+      targets: [sibling],
+      zoom,
+    });
+    const b = productionMoveSettle({
+      box: { left: escaped + 1, top: 0, width: 135, height: 292 },
+      targets: [sibling],
+      zoom,
+    });
+    expect(a.box.left).toBe(snapCoordToGrid(escaped, 1));
+    expect(b.box.left).toBe(a.box.left + 1);
+    assertBoxOnGrid(a.box, 1);
+    assertBoxOnGrid(b.box, 1);
+  });
+
+  it('center-stroke visual settle keeps ink on integer cells while hunting snap', () => {
+    const node = {
+      key: 'shape',
+      attrs: {
+        shapeType: 'rect',
+        'border-width': 1,
+        'border-color': '#333',
+        strokeAlign: 'center',
+        'stroke-enabled': 'true',
+        'stroke-visible': 'true',
+      },
+    };
+    const leftPath = { left: 0.5, top: 0.5, width: 134, height: 291 };
+    const leftVis = inflateBoxByVisualOutset(leftPath, node);
+    let path = { left: 140.5, top: 0.5, width: 134, height: 291 };
+
+    for (let i = 0; i < 25; i += 1) {
+      const vis0 = inflateBoxByVisualOutset(path, node);
+      const intendedLeft = leftVis.left + leftVis.width + 4 + Math.sin(i) * 6;
+      const dragged = {
+        ...vis0,
+        left: intendedLeft,
+        top: vis0.top + Math.cos(i * 0.5) * 2.4,
+      };
+      const { box: vis1 } = productionMoveSettle({
+        box: dragged,
+        targets: [leftVis],
+        zoom: 1,
+      });
+      const sdx = vis1.left - vis0.left;
+      const sdy = vis1.top - vis0.top;
+      path = { ...path, left: path.left + sdx, top: path.top + sdy };
+      const ink = inflateBoxByVisualOutset(path, node);
+      expect(ink.left).toBe(snapCoordToGrid(ink.left, 1));
+      expect(ink.top).toBe(snapCoordToGrid(ink.top, 1));
+      expect(ink.left + ink.width).toBe(snapCoordToGrid(ink.left + ink.width, 1));
+      expect(ink.top + ink.height).toBe(snapCoordToGrid(ink.top + ink.height, 1));
+    }
+  });
+
+  it('sticky hysteresis stops flush↔gap-4 flip-flop while pointer jitters', () => {
+    const left = { left: 0, top: 0, width: 100, height: 80 };
+    // Two competing X snaps ~4 apart: flush at 100, and right-edge align at 104
+    // (same-size sibling would use centers; here use a second target).
+    const rightAnchor = { left: 204, top: 0, width: 100, height: 80 };
+    const targets = [left, rightAnchor];
+    // Flush to left → box.left=100; flush to rightAnchor left → box.left=104.
+    let stickyAt: { x?: number; y?: number } = {};
+    const seen = new Set<number>();
+    for (let i = 0; i < 20; i += 1) {
+      const intended = 102 + (i % 2 === 0 ? -0.2 : 0.2);
+      const settled = productionMoveSettle({
+        box: { left: intended, top: 0, width: 100, height: 80 },
+        targets,
+        zoom: 1,
+        stickyAt,
+      });
+      stickyAt = settled.stickyAt;
+      seen.add(settled.box.left);
+      assertBoxOnGrid(settled.box, 1);
+    }
+    // Without sticky this chatters 100↔104; with sticky it should hold one side.
+    expect(seen.size).toBe(1);
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/pairSpacingMeasure.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/pairSpacingMeasure.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SMART_SNAP_PX,
+  collectPairSpacingGuides,
+  smartSnapThreshold,
+} from '../alignGuides';
+
+describe('collectPairSpacingGuides', () => {
+  it('shows horizontal clear gap between side-by-side boxes', () => {
+    const a = { left: 0, top: 0, width: 100, height: 80 };
+    const b = { left: 140, top: 10, width: 100, height: 120 };
+    const guides = collectPairSpacingGuides(a, b);
+    const gaps = guides.filter((g) => g.kind === 'gap');
+    expect(gaps.some((g) => g.kind === 'gap' && g.axis === 'x' && g.dist === 40)).toBe(true);
+  });
+
+  it('top offset uses measure in the gap with rails on both tops', () => {
+    // Slight y-overlap + x-gap (same geometry as the poster repro).
+    const a = { left: 0, top: 0, width: 135, height: 292 };
+    const b = { left: 200, top: 283, width: 135, height: 292 };
+    const guides = collectPairSpacingGuides(a, b);
+    const top = guides.find(
+      (g) => g.kind === 'gap' && g.axis === 'y' && g.dist === 283
+    );
+    expect(top).toBeTruthy();
+    if (top && top.kind === 'gap') {
+      // Measure sits in the horizontal gap, not at either box center.
+      expect(top.at).toBeGreaterThan(135);
+      expect(top.at).toBeLessThan(200);
+      expect(top.rails?.length).toBe(2);
+      const railAts = (top.rails || []).map((r) => r.at).sort((x, y) => x - y);
+      expect(railAts[0]).toBeCloseTo(0, 6);
+      expect(railAts[1]).toBeCloseTo(283, 6);
+      // Each rail reaches the measure line.
+      for (const r of top.rails || []) {
+        expect(Math.min(r.from, r.to)).toBeLessThanOrEqual(top.at + 1e-6);
+        expect(Math.max(r.from, r.to)).toBeGreaterThanOrEqual(top.at - 1e-6);
+      }
+    }
+  });
+
+  it('does not add bottom offset when tops already differ (no stray lower dashed)', () => {
+    const a = { left: 0, top: 0, width: 135, height: 292 };
+    const b = { left: 200, top: 283, width: 135, height: 292 };
+    const guides = collectPairSpacingGuides(a, b);
+    const yGaps = guides.filter((g) => g.kind === 'gap' && g.axis === 'y');
+    // Only the top-to-top offset — not a second bottom-to-bottom measure.
+    expect(yGaps).toHaveLength(1);
+    expect(yGaps[0]?.dist).toBe(283);
+  });
+
+  it('bottom offset appears only when tops are aligned', () => {
+    const a = { left: 0, top: 0, width: 100, height: 80 };
+    const b = { left: 140, top: 0, width: 80, height: 200 };
+    const guides = collectPairSpacingGuides(a, b);
+    const bottom = guides.find(
+      (g) => g.kind === 'gap' && g.axis === 'y' && g.dist === 120
+    );
+    expect(bottom).toBeTruthy();
+    if (bottom && bottom.kind === 'gap') {
+      expect(bottom.rails?.length).toBe(2);
+    }
+  });
+
+  it('skips aligned top offset when tops coincide and heights match', () => {
+    const a = { left: 0, top: 0, width: 100, height: 80 };
+    const b = { left: 140, top: 0, width: 80, height: 80 };
+    const guides = collectPairSpacingGuides(a, b);
+    const yGaps = guides.filter((g) => g.kind === 'gap' && g.axis === 'y');
+    expect(yGaps).toHaveLength(0);
+  });
+
+  it('shows vertical clear gap when stacked', () => {
+    const a = { left: 0, top: 0, width: 120, height: 60 };
+    const b = { left: 10, top: 100, width: 120, height: 60 };
+    const guides = collectPairSpacingGuides(a, b);
+    expect(guides.some((g) => g.kind === 'gap' && g.axis === 'y' && g.dist === 40)).toBe(
+      true
+    );
+  });
+
+  it('diagonal (no axis overlap) still shows both clearances — preview inspect', () => {
+    // Poster top-left vs rect below-right (figure-1 style: no x/y overlap).
+    const poster = { left: 0, top: 100, width: 155, height: 292 };
+    const rect = { left: 264.5, top: 467.5, width: 256, height: 114 };
+    const guides = collectPairSpacingGuides(poster, rect);
+    const gaps = guides.filter((g) => g.kind === 'gap');
+    // Horizontal: 264.5 - 155 = 109.5 → 110
+    expect(gaps.some((g) => g.kind === 'gap' && g.axis === 'x' && g.dist === 110)).toBe(
+      true
+    );
+    // Vertical: 467.5 - (100+292) = 75.5 → 76
+    expect(gaps.some((g) => g.kind === 'gap' && g.axis === 'y' && g.dist === 76)).toBe(
+      true
+    );
+  });
+
+  it('returns empty for invalid boxes', () => {
+    expect(
+      collectPairSpacingGuides(
+        { left: 0, top: 0, width: 0, height: 10 },
+        { left: 20, top: 0, width: 10, height: 10 }
+      )
+    ).toEqual([]);
+  });
+});
+
+describe('smartSnapThreshold screen-constant', () => {
+  it('keeps ~8 CSS px of magnet at every zoom including 5%', () => {
+    for (const zoom of [0.05, 0.13, 0.25, 1, 2, 40]) {
+      expect(smartSnapThreshold(zoom)).toBeCloseTo(SMART_SNAP_PX / zoom, 6);
+      expect(smartSnapThreshold(zoom) * zoom).toBeCloseTo(SMART_SNAP_PX, 6);
+    }
+  });
+});

--- a/apps/web/src/components/rcb/selection/alignGuides.ts
+++ b/apps/web/src/components/rcb/selection/alignGuides.ts
@@ -7,13 +7,7 @@ export type { ResizeHandle, SceneBox };
 export const DEFAULT_GRID_SIZE = 1;
 
 /** Screen-px threshold for object-to-object smart guides. */
-export const SMART_SNAP_PX = 5;
-/**
- * Cap scene-space snap for every zoom. Uncapped `SMART_SNAP_PX/zoom` stays
- * screen-constant, but at low zoom that is dozens of document cells and feels
- * like a distant magnet. High zoom is unchanged (5/zoom already &lt; this cap).
- */
-export const SMART_SNAP_SCENE_MAX = 8;
+export const SMART_SNAP_PX = 8;
 
 /** Alignment + spacing guide color. */
 export const SMART_GUIDE_COLOR = '#FF6B35';
@@ -38,16 +32,19 @@ export type SmartGuideGap = {
   to: number;
   at: number;
   dist: number;
+  /** Dashed extension rails (perpendicular to the measure), usually one per box edge. */
+  rails?: Array<{ from: number; to: number; at: number }>;
 };
 
 export type SmartGuideLine = SmartGuideAlign | SmartGuideGap;
 
 /**
- * Scene snap radius for guides — `min(screenPx/zoom, sceneCap)` at every zoom.
+ * Scene snap radius — screen pixels converted by zoom so magnet feel
+ * stays constant (8 CSS px at every zoom, including 5%).
  */
 export function smartSnapThreshold(zoom: number): number {
   const z = Math.max(0.05, Number(zoom) || 1);
-  return Math.min(SMART_SNAP_PX / z, SMART_SNAP_SCENE_MAX);
+  return SMART_SNAP_PX / z;
 }
 
 type AxisMark = { value: number; role: 'min' | 'mid' | 'max' };
@@ -220,6 +217,129 @@ function collectAlignGuides(box: SceneBox, targets: SceneBox[], epsilon: number)
 }
 
 /**
+ * Idle select↔hover spacing — clear gaps, plus edge offsets when neighbors
+ * share a cross-axis overlap (top/bottom for side-by-side, L/R when stacked).
+ *
+ * Measure line sits in the gap between boxes; dashed rails run on both edges
+ * being compared out to that measure line (not a short stub on one side only).
+ */
+export function collectPairSpacingGuides(a: SceneBox, b: SceneBox): SmartGuideLine[] {
+  if (!(a.width > 0) || !(a.height > 0) || !(b.width > 0) || !(b.height > 0)) return [];
+  const gaps = collectGapGuides(a, [b]);
+  const out: SmartGuideLine[] = [...gaps];
+  const aR = a.left + a.width;
+  const aB = a.top + a.height;
+  const bR = b.left + b.width;
+  const bB = b.top + b.height;
+  const yOv = rangeOverlap(a.top, aB, b.top, bB);
+  const xOv = rangeOverlap(a.left, aR, b.left, bR);
+  const sideBySide = yOv > 0 && (aR <= b.left + 1e-6 || bR <= a.left + 1e-6);
+  const stacked = xOv > 0 && (aB <= b.top + 1e-6 || bB <= a.top + 1e-6);
+
+  const pushOffset = (
+    axis: 'x' | 'y',
+    edgeA: number,
+    edgeB: number,
+    at: number,
+    rails: Array<{ from: number; to: number; at: number }>
+  ) => {
+    const dist = Math.abs(edgeB - edgeA);
+    if (dist <= 0.5) return;
+    out.push({
+      kind: 'gap',
+      axis,
+      from: Math.min(edgeA, edgeB),
+      to: Math.max(edgeA, edgeB),
+      at,
+      dist: Math.round(dist),
+      rails: rails.filter((r) => Math.abs(r.to - r.from) > 0.5),
+    });
+  };
+
+  /** Dashed stub from a box edge to the measure line (skip if measure cuts the box). */
+  const railFromBoxToAt = (
+    boxMin: number,
+    boxMax: number,
+    at: number,
+    edgeAt: number
+  ): { from: number; to: number; at: number } | null => {
+    if (at < boxMin - 1e-6) return { from: at, to: boxMin, at: edgeAt };
+    if (at > boxMax + 1e-6) return { from: boxMax, to: at, at: edgeAt };
+    return null;
+  };
+
+  if (sideBySide) {
+    // Vertical measure in the horizontal gap; rails on both tops (and bottoms if needed).
+    const aFacing = aR <= b.left + 1e-6 ? aR : a.left;
+    const bFacing = aR <= b.left + 1e-6 ? b.left : bR;
+    const atX = (aFacing + bFacing) / 2;
+    const topRails = [
+      railFromBoxToAt(a.left, aR, atX, a.top),
+      railFromBoxToAt(b.left, bR, atX, b.top),
+    ].filter(Boolean) as Array<{ from: number; to: number; at: number }>;
+    pushOffset('y', a.top, b.top, atX, topRails);
+    // Bottom offset only when tops already match — otherwise top delta is enough
+    // and a second rail pair reads as a stray "lower dashed" measure.
+    if (Math.abs(a.top - b.top) <= 0.5) {
+      const botRails = [
+        railFromBoxToAt(a.left, aR, atX, aB),
+        railFromBoxToAt(b.left, bR, atX, bB),
+      ].filter(Boolean) as Array<{ from: number; to: number; at: number }>;
+      pushOffset('y', aB, bB, atX, botRails);
+    }
+  } else if (stacked) {
+    const aFacing = aB <= b.top + 1e-6 ? aB : a.top;
+    const bFacing = aB <= b.top + 1e-6 ? b.top : bB;
+    const atY = (aFacing + bFacing) / 2;
+    const leftRails = [
+      railFromBoxToAt(a.top, aB, atY, a.left),
+      railFromBoxToAt(b.top, bB, atY, b.left),
+    ].filter(Boolean) as Array<{ from: number; to: number; at: number }>;
+    pushOffset('x', a.left, b.left, atY, leftRails);
+    if (Math.abs(a.left - b.left) <= 0.5) {
+      const rightRails = [
+        railFromBoxToAt(a.top, aB, atY, aR),
+        railFromBoxToAt(b.top, bB, atY, bR),
+      ].filter(Boolean) as Array<{ from: number; to: number; at: number }>;
+      pushOffset('x', aR, bR, atY, rightRails);
+    }
+  } else if (!gaps.length) {
+    // Diagonal (no x/y overlap): still show both clearances — preview inspect
+    // often picks a poster and a rect that sit corner-to-corner.
+    const aLeftOfB = aR <= b.left + 1e-6;
+    const bLeftOfA = bR <= a.left + 1e-6;
+    if (aLeftOfB || bLeftOfA) {
+      const leftBox = aLeftOfB ? a : b;
+      const rightBox = aLeftOfB ? b : a;
+      const from = leftBox.left + leftBox.width;
+      const to = rightBox.left;
+      const atY = Math.min(leftBox.top + leftBox.height, rightBox.top + rightBox.height);
+      const hRails = [
+        railFromBoxToAt(leftBox.top, leftBox.top + leftBox.height, atY, from),
+        railFromBoxToAt(rightBox.top, rightBox.top + rightBox.height, atY, to),
+      ].filter(Boolean) as Array<{ from: number; to: number; at: number }>;
+      pushOffset('x', from, to, atY, hRails);
+    }
+    const aAboveB = aB <= b.top + 1e-6;
+    const bAboveA = bB <= a.top + 1e-6;
+    if (aAboveB || bAboveA) {
+      const topBox = aAboveB ? a : b;
+      const botBox = aAboveB ? b : a;
+      const from = topBox.top + topBox.height;
+      const to = botBox.top;
+      const atX = Math.min(topBox.left + topBox.width, botBox.left + botBox.width);
+      const vRails = [
+        railFromBoxToAt(topBox.left, topBox.left + topBox.width, atX, from),
+        railFromBoxToAt(botBox.left, botBox.left + botBox.width, atX, to),
+      ].filter(Boolean) as Array<{ from: number; to: number; at: number }>;
+      pushOffset('y', from, to, atX, vRails);
+    }
+  }
+
+  return out;
+}
+
+/**
  * Nearest clear gap per cardinal direction when ranges overlap on the cross axis.
  * Does not require edge snap — spacing chrome appears while dragging beside a sibling.
  */
@@ -299,7 +419,7 @@ function collectGapGuides(box: SceneBox, targets: SceneBox[]): SmartGuideGap[] {
 }
 
 /** Scene epsilon: path marks must nearly coincide (do not scale with zoom snap threshold). */
-const GUIDE_COINCIDE_EPS = 0.51;
+export const GUIDE_COINCIDE_EPS = 0.51;
 
 function isOnGrid(value: number, gridSize: number): boolean {
   if (!(gridSize > 0) || !Number.isFinite(value)) return true;
@@ -378,13 +498,22 @@ export function snapMoveToSmartGuides(opts: {
   threshold: number;
   /** Skip snaps that leave the box origin off the document grid. */
   gridSize?: number;
-}): { box: SceneBox; guides: SmartGuideLine[] } {
+  /**
+   * Prior frame guide positions (`at`). Prefer staying on the same guides so
+   * nearby candidates (e.g. flush vs gap-4) do not flip-flop while dragging.
+   */
+  stickyAt?: { x?: number; y?: number } | null;
+}): { box: SceneBox; guides: SmartGuideLine[]; stickyAt: { x?: number; y?: number } } {
   const { box, targets, threshold } = opts;
   const gridSize = opts.gridSize ?? 0;
-  if (!(threshold > 0) || !targets.length) return { box, guides: [] };
+  const stickyAt = opts.stickyAt || null;
+  if (!(threshold > 0) || !targets.length) {
+    return { box, guides: [], stickyAt: {} };
+  }
 
   type Cand = {
     abs: number;
+    score: number;
     delta: number;
     at: number;
     from: number;
@@ -395,6 +524,9 @@ export function snapMoveToSmartGuides(opts: {
   let bestY: Cand | null = null;
 
   const roleRank = (r: AxisMark['role']) => (r === 'mid' ? 1 : 0);
+  // Small scene sticky only — do NOT scale with snap threshold or low zoom
+  // holds the wrong guide across dozens of cells and blocks the real magnet.
+  const hysteresis = Math.max(gridSize > 0 ? gridSize : 1, 2);
 
   const mx = boxXMarks(box);
   const my = boxYMarks(box);
@@ -411,16 +543,28 @@ export function snapMoveToSmartGuides(opts: {
         const nextLeft = box.left + delta;
         // Path control box / visual outer must stay on grid — reject snaps that leave it.
         if (gridSize > 0 && !isOnGrid(nextLeft, gridSize)) continue;
-        if (bestX && abs > bestX.abs + 1e-9) continue;
+        let score = abs;
+        if (stickyAt?.x != null && Math.abs(tm.value - stickyAt.x) <= 1e-6) {
+          score = Math.max(0, score - hysteresis);
+        }
+        if (bestX && score > bestX.score + 1e-9) continue;
         if (
           bestX &&
-          Math.abs(abs - bestX.abs) <= 1e-9 &&
+          Math.abs(score - bestX.score) <= 1e-9 &&
           roleRank(tm.role) > roleRank(bestX.role)
         ) {
           continue;
         }
+        if (
+          bestX &&
+          Math.abs(score - bestX.score) <= 1e-9 &&
+          roleRank(tm.role) === roleRank(bestX.role) &&
+          abs > bestX.abs + 1e-9
+        ) {
+          continue;
+        }
         const ext = mergeGuideExtent(box.top, box.top + box.height, t.top, t.top + t.height);
-        bestX = { abs, delta, at: tm.value, from: ext.from, to: ext.to, role: tm.role };
+        bestX = { abs, score, delta, at: tm.value, from: ext.from, to: ext.to, role: tm.role };
       }
     }
     for (const m of my) {
@@ -430,16 +574,28 @@ export function snapMoveToSmartGuides(opts: {
         if (abs > threshold) continue;
         const nextTop = box.top + delta;
         if (gridSize > 0 && !isOnGrid(nextTop, gridSize)) continue;
-        if (bestY && abs > bestY.abs + 1e-9) continue;
+        let score = abs;
+        if (stickyAt?.y != null && Math.abs(tm.value - stickyAt.y) <= 1e-6) {
+          score = Math.max(0, score - hysteresis);
+        }
+        if (bestY && score > bestY.score + 1e-9) continue;
         if (
           bestY &&
-          Math.abs(abs - bestY.abs) <= 1e-9 &&
+          Math.abs(score - bestY.score) <= 1e-9 &&
           roleRank(tm.role) > roleRank(bestY.role)
         ) {
           continue;
         }
+        if (
+          bestY &&
+          Math.abs(score - bestY.score) <= 1e-9 &&
+          roleRank(tm.role) === roleRank(bestY.role) &&
+          abs > bestY.abs + 1e-9
+        ) {
+          continue;
+        }
         const ext = mergeGuideExtent(box.left, box.left + box.width, t.left, t.left + t.width);
-        bestY = { abs, delta, at: tm.value, from: ext.from, to: ext.to, role: tm.role };
+        bestY = { abs, score, delta, at: tm.value, from: ext.from, to: ext.to, role: tm.role };
       }
     }
   }
@@ -473,6 +629,10 @@ export function snapMoveToSmartGuides(opts: {
           }
         : undefined,
     }),
+    stickyAt: {
+      x: bestX?.at,
+      y: bestY?.at,
+    },
   };
 }
 

--- a/apps/web/src/components/rcb/selection/chrome/SmartGuidesOverlay.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/SmartGuidesOverlay.tsx
@@ -12,7 +12,12 @@ import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { useRcbCamera } from '@/components/rcb/camera/context';
 import { CHROME_STROKE_PX } from '../SelectionChrome';
-import { SMART_GUIDE_COLOR, type SmartGuideGap, type SmartGuideLine } from '../alignGuides';
+import {
+  SMART_GUIDE_COLOR,
+  type SceneBox,
+  type SmartGuideGap,
+  type SmartGuideLine,
+} from '../alignGuides';
 import {
   getSceneSmartGuidesMount,
   getSceneWorldEpoch,
@@ -20,6 +25,7 @@ import {
 } from '../../shapes/shapeHostRegistry';
 
 const GUIDE_STROKE = SMART_GUIDE_COLOR;
+const SIZE_BADGE_FILL = '#3388ff';
 
 function isGapGuide(g: SmartGuideLine): g is SmartGuideGap {
   return g.kind === 'gap';
@@ -31,12 +37,14 @@ function GuideBadge({
   y,
   inv,
   anchor,
+  fill = GUIDE_STROKE,
 }: {
   text: string;
   x: number;
   y: number;
   inv: number;
   anchor: 'below' | 'right';
+  fill?: string;
 }) {
   const fontSize = 11 * inv;
   const padX = 5.5 * inv;
@@ -58,7 +66,7 @@ function GuideBadge({
         height={h}
         rx={radius}
         ry={radius}
-        fill={GUIDE_STROKE}
+        fill={fill}
       />
       <text
         x={cx}
@@ -81,13 +89,22 @@ function GuideMarkDot({ x, y, r }: { x: number; y: number; r: number }) {
   return <circle cx={x} cy={y} r={r} fill={GUIDE_STROKE} stroke="none" />;
 }
 
+function formatSizeBadge(box: SceneBox): string {
+  const w = Math.max(0, Math.round(box.width));
+  const h = Math.max(0, Math.round(box.height));
+  return `${w} × ${h}`;
+}
+
 export default function SmartGuidesOverlay({
   guides,
   mirrorNodeId: _mirrorNodeId = null,
+  sizeBox = null,
 }: {
   guides: SmartGuideLine[];
   /** Kept for call-site compat. */
   mirrorNodeId?: string | null;
+  /** Idle or inspect: blue WxH badge under the selected box. */
+  sizeBox?: SceneBox | null;
 }) {
   const camera = useRcbCamera();
   const z = Math.max(0.05, camera.zoom || 1);
@@ -96,6 +113,7 @@ export default function SmartGuidesOverlay({
   const stroke = Math.max(1 / z, CHROME_STROKE_PX / z);
   const tip = 5 * inv;
   const markR = Math.max(stroke * 2, 3.5 * inv);
+  const dash = `${5 * inv} ${4 * inv}`;
 
   // Remount when shared world SVG appears / is replaced.
   const [, setWorldEpoch] = useState(() => getSceneWorldEpoch());
@@ -112,7 +130,7 @@ export default function SmartGuidesOverlay({
   const guidesMount = getSceneSmartGuidesMount();
 
   const nodes = useMemo(() => {
-    if (!guides.length) return null;
+    if (!guides.length && !sizeBox) return null;
     const out: ReactNode[] = [];
     guides.forEach((g, i) => {
       if (isGapGuide(g)) {
@@ -124,6 +142,20 @@ export default function SmartGuidesOverlay({
         const midY = g.axis === 'y' ? (g.from + g.to) / 2 : g.at;
         out.push(
           <g key={`gap-${i}`}>
+            {g.rails?.map((rail, ri) => (
+              <line
+                key={`rail-${ri}`}
+                x1={g.axis === 'y' ? Math.min(rail.from, rail.to) : rail.at}
+                y1={g.axis === 'y' ? rail.at : Math.min(rail.from, rail.to)}
+                x2={g.axis === 'y' ? Math.max(rail.from, rail.to) : rail.at}
+                y2={g.axis === 'y' ? rail.at : Math.max(rail.from, rail.to)}
+                stroke={GUIDE_STROKE}
+                strokeWidth={stroke}
+                strokeDasharray={dash}
+                strokeLinecap="butt"
+                shapeRendering="geometricPrecision"
+              />
+            ))}
             <line
               x1={g.axis === 'x' ? x0 : g.at}
               y1={g.axis === 'x' ? g.at : y0}
@@ -179,8 +211,21 @@ export default function SmartGuidesOverlay({
         </g>
       );
     });
+    if (sizeBox && sizeBox.width > 0 && sizeBox.height > 0) {
+      out.push(
+        <GuideBadge
+          key="size-badge"
+          text={formatSizeBadge(sizeBox)}
+          x={sizeBox.left + sizeBox.width / 2}
+          y={sizeBox.top + sizeBox.height}
+          inv={inv}
+          anchor="below"
+          fill={SIZE_BADGE_FILL}
+        />
+      );
+    }
     return out;
-  }, [guides, inv, stroke, tip, markR]);
+  }, [guides, sizeBox, inv, stroke, tip, markR, dash]);
 
   if (!nodes || !guidesMount) return null;
 

--- a/apps/web/src/utils/renderProjectThumbnail.ts
+++ b/apps/web/src/utils/renderProjectThumbnail.ts
@@ -177,40 +177,6 @@ async function rasterizeElementTile(
   return null;
 }
 
-/** @deprecated Prefer saved element-snapshot thumbs; kept for rare live fallbacks. */
-export function collectProjectImageSrcs(document: unknown): string[] {
-  if (!document || typeof document !== 'object') return [];
-  const dsl = (document as { deltaSetLike?: unknown }).deltaSetLike;
-  if (!dsl || typeof dsl !== 'object') return [];
-  const out: string[] = [];
-  const seen = new Set<string>();
-  for (const [key, raw] of Object.entries(dsl as Record<string, unknown>)) {
-    if (key === 'ROOT' || !raw || typeof raw !== 'object') continue;
-    const node = raw as Record<string, unknown>;
-    if (!isExportableSceneNode(node)) continue;
-    if (String(node.key || '') !== 'image') continue;
-    const attrs = (node.attrs && typeof node.attrs === 'object'
-      ? node.attrs
-      : {}) as Record<string, unknown>;
-    const src = String(attrs.src || '').trim();
-    if (!src || seen.has(src)) continue;
-    if (
-      !(
-        src.startsWith('http://') ||
-        src.startsWith('https://') ||
-        src.startsWith('data:image/') ||
-        src.startsWith('/')
-      )
-    ) {
-      continue;
-    }
-    seen.add(src);
-    out.push(src);
-    if (out.length >= MAX_TILES) break;
-  }
-  return out;
-}
-
 export type ProjectCoverTiles = {
   /** Already-hosted image URLs — rare passthrough. */
   urls?: string[];
@@ -243,9 +209,10 @@ function resolveCoverTileRasterOpts(opts?: ProjectCoverTileOptions) {
 }
 
 /**
- * Up to 4 cover tiles for 最近打开 / 我的项目 / Publish.
- * Prefer one snapshot per artboard when there are 2+ boards (matches Share collage);
+ * Up to 4 cover tiles for list collage / Publish / cloud sync.
+ * Prefer one snapshot per artboard when there are 2+ boards;
  * else per-element crops; else one full-board cover.
+ * Tile rasters run in parallel so sync sends all four in one request.
  */
 export async function buildProjectCoverTiles(
   document: unknown,
@@ -257,34 +224,47 @@ export async function buildProjectCoverTiles(
 
   const frames = listArtboardFrames(document).slice(0, MAX_TILES);
   if (frames.length >= 2) {
-    const dataUrls: string[] = [];
-    for (const frame of frames) {
-      const slice = extractFrameDocument(document, frame, { contentFit: true });
-      if (!slice) continue;
-      const data = await renderDocumentThumbnail(slice, {
-        allowEmpty: true,
-        format: thumbFormat,
-        maxEdge: tileMax,
-      });
-      if (data) dataUrls.push(data);
-    }
+    const slices = frames
+      .map((frame) => extractFrameDocument(document, frame, { contentFit: true }))
+      .filter(Boolean);
+    const rendered = await Promise.all(
+      slices.map((slice) =>
+        renderDocumentThumbnail(slice, {
+          allowEmpty: true,
+          format: thumbFormat,
+          maxEdge: tileMax,
+        })
+      )
+    );
+    const dataUrls = rendered.filter((u): u is string => Boolean(u));
     if (dataUrls.length) return { dataUrls };
   }
 
   const ids = pickCoverElementIds(document);
   if (ids.length) {
-    const dataUrls: string[] = [];
-    for (const id of ids) {
-      const data = await rasterizeElementTile(document, id, {
-        maxEdge: opts?.maxEdge,
-        format: opts?.format,
-        compress: opts?.compress,
-      });
-      if (data) dataUrls.push(data);
-    }
+    const rendered = await Promise.all(
+      ids.map((id) =>
+        rasterizeElementTile(document, id, {
+          maxEdge: opts?.maxEdge,
+          format: opts?.format,
+          compress: opts?.compress,
+        })
+      )
+    );
+    const dataUrls = rendered.filter((u): u is string => Boolean(u));
     if (dataUrls.length) return { dataUrls };
   }
 
+  return buildProjectCoverSingle(document, opts);
+}
+
+/** Fallback: one full-board cover when collage tiles are unavailable. */
+export async function buildProjectCoverSingle(
+  document: unknown,
+  opts?: ProjectCoverTileOptions
+): Promise<ProjectCoverTiles> {
+  if (!document || typeof document !== 'object') return {};
+  const { format: thumbFormat, fullMax } = resolveCoverTileRasterOpts(opts);
   const one = await renderDocumentThumbnail(
     extractPlazaCoverDocument(document, { contentFit: true }) || document,
     {


### PR DESCRIPTION
## Summary
- Low-zoom smart guides: paint with coincide epsilon (not snap radius); softer sticky hysteresis; hide edit-mode bottom WxH badge
- Project save: reuse existing thumbnailUrl on debounce; collab persist prefers incremental PATCH; PATCH also warms share snapshots; draft IDB/hash/flush micro-optimizations
- Preview inspect: diagonal select↔hover pairs now show spacing annotations; share route `current_user` fix

## Test plan
- [ ] Drag near siblings at ~31% zoom — align strokes only when edges truly meet; snap still works within ~8 screen px
- [ ] Edit project with existing covers — Network shows PATCH without scene PNG refetch on every debounce
- [ ] With collab on, edit node — PATCH `/projects/:id` with upsertNodes (not full PUT unless conflict/large delta)
- [ ] Preview/Inspect: select A, hover diagonal B — both H/V spacing labels appear
- [ ] Refresh share preview after PATCH — content tracks live project