### PR TITLE
Add vector pencil brushes, hardness, and sharper live tip preview

### DIFF
--- a/apps/web/src/components/editor/chrome/PenStrokeToolbar.tsx
+++ b/apps/web/src/components/editor/chrome/PenStrokeToolbar.tsx
@@ -37,9 +37,13 @@ import {
 } from '@/store/modules/editor';
 import { cn } from '@/utils/classnames';
 
-const CUSTOM_BRUSH_STORAGE_KEY = 'recombine-custom-pencil-brushes-v2';
+const CUSTOM_BRUSH_STORAGE_KEY = 'recombine-custom-pencil-brushes-v3';
 const MAX_CUSTOM_BRUSHES = 48;
 const MAX_BRUSH_FILE_BYTES = 2.5 * 1024 * 1024;
+const LEGACY_CUSTOM_BRUSH_KEYS = [
+  'recombine-custom-pencil-brushes-v1',
+  'recombine-custom-pencil-brushes-v2',
+];
 
 type StoredBrush = {
   id: string;
@@ -129,15 +133,15 @@ function persistCustomBrushes(list: StoredBrush[]) {
 }
 
 function hydrateCustomPencilBrushes(): PencilBrushDef[] {
-  // Migrate v1 tip-only store if present.
-  const v2 = localStorage.getItem(CUSTOM_BRUSH_STORAGE_KEY);
-  if (!v2) {
-    const v1 = localStorage.getItem('recombine-custom-pencil-brushes-v1');
-    if (v1) {
-      return persistCustomBrushes(parseStoredBrushes(v1));
+  // Drop legacy custom stores — old tip/freehand leftovers were cluttering the wheel.
+  try {
+    for (const key of LEGACY_CUSTOM_BRUSH_KEYS) {
+      localStorage.removeItem(key);
     }
+  } catch {
+    /* ignore */
   }
-  return persistCustomBrushes(parseStoredBrushes(v2));
+  return persistCustomBrushes(parseStoredBrushes(localStorage.getItem(CUSTOM_BRUSH_STORAGE_KEY)));
 }
 
 function listStoredCustomBrushes(): StoredBrush[] {
@@ -268,7 +272,7 @@ function BrushStrokePreview({
     );
   }
 
-  const d = brushPreviewPath(brush, 9);
+  const d = brushPreviewPath(brush, 9, hardness);
   return (
     <svg
       className={className}
@@ -689,11 +693,15 @@ function PenStrokeToolbar({
         {isPencil ? (
           <>
             <span className="mx-0.5 h-4 w-px bg-[var(--line)]" aria-hidden />
-            {/* Hardness — tip edge softness; also drives dab spacing. */}
+            {/* Hardness: tip edge for stamps; pressure width / taper for vector ink. */}
             <label
               className="inline-flex h-6 shrink-0 items-center gap-1 rounded-[4px] bg-[var(--accent-soft)] px-1.5"
               onPointerDown={(e) => e.stopPropagation()}
-              title="硬度（笔尖边缘软硬）"
+              title={
+                brush.kind === 'stamp'
+                  ? '硬度（笔尖边缘软硬）'
+                  : '硬度（软=压感粗细更明显，硬=更均匀）'
+              }
             >
               <span className="shrink-0 text-[10px] text-[var(--muted)]">硬</span>
               <input

--- a/apps/web/src/components/editor/panels/agent/designTools.ts
+++ b/apps/web/src/components/editor/panels/agent/designTools.ts
@@ -399,8 +399,11 @@ function resolveCreateShapeBorderWidth(opts: {
   return 0;
 }
 
-/** Tip brush ids Agent may emit (matches FE PENCIL_BRUSHES). */
+/** Tip + vector brush ids Agent may emit (matches FE PENCIL_BRUSHES). */
 const PENCIL_TIP_BRUSH_IDS = new Set([
+  'vector-ink',
+  'vector-even',
+  'vector-calligraphy',
   'solid',
   'pencil-hb',
   'soft',
@@ -418,7 +421,7 @@ const PENCIL_TIP_BRUSH_IDS = new Set([
   'bold',
 ]);
 
-/** Legacy freehand / seed ids → tip brush (keep in sync with pencilBrushes LEGACY_FREEHAND_ALIAS). */
+/** Legacy freehand / seed ids → tip / vector brush (keep in sync with pencilBrushes). */
 const PENCIL_BRUSH_LEGACY_ALIAS: Record<string, string> = {
   crayon: 'chalk',
   dry: 'bristle',
@@ -428,6 +431,14 @@ const PENCIL_BRUSH_LEGACY_ALIAS: Record<string, string> = {
   'tip-hard': 'solid',
   'tip-chalk': 'chalk',
   'tip-bristle': 'bristle',
+  freehand: 'vector-ink',
+  vector: 'vector-ink',
+  blob: 'vector-ink',
+  even: 'vector-even',
+  'vector-uniform': 'vector-even',
+  'vector-marker': 'vector-even',
+  'vector-brush': 'vector-calligraphy',
+  'vector-script': 'vector-calligraphy',
 };
 
 function resolvePencilBrushStyle(

--- a/apps/web/src/components/rcb/scene/paint/sceneToSvg.ts
+++ b/apps/web/src/components/rcb/scene/paint/sceneToSvg.ts
@@ -982,11 +982,16 @@ function createShape(ctx: DrawCtx, document: any, node: any, nodeId: string) {
       // Outline is built around `pts` in place — do not translate relative to the path.
       // Keep an invisible centerline baseline for selection chrome hit-testing.
       const pressures = parsePathPressures(node.attrs?.pathPressure, pts.length);
+      const hardnessRaw = Number(node.attrs?.brushHardness);
+      const freehandHardness = Number.isFinite(hardnessRaw)
+        ? Math.max(0, Math.min(100, hardnessRaw))
+        : 80;
       const outlineD = pencilInkPathFromPoints(pts, strokeWidth, brushId, {
         linecap: strokeOpen.linecap,
         dasharray: strokeFull.dasharray,
         pressures,
-        pressureEnabled: true,
+        pressureEnabled: boolEffectAttr(node.attrs?.pressureEnabled, true),
+        hardness: freehandHardness,
       });
       const g = appendChild(parent, svgEl('g'));
       if (outlineD) {

--- a/apps/web/src/components/rcb/tools/PencilDrawFeature.tsx
+++ b/apps/web/src/components/rcb/tools/PencilDrawFeature.tsx
@@ -37,6 +37,7 @@ import {
   type RcbCamera as CanvasCamera,
 } from '../core/types';
 import { sceneSurfaceSvgProps } from '@/components/rcb/scene/paint/sceneToSvg';
+import { readDevicePixelRatio } from '@/components/rcb/core/dpr';
 
 type SceneBox = { left: number; top: number; width: number; height: number };
 
@@ -76,7 +77,9 @@ export const ERASER_CURSOR = `url("${eraserCursorUrl}") 3 15, crosshair`;
 export const PEN_CURSOR = `url("${penCursorUrl}") 1 1, crosshair`;
 export const BUCKET_CURSOR = `url("${bucketCursorUrl}") 15 18, fill`;
 
-const STAMP_PREVIEW_MAX_PX = 1536;
+/** Cap live tip bitmap edge (device px). Full-viewport @2× needs ~3–4k. */
+const STAMP_PREVIEW_MAX_PX = 4096;
+
 const tipImageCache = new Map<string, HTMLImageElement>();
 
 function tipImageForSrc(src: string): HTMLImageElement | null {
@@ -94,6 +97,7 @@ function tipImageForSrc(src: string): HTMLImageElement | null {
 
 type StampLiveBlit = {
   boxKey: string;
+  /** Device pixels per scene unit used for the bitmap. */
   scale: number;
   painted: number;
   tipKey: string;
@@ -101,7 +105,7 @@ type StampLiveBlit = {
 
 /**
  * Paint tip stamps onto the live canvas — no toDataURL (that was the draw lag).
- * Incremental when the view box / tip stay the same.
+ * Bitmap density tracks camera zoom × DPR so preview isn't soft while drawing.
  */
 function blitStampLivePreview(
   canvas: HTMLCanvasElement,
@@ -110,9 +114,15 @@ function blitStampLivePreview(
   tip: HTMLImageElement,
   strokeOpacity: number,
   tipKey: string,
-  state: StampLiveBlit
+  state: StampLiveBlit,
+  cameraZoom: number
 ): StampLiveBlit {
-  const scale = Math.min(1, STAMP_PREVIEW_MAX_PX / Math.max(box.width, box.height));
+  const dpr = Math.max(1, readDevicePixelRatio());
+  const zoom = Math.max(0.05, cameraZoom || 1);
+  // Match on-screen density (scene → CSS zoom → device px).
+  const want = dpr * zoom;
+  const maxSide = STAMP_PREVIEW_MAX_PX;
+  const scale = Math.min(want, maxSide / Math.max(box.width, box.height, 1));
   const cw = Math.max(1, Math.ceil(box.width * scale));
   const ch = Math.max(1, Math.ceil(box.height * scale));
   const boxKey = `${box.left}|${box.top}|${box.width}|${box.height}|${cw}x${ch}`;
@@ -131,6 +141,8 @@ function blitStampLivePreview(
     if (canvas.height !== ch) canvas.height = ch;
     ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.clearRect(0, 0, cw, ch);
+    ctx.imageSmoothingEnabled = true;
+    if ('imageSmoothingQuality' in ctx) ctx.imageSmoothingQuality = 'high';
     ctx.setTransform(scale, 0, 0, scale, -box.left * scale, -box.top * scale);
     paintStampDabs(ctx, dabs, tip, strokeOpacity, 0);
     return { boxKey, scale, painted: dabs.length, tipKey };
@@ -467,7 +479,8 @@ function PencilDrawFeature({
           tipImg,
           opacityRef.current,
           tinted,
-          stampBlitRef.current
+          stampBlitRef.current,
+          zoom
         );
       }
       setPreview((prev) => {
@@ -489,6 +502,7 @@ function PencilDrawFeature({
     const hasPressure = pressures.some((p) => typeof p === 'number' && Number.isFinite(p));
     const d = outlinePathFromPoints(points, widthRef.current, brush.id, {
       pressureEnabled: pressureRef.current,
+      hardness: hardnessRef.current,
       pressures: hasPressure
         ? pressures.map((p) => (typeof p === 'number' && Number.isFinite(p) ? p : 0.5))
         : undefined,

--- a/apps/web/src/components/rcb/tools/__tests__/brushPack.test.ts
+++ b/apps/web/src/components/rcb/tools/__tests__/brushPack.test.ts
@@ -33,15 +33,22 @@ describe('recombyn brush pack', () => {
     expect(JSON.parse(json).format).toBe(BRUSH_PACK_FORMAT);
   });
 
-  it('builtin wheel is tip stamps including pencil', () => {
+  it('builtin wheel starts with vector brushes then tip stamps', () => {
     setOfficialPencilBrushes(null);
     setCustomPencilBrushes([]);
     const list = listPencilBrushes();
-    expect(list.every((b) => b.kind === 'stamp' && Boolean(b.stampSrc))).toBe(true);
+    expect(list.slice(0, 3).map((b) => b.id)).toEqual([
+      'vector-ink',
+      'vector-even',
+      'vector-calligraphy',
+    ]);
+    expect(list.slice(0, 3).every((b) => b.kind === 'freehand')).toBe(true);
     expect(list.map((b) => b.id)).toEqual(PENCIL_BRUSHES.map((b) => b.id));
     expect(findPencilBrush('pencil-hb').stampSrc).toMatch(/\/brushes\/tips\/pencil\.png$/);
     expect(findPencilBrush('solid').kind).toBe('stamp');
-    expect(TIP_STAMP_BRUSHES).toBe(PENCIL_BRUSHES);
+    expect(findPencilBrush('vector-even').kind).toBe('freehand');
+    expect(findPencilBrush('vector-calligraphy').options.thinning).toBeGreaterThan(0.5);
+    expect(TIP_STAMP_BRUSHES.every((b) => b.kind === 'stamp')).toBe(true);
   });
 
   it('keeps fixed tip spacing (does not sparsify into dots)', () => {

--- a/apps/web/src/components/rcb/tools/__tests__/tipStamps.test.ts
+++ b/apps/web/src/components/rcb/tools/__tests__/tipStamps.test.ts
@@ -8,6 +8,7 @@ import {
   findPencilBrush,
   isStampBrush,
   listPencilBrushes,
+  outlinePathFromPoints,
   paintStampDabs,
   setCustomPencilBrushes,
   setOfficialPencilBrushes,
@@ -18,18 +19,70 @@ import {
 const TIPS_DIR = resolve(__dirname, '../../../../../public/brushes/tips');
 
 describe('pencil tip stamps', () => {
-  it('every builtin brush is a tip stamp with a public tip file', () => {
+  it('builtin tip stamps have public tip files; vector brushes are freehand', () => {
     setOfficialPencilBrushes(null);
     setCustomPencilBrushes([]);
     const list = listPencilBrushes();
     expect(list.length).toBeGreaterThan(5);
-    for (const b of list) {
-      expect(b.kind).toBe('stamp');
+    const vectors = list.filter((b) => b.kind === 'freehand');
+    expect(vectors.map((b) => b.id)).toEqual([
+      'vector-ink',
+      'vector-even',
+      'vector-calligraphy',
+    ]);
+    for (const v of vectors) {
+      expect(isStampBrush(v.id)).toBe(false);
+    }
+    for (const b of list.filter((x) => x.kind === 'stamp')) {
       expect(b.stampSrc).toMatch(/^\/brushes\/tips\/.+\.png$/);
       expect(isStampBrush(b.id, b.stampSrc)).toBe(true);
       const file = String(b.stampSrc).replace('/brushes/tips/', '');
       expect(existsSync(resolve(TIPS_DIR, file)), `missing tip ${file}`).toBe(true);
     }
+  });
+
+  it('vector brushes build filled freehand outlines (not stamp)', () => {
+    setOfficialPencilBrushes(null);
+    setCustomPencilBrushes([]);
+    for (const id of ['vector-ink', 'vector-even', 'vector-calligraphy'] as const) {
+      const brush = findPencilBrush(id);
+      expect(brush.kind).toBe('freehand');
+      expect(isStampBrush(brush.id, brush.stampSrc)).toBe(false);
+      const d = outlinePathFromPoints(
+        [
+          { x: 0, y: 10, pressure: 0.4 },
+          { x: 20, y: 8, pressure: 0.8 },
+          { x: 40, y: 12, pressure: 0.5 },
+          { x: 60, y: 9, pressure: 0.7 },
+        ],
+        8,
+        id,
+        { pressureEnabled: true }
+      );
+      expect(d.length).toBeGreaterThan(20);
+      expect(d.startsWith('M') || d.startsWith('m')).toBe(true);
+    }
+  });
+
+  it('vector hardness soft vs hard changes outline (pressure width)', () => {
+    setOfficialPencilBrushes(null);
+    setCustomPencilBrushes([]);
+    const pts = [
+      { x: 0, y: 10, pressure: 0.2 },
+      { x: 30, y: 10, pressure: 0.95 },
+      { x: 60, y: 10, pressure: 0.25 },
+    ];
+    const soft = outlinePathFromPoints(pts, 10, 'vector-ink', {
+      pressureEnabled: true,
+      hardness: 5,
+    });
+    const hard = outlinePathFromPoints(pts, 10, 'vector-ink', {
+      pressureEnabled: true,
+      hardness: 95,
+    });
+    expect(soft).not.toBe(hard);
+    expect(soft.length).toBeGreaterThan(20);
+    expect(hard.length).toBeGreaterThan(20);
   });
 
   it('buildStampDabs places overlapping tips (not sparse dots)', () => {

--- a/apps/web/src/components/rcb/tools/pencilBrushes.ts
+++ b/apps/web/src/components/rcb/tools/pencilBrushes.ts
@@ -74,11 +74,75 @@ function tipBrush(
   };
 }
 
+function vectorBrush(
+  id: string,
+  label: string,
+  opts: {
+    sizeFactor?: number;
+    thinning?: number;
+    smoothing?: number;
+    streamline?: number;
+    startTaper?: number;
+    endTaper?: number;
+  }
+): PencilBrushDef {
+  return {
+    id,
+    label,
+    kind: 'freehand',
+    sizeFactor: opts.sizeFactor ?? 1,
+    options: {
+      thinning: opts.thinning ?? 0.4,
+      smoothing: opts.smoothing ?? 0.5,
+      streamline: opts.streamline ?? 0.4,
+      easing: (t) => t,
+      start: { taper: opts.startTaper ?? 0, cap: true },
+      end: { taper: opts.endTaper ?? 0, cap: true },
+    },
+  };
+}
+
 /**
- * Builtin wheel — tip stamps only.
- * Spacing/hardness are tool params (like PS), not hard-coded per tip — uploads share the same path.
+ * Illustrator-style Blob Brushes: filled SVG outlines (no tip texture).
+ * Stay sharp at any zoom — not raster tip stamps.
  */
-export const PENCIL_BRUSHES: PencilBrushDef[] = [
+export const VECTOR_INK_BRUSHES: PencilBrushDef[] = [
+  // Balanced pressure ink (default vector).
+  vectorBrush('vector-ink', '矢量墨线', {
+    thinning: 0.4,
+    smoothing: 0.5,
+    streamline: 0.4,
+    startTaper: 12,
+    endTaper: 18,
+  }),
+  // Near-constant width — like a marker / pen stroke.
+  vectorBrush('vector-even', '矢量匀线', {
+    sizeFactor: 1,
+    thinning: 0.05,
+    smoothing: 0.55,
+    streamline: 0.45,
+    startTaper: 0,
+    endTaper: 0,
+  }),
+  // Strong pressure + taper — calligraphy feel.
+  vectorBrush('vector-calligraphy', '矢量书法', {
+    sizeFactor: 1.15,
+    thinning: 0.72,
+    smoothing: 0.42,
+    streamline: 0.35,
+    startTaper: 28,
+    endTaper: 42,
+  }),
+];
+
+/** @deprecated Prefer VECTOR_INK_BRUSHES[0]; kept for older imports. */
+export const VECTOR_INK_BRUSH = VECTOR_INK_BRUSHES[0];
+
+/**
+ * Builtin tip stamps (PS-like tip texture along the path).
+ * Spacing/hardness are tool params; uploads share the same stamp path.
+ */
+export const TIP_STAMP_BRUSHES: PencilBrushDef[] = [
   tipBrush('solid', '硬笔', 'hard-round.png', { sizeFactor: 1 }),
   tipBrush('pencil-hb', '铅笔', 'pencil.png', { sizeFactor: 0.95 }),
   tipBrush('soft', '软笔', 'soft-round.png', { sizeFactor: 1.35 }),
@@ -96,8 +160,8 @@ export const PENCIL_BRUSHES: PencilBrushDef[] = [
   tipBrush('bold', '粗头', 'bold.png', { sizeFactor: 2.3 }),
 ];
 
-/** Alias for tip subset (same as builtins). */
-export const TIP_STAMP_BRUSHES = PENCIL_BRUSHES;
+/** Builtin wheel — vector brushes first, then tip stamps. */
+export const PENCIL_BRUSHES: PencilBrushDef[] = [...VECTOR_INK_BRUSHES, ...TIP_STAMP_BRUSHES];
 
 /** Open portable pack (JSON + tip data-URLs). Not Photoshop .abr. */
 export const BRUSH_PACK_FORMAT = 'recombyn-brushpack' as const;
@@ -149,7 +213,7 @@ export function setOfficialPencilBrushes(list: PencilBrushDef[] | null) {
   officialBrushes = list.filter((b) => b?.id);
 }
 
-/** Legacy ids → nearest builtin tip. */
+/** Legacy ids → nearest builtin tip / vector. */
 const LEGACY_FREEHAND_ALIAS: Record<string, string> = {
   crayon: 'chalk',
   dry: 'bristle',
@@ -159,19 +223,34 @@ const LEGACY_FREEHAND_ALIAS: Record<string, string> = {
   'tip-hard': 'solid',
   'tip-chalk': 'chalk',
   'tip-bristle': 'bristle',
+  /** Older freehand-only seeds → vector family. */
+  freehand: 'vector-ink',
+  vector: 'vector-ink',
+  blob: 'vector-ink',
+  even: 'vector-even',
+  'vector-uniform': 'vector-even',
+  'vector-marker': 'vector-even',
+  'vector-brush': 'vector-calligraphy',
+  'vector-script': 'vector-calligraphy',
 };
 
 export function listPencilBrushes(): PencilBrushDef[] {
   const base = officialBrushes?.length ? officialBrushes : PENCIL_BRUSHES;
-  return [...base, ...customBrushes];
+  // Official API list may omit vector brushes — keep the full vector set up front.
+  const missingVectors = VECTOR_INK_BRUSHES.filter((v) => !base.some((b) => b.id === v.id));
+  return [...missingVectors, ...base, ...customBrushes];
 }
 
 export function findPencilBrush(id: string | undefined | null): PencilBrushDef {
-  const fallback = (officialBrushes && officialBrushes[0]) || PENCIL_BRUSHES[0];
+  // Prefer solid tip as fallback (not vector-ink) so unknown ids stay textured.
+  const fallback =
+    (officialBrushes && officialBrushes[0]) || TIP_STAMP_BRUSHES[0] || PENCIL_BRUSHES[0];
   if (!id || LEGACY_STAMP_IDS.has(id)) return fallback;
   const resolved = LEGACY_FREEHAND_ALIAS[id] || id;
   const custom = customBrushes.find((b) => b.id === id || b.id === resolved);
   if (custom) return custom;
+  const vector = VECTOR_INK_BRUSHES.find((b) => b.id === resolved);
+  if (vector) return vector;
   const official = officialBrushes?.find((b) => b.id === resolved || b.id === id);
   if (official) return official;
   return PENCIL_BRUSHES.find((b) => b.id === resolved) || fallback;
@@ -787,7 +866,43 @@ export type PencilStrokeDrawOpts = {
   pressures?: number[];
   /** When false, force constant pressure (ignore brush simulatePressure + real pressure). */
   pressureEnabled?: boolean;
+  /**
+   * Tip / freehand hardness 0–100.
+   * Stamp: tip edge + dab spacing. Freehand: soft → more pressure width + taper; hard → flatter.
+   */
+  hardness?: number;
 };
+
+function clampStrokeHardness(hardness?: number | null): number {
+  const n = Number(hardness);
+  if (!Number.isFinite(n)) return 80;
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+/** Soft (0) → more taper; hard (100) → flatter ends. */
+function applyFreehandHardness(
+  options: Omit<StrokeOptions, 'size'>,
+  hardness0to100: number
+): Omit<StrokeOptions, 'size'> {
+  const h = clampStrokeHardness(hardness0to100) / 100;
+  const taperMul = 1.55 - h * 1.3; // soft≈1.55, hard≈0.25
+  const start = (options.start || {}) as { taper?: number; cap?: boolean };
+  const end = (options.end || {}) as { taper?: number; cap?: boolean };
+  return {
+    ...options,
+    smoothing: Math.min(0.85, Number(options.smoothing ?? 0.5) + (1 - h) * 0.1),
+    start: {
+      ...start,
+      taper: Math.max(0, Number(start.taper ?? 0) * taperMul),
+      cap: start.cap !== false,
+    },
+    end: {
+      ...end,
+      taper: Math.max(0, Number(end.taper ?? 0) * taperMul),
+      cap: end.cap !== false,
+    },
+  };
+}
 
 function extendPolylineEnds(points: Pt[], pad: number): Pt[] {
   if (points.length < 2 || pad <= 0) return points;
@@ -823,9 +938,13 @@ export function outlinePathFromPoints(
     const pr = strokeOpts?.pressures?.[i];
     return pr != null && Number.isFinite(pr) ? { ...p, pressure: pr } : { ...p };
   });
-  const options: Omit<StrokeOptions, 'size'> = {
-    ...(brush.kind === 'stamp' ? FREEHAND_DEFAULTS : brush.options),
-  };
+  const options: Omit<StrokeOptions, 'size'> = applyFreehandHardness(
+    {
+      ...(brush.kind === 'stamp' ? FREEHAND_DEFAULTS : brush.options),
+    },
+    strokeOpts?.hardness ?? 80
+  );
+  const hard01 = clampStrokeHardness(strokeOpts?.hardness) / 100;
   const cap = strokeOpts?.linecap;
   if (cap === 'butt') {
     options.start = { ...(options.start as object), taper: 0, cap: false };
@@ -850,11 +969,12 @@ export function outlinePathFromPoints(
     pts,
     { ...brush, simulatePressure: false, options }
   );
-  // Real pressure only — never invent velocity pressure.
+  // Soft → full pressure thinning; hard → nearly constant width.
+  const thinning = hasRealPressure ? Math.max(0.08, 1 - hard01 * 0.88) : 0;
   const outline = getStroke(input, {
     size,
     ...options,
-    thinning: hasRealPressure ? 1 : 0,
+    thinning,
     simulatePressure: false,
     last: true,
   });
@@ -1000,9 +1120,14 @@ function buildBrushPreviewPoints(): Pt[] {
 
 export const BRUSH_PREVIEW_POINTS: Pt[] = buildBrushPreviewPoints();
 
-export function brushPreviewPath(brush: PencilBrushDef, previewWidth = 10): string {
+export function brushPreviewPath(
+  brush: PencilBrushDef,
+  previewWidth = 10,
+  hardness = 80
+): string {
   return outlinePathFromPoints(BRUSH_PREVIEW_POINTS, previewWidth, brush.id, {
     pressureEnabled: true,
+    hardness,
   });
 }
 


### PR DESCRIPTION
## Summary
- Add three vector freehand brushes (矢量墨线 / 匀线 / 书法) as sharp SVG outlines with hardness mapped to pressure width and taper.
- Live tip-stamp preview paints at zoom × DPR so strokes look less soft while drawing.
- Clear legacy custom-brush localStorage (v1/v2) so leftover imported tips no longer clutter the wheel.

## Test plan
- [ ] Brush list shows three vector brushes first; tip brushes still work
- [ ] Vector ink + hardness soft vs hard changes width variation; zoom stays sharp
- [ ] Tip stamp live draw looks sharper on retina / zoomed viewports
- [ ] Refresh after upgrade: no orphan custom brush with delete icon unless newly imported
- [ ] `npx vitest run src/components/rcb/tools/__tests__/tipStamps.test.ts src/components/rcb/tools/__tests__/brushPack.test.ts`