### PR TITLE
Make local desktop BYOK-only and hide cloud billing

### DIFF
--- a/apps/api/app/alembic/versions/0002_sync_missing_columns.py
+++ b/apps/api/app/alembic/versions/0002_sync_missing_columns.py
@@ -1,0 +1,140 @@
+"""Sync columns missing from pre-Alembic SQLite (stamped 0001 no-op).
+
+Revision ID: 0002_sync_missing_columns
+Revises: 0001_baseline
+Create Date: 2026-08-08
+
+``0001_baseline`` used ``create_all``, which does not ALTER existing tables.
+Local SQLite DBs stamped at 0001 can lack columns added to SQLModel later
+(e.g. ``users.default_avatar``), breaking desktop-local auto-login.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0002_sync_missing_columns"
+down_revision = "0001_baseline"
+branch_labels = None
+depends_on = None
+
+# (table, column_name, sa.Column(...)) — only added when missing.
+_COLUMNS: list[tuple[str, str, sa.Column]] = [
+    ("users", "default_avatar", sa.Column("default_avatar", sa.Text(), nullable=True)),
+    (
+        "users",
+        "role",
+        sa.Column("role", sa.String(length=16), nullable=False, server_default="user"),
+    ),
+    (
+        "users",
+        "status",
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="active"),
+    ),
+    ("chat_messages", "meta_json", sa.Column("meta_json", sa.Text(), nullable=True)),
+    ("chat_sessions", "meta_json", sa.Column("meta_json", sa.Text(), nullable=True)),
+    (
+        "card_keys",
+        "kind",
+        sa.Column("kind", sa.String(length=16), nullable=False, server_default="token"),
+    ),
+    ("card_keys", "plan_id", sa.Column("plan_id", sa.String(length=16), nullable=True)),
+    ("plaza_submissions", "cover_json", sa.Column("cover_json", sa.Text(), nullable=True)),
+    (
+        "plaza_submissions",
+        "cover_image_url",
+        sa.Column("cover_image_url", sa.Text(), nullable=True),
+    ),
+    (
+        "plaza_submissions",
+        "custom_cover_image_url",
+        sa.Column("custom_cover_image_url", sa.Text(), nullable=True),
+    ),
+    (
+        "plaza_submissions",
+        "panel_urls_json",
+        sa.Column("panel_urls_json", sa.Text(), nullable=True),
+    ),
+    (
+        "plaza_submissions",
+        "like_count",
+        sa.Column("like_count", sa.Integer(), nullable=False, server_default="0"),
+    ),
+    (
+        "plaza_submissions",
+        "use_count",
+        sa.Column("use_count", sa.Integer(), nullable=False, server_default="0"),
+    ),
+    (
+        "plaza_submissions",
+        "is_visible",
+        sa.Column("is_visible", sa.Integer(), nullable=False, server_default="1"),
+    ),
+    (
+        "projects",
+        "thumbnail_custom",
+        sa.Column("thumbnail_custom", sa.Integer(), nullable=False, server_default="0"),
+    ),
+    (
+        "projects",
+        "revision",
+        sa.Column("revision", sa.Integer(), nullable=False, server_default="1"),
+    ),
+    (
+        "user_balances",
+        "image_credits",
+        sa.Column("image_credits", sa.Integer(), nullable=False, server_default="0"),
+    ),
+    (
+        "user_balances",
+        "plan_id",
+        sa.Column("plan_id", sa.String(length=16), nullable=False, server_default="free"),
+    ),
+    (
+        "user_balances",
+        "plan_expires_at",
+        sa.Column("plan_expires_at", sa.Float(), nullable=True),
+    ),
+]
+
+
+def _columns_by_table() -> dict[str, list[tuple[str, sa.Column]]]:
+    grouped: dict[str, list[tuple[str, sa.Column]]] = defaultdict(list)
+    for table, col_name, column in _COLUMNS:
+        grouped[table].append((col_name, column))
+    return grouped
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    tables = set(insp.get_table_names())
+    for table, cols in _columns_by_table().items():
+        if table not in tables:
+            continue
+        existing = {c["name"] for c in insp.get_columns(table)}
+        to_add = [(name, column) for name, column in cols if name not in existing]
+        if not to_add:
+            continue
+        with op.batch_alter_table(table) as batch:
+            for _name, column in to_add:
+                batch.add_column(column)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    tables = set(insp.get_table_names())
+    for table, cols in reversed(list(_columns_by_table().items())):
+        if table not in tables:
+            continue
+        existing = {c["name"] for c in insp.get_columns(table)}
+        to_drop = [name for name, _column in cols if name in existing]
+        if not to_drop:
+            continue
+        with op.batch_alter_table(table) as batch:
+            for name in to_drop:
+                batch.drop_column(name)

--- a/apps/api/app/api/routes/chat.py
+++ b/apps/api/app/api/routes/chat.py
@@ -45,6 +45,13 @@ _MESSAGE_TOKEN_COST = 10
 _FREE_IMAGE_MODEL = "doubao-seedream-4-0"
 
 
+def _desktop_local() -> bool:
+    """Tauri local flavor — BYOK only, no platform catalog / wallet billing."""
+    from app.core.config import settings
+
+    return bool(getattr(settings, "desktop_local_auto_login", False))
+
+
 class ChatMessageIn(BaseModel):
     message: str = Field(..., min_length=1)
     model: str | None = None
@@ -90,6 +97,8 @@ class VideoGenerateIn(BaseModel):
 
 
 def _charge(user_id: str, amount: int, detail: str) -> None:
+    if _desktop_local():
+        return
     try:
         spend_tokens(user_id, amount, detail)
     except ValueError as err:
@@ -99,6 +108,8 @@ def _charge(user_id: str, amount: int, detail: str) -> None:
 
 
 def _charge_image_credits(user_id: str, amount: int, detail: str) -> None:
+    if _desktop_local():
+        return
     try:
         spend_image_credits(user_id, amount, detail)
     except ValueError as err:
@@ -119,6 +130,9 @@ def _charge_image(
     Free plan: force Seedream 4.0; use 积分 or today's free daily run.
     Returns (model id to call, credits actually charged).
     """
+    if _desktop_local():
+        mid = (requested_model or "").strip() or None
+        return mid, 0
     n = max(1, min(4, int(count or 1)))
     plan = get_user_plan(user_id)
     if plan == "free":
@@ -148,6 +162,17 @@ def _charge_image(
 def get_models(request: Request) -> dict[str, Any]:
     # Keep text/chat and image catalogs separate — FE merges with dedupe.
     # Do not use list_all_models() here or image ids appear twice under models + imageModels.
+    # Local desktop: no platform seed catalog — UI uses BYOK/custom providers only.
+    if _desktop_local():
+        return {
+            "models": [],
+            "available": True,
+            "imageModels": [],
+            "videoModels": [],
+            "clientRegion": "local",
+            "openrouterAvailable": False,
+        }
+
     from app.services.geoip import (
         filter_catalog_models_for_region,
         openrouter_allowed_for_country,

--- a/apps/api/app/services/design/runtime/orchestrator.py
+++ b/apps/api/app/services/design/runtime/orchestrator.py
@@ -75,6 +75,11 @@ def _reserve_design_hold(user_id: str, hold: int, *, mode: str) -> tuple[int, bo
     Spend ``hold`` credits, or reserve the free daily run when balance is short.
     Returns (hold_to_settle, free_daily). free_daily ⇒ hold 0 and force Auto.
     """
+    from app.core.config import settings
+
+    # Local desktop (BYOK): no cloud wallet.
+    if bool(getattr(settings, "desktop_local_auto_login", False)):
+        return 0, False
     need = max(0, int(hold or 0))
     if need <= 0:
         return 0, False
@@ -214,15 +219,18 @@ async def run_design_job(
 
     # —— Agent / single_model: permission → ReAct controller ——
     if mode in ("agent", "single_model"):
+        from app.core.config import settings
+
+        desktop_local = bool(getattr(settings, "desktop_local_auto_login", False))
         hold_need = AGENT_HOLD if mode == "agent" else SINGLE_HOLD
         bal = int(get_user_tokens(user_id) or 0)
         free_left = int(free_daily_remaining(user_id) or 0)
-        can = bal >= hold_need or free_left > 0
+        can = desktop_local or bal >= hold_need or free_left > 0
         yield {
             "type": "permission",
             "can_call_llm": bool(can),
             "balance": bal,
-            "need": hold_need,
+            "need": 0 if desktop_local else hold_need,
             "free_daily": free_left > 0,
         }
         if not can:

--- a/apps/web/src-tauri/src/local_api.rs
+++ b/apps/web/src-tauri/src/local_api.rs
@@ -119,8 +119,11 @@ fn apply_local_env(cmd: &mut Command, data_dir: &Path) {
   let db_path = storage.join("recombyn.db");
   let upload_dir = storage.join("uploads");
   let result_dir = storage.join("results");
+  // Explicit sqlite URL — empty DATABASE_URL can be dropped on Windows spawn and
+  // then apps/api/.env MySQL would be used by mistake.
+  let db_url = format!("sqlite:///{}", db_path.to_string_lossy().replace('\\', "/"));
 
-  cmd.env("DATABASE_URL", "")
+  cmd.env("DATABASE_URL", db_url)
     .env("SQLITE_DB_PATH", db_path.to_string_lossy().as_ref())
     .env("UPLOAD_DIR", upload_dir.to_string_lossy().as_ref())
     .env("RESULT_DIR", result_dir.to_string_lossy().as_ref())

--- a/apps/web/src/components/account/AccountProfileTab.tsx
+++ b/apps/web/src/components/account/AccountProfileTab.tsx
@@ -8,6 +8,7 @@ import { UserAvatar } from '@/components/layout/UserAccountPanel';
 import { setUser, type AuthUser } from '@/store/modules/auth';
 import { formatTokens } from '@/utils/wallet';
 import { docsUrl } from '@/utils/docsUrl';
+import { isDesktopLocal } from '@/utils/apiBase';
 import { cn } from '@/utils/classnames';
 
 const NAME_RE = /^[\p{L}\p{N}\s.'\-_]{1,40}$/u;
@@ -246,6 +247,7 @@ function AccountProfileTab({
         </dl>
       </section>
 
+      {!isDesktopLocal() ? (
       <section className="rounded-xl bg-[var(--account-card)] p-6 ring-1 ring-[var(--line)]">
         <h2 className="mb-5 text-[15px] font-semibold text-[var(--ink)]">
           {t('account.billingSection')}
@@ -289,6 +291,7 @@ function AccountProfileTab({
           </button>
         </div>
       </section>
+      ) : null}
 
       <p className="pt-1 text-[12px] text-[var(--muted)]">
         <a

--- a/apps/web/src/components/editor/panels/agent/AgentModelsPanel.tsx
+++ b/apps/web/src/components/editor/panels/agent/AgentModelsPanel.tsx
@@ -12,10 +12,13 @@ import { fetchDesignCatalog } from '@/apis/design';
 import { Dropdown, SegmentedControl, Select, Tooltip } from '@/components/base';
 import AccountSettingsDialog from '@/components/layout/AccountSettingsDialog';
 import { cn } from '@/utils/classnames';
+import { isDesktopLocal } from '@/utils/apiBase';
 import { planAllowsCustomModels, type PlanId } from '@/utils/wallet';
 import {
   createCustomLlmProviderId,
+  customProvidersAsModels,
   hydrateCustomLlmProviders,
+  isCustomModelId,
   persistCustomLlmProvider,
   removeCustomLlmProvider,
   type CustomLlmProvider,
@@ -197,9 +200,53 @@ function resolveNamedPreset(
   };
 }
 
+function emptyCustomRoutePrefs(): AgentRoutePrefs {
+  return {
+    preset: 'custom',
+    fast: '',
+    standard: '',
+    reasoning: '',
+    vision: '',
+    image: '',
+  };
+}
+
+/** Seed values when switching into the custom lane from another preset. */
+function seedCustomLaneFromPrefs(prefs: AgentRoutePrefs): AgentRoutePrefs {
+  if (prefs.preset === 'balanced' || prefs.preset === 'quality') {
+    return resolveNamedPreset(prefs.preset);
+  }
+  if (prefs.preset === 'custom') return prefs;
+  return resolveNamedPreset('balanced');
+}
+
 export function loadAgentRoutePrefs(
   rules?: Record<string, string> | null
 ): AgentRoutePrefs {
+  // Local desktop: no platform catalog — only custom/BYOK lane picks.
+  if (isDesktopLocal()) {
+    try {
+      const raw =
+        localStorage.getItem(ROUTE_PREFS_KEY) ||
+        localStorage.getItem(ROUTE_PREFS_KEY_LEGACY);
+      if (!raw) return emptyCustomRoutePrefs();
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      if (!parsed || typeof parsed !== 'object') return emptyCustomRoutePrefs();
+      const migrated = migrateLegacyRouteKeys(parsed);
+      const keep = (id: string | undefined) =>
+        isCustomModelId(String(id || '').trim()) ? String(id).trim() : '';
+      return {
+        preset: 'custom',
+        fast: keep(migrated.fast),
+        standard: keep(migrated.standard),
+        reasoning: keep(migrated.reasoning),
+        vision: keep(migrated.vision),
+        image: keep(migrated.image),
+      };
+    } catch {
+      return emptyCustomRoutePrefs();
+    }
+  }
   try {
     const raw =
       localStorage.getItem(ROUTE_PREFS_KEY) ||
@@ -316,6 +363,81 @@ function parseCustomModelKind(value: string): CustomModelKind {
   return 'text';
 }
 
+type RouteLaneT = (key: string, opts?: Record<string, unknown>) => string;
+
+function renderRouteLaneSelectLabel(opts: {
+  model: LlmModel | null;
+  label: string;
+  muted: boolean;
+}): ReactNode {
+  const { model, label, muted } = opts;
+  return (
+    <span className="flex min-w-0 items-center gap-2 pr-4">
+      {model ? <ModelBrandIcon model={model} size={18} className="shrink-0" /> : null}
+      <span className={cn('truncate', muted ? 'text-[var(--muted)]' : '')}>{label}</span>
+    </span>
+  );
+}
+
+function renderRouteLaneOptionMeta(
+  full: LlmModel | null,
+  t: RouteLaneT
+): ReactNode {
+  if (!full) return null;
+  if (isUserCustomModel(full)) {
+    return <ModelMetaBadge label={t('agent.modelBadgeCustom')} />;
+  }
+  const priceTag = modelPriceTagInfo(full, t);
+  if (!priceTag) return null;
+  return <ModelPriceTag level={priceTag.level} label={priceTag.label} />;
+}
+
+function renderRouteLaneSelectOption(
+  opt: { value: string | number; label: ReactNode },
+  catalogPool: LlmModel[],
+  t: RouteLaneT
+): ReactNode {
+  const full = catalogPool.find((x) => x.id === opt.value) || null;
+  const desc = full ? modelDescription(full, t) : undefined;
+  return (
+    <span className="flex w-full min-w-0 items-start gap-2.5">
+      {full ? <ModelBrandIcon model={full} size={18} className="mt-0.5 shrink-0" /> : null}
+      <span className="min-w-0 flex-1 overflow-hidden">
+        <span className="flex min-w-0 items-start justify-between gap-2">
+          <span className="min-w-0 flex-1 truncate text-[13px] font-medium leading-5 text-[var(--ink)]">
+            {opt.label}
+          </span>
+          {renderRouteLaneOptionMeta(full, t)}
+        </span>
+        {desc ? (
+          <span className="mt-0.5 block min-w-0 max-w-full truncate text-[11px] leading-[1.35] text-[var(--muted)]">
+            {desc}
+          </span>
+        ) : null}
+      </span>
+    </span>
+  );
+}
+
+/** Select `value` — only named presets; everything else maps to platform. */
+function selectValueForRoutePreset(preset: AgentRoutePreset): AgentRoutePreset {
+  if (preset === 'balanced' || preset === 'quality' || preset === 'custom') return preset;
+  return 'platform';
+}
+
+function routePresetNoteText(preset: AgentRoutePreset, t: RouteLaneT): string {
+  switch (preset) {
+    case 'balanced':
+      return t('account.agentRouteBalancedNote');
+    case 'quality':
+      return t('account.agentRouteQualityNote');
+    case 'custom':
+      return t('account.agentRouteCard.custom.desc');
+    default:
+      return t('account.agentRoutePlatformNote');
+  }
+}
+
 function customModelKindLabelKey(
   kind: CustomModelKind
 ): 'agent.providerModelKindText' | 'agent.providerModelKindVision' {
@@ -404,7 +526,10 @@ function AgentRoutePrefsEditor({
   onChanged,
 }: AgentRoutePrefsEditorProps): ReactNode {
   const { t } = useTranslation();
-  const [routePrefs, setRoutePrefs] = useState<AgentRoutePrefs>({ preset: 'platform' });
+  const desktopLocal = isDesktopLocal();
+  const [routePrefs, setRoutePrefs] = useState<AgentRoutePrefs>(() =>
+    desktopLocal ? emptyCustomRoutePrefs() : { preset: 'platform' }
+  );
   const [routeSaved, setRouteSaved] = useState(false);
   const [textModels, setTextModels] = useState<LlmModel[]>([]);
   const [imageModels, setImageModels] = useState<LlmModel[]>([]);
@@ -438,8 +563,17 @@ function AgentRoutePrefsEditor({
         const orOk = res?.openrouterAvailable !== false;
         cachedOpenrouterAvailable = orOk;
         setOpenrouterAvailable(orOk);
-        setTextModels(res?.models || []);
-        setImageModels(res?.imageModels || []);
+        const platformText = res?.models || [];
+        const platformImage = res?.imageModels || [];
+        // Local: API returns empty platform catalog — fill lanes from BYOK only.
+        if (isDesktopLocal()) {
+          const byok = customProvidersAsModels();
+          setTextModels(byok);
+          setImageModels([]);
+        } else {
+          setTextModels(platformText);
+          setImageModels(platformImage);
+        }
         setRoutePrefs(loadAgentRoutePrefs(cachedPresetRules));
       })
       .catch(() => undefined);
@@ -448,9 +582,22 @@ function AgentRoutePrefsEditor({
     };
   }, []);
 
+  // Refresh BYOK lane options when providers change (local desktop).
+  useEffect(() => {
+    if (!desktopLocal) return;
+    let cancelled = false;
+    void hydrateCustomLlmProviders().then(() => {
+      if (cancelled) return;
+      setTextModels(customProvidersAsModels());
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [desktopLocal]);
+
   const commit = (next: AgentRoutePrefs) => {
     setRoutePrefs(next);
-    if (next.preset === 'custom') {
+    if (desktopLocal || next.preset === 'custom') {
       saveAgentRoutePrefs({
         preset: 'custom',
         fast: next.fast,
@@ -469,13 +616,12 @@ function AgentRoutePrefsEditor({
   };
 
   const applyPreset = (preset: AgentRoutePreset) => {
+    if (desktopLocal) {
+      commit({ ...routePrefs, preset: 'custom' });
+      return;
+    }
     if (preset === 'custom') {
-      const seed =
-        routePrefs.preset === 'balanced' || routePrefs.preset === 'quality'
-          ? resolveNamedPreset(routePrefs.preset)
-          : routePrefs.preset === 'custom'
-            ? routePrefs
-            : resolveNamedPreset('balanced');
+      const seed = seedCustomLaneFromPrefs(routePrefs);
       commit({
         preset: 'custom',
         fast: routePrefs.fast || seed.fast,
@@ -519,12 +665,14 @@ function AgentRoutePrefsEditor({
   const reasoningOpts = modelOptions(catalogPool, 'reasoning');
   const visionOpts = modelOptions(catalogPool, 'vision');
   const imageOpts = modelOptions(catalogPool, 'image');
-  const presetOptions = [
-    { value: 'platform', label: t('account.agentRoutePresetPlatform') },
-    { value: 'balanced', label: t('account.agentRoutePresetBalanced') },
-    { value: 'quality', label: t('account.agentRoutePresetQuality') },
-    { value: 'custom', label: t('account.agentRoutePresetCustom') },
-  ];
+  const presetOptions = desktopLocal
+    ? [{ value: 'custom', label: t('account.agentRoutePresetCustom') }]
+    : [
+        { value: 'platform', label: t('account.agentRoutePresetPlatform') },
+        { value: 'balanced', label: t('account.agentRoutePresetBalanced') },
+        { value: 'quality', label: t('account.agentRoutePresetQuality') },
+        { value: 'custom', label: t('account.agentRoutePresetCustom') },
+      ];
 
   const presetShortLabel = routePresetShortLabel(routePrefs.preset, t);
 
@@ -536,16 +684,19 @@ function AgentRoutePrefsEditor({
     { key: 'image' as const, label: t('account.agentRouteImage'), opts: imageOpts },
   ];
 
+  const laneEmptyLabel = t('account.agentRouteLaneEmpty');
+
   const modelLabelOf = (id: string | undefined, opts: { id: string; label: string }[]) => {
     const v = String(id || '').trim();
-    if (!v) return opts[0]?.label || '—';
+    if (!v) return opts[0]?.label || laneEmptyLabel;
     return opts.find((o) => o.id === v)?.label || v;
   };
 
+  /** Only return a catalog hit — never invent a stub (stub still draws a brand icon). */
   const modelRefOf = (id: string | undefined, opts: { id: string; label: string }[]) => {
     const v = String(id || '').trim() || opts[0]?.id || '';
     if (!v) return null;
-    return catalogPool.find((m) => m.id === v) || { id: v, label: opts.find((o) => o.id === v)?.label || v };
+    return catalogPool.find((m) => m.id === v) || null;
   };
 
   const headerTitle = modeLabel || t('agent.interactionAgent');
@@ -553,7 +704,9 @@ function AgentRoutePrefsEditor({
   const multimodalAuto = routePrefs.preset !== 'custom';
 
   if (compact) {
-    const presetOrder = ['platform', 'balanced', 'quality'] as const;
+    const presetOrder = (
+      desktopLocal ? (['custom'] as const) : (['platform', 'balanced', 'quality'] as const)
+    );
 
     let submenuTitle = '';
     let submenuOptions: Array<{ id: string; label: string; desc?: string; model?: LlmModel | null }> =
@@ -830,6 +983,7 @@ function AgentRoutePrefsEditor({
             <div className="mt-1 px-0.5">
               {fieldRows.map((row) => {
                 const active = submenu?.kind === 'field' && submenu.key === row.key;
+                const laneModel = modelRefOf(routePrefs[row.key], row.opts);
                 return (
                   <div key={row.key}>
                     {routeSideDropdown({
@@ -856,10 +1010,7 @@ function AgentRoutePrefsEditor({
                             {row.label}
                           </span>
                           <span className="inline-flex w-[6.75rem] shrink-0 items-center justify-start gap-1 text-[12px] text-[var(--muted)]">
-                            <ModelBrandIcon
-                              model={modelRefOf(routePrefs[row.key], row.opts)}
-                              size={14}
-                            />
+                            {laneModel ? <ModelBrandIcon model={laneModel} size={14} /> : null}
                             <span className="min-w-0 flex-1 truncate text-left">
                               {modelLabelOf(routePrefs[row.key], row.opts)}
                             </span>
@@ -895,13 +1046,7 @@ function AgentRoutePrefsEditor({
         <Select
           size="large"
           className={selectCls}
-          value={
-            routePrefs.preset === 'balanced' ||
-            routePrefs.preset === 'quality' ||
-            routePrefs.preset === 'custom'
-              ? routePrefs.preset
-              : 'platform'
-          }
+          value={selectValueForRoutePreset(routePrefs.preset)}
           options={presetOptions}
           onChange={(v) => applyPreset(String(v) as AgentRoutePreset)}
         />
@@ -913,13 +1058,7 @@ function AgentRoutePrefsEditor({
         </p>
       ) : (
         <p className="text-[12px] leading-relaxed text-[var(--muted)]">
-          {routePrefs.preset === 'balanced'
-            ? t('account.agentRouteBalancedNote')
-            : routePrefs.preset === 'quality'
-              ? t('account.agentRouteQualityNote')
-              : routePrefs.preset === 'custom'
-                ? t('account.agentRouteCard.custom.desc')
-                : t('account.agentRoutePlatformNote')}
+          {routePresetNoteText(routePrefs.preset, t)}
         </p>
       )}
 
@@ -929,60 +1068,25 @@ function AgentRoutePrefsEditor({
             const currentId =
               String(routePrefs[row.key] || '').trim() || row.opts[0]?.id || '';
             const currentModel = modelRefOf(routePrefs[row.key], row.opts);
+            const emptyLane = !currentId;
             return (
               <label key={row.key} className="block">
                 <span className={labelCls}>{row.label}</span>
                 <Select
                   size="large"
                   className={selectCls}
-                  value={currentId}
+                  value={currentId || undefined}
+                  placeholder={laneEmptyLabel}
                   options={row.opts.map((m) => ({ value: m.id, label: m.label }))}
                   onChange={(v) => patchRouteField(row.key, String(v))}
-                  labelRender={() => (
-                    <span className="flex min-w-0 items-center gap-2 pr-4">
-                      <ModelBrandIcon model={currentModel} size={18} className="shrink-0" />
-                      <span className="truncate">
-                        {modelLabelOf(routePrefs[row.key], row.opts)}
-                      </span>
-                    </span>
-                  )}
-                  optionRender={(opt) => {
-                    const full = catalogPool.find((x) => x.id === opt.value) || null;
-                    const custom = full ? isUserCustomModel(full) : false;
-                    const priceTag = full && !custom ? modelPriceTagInfo(full, t) : null;
-                    const desc = full ? modelDescription(full, t) : undefined;
-                    return (
-                      <span className="flex w-full min-w-0 items-start gap-2.5">
-                        {full ? (
-                          <ModelBrandIcon model={full} size={18} className="mt-0.5 shrink-0" />
-                        ) : (
-                          <span
-                            className="mt-0.5 inline-flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded bg-[var(--line)]/40 text-[10px] font-semibold text-[var(--muted)]"
-                            aria-hidden
-                          >
-                            A
-                          </span>
-                        )}
-                        <span className="min-w-0 flex-1 overflow-hidden">
-                          <span className="flex min-w-0 items-start justify-between gap-2">
-                            <span className="min-w-0 flex-1 truncate text-[13px] font-medium leading-5 text-[var(--ink)]">
-                              {opt.label}
-                            </span>
-                            {custom ? (
-                              <ModelMetaBadge label={t('agent.modelBadgeCustom')} />
-                            ) : priceTag ? (
-                              <ModelPriceTag level={priceTag.level} label={priceTag.label} />
-                            ) : null}
-                          </span>
-                          {desc ? (
-                            <span className="mt-0.5 block min-w-0 max-w-full truncate text-[11px] leading-[1.35] text-[var(--muted)]">
-                              {desc}
-                            </span>
-                          ) : null}
-                        </span>
-                      </span>
-                    );
-                  }}
+                  labelRender={() =>
+                    renderRouteLaneSelectLabel({
+                      model: currentModel,
+                      label: modelLabelOf(routePrefs[row.key], row.opts),
+                      muted: emptyLane || !currentModel,
+                    })
+                  }
+                  optionRender={(opt) => renderRouteLaneSelectOption(opt, catalogPool, t)}
                 />
               </label>
             );
@@ -1002,7 +1106,8 @@ function AgentModelsPanel({
 }: Props): ReactNode {
   const { t } = useTranslation();
   const planId = useSelector((state: any) => (state.wallet?.planId as PlanId) || 'free');
-  const canCustom = planAllowsCustomModels(planId);
+  // Local desktop: BYOK is always allowed (no cloud membership).
+  const canCustom = isDesktopLocal() || planAllowsCustomModels(planId);
   const [providers, setProviders] = useState<CustomLlmProvider[]>([]);
   const [name, setName] = useState('');
   const [website, setWebsite] = useState('');
@@ -1014,6 +1119,7 @@ function AgentModelsPanel({
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   const askUpgrade = () => {
+    if (isDesktopLocal()) return;
     if (onRequestUpgrade) onRequestUpgrade();
     else setSettingsOpen(true);
   };

--- a/apps/web/src/components/layout/AccountSettingsDialog.tsx
+++ b/apps/web/src/components/layout/AccountSettingsDialog.tsx
@@ -18,6 +18,7 @@ import AgentModelsPanel from '@/components/editor/panels/agent/AgentModelsPanel'
 import AccountProfilePanel from '@/components/layout/AccountProfilePanel';
 import AccountNotificationsPanel from '@/components/layout/AccountNotificationsPanel';
 import { FloatingToolbar } from '@/components/editor/chrome/FloatingToolbar';
+import { isDesktopLocal } from '@/utils/apiBase';
 import { cn } from '@/utils/classnames';
 
 /** Content tabs inside the shell (plans / top-up open as separate dialogs). */
@@ -60,12 +61,14 @@ function SettingsMobileNavBar({
   onSelectTab,
   onOpenPlans,
   onOpenRedeem,
+  hideCommerce,
 }: {
   tab: ContentTab;
   contentNav: { id: ContentTab; label: string }[];
   onSelectTab: (id: ContentTab) => void;
-  onOpenPlans: () => void;
-  onOpenRedeem: () => void;
+  onOpenPlans?: () => void;
+  onOpenRedeem?: () => void;
+  hideCommerce?: boolean;
 }) {
   const { t } = useTranslation();
 
@@ -79,26 +82,30 @@ function SettingsMobileNavBar({
         aria-label={t('wallet.settingsTitle')}
         className="pointer-events-auto max-w-full gap-1 overflow-x-auto px-1.5 py-1"
       >
-        <button
-          type="button"
-          title={t('wallet.settingsNavPlans')}
-          aria-label={t('wallet.settingsNavPlans')}
-          onClick={onOpenPlans}
-          className={cn(MOBILE_NAV_BTN, 'text-[var(--muted)] hover:text-[var(--ink)]')}
-        >
-          <HiOutlineCubeTransparent className="h-4 w-4" strokeWidth={1.75} />
-        </button>
-        <button
-          type="button"
-          title={t('wallet.settingsNavRedeem')}
-          aria-label={t('wallet.settingsNavRedeem')}
-          onClick={onOpenRedeem}
-          className={cn(MOBILE_NAV_BTN, 'text-[var(--muted)] hover:text-[var(--ink)]')}
-        >
-          <HiOutlineBolt className="h-4 w-4" strokeWidth={1.75} />
-        </button>
+        {!hideCommerce ? (
+          <>
+            <button
+              type="button"
+              title={t('wallet.settingsNavPlans')}
+              aria-label={t('wallet.settingsNavPlans')}
+              onClick={onOpenPlans}
+              className={cn(MOBILE_NAV_BTN, 'text-[var(--muted)] hover:text-[var(--ink)]')}
+            >
+              <HiOutlineCubeTransparent className="h-4 w-4" strokeWidth={1.75} />
+            </button>
+            <button
+              type="button"
+              title={t('wallet.settingsNavRedeem')}
+              aria-label={t('wallet.settingsNavRedeem')}
+              onClick={onOpenRedeem}
+              className={cn(MOBILE_NAV_BTN, 'text-[var(--muted)] hover:text-[var(--ink)]')}
+            >
+              <HiOutlineBolt className="h-4 w-4" strokeWidth={1.75} />
+            </button>
 
-        <span className="mx-0.5 h-4 w-px shrink-0 bg-[var(--line)]" aria-hidden />
+            <span className="mx-0.5 h-4 w-px shrink-0 bg-[var(--line)]" aria-hidden />
+          </>
+        ) : null}
 
         {contentNav.map((item) => {
           const active = tab === item.id;
@@ -134,6 +141,7 @@ function AccountSettingsDialog({
   initialTab = 'profile',
 }: Props) {
   const { t } = useTranslation();
+  const desktopLocal = isDesktopLocal();
   const [tab, setTab] = useState<ContentTab>(toContentTab(initialTab));
   const [plansOpen, setPlansOpen] = useState(false);
   const [redeemOpen, setRedeemOpen] = useState(false);
@@ -145,12 +153,15 @@ function AccountSettingsDialog({
       return;
     }
     // Never auto-open plans/redeem — user clicks the left rail.
-    const nextTab =
+    let nextTab: AccountSettingsTab =
       initialTab === 'plans' || initialTab === 'redeem' ? 'billing' : initialTab;
+    if (desktopLocal && (nextTab === 'billing' || nextTab === 'plans' || nextTab === 'redeem')) {
+      nextTab = 'profile';
+    }
     setTab(toContentTab(nextTab));
     setPlansOpen(false);
     setRedeemOpen(false);
-  }, [open, initialTab]);
+  }, [open, initialTab, desktopLocal]);
 
   const dismiss = useCallback(() => {
     const active = document.activeElement;
@@ -161,7 +172,9 @@ function AccountSettingsDialog({
   const contentNav: { id: ContentTab; label: string }[] = [
     { id: 'profile', label: t('wallet.settingsNavProfile') },
     { id: 'agent', label: t('wallet.settingsNavAgent') },
-    { id: 'billing', label: t('wallet.settingsNavBilling') },
+    ...(desktopLocal
+      ? []
+      : [{ id: 'billing' as const, label: t('wallet.settingsNavBilling') }]),
     { id: 'notices', label: t('wallet.settingsNavNotices') },
   ];
 
@@ -215,24 +228,31 @@ function AccountSettingsDialog({
                       {t('wallet.settingsTitle')}
                     </h2>
                     <nav className="flex flex-1 flex-col gap-0.5">
-                      <button
-                        type="button"
-                        onClick={() => setPlansOpen(true)}
-                        className={actionBtn}
-                      >
-                        <HiOutlineCubeTransparent className="h-4 w-4 shrink-0" strokeWidth={1.75} />
-                        {t('wallet.settingsNavPlans')}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setRedeemOpen(true)}
-                        className={actionBtn}
-                      >
-                        <HiOutlineBolt className="h-4 w-4 shrink-0" strokeWidth={1.75} />
-                        {t('wallet.settingsNavRedeem')}
-                      </button>
+                      {!desktopLocal ? (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => setPlansOpen(true)}
+                            className={actionBtn}
+                          >
+                            <HiOutlineCubeTransparent
+                              className="h-4 w-4 shrink-0"
+                              strokeWidth={1.75}
+                            />
+                            {t('wallet.settingsNavPlans')}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setRedeemOpen(true)}
+                            className={actionBtn}
+                          >
+                            <HiOutlineBolt className="h-4 w-4 shrink-0" strokeWidth={1.75} />
+                            {t('wallet.settingsNavRedeem')}
+                          </button>
 
-                      <div className="my-2 border-t border-[var(--line)]" />
+                          <div className="my-2 border-t border-[var(--line)]" />
+                        </>
+                      ) : null}
 
                       {contentNav.map((item) => {
                         const active = tab === item.id;
@@ -280,15 +300,19 @@ function AccountSettingsDialog({
                     <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-5">
                       {tab === 'profile' && <AccountProfilePanel />}
                       {tab === 'agent' && (
-                        <AgentModelsPanel onRequestUpgrade={() => setPlansOpen(true)} />
+                        <AgentModelsPanel
+                          onRequestUpgrade={
+                            desktopLocal ? undefined : () => setPlansOpen(true)
+                          }
+                        />
                       )}
-                      {tab === 'billing' && (
+                      {tab === 'billing' && !desktopLocal ? (
                         <WalletLedgerPanel
                           embedded
                           onRequestPlans={() => setPlansOpen(true)}
                           onRequestRedeem={() => setRedeemOpen(true)}
                         />
-                      )}
+                      ) : null}
                       {tab === 'notices' && <AccountNotificationsPanel />}
                     </div>
                   </div>
@@ -298,8 +322,9 @@ function AccountSettingsDialog({
                     tab={tab}
                     contentNav={contentNav}
                     onSelectTab={setTab}
-                    onOpenPlans={() => setPlansOpen(true)}
-                    onOpenRedeem={() => setRedeemOpen(true)}
+                    hideCommerce={desktopLocal}
+                    onOpenPlans={desktopLocal ? undefined : () => setPlansOpen(true)}
+                    onOpenRedeem={desktopLocal ? undefined : () => setRedeemOpen(true)}
                   />
                 </DialogPanel>
               </TransitionChild>

--- a/apps/web/src/components/layout/PlansDialog.tsx
+++ b/apps/web/src/components/layout/PlansDialog.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-icons/hi2';
 import { Dialog, message } from '@/components/base';
 import { PLAN_CATALOG, PLAN_ORDER, type PlanId } from '@/utils/wallet';
+import { isDesktopLocal } from '@/utils/apiBase';
 import { cn } from '@/utils/classnames';
 
 type PlansPanelProps = {
@@ -316,6 +317,8 @@ type DialogProps = {
 /** Standalone membership dialog. */
 function PlansDialog({ open, onClose }: DialogProps) {
   const { t } = useTranslation();
+  // Local desktop has no cloud subscription — never surface the catalog.
+  if (isDesktopLocal()) return null;
   return (
     <Dialog
       show={open}

--- a/apps/web/src/components/layout/RedeemDialog.tsx
+++ b/apps/web/src/components/layout/RedeemDialog.tsx
@@ -7,6 +7,7 @@ import { redeemCardKey } from '@/apis/wallet';
 import { normalizePlanId, type LedgerEntry, type PlanId } from '@/utils/wallet';
 import { syncFromServer } from '@/store/modules/wallet';
 import { buildLoginUrl } from '@/utils/authReturnTo';
+import { isDesktopLocal } from '@/utils/apiBase';
 
 type RedeemPanelProps = {
   active?: boolean;
@@ -135,6 +136,7 @@ type DialogProps = {
 /** Standalone redeem dialog (legacy callers). Prefer AccountSettingsDialog. */
 function RedeemDialog({ open, onClose, onRedeemed }: DialogProps) {
   const { t } = useTranslation();
+  if (isDesktopLocal()) return null;
   const dismiss = () => {
     // Blur before hide — cancel/redeem call parent setState and skip Dialog.onClose blur.
     const active = document.activeElement;

--- a/apps/web/src/components/layout/UserAccountPanel.tsx
+++ b/apps/web/src/components/layout/UserAccountPanel.tsx
@@ -39,6 +39,7 @@ import { docsUrl, openExternalUrl } from '@/utils/docsUrl';
 import { SUPPORTED_LANGS } from '@/i18n';
 import { buildLocaleSwitchUrl, normalizeI18nLang } from '@/i18n/localePath';
 import { applyTheme, getStoredThemeMode, type ThemeMode } from '@/theme';
+import { isDesktopLocal } from '@/utils/apiBase';
 import { cn } from '@/utils/classnames';
 
 const NARROW_MQ = '(max-width: 767px)';
@@ -247,8 +248,11 @@ function UserAccountPanel({ open, onOpenChange, children }: Props) {
   const planId = useSelector((state: any) => state.wallet?.planId ?? 'free') as PlanId;
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const desktopLocal = isDesktopLocal();
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [settingsTab, setSettingsTab] = useState<AccountSettingsTab>('billing');
+  const [settingsTab, setSettingsTab] = useState<AccountSettingsTab>(
+    desktopLocal ? 'profile' : 'billing'
+  );
   const [plansOpen, setPlansOpen] = useState(false);
   const [flyout, setFlyout] = useState<FlyoutKind>(null);
   const [themeMode, setThemeMode] = useState<ThemeMode>(() => getStoredThemeMode());
@@ -361,13 +365,18 @@ function UserAccountPanel({ open, onOpenChange, children }: Props) {
     close();
   };
 
-  const openSettings = (tab: AccountSettingsTab = 'billing') => {
+  const openSettings = (tab: AccountSettingsTab = desktopLocal ? 'profile' : 'billing') => {
     close();
-    setSettingsTab(tab);
+    setSettingsTab(
+      desktopLocal && (tab === 'billing' || tab === 'plans' || tab === 'redeem')
+        ? 'profile'
+        : tab
+    );
     setSettingsOpen(true);
   };
 
   const openPlans = () => {
+    if (desktopLocal) return;
     close();
     setPlansOpen(true);
   };
@@ -412,8 +421,8 @@ function UserAccountPanel({ open, onOpenChange, children }: Props) {
                 </div>
               </div>
 
-              {/* Plan + upgrade — hide while drilling into lang/theme */}
-              {!flyout ? (
+              {/* Plan + upgrade — cloud / web only; hide while drilling into lang/theme */}
+              {!flyout && !desktopLocal ? (
                 <div className="border-t border-[var(--line)] px-3.5 py-3">
                   <button
                     type="button"

--- a/apps/web/src/components/layout/WalletAccountChip.tsx
+++ b/apps/web/src/components/layout/WalletAccountChip.tsx
@@ -8,6 +8,7 @@ import type { MenuItemType } from '@/components/base/dropdown/MenuItem';
 import UserAccountPanel, { UserAvatar } from '@/components/layout/UserAccountPanel';
 import { formatTokens } from '@/utils/wallet';
 import { buildLoginUrl } from '@/utils/authReturnTo';
+import { isDesktopLocal } from '@/utils/apiBase';
 import { cn } from '@/utils/classnames';
 
 type Props = {
@@ -39,22 +40,28 @@ function WalletAccountChip({ className }: Props) {
   ];
 
   if (user) {
+    const local = isDesktopLocal();
     return (
       <UserAccountPanel open={accountOpen} onOpenChange={setAccountOpen}>
         <button
           type="button"
           className={cn(
-            'pointer-events-auto flex h-8 max-w-[12rem] items-center gap-2 rounded-full bg-[var(--accent-soft)] pl-2.5 pr-0.5 transition hover:opacity-90',
+            'pointer-events-auto flex h-8 items-center transition hover:opacity-90',
+            local
+              ? 'w-8 justify-center rounded-full bg-[var(--accent-soft)]'
+              : 'max-w-[12rem] gap-2 rounded-full bg-[var(--accent-soft)] pl-2.5 pr-0.5',
             className
           )}
-          title={tip}
+          title={local ? user?.name || user?.email || t('home.account') : tip}
         >
-          <span className="inline-flex min-w-0 items-center gap-1 text-[var(--ink)]">
-            <HiOutlineBolt className="h-3.5 w-3.5 shrink-0 text-[var(--muted)]" aria-hidden />
-            <span className="min-w-0 truncate text-[12px] font-semibold tabular-nums tracking-tight">
-              {formatTokens(tokens)}
+          {!local ? (
+            <span className="inline-flex min-w-0 items-center gap-1 text-[var(--ink)]">
+              <HiOutlineBolt className="h-3.5 w-3.5 shrink-0 text-[var(--muted)]" aria-hidden />
+              <span className="min-w-0 truncate text-[12px] font-semibold tabular-nums tracking-tight">
+                {formatTokens(tokens)}
+              </span>
             </span>
-          </span>
+          ) : null}
           <UserAvatar name={user.name} email={user.email} avatar={user.avatar} size={28} />
         </button>
       </UserAccountPanel>

--- a/apps/web/src/components/layout/WalletLedgerPanel.tsx
+++ b/apps/web/src/components/layout/WalletLedgerPanel.tsx
@@ -18,6 +18,7 @@ import {
   type LedgerEntry,
   type PlanId,
 } from '@/utils/wallet';
+import { isDesktopLocal } from '@/utils/apiBase';
 import { cn } from '@/utils/classnames';
 import ProgressBar from '@/components/base/progress';
 import { SegmentedControl } from '@/components/base';
@@ -126,6 +127,7 @@ function WalletLedgerPanel({
 }: Props = {}) {
   const { t, i18n } = useTranslation();
   const dispatch = useDispatch();
+  const desktopLocal = isDesktopLocal();
   const [searchParams, setSearchParams] = useSearchParams();
   const tokens = useSelector((state: any) => state.wallet?.tokens ?? 0);
   const planId = useSelector((state: any) => state.wallet?.planId ?? 'free') as PlanId;
@@ -141,22 +143,24 @@ function WalletLedgerPanel({
   const [redeemOpen, setRedeemOpen] = useState(false);
   const [plansOpen, setPlansOpen] = useState(false);
 
-  /** Deep-link ?redeem=1 still opens redeem (legacy) — skip when embedded. */
+  /** Deep-link ?redeem=1 still opens redeem (legacy) — skip when embedded / local desktop. */
   useEffect(() => {
-    if (embedded) return;
+    if (embedded || desktopLocal) return;
     const flag = (searchParams.get('redeem') || '').trim();
     if (!flag || flag === '0' || flag.toLowerCase() === 'false') return;
     setRedeemOpen(true);
     const next = new URLSearchParams(searchParams);
     next.delete('redeem');
     setSearchParams(next, { replace: true });
-  }, [searchParams, setSearchParams, embedded]);
+  }, [searchParams, setSearchParams, embedded, desktopLocal]);
 
   const openPlans = () => {
+    if (desktopLocal) return;
     if (embedded && onRequestPlans) onRequestPlans();
     else setPlansOpen(true);
   };
   const openRedeem = () => {
+    if (desktopLocal) return;
     if (embedded && onRequestRedeem) onRequestRedeem();
     else setRedeemOpen(true);
   };
@@ -276,9 +280,11 @@ function WalletLedgerPanel({
               <p className="pt-1 text-[12px] text-[var(--muted)]">{t('wallet.planExpiresUnknown')}</p>
             ) : null}
           </div>
-          <button type="button" onClick={openPlans} className={ghostBtn}>
-            {isTopOfferedPlan(planId) ? t('wallet.adjustPlan') : t('wallet.upgrade')}
-          </button>
+          {!desktopLocal ? (
+            <button type="button" onClick={openPlans} className={ghostBtn}>
+              {isTopOfferedPlan(planId) ? t('wallet.adjustPlan') : t('wallet.upgrade')}
+            </button>
+          ) : null}
         </Card>
 
         {/* Plan credits (included) */}
@@ -342,18 +348,20 @@ function WalletLedgerPanel({
           </div>
         </Card>
 
-        {/* Card-key redeem — our payment channel */}
-        <Card className="flex flex-wrap items-center justify-between gap-3 px-5 py-4">
-          <div className="min-w-0">
-            <div className="text-[15px] font-medium text-[var(--ink)]">{t('wallet.redeemTitle')}</div>
-            <p className="mt-1 text-[13px] leading-relaxed text-[var(--muted)]">
-              {t('wallet.redeemSectionHint')}
-            </p>
-          </div>
-          <button type="button" onClick={openRedeem} className={primaryBtn}>
-            {t('wallet.redeem')}
-          </button>
-        </Card>
+        {/* Card-key redeem — cloud payment channel only */}
+        {!desktopLocal ? (
+          <Card className="flex flex-wrap items-center justify-between gap-3 px-5 py-4">
+            <div className="min-w-0">
+              <div className="text-[15px] font-medium text-[var(--ink)]">{t('wallet.redeemTitle')}</div>
+              <p className="mt-1 text-[13px] leading-relaxed text-[var(--muted)]">
+                {t('wallet.redeemSectionHint')}
+              </p>
+            </div>
+            <button type="button" onClick={openRedeem} className={primaryBtn}>
+              {t('wallet.redeem')}
+            </button>
+          </Card>
+        ) : null}
 
         {/* Ledger */}
         <Card className="overflow-hidden">

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -694,6 +694,7 @@ const en = {
     agentRouteVision: 'Multimodal',
     agentRouteImage: 'Image model',
     agentRouteFollowPlatform: 'Follow platform',
+    agentRouteLaneEmpty: 'Select a model',
     agentRouteCostNote:
       'Models are not all called at once; platform caps retries. Costlier models only run for matching lanes or vision steps.',
     agentRoutePlatformNote: 'Using Standard routes (domestic Seed / DeepSeek / Seedream preferred).',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -673,6 +673,7 @@ const ja = {
     agentRouteVision: 'マルチモーダル',
     agentRouteImage: '画像モデル',
     agentRouteFollowPlatform: 'プラットフォームに従う',
+    agentRouteLaneEmpty: 'モデルを選択',
     agentRouteCostNote:
       '一度に全モデルを呼びません。再試行回数は上限あり。高コストモデルは該当車線または画像時のみ。',
     agentRoutePlatformNote: 'スタンダード（プラットフォーム既定）ルートを使用中です。',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -687,6 +687,7 @@ const zhCN = {
     agentRouteVision: '多模态',
     agentRouteImage: '生图模型',
     agentRouteFollowPlatform: '跟随平台',
+    agentRouteLaneEmpty: '请选择模型',
     agentRouteCostNote:
       '不会一次调用多个模型；失败重试由平台限制次数。贵模型仅在对应车道或看图时使用。',
     agentRoutePlatformNote: '当前使用标准版路由（优先国内 Seed / DeepSeek / Seedream）。',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -666,6 +666,7 @@ const zhTW = {
     agentRouteVision: '多模態',
     agentRouteImage: '生圖模型',
     agentRouteFollowPlatform: '跟隨平台',
+    agentRouteLaneEmpty: '請選擇模型',
     agentRouteCostNote:
       '不會一次呼叫多個模型；失敗重試由平台限制次數。貴模型僅在對應車道或看圖時使用。',
     agentRoutePlatformNote: '目前使用標準版（平台預設）路由，無需額外設定。',

--- a/apps/web/src/utils/apiBase.ts
+++ b/apps/web/src/utils/apiBase.ts
@@ -36,6 +36,11 @@ export function getDesktopMode(): DesktopMode | null {
   return null;
 }
 
+/** Local desktop: OS auto-login + SQLite — no cloud plans / redeem / billing UI. */
+export function isDesktopLocal(): boolean {
+  return getDesktopMode() === 'local';
+}
+
 /** Origin for API calls; empty string → same-origin relative paths. */
 export function getApiBaseUrl(): string {
   const explicit = (

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -11,6 +11,10 @@ UI still calls `/api/v1/...` on **`127.0.0.1:8000`**. Projects, skills, uploads,
 
 **Login:** Local desktop auto-signs in as the OS user (`DESKTOP_LOCAL_AUTO_LOGIN`, loopback-only `POST /auth/desktop-local`). No email OTP. Cloud desktop / browser still use normal login.
 
+**Billing UI:** Local flavor hides plans / redeem / upgrade (no cloud account switch in-app — use the Cloud desktop build for that).
+
+**Models:** Local does **not** expose the platform LLM catalog (no Seedream / OpenRouter entries for end users). Add your own OpenAI-compatible providers + API keys under Agent settings (BYOK). Wallet holds are skipped.
+
 ## Prerequisites
 
 1. **Node.js** + repo `npm install`
@@ -77,9 +81,10 @@ Cloud desktop
 | Symptom | What to try |
 |---------|-------------|
 | Skills / projects “Request failed” | Re-login — old cloud JWT won’t match a fresh local SQLite DB |
+| Still shows email/OTP login | Auto-login failed — often stale SQLite schema; pull latest, restart `dev:desktop`, or delete `apps/api/storage/recombyn.db` |
 | Sidecar build fails | `cd apps/api && .venv\Scripts\activate && pip install -e ".[desktop]"` |
 | Release app won’t start API | Confirm `sidecars/recombyn-api/recombyn-api.exe` exists before/after build |
-| Port 8000 in use | Quit other API / previous desktop; or reuse the existing listener |
+| Port 8000 in use | Quit other API / previous desktop; `ensure-desktop-api` refuses a listener without working auto-login |
 | Want cloud MySQL in desktop | Use **cloud** flavor, not local |
 
 ## Related

--- a/scripts/ensure-desktop-api.mjs
+++ b/scripts/ensure-desktop-api.mjs
@@ -1,6 +1,7 @@
 /**
  * Ensure a local FastAPI is listening on 127.0.0.1:8000 for desktop-local.
- * If already up, do nothing. Otherwise spawn uvicorn (venv preferred).
+ * Spawns uvicorn from apps/api/.venv with SQLite + DESKTOP_LOCAL_AUTO_LOGIN.
+ * Reuses an existing listener only if desktop-local auto-login succeeds (HTTP 200).
  */
 import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
@@ -13,21 +14,52 @@ const apiRoot = path.join(repoRoot, 'apps', 'api');
 const win = process.platform === 'win32';
 const HOST = '127.0.0.1';
 const PORT = 8000;
+const sqliteRel = path.join('storage', 'recombyn.db').replace(/\\/g, '/');
 
-function healthOk(timeoutMs = 800) {
+function request(method, urlPath, { timeoutMs = 1200, body } = {}) {
   return new Promise((resolve) => {
-    const req = http.get(
-      { host: HOST, port: PORT, path: '/api/v1/health', timeout: timeoutMs },
+    const req = http.request(
+      {
+        host: HOST,
+        port: PORT,
+        path: urlPath,
+        method,
+        timeout: timeoutMs,
+        headers: body
+          ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) }
+          : undefined,
+      },
       (res) => {
-        res.resume();
-        resolve(res.statusCode != null && res.statusCode < 500);
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
       }
     );
     req.on('timeout', () => {
       req.destroy();
-      resolve(false);
+      resolve({ status: 0, body: '' });
     });
-    req.on('error', () => resolve(false));
+    req.on('error', () => resolve({ status: 0, body: '' }));
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+async function healthOk(timeoutMs = 800) {
+  const res = await request('GET', '/api/v1/health', { timeoutMs });
+  return res.status > 0 && res.status < 500;
+}
+
+/** Probe POST /auth/desktop-local — must return 200 for local flavor. */
+async function probeDesktopLocalLogin(timeoutMs = 2500) {
+  return request('POST', '/api/v1/auth/desktop-local', {
+    timeoutMs,
+    body: '{}',
   });
 }
 
@@ -37,33 +69,66 @@ function resolvePython() {
   return win ? 'python' : 'python3';
 }
 
-export async function ensureDesktopApi() {
-  if (await healthOk()) {
-    console.log(`[desktop:local] API already on http://${HOST}:${PORT}`);
-    return { started: false, child: null };
-  }
+function desktopApiEnv() {
+  // Explicit sqlite URL — empty DATABASE_URL is dropped on some Windows spawn paths,
+  // which would fall back to cloud MySQL in apps/api/.env.
+  return {
+    ...process.env,
+    DATABASE_URL: `sqlite:///${sqliteRel}`,
+    SQLITE_DB_PATH: sqliteRel,
+    S3_ENABLED: 'false',
+    DESKTOP_LOCAL_AUTO_LOGIN: 'true',
+    RECOMBYN_API_ROOT: apiRoot,
+  };
+}
 
+function spawnDesktopApi() {
   const py = resolvePython();
   console.log(`[desktop:local] starting API via ${py} (cwd=${apiRoot})`);
+  return spawn(py, ['-m', 'uvicorn', 'app.main:app', '--host', HOST, '--port', String(PORT)], {
+    cwd: apiRoot,
+    stdio: 'inherit',
+    env: desktopApiEnv(),
+    shell: false,
+    detached: false,
+    windowsHide: true,
+  });
+}
 
-  const child = spawn(
-    py,
-    ['-m', 'uvicorn', 'app.main:app', '--host', HOST, '--port', String(PORT)],
-    {
-      cwd: apiRoot,
-      stdio: 'inherit',
-      env: {
-        ...process.env,
-        // Always isolate desktop-local from cloud MySQL in apps/api/.env.
-        DATABASE_URL: '',
-        S3_ENABLED: 'false',
-        DESKTOP_LOCAL_AUTO_LOGIN: 'true',
-        RECOMBYN_API_ROOT: apiRoot,
-      },
-      shell: win,
-      detached: false,
+function formatProbeFailure(res) {
+  if (res.status === 404) {
+    return (
+      'desktop-local login disabled (set DESKTOP_LOCAL_AUTO_LOGIN=true) ' +
+      `or stale API without the route — body=${res.body.slice(0, 200)}`
+    );
+  }
+  if (res.status === 500) {
+    return (
+      'desktop-local login crashed (often stale SQLite schema). ' +
+      'Restart after pulling migrations, or delete apps/api/storage/recombyn.db and retry. ' +
+      `body=${res.body.slice(0, 200)}`
+    );
+  }
+  if (res.status === 403) {
+    return 'desktop-local rejected non-loopback client';
+  }
+  return `desktop-local probe HTTP ${res.status} body=${res.body.slice(0, 200)}`;
+}
+
+export async function ensureDesktopApi() {
+  if (await healthOk()) {
+    const probe = await probeDesktopLocalLogin();
+    if (probe.status === 200) {
+      console.log(`[desktop:local] API already on http://${HOST}:${PORT} (auto-login ok)`);
+      return { started: false, child: null };
     }
-  );
+    throw new Error(
+      `[desktop:local] something already listens on :${PORT} but auto-login failed — ` +
+        `${formatProbeFailure(probe)}. Stop that API and re-run npm run dev:desktop.`
+    );
+  }
+
+  const child = spawnDesktopApi();
 
   const deadline = Date.now() + 60_000;
   while (Date.now() < deadline) {
@@ -71,6 +136,15 @@ export async function ensureDesktopApi() {
       throw new Error(`[desktop:local] API exited early (code ${child.exitCode})`);
     }
     if (await healthOk(1200)) {
+      const probe = await probeDesktopLocalLogin();
+      if (probe.status !== 200) {
+        try {
+          child.kill();
+        } catch {
+          /* ignore */
+        }
+        throw new Error(`[desktop:local] API came up but ${formatProbeFailure(probe)}`);
+      }
       console.log(`[desktop:local] API ready at http://${HOST}:${PORT}`);
       return { started: true, child };
     }


### PR DESCRIPTION
## Summary
- Local desktop hides plans/redeem/upgrade and skips wallet holds; platform LLM catalog is empty so users only configure BYOK providers.
- Fix desktop-local auto-login against stale SQLite (0002_sync_missing_columns) and harden ensure-desktop-api / explicit sqlite URL spawn.
- Clean Agent route prefs UI for empty local lanes (no phantom brand icons) and flatten nested ternaries in AgentModelsPanel.

## Test plan
- [ ] npm run dev:desktop — OS auto-login works; no plans/redeem in account menu
- [ ] Agent settings — only custom lanes; empty lanes show placeholder without icons
- [ ] Add a BYOK provider, select it on a lane, run a design turn without credit errors
- [ ] Cloud/web unchanged: plans UI and platform models still available