### PR TITLE
Close account menu after language/theme pick

### DIFF
--- a/apps/web/src/components/layout/UserAccountPanel.tsx
+++ b/apps/web/src/components/layout/UserAccountPanel.tsx
@@ -383,6 +383,7 @@ function UserAccountPanel({ open, onOpenChange, children }: Props) {
 
   const changeLang = (code: string) => {
     setFlyout(null);
+    close();
     if (normalizeI18nLang(code) === currentLang) return;
     // Remount Router with new basename (`/zh/home` ↔ `/home`).
     window.location.assign(buildLocaleSwitchUrl(code));
@@ -392,6 +393,7 @@ function UserAccountPanel({ open, onOpenChange, children }: Props) {
     applyTheme(next);
     setThemeMode(next);
     setFlyout(null);
+    close();
   };
 
   const openSettings = (tab: AccountSettingsTab = 'billing') => {


### PR DESCRIPTION
## Summary
- Close the user account panel when choosing a language or theme from the submenu/flyout (not only the secondary panel).

## Test plan
- [ ] Open account menu → language flyout → pick a language → both menus close (same language: closes without reload; different: navigates)
- [ ] Open account menu → theme flyout → pick theme → both menus close and theme applies
- [ ] Narrow viewport: drill-in lang/theme pick also closes the account panel