### PR TITLE
Fix CI Web/API unit failures after PR #74

### DIFF
--- a/apps/api/app/services/llm/design_tools.py
+++ b/apps/api/app/services/llm/design_tools.py
@@ -155,6 +155,9 @@ def pydantic_model_from_args_schema(
     required = set(parameters.get("required") or [])
     field_defs: dict[str, Any] = {}
     for key, meta in props.items():
+        # Seed meta like ``_rev`` is not a model arg (Pydantic forbids leading ``_``).
+        if not str(key).strip() or str(key).startswith("_"):
+            continue
         meta = meta if isinstance(meta, dict) else {}
         typ = _python_type_from_json_prop(meta)
         desc_f = str(meta.get("description") or key)

--- a/apps/api/tests/unit_tests/test_skill_store.py
+++ b/apps/api/tests/unit_tests/test_skill_store.py
@@ -163,11 +163,11 @@ def test_namespace_split_and_qualify(monkeypatch):
     assert qualify_skill_key(NS_CORE, "design_methodology") == "design_methodology"
     assert qualify_skill_key(NS_USER, "my_brand") == "user.my_brand"
     assert resolve_storage_skill_key("core.design_methodology") == "design_methodology"
-    # Stub one ext row so ns.ext resolve stays covered when monkeypatched.
-    from app.services.design.prompts import skill_store as skill_mod
+    # Patch the runtime module binding (resolve_storage_skill_key calls it in-file).
+    from app.services.design.prompts.skill_store import runtime as skill_runtime
 
     monkeypatch.setattr(
-        skill_mod,
+        skill_runtime,
         "list_runtime_skills",
         lambda **_kwargs: [
             {
@@ -235,9 +235,13 @@ def test_hot_reload_signature_stable():
     assert reload_skills_if_disk_changed() is False
 
 
-def test_seed_sync_does_not_overwrite_existing_rows():
-    """Community seed is cold-start only: never updates existing rows."""
+def test_seed_sync_preserves_custom_body_when_markers_present():
+    """Seed upsert is cold-start only; marker bump only replaces stale bodies."""
     from app.services.db import connect
+    from app.services.design.prompts.skill_store.ensure import _SEED_SKILL_BODY_MARKERS
+
+    markers = _SEED_SKILL_BODY_MARKERS.get("design_methodology") or ()
+    assert markers, "expected design_methodology seed markers"
 
     with connect() as conn:
         row = conn.execute(
@@ -247,9 +251,11 @@ def test_seed_sync_does_not_overwrite_existing_rows():
         assert row is not None
         before = str(row["prompt_positive"] or "")
         assert str(row["source"] or "") == SOURCE_SEED
+        # Keep required markers so the body is treated as non-stale customization.
+        custom = "OPS_CUSTOM_BODY\n" + "\n".join(markers)
         conn.execute(
             "UPDATE design_skill SET prompt_positive = ? WHERE skill_key = ?",
-            ("OPS_CUSTOM_BODY", "design_methodology"),
+            (custom, "design_methodology"),
         )
         conn.commit()
 
@@ -262,7 +268,7 @@ def test_seed_sync_does_not_overwrite_existing_rows():
             ("design_methodology",),
         ).fetchone()
         assert str(row["source"] or "") == SOURCE_SEED
-        assert str(row["prompt_positive"] or "") == "OPS_CUSTOM_BODY"
+        assert str(row["prompt_positive"] or "") == custom
         conn.execute(
             "UPDATE design_skill SET prompt_positive = ? WHERE skill_key = ?",
             (before, "design_methodology"),

--- a/apps/web/src/components/editor/panels/agent/__tests__/tipPencilAgentOps.test.ts
+++ b/apps/web/src/components/editor/panels/agent/__tests__/tipPencilAgentOps.test.ts
@@ -1,20 +1,65 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { createShapeNode } from '@/components/rcb/scene/document/sceneDocument';
 import { findPencilBrush } from '@/components/rcb/tools/pencilBrushes';
 
-function loadPencilOps() {
-  const p = resolve(process.cwd(), '../api/tmp/agent_pencil_tip_fixture.json');
-  return JSON.parse(readFileSync(p, 'utf-8')) as Array<{
-    name: string;
-    args: Record<string, unknown>;
-  }>;
-}
+/** Inline agent create_shape pencil ops — do not read apps/api/tmp fixtures. */
+const TIP_PENCIL_OPS: Array<{ name: string; args: Record<string, unknown> }> = [
+  {
+    name: 'create_shape',
+    args: {
+      shapeType: 'pencil',
+      x: 40,
+      y: 40,
+      width: 120,
+      height: 80,
+      stroke: '#333333',
+      borderWidth: 2,
+      path: 'M 0 40 L 40 10 L 80 50 L 120 20',
+      brushStyle: 'calligraphy',
+      brushHardness: 72,
+      pathPressure: '0.4,0.8,0.55,0.9',
+      pressureEnabled: true,
+    },
+  },
+  {
+    name: 'create_shape',
+    args: {
+      shapeType: 'pencil',
+      x: 40,
+      y: 140,
+      width: 120,
+      height: 80,
+      stroke: '#222222',
+      borderWidth: 2,
+      path: 'M 0 20 L 30 60 L 70 15 L 120 45',
+      brushStyle: 'pencil-hb',
+      brushHardness: 88,
+      pathPressure: '0.3,0.7,0.5,0.85',
+      pressureEnabled: true,
+    },
+  },
+  {
+    name: 'create_shape',
+    args: {
+      shapeType: 'pencil',
+      x: 40,
+      y: 240,
+      width: 120,
+      height: 80,
+      stroke: '#111111',
+      borderWidth: 3,
+      path: 'M 10 40 L 50 10 L 90 55 L 110 25',
+      brushStyle: 'soft',
+      brushHardness: 45,
+      pathPressure: '0.5,0.9,0.35,0.75',
+      pressureEnabled: true,
+    },
+  },
+];
 
 describe('agent tip pencil ops → FE attrs', () => {
   it('maps tip brushStyle / hardness / pressure onto nodes', () => {
-    const ops = loadPencilOps();
+    const ops = TIP_PENCIL_OPS;
     expect(ops.length).toBeGreaterThanOrEqual(3);
 
     const created: any[] = [];


### PR DESCRIPTION
## Summary
- Inline tip-pencil agent ops in `tipPencilAgentOps.test.ts` so CI no longer depends on `apps/api/tmp` fixtures.
- Skip underscore-prefixed seed meta (`_rev`) when building Pydantic canvas args models.
- Patch `skill_store.runtime.list_runtime_skills` for namespace resolve tests; assert seed sync preserves custom bodies that still include required markers.

## Test plan
- [x] `vitest run tipPencilAgentOps.test.ts`
- [x] `pytest` skill_store + langchain tool factory cases that failed on main
- [ ] CI Web Tests / unit + API Tests / pytest green

Made with [Cursor](https://cursor.com)