### PR TITLE
Self-host console login + multi-artboard agent paint

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -120,6 +120,10 @@ CARD_KEY_OPS_PASSWORD=change-me-card-key-ops
 # XIANYU_QR_URL=https://example.com/xianyu-qr.png
 # WECHAT_QR_URL=https://example.com/wechat-qr.png
 
+# Self-host only: when SES is unset, print login OTP to API logs (mode=console).
+# docker compose defaults this to true. Leave false/unset on Recombyn Cloud / public prod.
+# AUTH_CONSOLE_LOGIN_CODE=true
+
 # Tencent Cloud SES — email registration verification codes
 # TENCENT_SECRET_ID=
 # TENCENT_SECRET_KEY=

--- a/apps/api/app/api/routes/auth.py
+++ b/apps/api/app/api/routes/auth.py
@@ -74,6 +74,24 @@ def _super_admin_test_code() -> str:
     return (getattr(settings, "super_admin_test_code", None) or "").strip()
 
 
+def _console_login_code_enabled() -> bool:
+    """Opt-in self-host path — Cloud / prod must keep AUTH_CONSOLE_LOGIN_CODE off."""
+    return bool(getattr(settings, "auth_console_login_code", False))
+
+
+def _issue_console_login_code(email: str) -> dict[str, Any]:
+    """Self-host without SES: store OTP and print it to API logs."""
+    code = generate_code()
+    store_code(email, code)
+    logger.warning(
+        "LOGIN CODE (AUTH_CONSOLE_LOGIN_CODE) email=%s code=%s — "
+        "enter this in the UI; configure SES for real mail, or disable the flag",
+        email,
+        code,
+    )
+    return {"ok": True, "expiresIn": 300, "mode": "console"}
+
+
 def _normalize_email(raw: str) -> str:
     email = (raw or "").strip().lower()
     if "@" not in email or "." not in email.split("@")[-1]:
@@ -261,6 +279,8 @@ def email_send_code(body: EmailSendCodeIn, request: Request) -> dict[str, Any]:
         )
 
     if not ses_configured():
+        if _console_login_code_enabled():
+            return _issue_console_login_code(email)
         raise HTTPException(
             status_code=503,
             detail="Email signup is temporarily unavailable. Try again later or use another sign-in method.",

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -85,7 +85,8 @@ class Settings(BaseSettings):
     # Per LLM/IO node; 0 disables node TimeoutPolicy.
     design_graph_node_timeout_sec: float = 180.0
     # Per paint_ops LLM attempt (in-node); fail fast so empty-ops retries can run.
-    design_paint_attempt_timeout_sec: float = 75.0
+    # Pencil/pathPressure illustration batches often need >75s on slow reasoners.
+    design_paint_attempt_timeout_sec: float = 180.0
     # Verbose [exec]/llm_step] stage timers to stdout (off by default).
     design_exec_trace: bool = False
     # Whole run_agent_graph wall clock; 0 disables.
@@ -188,6 +189,9 @@ class Settings(BaseSettings):
 
     # Local-only admin OTP (apps/api/.env). Empty = disabled. Never set in production.
     super_admin_test_code: str = ""
+    # Self-host only: when SES is unset, print login OTP to API logs (never on Cloud).
+    # docker-compose sets true; leave false/unset for hosted production.
+    auth_console_login_code: bool = False
 
     # Token wallet — card-key redeem (no WeChat/Alipay membership)
     # HMAC-SHA256(plaintext, CARD_KEY_SALT); never store plaintext in DB.

--- a/apps/api/app/services/design/runtime/graph/emit_sse.py
+++ b/apps/api/app/services/design/runtime/graph/emit_sse.py
@@ -114,11 +114,39 @@ def _emit_design_loading_artboard(rt: Any) -> bool:
     )
 
 def _emit_canvas_size_from_ops(rt: Any, step_ops: list[dict[str, Any]]) -> bool:
-    """Open an artboard only when ops include create_frame.
+    """Open an artboard only when ops include a single create_frame.
 
     Infinite canvas: create_shape / create_text / … do not need a frame plate.
+    Multi create_frame (UI set / multi-poster): FE applies each plate — do not
+    host-open one shimmer board that would collapse the set.
     """
-    from app.services.design.runtime.graph.paint_kit import _wh_from_create_frame_ops
+    from app.services.design.runtime.graph.paint_kit import (
+        _count_create_frame_ops,
+        _is_multi_artboard_batch,
+        _wh_from_create_frame_ops,
+    )
+
+    if _is_multi_artboard_batch(step_ops):
+        st = rt.run
+        n = _count_create_frame_ops(step_ops)
+        _emit(
+            {
+                "type": "activity",
+                "id": f"multi-artboard-{st.task_id[:8]}-{n}",
+                "kind": "explored",
+                "status": "done",
+                "stage": "scene",
+                "detail": f"multi_artboard:{n}",
+                "summary": f"{n} artboards",
+                "index": int(getattr(st, "round", 0) or 0),
+            }
+        )
+        st.push_log(
+            phase="canvas_size",
+            intent=str(rt.classified_intent or st.intent or ""),
+            summary=f"multi_artboard {n} (paint_ops)",
+        )
+        return False
     ow, oh = _wh_from_create_frame_ops(step_ops)
     if ow <= 0 or oh <= 0:
         return False

--- a/apps/api/app/services/design/runtime/graph/nodes/apply.py
+++ b/apps/api/app/services/design/runtime/graph/nodes/apply.py
@@ -35,7 +35,7 @@ from app.services.design.runtime.graph.support import (
     _ops_have_create_frame,
     _persist_progress,
     _prompt_text,
-    _strip_create_frame_ops,
+    _paint_ops_for_host,
     _validate_ops_payload,
 )
 
@@ -118,7 +118,7 @@ async def _node_apply_confirm(state: GraphState) -> Command:
         st.push_log(**_hydrate_log_kwargs(step_ops, img_mid=img_mid, n_img=n_img))
     paint_ops = list(step_ops)
     if _ops_have_create_frame(step_ops):
-        paint_ops = _strip_create_frame_ops(step_ops)
+        paint_ops = _paint_ops_for_host(step_ops)
     paint_ops = _filter_unemitted_ops(st, paint_ops)
     rt.paint_ops = paint_ops
     rt.step_ops = step_ops
@@ -308,7 +308,7 @@ async def _node_action(state: GraphState) -> Command:
         st.push_log(**_hydrate_log_kwargs(step_ops, img_mid=img_mid, n_img=n_img))
     paint_ops = list(step_ops)
     if _ops_have_create_frame(step_ops):
-        paint_ops = _strip_create_frame_ops(step_ops)
+        paint_ops = _paint_ops_for_host(step_ops)
     paint_ops = _filter_unemitted_ops(st, paint_ops)
     rt.paint_ops = paint_ops
     ops_sent = bool(paint_ops)

--- a/apps/api/app/services/design/runtime/graph/paint_kit.py
+++ b/apps/api/app/services/design/runtime/graph/paint_kit.py
@@ -97,22 +97,58 @@ def _structure_verify_issues(
         issues.append(f"most nodes have invalid size ({zero_box}/{len(clean_nodes)})")
     return issues
 
+# Multi-screen / multi-poster sets in one paint batch (login + home + …).
+_MAX_CREATE_FRAMES_PER_BATCH = 8
+
+
+def _op_tool_name(o: dict[str, Any]) -> str:
+    return str(o.get("name") or o.get("op_key") or "").strip()
+
+
 def _ops_have_create_frame(ops: list[dict[str, Any]]) -> bool:
+    return _count_create_frame_ops(ops) > 0
+
+
+def _count_create_frame_ops(ops: list[dict[str, Any]]) -> int:
+    n = 0
+    for o in ops or []:
+        if isinstance(o, dict) and _op_tool_name(o) == "create_frame":
+            n += 1
+    return n
+
+
+def _is_multi_artboard_batch(ops: list[dict[str, Any]]) -> bool:
+    """Two+ create_frame → FE applies each plate; host must not collapse to one."""
+    return _count_create_frame_ops(ops) >= 2
+
+
+def _cap_create_frame_ops(
+    ops: list[dict[str, Any]],
+    *,
+    limit: int = _MAX_CREATE_FRAMES_PER_BATCH,
+) -> list[dict[str, Any]]:
+    """Keep at most ``limit`` create_frame ops; content after a dropped frame still applies."""
+    if limit <= 0:
+        return [o for o in (ops or []) if isinstance(o, dict)]
+    out: list[dict[str, Any]] = []
+    kept = 0
     for o in ops or []:
         if not isinstance(o, dict):
             continue
-        name = str(o.get("name") or o.get("op_key") or "").strip()
-        if name == "create_frame":
-            return True
-    return False
+        if _op_tool_name(o) == "create_frame":
+            if kept >= limit:
+                continue
+            kept += 1
+        out.append(o)
+    return out
+
 
 def _wh_from_create_frame_ops(ops: list[dict[str, Any]]) -> tuple[int, int]:
     """First create_frame width/height in a validated op batch."""
     for o in ops or []:
         if not isinstance(o, dict):
             continue
-        name = str(o.get("name") or o.get("op_key") or "").strip()
-        if name != "create_frame":
+        if _op_tool_name(o) != "create_frame":
             continue
         args = o.get("args") if isinstance(o.get("args"), dict) else {}
         try:
@@ -124,17 +160,27 @@ def _wh_from_create_frame_ops(ops: list[dict[str, Any]]) -> tuple[int, int]:
             return fw, fh
     return 0, 0
 
+
 def _strip_create_frame_ops(ops: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Host opens the artboard; drop model create_frame to avoid a second plate."""
     out: list[dict[str, Any]] = []
     for o in ops or []:
         if not isinstance(o, dict):
             continue
-        name = str(o.get("name") or o.get("op_key") or "").strip()
-        if name == "create_frame":
+        if _op_tool_name(o) == "create_frame":
             continue
         out.append(o)
     return out
+
+
+def _paint_ops_for_host(ops: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Single create_frame → host owns the plate (strip). Multi → keep create_frame ops."""
+    capped = _cap_create_frame_ops(ops)
+    if _is_multi_artboard_batch(capped):
+        return capped
+    if _ops_have_create_frame(capped):
+        return _strip_create_frame_ops(capped)
+    return capped
 
 def _prompt_compact_len(prompt: str | None) -> int:
     return len(re.sub(r"\s+", "", str(prompt or "")))
@@ -311,8 +357,12 @@ __all__ = [
     '_ops_patch_too_broad',
     '_structure_verify_issues',
     '_ops_have_create_frame',
+    '_count_create_frame_ops',
+    '_is_multi_artboard_batch',
+    '_cap_create_frame_ops',
     '_wh_from_create_frame_ops',
     '_strip_create_frame_ops',
+    '_paint_ops_for_host',
     '_prompt_compact_len',
     '_is_lean_paint_turn',
     '_paint_tool_keys_for_turn',

--- a/apps/api/data/canvas_actions_seed.json
+++ b/apps/api/data/canvas_actions_seed.json
@@ -41,7 +41,7 @@
       "kind": "create",
       "label": "Create shape",
       "sort_order": 20,
-      "model_hint": "Add a shape. Args: shapeType|type = rect|ellipse|circle|line|arrow|triangle|polygon|star|path|pen|pencil (+ path for pen/pencil/path; sides for polygon/star), x,y,width,height, fill, stroke, borderWidth, strokeAlign=center|inside|outside (default center — ink + selection indicator sit on stroke mid-band; outside/inside shift the band). Optional: strokeStyle, strokeLinecap, strokeLinejoin, strokeOpacity. Pen=pen+path; brush=pencil+path (stroke-only; brushStyle?; pathPressure?). Line/arrow are open center strokes (full arrow path includes head). Icons: create_svg / create_icon.",
+      "model_hint": "Add a shape. Args: shapeType|type = rect|ellipse|circle|line|arrow|triangle|polygon|star|path|pen|pencil (+ path for pen/pencil/path; sides for polygon/star), x,y,width,height, fill, stroke, borderWidth, strokeAlign=center|inside|outside (default center — ink + selection indicator sit on stroke mid-band; outside/inside shift the band). Optional: strokeStyle, strokeLinecap, strokeLinejoin, strokeOpacity. Pen=pen+path; brush/板绘=pencil+path+pathPressure (csv 0.05-1 per point)+brushStyle (calligraphy|soft|marker|fountain|solid); stroke-only. Line/arrow are open center strokes (full arrow path includes head). Icons: create_svg / create_icon. For Q-illustration / pencil sketch do NOT collage with circles — use multiple pencil strokes with pressure.",
       "args_schema": {
         "shapeType": "rect|ellipse|circle|line|arrow|triangle|polygon|star|path|pen|pencil",
         "x": "number",
@@ -145,7 +145,7 @@
       "kind": "frame",
       "label": "Create frame",
       "sort_order": 60,
-      "model_hint": "Create a frame/artboard. Args: x,y,width,height, name?",
+      "model_hint": "Create a frame/artboard. Args: x,y,width,height,name?. Multi-screen or multi-poster: one create_frame per board (name it), then that board's content, then the next create_frame — do not merge into one tall frame.",
       "args_schema": {
         "x": "number",
         "y": "number",

--- a/apps/api/data/design_prompt_packs/agent.prompt.intent_classify.md
+++ b/apps/api/data/design_prompt_packs/agent.prompt.intent_classify.md
@@ -6,7 +6,7 @@
 # Intents (exactly one)
 - chat: greeting / identity / no canvas work
 - canvas_op: the request can be fulfilled by one or a few ops from the 画布工具目录 (e.g. create_*/update_*/delete_*). Prefer canvas_op whenever catalog tools are sufficient.
-- design: creative composition that is NOT just applying catalog tools — new page/poster/layout system, multi-section IA, redesign from reference that needs design judgment beyond a single property/tool call
+- design: creative composition that is NOT just applying catalog tools — new page/poster/layout system, multi-section IA, multi-screen UI set (login+home+profile), multiple distinct posters/artboards, redesign from reference that needs design judgment beyond a single property/tool call
 
 # paint_lane (required when intent is canvas_op or design; empty for chat)
 - create: primarily adding new nodes (create_* tools)

--- a/apps/api/data/design_prompt_packs/agent.prompt.paint_system.md
+++ b/apps/api/data/design_prompt_packs/agent.prompt.paint_system.md
@@ -3,6 +3,8 @@ Your ONLY job: emit non-empty tool_ops that change the canvas.
 Rules:
 - tool_ops must be a non-empty array; use TOOL_DETAILS / catalogs in system.
 - Prefer create_frame then add content inside the focus frame when creating.
+- Multi-screen / multi-poster (e.g. login + home + profile, or two different posters): emit one create_frame per screen/poster (set name), then that board's content ops, then the next create_frame. Do NOT merge into one tall/wide frame. Cap about 8 boards per step.
+- Brush / pencil / Q-illustration / 板绘 / 线稿 / 压感: use create_shape with shapeType=pencil (NOT circle/ellipse collage). Each stroke needs path (SVG M/L polyline), pathPressure (csv 0.05–1 aligned to points — light start/end, heavier mid), brushStyle (calligraphy|soft|marker|fountain|solid), stroke + borderWidth. Prefer several expressive strokes over geometric primitives.
 - Artboard/page fill → create_shape full-bleed rect (or update existing bg). Do NOT use set_canvas_background for board/page fills (infinite-canvas chrome only; often blocked by skill allowlist).
 - Clear / wipe board → delete_nodes with ALL node ids from SCENE (or delete_frame if removing the board). NEVER fake-clear by covering with an opaque full-bleed rect.
 - One clear visual focus; keep surroundings disciplined (avoid generic AI template looks).

--- a/apps/api/tests/unit_tests/test_multi_artboard_paint.py
+++ b/apps/api/tests/unit_tests/test_multi_artboard_paint.py
@@ -1,0 +1,57 @@
+"""Multi create_frame batches keep plates; single create_frame is host-owned."""
+
+from __future__ import annotations
+
+from app.services.design.runtime.graph.paint_kit import (
+    _cap_create_frame_ops,
+    _count_create_frame_ops,
+    _is_multi_artboard_batch,
+    _paint_ops_for_host,
+    _strip_create_frame_ops,
+)
+
+
+def _frame(name: str, w: int = 390, h: int = 844) -> dict:
+    return {
+        "name": "create_frame",
+        "args": {"name": name, "width": w, "height": h, "x": 0, "y": 0},
+    }
+
+
+def _shape(label: str) -> dict:
+    return {
+        "name": "create_shape",
+        "args": {"shapeType": "rect", "x": 0, "y": 0, "width": 100, "height": 40, "name": label},
+    }
+
+
+def test_count_and_multi_detect() -> None:
+    ops = [_frame("Login"), _shape("a"), _frame("Home"), _shape("b")]
+    assert _count_create_frame_ops(ops) == 2
+    assert _is_multi_artboard_batch(ops) is True
+    assert _is_multi_artboard_batch([_frame("Only")]) is False
+
+
+def test_host_keeps_create_frame_when_multi() -> None:
+    ops = [_frame("Login"), _shape("a"), _frame("Home"), _shape("b")]
+    out = _paint_ops_for_host(ops)
+    names = [o["name"] for o in out]
+    assert names.count("create_frame") == 2
+    assert names == ["create_frame", "create_shape", "create_frame", "create_shape"]
+
+
+def test_host_strips_single_create_frame() -> None:
+    ops = [_frame("Poster"), _shape("hero")]
+    out = _paint_ops_for_host(ops)
+    assert all(o["name"] != "create_frame" for o in out)
+    assert out == _strip_create_frame_ops(ops)
+
+
+def test_cap_create_frames() -> None:
+    ops = [_frame(f"F{i}") for i in range(10)] + [_shape("tail")]
+    capped = _cap_create_frame_ops(ops, limit=8)
+    assert _count_create_frame_ops(capped) == 8
+    assert capped[-1]["name"] == "create_shape"
+    painted = _paint_ops_for_host(ops)
+    assert _count_create_frame_ops(painted) == 8
+    assert painted[-1]["name"] == "create_shape"

--- a/apps/web/src/components/editor/panels/agent/__tests__/multiArtboardPaint.test.ts
+++ b/apps/web/src/components/editor/panels/agent/__tests__/multiArtboardPaint.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Multi-artboard paint: sequential create_frame retargets content onto sibling boards.
+ * Mirrors applyAgentToolOps + handleStreamToolOps multi path in runDesignAgent.ts.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { createEmptyDocument } from '@/components/rcb/scene/document/sceneDocument';
+import { executeDesignTool } from '../designTools';
+
+describe('multi-artboard create_frame apply', () => {
+  it('creates two sibling frames and paints content into each after retarget', () => {
+    let doc = createEmptyDocument({ width: 1440, height: 900 });
+    const dispatch = vi.fn((action: { type?: string; payload?: any }) => {
+      const type = String(action?.type || '');
+      const p = action?.payload;
+      if (type.endsWith('/addArtboardFrame') || type.includes('addArtboardFrame')) {
+        const id = `frame_${(doc.frames?.length || 0) + 1}`;
+        const frame = {
+          id,
+          name: p?.name || 'Frame',
+          x: Number(p?.x) || 0,
+          y: Number(p?.y) || 0,
+          width: Number(p?.width) || 390,
+          height: Number(p?.height) || 844,
+          backgroundColor: p?.backgroundColor || '#fff',
+        };
+        doc = {
+          ...doc,
+          frames: [...(doc.frames || []), frame],
+          stackOrder: [...(doc.stackOrder || []), `frame:${id}`],
+        };
+        return;
+      }
+      if (type.endsWith('/setDocument') || type.includes('setDocument')) {
+        if (p && typeof p === 'object') doc = p;
+      }
+    });
+
+    const getDocument = () => doc;
+    const toolCtx: {
+      dispatch: typeof dispatch;
+      getDocument: typeof getDocument;
+      skipHistory: true;
+      targetFrameId: string | null;
+      allowDestructive: true;
+    } = {
+      dispatch,
+      getDocument,
+      skipHistory: true,
+      targetFrameId: null,
+      allowDestructive: true,
+    };
+
+    const ops = [
+      {
+        name: 'create_frame',
+        args: { name: 'Login', width: 390, height: 844, x: 0, y: 0 },
+      },
+      {
+        name: 'create_shape',
+        args: {
+          shapeType: 'rect',
+          x: 20,
+          y: 20,
+          width: 100,
+          height: 40,
+          fill: '#111',
+          name: 'login-btn',
+        },
+      },
+      {
+        name: 'create_frame',
+        args: { name: 'Home', width: 390, height: 844, x: 0, y: 0 },
+      },
+      {
+        name: 'create_shape',
+        args: {
+          shapeType: 'rect',
+          x: 20,
+          y: 20,
+          width: 120,
+          height: 48,
+          fill: '#0a7',
+          name: 'home-hero',
+        },
+      },
+    ];
+
+    expect(ops.filter((o) => o.name === 'create_frame').length).toBeGreaterThanOrEqual(2);
+
+    const frameIds: string[] = [];
+    for (const op of ops) {
+      const res = executeDesignTool(op.name, JSON.stringify(op.args), toolCtx);
+      if (res.status === 'error') {
+        throw new Error(`${op.name} failed: ${res.summary}`);
+      }
+      if (op.name === 'create_frame') {
+        const fid = String(res.artifacts?.frameId || '');
+        expect(fid).toBeTruthy();
+        toolCtx.targetFrameId = fid;
+        frameIds.push(fid);
+      }
+    }
+
+    expect(doc.frames.length).toBe(2);
+    expect(String(doc.frames[0].name)).toBe('Login');
+    expect(String(doc.frames[1].name)).toBe('Home');
+    expect(frameIds).toEqual(['frame_1', 'frame_2']);
+
+    const f0 = doc.frames[0];
+    const f1 = doc.frames[1];
+    const overlap =
+      Number(f0.x) < Number(f1.x) + Number(f1.width) &&
+      Number(f0.x) + Number(f0.width) > Number(f1.x) &&
+      Number(f0.y) < Number(f1.y) + Number(f1.height) &&
+      Number(f0.y) + Number(f0.height) > Number(f1.y);
+    expect(overlap).toBe(false);
+
+    const nodeCount = Object.keys(doc.deltaSetLike || {}).filter(
+      (k) => k !== 'ROOT' && !String(k).startsWith('page')
+    ).length;
+    expect(nodeCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('host single-plate path strips create_frame from paint batch', () => {
+    const ops = [
+      { name: 'create_frame', args: { name: 'Only', width: 390, height: 844 } },
+      {
+        name: 'create_shape',
+        args: { shapeType: 'rect', x: 0, y: 0, width: 10, height: 10 },
+      },
+    ];
+    const liveFrameId = 'host_opened';
+    const paintOps = liveFrameId
+      ? ops.filter((o) => o.name !== 'create_frame')
+      : ops;
+    expect(paintOps).toHaveLength(1);
+    expect(paintOps[0].name).toBe('create_shape');
+  });
+});

--- a/apps/web/src/components/editor/panels/agent/runDesignAgent.ts
+++ b/apps/web/src/components/editor/panels/agent/runDesignAgent.ts
@@ -1034,6 +1034,34 @@ async function applyAgentToolOps(opts: {
     return { created, updated, deleted, nodeIds, frameId: outFrameId, opResults };
   }
 
+  const pickTargetFrameIdForCreate = (
+    doc: any,
+    args: Record<string, unknown>,
+    fallback: string | null
+  ): string | null => {
+    const frames = Array.isArray(doc?.frames) ? doc.frames : [];
+    if (frames.length <= 1) {
+      return fallback || (frames[0]?.id != null ? String(frames[0].id) : null);
+    }
+    const x = Number(args.x);
+    const y = Number(args.y);
+    if (!Number.isFinite(x) || !Number.isFinite(y)) return fallback;
+    let best: { id: string; area: number } | null = null;
+    for (const f of frames) {
+      const id = String(f?.id || '').trim();
+      if (!id) continue;
+      const fx = Number(f.x) || 0;
+      const fy = Number(f.y) || 0;
+      const fw = Math.max(1, Number(f.width) || 1);
+      const fh = Math.max(1, Number(f.height) || 1);
+      if (x >= fx && x < fx + fw && y >= fy && y < fy + fh) {
+        const area = fw * fh;
+        if (!best || area < best.area) best = { id, area };
+      }
+    }
+    return best?.id || fallback;
+  };
+
   dispatch(pushEditorHistory());
   for (let i = 0; i < allowed.length; i++) {
     if (signal?.aborted) break;
@@ -1051,7 +1079,19 @@ async function applyAgentToolOps(opts: {
       continue;
     }
     const opId = String((op as { op_id?: string })?.op_id || '');
-    const args = op?.args && typeof op.args === 'object' ? op.args : {};
+    const args = op?.args && typeof op.args === 'object' ? { ...op.args } : {};
+    if (
+      name.startsWith('create_') &&
+      name !== 'create_frame' &&
+      name !== 'create_page'
+    ) {
+      const picked = pickTargetFrameIdForCreate(
+        getDocument(),
+        args,
+        toolCtx.targetFrameId
+      );
+      if (picked) toolCtx.targetFrameId = picked;
+    }
     if (name === 'create_shape' && (args.path != null || String(args.type || args.shapeType || '') === 'path')) {
       console.info('[tool_ops raw create_shape]', {
         i,
@@ -2912,14 +2952,23 @@ export async function runDesignAgent(params: RunDesignAgentParams): Promise<void
       const pinned = explicitPinnedFrameId({
         pinnedFrameId: params.pinnedFrameId,
       });
-      const aiCreatesFrame = ops.some(
+      const createFrameCount = ops.filter(
         (o: { name?: string }) => String(o?.name || '').trim() === 'create_frame'
-      );
+      ).length;
+      const multiArtboards = createFrameCount >= 2;
+      const aiCreatesFrame = createFrameCount > 0;
       // Free-canvas add (rect/text/…) must not inherit ambient FOCUS / page frame.
       const bindToBoard = Boolean(pinned || aiCreatesFrame || editInPlace);
 
-      // Fallback if backend did not emit open_artboard: Host opens plate first.
-      if (!pinned && !live.frameId && aiCreatesFrame && !editInPlace) {
+      // Single-plate fallback if backend did not emit open_artboard.
+      // Multi create_frame: do not pre-open — applyAgentToolOps retargets after each plate.
+      if (
+        !pinned &&
+        !live.frameId &&
+        aiCreatesFrame &&
+        !editInPlace &&
+        !multiArtboards
+      ) {
         const fromOp = sizeFromCreateFrameOp(ops);
         const resolved =
           parseResolvedSize(paintCanvasSize()) ||
@@ -2940,21 +2989,25 @@ export async function runDesignAgent(params: RunDesignAgentParams): Promise<void
         }
       }
 
-      // Host already opened → drop model create_frame so we don't get a second plate.
-      // Do not reject create_* that carry frameId — placement follows the model / user intent.
+      // Host already opened one plate → drop model create_frame (avoid duplicate).
+      // Multi-artboard batches keep every create_frame so sibling boards are created.
       const paintOps =
-        live.frameId || pinned
-          ? ops.filter((o) => String(o?.name || '').trim() !== 'create_frame')
-          : ops;
+        multiArtboards
+          ? ops
+          : live.frameId || pinned
+            ? ops.filter((o) => String(o?.name || '').trim() !== 'create_frame')
+            : ops;
 
-      const frameId = bindToBoard
-        ? resolveToolOpsFrameId({
-            editInPlace,
-            liveFrameId: live.frameId,
-            targetFrameId: params.targetFrameId,
-            pinnedFrameId: params.pinnedFrameId,
-          })
-        : null;
+      const frameId = multiArtboards
+        ? null
+        : bindToBoard
+          ? resolveToolOpsFrameId({
+              editInPlace,
+              liveFrameId: live.frameId,
+              targetFrameId: params.targetFrameId,
+              pinnedFrameId: params.pinnedFrameId,
+            })
+          : null;
       if (frameId) {
         live.frameId = frameId;
         // Plate scan-light only for new/blank boards — not for adding a rect onto a page.

--- a/apps/web/src/components/layout/LoginDialog.tsx
+++ b/apps/web/src/components/layout/LoginDialog.tsx
@@ -496,14 +496,16 @@ function LoginDialog({ open, onClose, returnTo, onSuccess }: LoginDialogProps) {
     const trimmed = email.trim().toLowerCase();
     const body: { email: string; captchaToken?: string } = { email: trimmed };
     if (captchaToken) body.captchaToken = captchaToken;
-    await sendEmailCode(body);
+    const res = await sendEmailCode(body);
     setPendingCaptchaToken(null);
     setShowCaptcha(false);
     setCaptchaResume(null);
     setEmail(trimmed);
     setCodeSent(true);
     startResendCooldown();
-    message.success(t('auth.codeSent'));
+    message.success(
+      res?.mode === 'console' ? t('auth.codeSentConsole') : t('auth.codeSent')
+    );
   };
 
   const onGoogleContinue = () => {

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -313,6 +313,7 @@ const en = {
     resendIn: 'Resend in {{seconds}}s',
     resent: 'Code resent',
     codeSent: 'Verification code sent — check your email',
+    codeSentConsole: 'Verification code printed in the API server console (self-host)',
     linkInvalid: 'Login link is invalid or expired',
     activating: 'Signing you in…',
     checkEmailTitle: 'Check your email',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -300,6 +300,7 @@ const ja = {
     resendIn: '{{seconds}}秒後に再送信',
     resent: '確認コードを再送信しました',
     codeSent: '確認コードをメールに送信しました',
+    codeSentConsole: '確認コードは API サーバーのコンソールに出力されました（セルフホスト）',
     passwordTitle: 'パスワードを設定',
     passwordSubtitle: 'ログイン用パスワードを設定して登録を完了',
     nickname: 'ニックネーム（任意）',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -311,6 +311,7 @@ const zhCN = {
     resendIn: '{{seconds}}s 后可重发',
     resent: '验证码已重新发送',
     codeSent: '验证码已发送，请查收邮件',
+    codeSentConsole: '验证码已打印到 API 服务端控制台（自托管）',
     linkInvalid: '登录链接无效或已过期',
     activating: '正在登录…',
     checkEmailTitle: '查收登录邮件',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -299,6 +299,7 @@ const zhTW = {
     resendIn: '{{seconds}}s 後可重發',
     resent: '已重新發送驗證碼',
     codeSent: '驗證碼已發送到信箱',
+    codeSentConsole: '驗證碼已列印到 API 伺服器主控台（自託管）',
     passwordTitle: '設定密碼',
     passwordSubtitle: '設定登入密碼以完成信箱註冊',
     nickname: '暱稱（選填）',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,8 @@ services:
       # Must match collab service. Public URL is what browsers open (via web nginx).
       - COLLAB_TOKEN_SECRET=${COLLAB_TOKEN_SECRET:-dev-collab-token-secret-change-me}
       - COLLAB_PUBLIC_WS_URL=${COLLAB_PUBLIC_WS_URL:-ws://localhost:3000/collab}
+      # Self-host: print login OTP to API logs when SES is unset (never enable on Cloud).
+      - AUTH_CONSOLE_LOGIN_CODE=${AUTH_CONSOLE_LOGIN_CODE:-true}
     depends_on:
       redis:
         condition: service_healthy

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -76,6 +76,19 @@ docker compose up -d --build
 
 On first API start, schema + seed data are applied automatically.
 
+### First login (no mail provider)
+
+Self-host only (`AUTH_CONSOLE_LOGIN_CODE=true`, set by default in `docker-compose.yml`).  
+When SES is unset, email login prints the OTP to API logs — **do not enable this on Cloud / public production**.
+
+1. Open the web UI → sign in with any email you control.
+2. Request a code — the UI says to check API logs.
+3. Read `LOGIN CODE (AUTH_CONSOLE_LOGIN_CODE) … code=######` in the API container / `npm run dev:api` terminal.
+4. Enter that 6-digit code in the UI.
+
+Dev without compose: set `AUTH_CONSOLE_LOGIN_CODE=true` in `apps/api/.env`.  
+Configure SES (`TENCENT_SECRET_*`, `SES_FROM_EMAIL`, `SES_TEMPLATE_ID`, …) for real email. Google OAuth is optional (`GOOGLE_CLIENT_ID`).
+
 Bring your own LLM keys (DeepSeek / Doubao / OpenRouter / …). Without keys, Agent features will not call models.
 
 ### Credits & membership (self-host)
@@ -153,6 +166,7 @@ Do this **before** exposing port 3000 / 8000 to the internet:
 8. Restrict CORS (`CORS_ORIGINS`) to your real origins.
 9. Confirm Redis/MySQL are host-only (`127.0.0.1:…` in compose — do not publish them publicly).
 10. Confirm DB backups (`DB_BACKUP_*`) or cloud automated backups.
+11. Set `AUTH_CONSOLE_LOGIN_CODE=false` (or unset) once SES/Google auth is configured — never leave log OTPs on a public host.
 
 API startup logs **warnings** if admin password, collab secret, default MySQL password, card salt, or BYOK key look like local defaults.
 


### PR DESCRIPTION
## Summary
- Opt-in `AUTH_CONSOLE_LOGIN_CODE` prints login OTP to the API console when SES is unset (compose defaults on; Cloud/prod stays off), with LoginDialog + i18n for `mode: console`.
- Keep ≥2 `create_frame` ops in one agent run (no single-host strip), FE retargets by world coords; paint timeout 75→180s; pencil/`pathPressure` prompt hints.
- Unit tests for multi-artboard paint (API + FE).

## Test plan
- [ ] Self-host: unset SES, `AUTH_CONSOLE_LOGIN_CODE=true`, send-code → OTP in API logs, UI shows console message, verify login works
- [ ] Cloud/prod: `AUTH_CONSOLE_LOGIN_CODE` false → send-code still requires SES (no console leak)
- [ ] Agent: ask for 2+ artboards in one run → both frames keep; single frame still uses host open_artboard path
- [ ] `pytest apps/api/tests/unit_tests/test_multi_artboard_paint.py`
- [ ] FE `multiArtboardPaint.test.ts` passes