### PR TITLE
Fix API CI: permission gate test with wallet billing off

### DIFF
--- a/apps/api/tests/integration_tests/test_design_golden_paths.py
+++ b/apps/api/tests/integration_tests/test_design_golden_paths.py
@@ -66,6 +66,11 @@ def _run(**kwargs):
 
 @pytest.mark.integration
 def test_permission_gate_denies_when_broke(monkeypatch):
+    # Platform credit gate only applies when wallet billing is on (SaaS).
+    monkeypatch.setattr(
+        "app.services.design.runtime.orchestrator.is_wallet_billing_enabled",
+        lambda: True,
+    )
     monkeypatch.setattr(
         "app.services.design.runtime.orchestrator.get_user_tokens",
         lambda _uid: 0,


### PR DESCRIPTION
## Summary
- Wallet billing defaults to off (self-host); the broke-user permission golden path incorrectly assumed SaaS gating always ran.
- Test now enables `is_wallet_billing_enabled` when asserting denial.

## Test plan
- [x] `pytest tests/integration_tests/test_design_golden_paths.py::test_permission_gate_denies_when_broke`
- [ ] CI API Tests green on this PR