### PR TITLE
Host built docs on recombyn/recombyn Pages (no separate help repo)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="docs/self-hosting.md"><strong>Self Host</strong></a> ·
   <a href="https://recombyn.com"><strong>Cloud</strong></a> ·
-  <a href="https://recombyn.github.io/help/"><strong>Docs</strong></a>
+  <a href="https://recombyn.github.io/recombyn/"><strong>Docs</strong></a>
 </p>
 
 <p align="center">
@@ -107,7 +107,7 @@ deploy/            Dockerfile / Nginx
 e2e/               Playwright
 ```
 
-ユーザー向けヘルプは**プライベート**リポジトリで管理し、[recombyn.github.io/help](https://recombyn.github.io/help/) に公開しています。
+ユーザー向けヘルプの**ソース**はプライベート管理。CI がビルド成果物だけを本リポジトリの `gh-pages` に載せ、[recombyn.github.io/recombyn/](https://recombyn.github.io/recombyn/) で公開します。
 
 ## ドキュメント / コミュニティ
 
@@ -132,7 +132,7 @@ e2e/               Playwright
 - Recombyn（または実質同種の平台）を一般向け登録サイト / SaaS として提供する（有償・無償問わず）
 - 公式ブランド・サイト・サポートを装う（名称、ロゴ、ドメインなど）
 
-公式: [recombyn.com](https://recombyn.com) · ヘルプ: [docs](https://recombyn.github.io/help/) · ソース: [github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)
+公式: [recombyn.com](https://recombyn.com) · ヘルプ: [docs](https://recombyn.github.io/recombyn/) · ソース: [github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)
 
 模倣・無断ホスティングは `702680355@qq.com` へ（リンクとスクショ添付）。全文は [LICENSE](./LICENSE)。
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="docs/self-hosting.md"><strong>Self Host</strong></a> ·
   <a href="https://recombyn.com"><strong>Cloud</strong></a> ·
-  <a href="https://recombyn.github.io/help/"><strong>Docs</strong></a>
+  <a href="https://recombyn.github.io/recombyn/"><strong>Docs</strong></a>
 </p>
 
 <p align="center">
@@ -107,7 +107,7 @@ deploy/            Dockerfiles / Nginx
 e2e/               Playwright
 ```
 
-User-facing help docs are maintained in a **private** repo and published at [recombyn.github.io/help](https://recombyn.github.io/help/).
+User-facing help **source** is private; CI publishes only the built static site to this repo’s `gh-pages` branch → [recombyn.github.io/recombyn/](https://recombyn.github.io/recombyn/).
 
 ## Documentation
 
@@ -146,7 +146,7 @@ Learning, personal use, and single-org internal deploy are fine. **Without autho
 - Offer Recombyn (or a substantially similar platform) as a public sign-up site / SaaS — paid or free
 - Impersonate the official brand, site, or support (name, logo, domain, etc.)
 
-Official: [recombyn.com](https://recombyn.com) · Help: [docs](https://recombyn.github.io/help/) · Source: [github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)
+Official: [recombyn.com](https://recombyn.com) · Help: [docs](https://recombyn.github.io/recombyn/) · Source: [github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)
 
 Report clones or unauthorized hosting to `702680355@qq.com` (include links and screenshots). Full terms: [LICENSE](./LICENSE).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="docs/self-hosting.md"><strong>自托管</strong></a> ·
   <a href="https://recombyn.com"><strong>Cloud</strong></a> ·
-  <a href="https://recombyn.github.io/help/"><strong>文档</strong></a>
+  <a href="https://recombyn.github.io/recombyn/"><strong>文档</strong></a>
 </p>
 
 <p align="center">
@@ -106,7 +106,7 @@ deploy/            Dockerfile / Nginx
 e2e/               Playwright
 ```
 
-面向用户的帮助文档在**私有**仓库维护，发布于 [recombyn.github.io/help](https://recombyn.github.io/help/)。
+面向用户的帮助文档**源码**在私有仓维护；CI 只把打包后的静态站推到本仓库 `gh-pages`，见 [recombyn.github.io/recombyn/](https://recombyn.github.io/recombyn/)。
 
 ## 文档与社区
 
@@ -130,7 +130,7 @@ e2e/               Playwright
 - 把 Recombyn（或其实质相同平台）做成面向公众注册的网站 / SaaS（收费或免费都不行）
 - 冒充官方品牌、官网或客服（名称、Logo、域名等）
 
-官方站点：[recombyn.com](https://recombyn.com) · 帮助文档：[docs](https://recombyn.github.io/help/) · 源码仓库：[github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)
+官方站点：[recombyn.com](https://recombyn.com) · 帮助文档：[docs](https://recombyn.github.io/recombyn/) · 源码仓库：[github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)
 
 发现仿冒或违规托管，请发邮件至 `702680355@qq.com`（附链接与截图）。完整条款见 [LICENSE](./LICENSE)。
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -6,9 +6,9 @@ GOOGLE_CLIENT_ID=
 # VITE_GOOGLE_CLIENT_ID=
 
 # Docs site (help + legal). Unset in local → http://localhost:5175 (private docs repo).
-# Production builds default to GitHub Pages: https://recombyn.github.io/help
+# Production builds default to GitHub Pages: https://recombyn.github.io/recombyn
 # VITE_DOCS_URL=http://localhost:5175
-# VITE_DOCS_URL=https://recombyn.github.io/help
+# VITE_DOCS_URL=https://recombyn.github.io/recombyn
 
 # Canvas multiplayer (Yjs). Vite DEV defaults ON (disable with ?collab=0).
 # Production builds: bake via Docker build-arg VITE_COLLAB_ENABLED (compose default true).

--- a/apps/web/src/utils/docsUrl.ts
+++ b/apps/web/src/utils/docsUrl.ts
@@ -1,7 +1,7 @@
 /**
  * External docs site (help guides + standalone legal). Not served by the main app.
  *
- * - Production: GitHub Pages https://recombyn.github.io/help (or VITE_DOCS_URL)
+ * - Production: GitHub Pages https://recombyn.github.io/recombyn (or VITE_DOCS_URL)
  * - Local web (localhost / 127.0.0.1): local docs on :5175 unless VITE_DOCS_URL
  *   already points at a local origin (custom port).
  * - Tauri desktop: always prefer hosted docs (local :5175 is a web-dev convenience).
@@ -9,7 +9,7 @@
 
 declare const __DOCS_URL__: string;
 
-const PROD_DOCS = 'https://recombyn.github.io/help';
+const PROD_DOCS = 'https://recombyn.github.io/recombyn';
 const LOCAL_DOCS_PORT = 5175;
 
 function bakedOrigin(): string {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig(({ mode }) => {
   const docsUrl = (
     envWeb.VITE_DOCS_URL ||
     envRoot.VITE_DOCS_URL ||
-    (mode === 'development' ? 'http://localhost:5175' : 'https://recombyn.github.io/help')
+    (mode === 'development' ? 'http://localhost:5175' : 'https://recombyn.github.io/recombyn')
   ).replace(/\/$/, '');
   // Desktop flavors: local (sidecar SQLite API) | cloud (remote API). Browser builds leave empty.
   const desktopMode = (

--- a/docs/design-agent-runtime.md
+++ b/docs/design-agent-runtime.md
@@ -291,4 +291,4 @@ Prompt pack `usedBy` stages: `intent` / `decide` / `paint` / `apply` / `observe`
 - LangGraph checkpointer: [postgres-switch.md](./postgres-switch.md#langgraph-checkpointer-design-agent--create_agent)
 - Architecture: [architecture.md](./architecture.md)
 - Skill namespaces: [design_skills/README.md](../apps/api/data/design_skills/README.md)
-- User-facing Agent guide: [recombyn.github.io/help · Agent](https://recombyn.github.io/help/guide/agent)
+- User-facing Agent guide: [recombyn.github.io/recombyn · Agent](https://recombyn.github.io/recombyn/guide/agent)


### PR DESCRIPTION
## Summary
- Point docs URLs back to https://recombyn.github.io/recombyn/ (static build on `gh-pages`).
- Clarify that help **source** stays private; only packaged assets are published on this repo.
- Redundant public `recombyn/help` repo archived.

## Test plan
- [ ] Open https://recombyn.github.io/recombyn/sponsor
- [ ] Confirm README docs links
