### PR TITLE
Fix Lottie snap stickiness and selection chrome drift

### DIFF
--- a/apps/web/src/components/editor/canvas/SvgCanvas.tsx
+++ b/apps/web/src/components/editor/canvas/SvgCanvas.tsx
@@ -2947,6 +2947,12 @@ function SvgCanvas({
                 document={document}
                 hidden={geometryTransforming}
                 readOnly={readOnly}
+                geometryOverrides={
+                  videoLiveGeom as Record<
+                    string,
+                    { left: number; top: number; width: number; height: number }
+                  > | null
+                }
               />
             </>
           ) : null}

--- a/apps/web/src/components/editor/nodes/LottieGeneratorNode/LottieGeneratorOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/LottieGeneratorNode/LottieGeneratorOverlay.tsx
@@ -5,19 +5,30 @@ import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import LottieGeneratorCard from '@/components/editor/nodes/LottieGeneratorNode/LottieGeneratorCard';
 import { EMPTY_ID_LIST } from '@/store/modules/editor';
 
+export type LottieGenGeomOverride = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+};
+
 /**
  * World-layer Lottie Generator composers (same lattice as video/image generators).
  * SVG keeps the hit target; the title row comes from the shared selection label.
+ * `geometryOverrides` matches finished Lottie/video so the plate stays glued to chrome
+ * while Redux is still on the pre-gesture document.
  */
 function LottieGeneratorOverlay({
   document,
   hidden,
   readOnly,
+  geometryOverrides = null,
 }: {
   document: any;
   /** Hide while move / resize / rotate is in progress. */
   hidden?: boolean;
   readOnly?: boolean;
+  geometryOverrides?: Record<string, LottieGenGeomOverride> | null;
 }): ReactNode {
   const selectedNodeIds: string[] = useSelector(
     (state: any) => (state.editor.selectedNodeIds as string[]) ?? EMPTY_ID_LIST
@@ -38,13 +49,19 @@ function LottieGeneratorOverlay({
         const node = document?.deltaSetLike?.[nodeId];
         if (!node) return null;
         const { left, top } = nodeLeftTop(document, node);
-        const width = Math.max(1, Number(node.width) || 1);
-        const height = Math.max(1, Number(node.height) || 1);
+        const ov = geometryOverrides?.[nodeId];
+        const width = Math.max(1, ov ? ov.width : Number(node.width) || 1);
+        const height = Math.max(1, ov ? ov.height : Number(node.height) || 1);
         return (
           <LottieGeneratorCard
             key={nodeId}
             nodeId={nodeId}
-            sceneBox={{ x: left, y: top, width, height }}
+            sceneBox={{
+              x: ov ? ov.left : left,
+              y: ov ? ov.top : top,
+              width,
+              height,
+            }}
             showComposer={!hidden && selectedNodeIds.length === 1 && selectedNodeIds[0] === nodeId}
             disabled={readOnly}
           />

--- a/apps/web/src/components/rcb/core/geometry/__tests__/baseline.test.ts
+++ b/apps/web/src/components/rcb/core/geometry/__tests__/baseline.test.ts
@@ -138,6 +138,18 @@ describe('getShapeBaseline', () => {
     expect(b?.d).toContain('C ');
   });
 
+  it('lottie generator uses sharp box baseline like image/video generators', () => {
+    const b = getShapeBaseline({
+      key: 'lottie',
+      width: 80,
+      height: 80,
+      attrs: { lottieGenerator: true },
+    });
+    expect(b?.closed).toBe(true);
+    expect(b?.kind).toBe('box');
+    expect(b?.d).toMatch(/^M 0 0/);
+  });
+
   it('scales path baseline on live resize', () => {
     const b = getShapeBaseline(
       {

--- a/apps/web/src/components/rcb/core/geometry/baseline.ts
+++ b/apps/web/src/components/rcb/core/geometry/baseline.ts
@@ -81,7 +81,14 @@ export function getShapeBaseline(
   const key = String(node.key || '');
   const shapeType = resolveShapeType(node);
 
-  if (shapeType === 'text' || shapeType === 'image' || key === 'text' || key === 'image' || key === 'video') {
+  if (
+    shapeType === 'text' ||
+    shapeType === 'image' ||
+    key === 'text' ||
+    key === 'image' ||
+    key === 'video' ||
+    key === 'lottie'
+  ) {
     // Match sceneToSvg plate / clip path (generators are always sharp).
     const gen =
       (key === 'image' &&
@@ -93,7 +100,12 @@ export function getShapeBaseline(
         (node.attrs?.videoGenerator === true ||
           node.attrs?.videoGenerator === 'true' ||
           node.attrs?.videoGenerator === 1 ||
-          node.attrs?.videoGenerator === '1'));
+          node.attrs?.videoGenerator === '1')) ||
+      (key === 'lottie' &&
+        (node.attrs?.lottieGenerator === true ||
+          node.attrs?.lottieGenerator === 'true' ||
+          node.attrs?.lottieGenerator === 1 ||
+          node.attrs?.lottieGenerator === '1'));
     const r = gen
       ? { tl: 0, tr: 0, br: 0, bl: 0 }
       : key === 'text'

--- a/apps/web/src/components/rcb/scene/paint/sceneToSvg.ts
+++ b/apps/web/src/components/rcb/scene/paint/sceneToSvg.ts
@@ -2338,8 +2338,8 @@ function previewResizeImage(
 ): boolean {
   const anyEl = el as any;
   const key = String(anyEl.sceneNodeKey || el.getAttribute('data-scene-node-key') || '');
-  // Video plates use the same poster/<image> (or path) group layout as images.
-  if (key !== 'image' && key !== 'video') {
+  // Video / lottie plates use the same poster/<image> (or path) group layout as images.
+  if (key !== 'image' && key !== 'video' && key !== 'lottie') {
     return false;
   }
 
@@ -2581,7 +2581,7 @@ export function previewSvgNodeGeometry(
   const anyEl = el as any;
   const nodeKey = String(anyEl.sceneNodeKey || el.getAttribute('data-scene-node-key') || '');
 
-  if (nodeKey === 'image' || nodeKey === 'video') {
+  if (nodeKey === 'image' || nodeKey === 'video' || nodeKey === 'lottie') {
     return previewResizeImage(el, box);
   }
   if (nodeKey === 'svg') {

--- a/apps/web/src/components/rcb/selection/HostPathChrome.tsx
+++ b/apps/web/src/components/rcb/selection/HostPathChrome.tsx
@@ -56,12 +56,14 @@ function liveShapeGeomBox(nodeId: string): SceneBox | null {
   return { left, top, width, height };
 }
 
-/** Shape / image / video / path on SVG host (not text / frame). */
+/** Shape / image / video / lottie / path on SVG host (not text / frame). */
 function nodeUsesPathChrome(node: any): boolean {
   if (!node) return false;
   const key = String(node.key || '');
   if (key === 'text' || key === 'frame') return false;
-  if (key === 'image' || key === 'video') return true;
+  // Media plates share the host lattice so chrome tracks SVG `__sceneLeft` —
+  // world SelectionChrome from Redux alone drifts after sticky re-align.
+  if (key === 'image' || key === 'video' || key === 'lottie') return true;
   if (key === 'shape' || key === 'path' || key === 'rect' || key === 'ellipse') return true;
   return Boolean(node.attrs?.shapeType);
 }

--- a/apps/web/src/components/rcb/selection/__tests__/moveSnapStickiness.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/moveSnapStickiness.test.ts
@@ -148,4 +148,35 @@ describe('move snap stickiness + grid integrity', () => {
     // Without sticky this chatters 100↔104; with sticky it should hold one side.
     expect(seen.size).toBe(1);
   });
+
+  it('after first sticky flush, intentional move to competing guide re-aligns (not stuck)', () => {
+    // Repro: first horizontal snap locks sticky; hunting the neighbor magnet
+    // felt "卡住" until a vertical nudge left the band. Sticky may break ties /
+    // ±jitter, but must not keep a guide that is clearly farther than another.
+    const left = { left: 0, top: 0, width: 100, height: 80 };
+    const rightAnchor = { left: 204, top: 0, width: 100, height: 80 };
+    const targets = [left, rightAnchor];
+    let stickyAt: { x?: number; y?: number } = {};
+
+    const first = productionMoveSettle({
+      box: { left: 100.4, top: 0, width: 100, height: 80 },
+      targets,
+      zoom: 1,
+      stickyAt,
+    });
+    expect(first.box.left).toBe(100);
+    stickyAt = first.stickyAt;
+    expect(stickyAt.x).toBe(100);
+
+    // Pointer clearly prefers the competing flush (104): ~1.2px closer raw.
+    // Old hysteresis=2 kept score(sticky)=0.8 < 1.2 → stuck at 100.
+    const second = productionMoveSettle({
+      box: { left: 102.8, top: 0, width: 100, height: 80 },
+      targets,
+      zoom: 1,
+      stickyAt,
+    });
+    expect(second.box.left).toBe(104);
+    assertBoxOnGrid(second.box, 1);
+  });
 });

--- a/apps/web/src/components/rcb/selection/__tests__/videoImageLayerParity.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/videoImageLayerParity.test.ts
@@ -38,6 +38,21 @@ function videoNode(box: { x: number; y: number; width: number; height: number })
   };
 }
 
+function lottieGenNode(box: { x: number; y: number; width: number; height: number }) {
+  return {
+    key: 'lottie',
+    x: box.x,
+    y: box.y,
+    width: box.width,
+    height: box.height,
+    attrs: {
+      animationData: '',
+      lottieGenerator: true,
+      assetKind: 'lottie',
+    },
+  };
+}
+
 const box = { x: 10, y: 20, width: 28, height: 38 };
 const doc = { x: 0, y: 0, deltaSetLike: {} };
 
@@ -154,5 +169,25 @@ describe('video move preview geom == HTML plate override', () => {
       width: htmlOverride.width,
       height: htmlOverride.height,
     });
+  });
+
+  it('lottie generator move keeps SVG geom on the same lattice as image/video', async () => {
+    const { root, layer } = svgRoot({
+      'data-rcb-infinite': '1',
+      'data-rcb-world-surface': '1',
+    });
+    const node = lottieGenNode(box);
+    const el = await nodeToSvgElement(root, layer, doc, node, 'lottie-gen-move');
+    expect(el).toBeTruthy();
+    const nodeEls = new Map<string, SVGElement>([['lottie-gen-move', el!]]);
+    const moved = { left: 50, top: 60, width: 28, height: 38 };
+    expect(previewSvgNodeGeometry(nodeEls, 'lottie-gen-move', moved)).toBe(true);
+    const anyEl = el as any;
+    expect({
+      left: Number(anyEl.__sceneLeft),
+      top: Number(anyEl.__sceneTop),
+      width: Number(anyEl.sceneWidth),
+      height: Number(anyEl.sceneHeight),
+    }).toEqual(moved);
   });
 });

--- a/apps/web/src/components/rcb/selection/alignGuides.ts
+++ b/apps/web/src/components/rcb/selection/alignGuides.ts
@@ -524,9 +524,11 @@ export function snapMoveToSmartGuides(opts: {
   let bestY: Cand | null = null;
 
   const roleRank = (r: AxisMark['role']) => (r === 'mid' ? 1 : 0);
-  // Small scene sticky only — do NOT scale with snap threshold or low zoom
-  // holds the wrong guide across dozens of cells and blocks the real magnet.
-  const hysteresis = Math.max(gridSize > 0 ? gridSize : 1, 2);
+  // Tie-break / anti-chatter only (±jitter around a midpoint). Do NOT use a
+  // large bonus: hysteresis=2 kept the first flush when the competing guide was
+  // already ~1px closer ("first snap OK, later stuck until I nudge Y").
+  // Do NOT scale with snap threshold / low zoom either.
+  const hysteresis = Math.max(gridSize > 0 ? gridSize : 1, 1);
 
   const mx = boxXMarks(box);
   const my = boxYMarks(box);


### PR DESCRIPTION
## Summary
- Tighten move-snap sticky hysteresis so the first magnet does not block intentional re-align (horizontal hunt no longer stuck until a vertical nudge).
- Keep Lottie (including generators) on the same host chrome / preview geom lattice as image and video so the control box stays glued after repeated snaps.
- Add regression tests for sticky re-align escape, Lottie baseline, and Lottie move preview geom.

## Test plan
- [ ] Drag two Lottie generators horizontally to align, then hunt a competing guide — should re-snap without needing a vertical nudge
- [ ] Repeat align/move several times — selection chrome should stay on the plate (no detach like before)
- [ ] `npx vitest run src/components/rcb/selection/__tests__/moveSnapStickiness.test.ts src/components/rcb/selection/__tests__/videoImageLayerParity.test.ts src/components/rcb/core/geometry/__tests__/baseline.test.ts`