### PR TITLE
Ship server-side project covers and oriented multi-select rotate chrome

### DIFF
--- a/apps/api/app/api/routes/projects.py
+++ b/apps/api/app/api/routes/projects.py
@@ -78,6 +78,11 @@ class BatchDeleteIn(BaseModel):
     ids: list[str] = Field(..., min_length=1, max_length=100)
 
 
+class ExtractCoversIn(BaseModel):
+    """Optional live document; otherwise server uses the stored project document."""
+    document: dict[str, Any] | None = None
+
+
 @router.get("", response_model=ProjectListOut)
 def list_my_projects(
     current_user: CurrentUser,
@@ -104,6 +109,24 @@ def get_one(
     row = project_store.get_project(current_user.id, project_id)
     if not row:
         raise HTTPException(status_code=404, detail="Not found")
+    return {"project": row}
+
+
+@router.post("/{project_id}/covers", response_model=ProjectOneOut)
+def extract_covers(
+    current_user: CurrentUser,
+    project_id: str,
+    body: ExtractCoversIn | None = None,
+) -> dict[str, Any]:
+    """Build ≤4 cover tiles from document elements (Publish tab)."""
+    try:
+        row = project_store.extract_project_covers(
+            current_user.id,
+            project_id,
+            document=(body.document if body else None),
+        )
+    except ProjectNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Not found") from exc
     return {"project": row}
 
 

--- a/apps/api/app/api/routes/uploads.py
+++ b/apps/api/app/api/routes/uploads.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import ipaddress
 import logging
+import re
 import socket
 from typing import Any
 from urllib.parse import unquote, urljoin, urlparse
 
 import httpx
 from fastapi import APIRouter, File, HTTPException, Query, UploadFile
-from app.api.deps import CurrentUser
+from app.api.deps import CurrentUser, OptionalUser
 from fastapi.responses import Response
 
 from app.core.config import settings
@@ -23,9 +24,15 @@ logger = logging.getLogger(__name__)
 _MAX_PROXY_BYTES = 25 * 1024 * 1024
 _PROXY_TIMEOUT = httpx.Timeout(60.0, connect=20.0)
 
+# List/home covers: <img src> cannot send Bearer — these keys are readable without login.
+_PUBLIC_PROJECT_COVER_KEY = re.compile(
+    r"^projects/[^/]+/[^/]+/thumb[^/]*\.(?:jpe?g|png|webp|gif)$",
+    re.IGNORECASE,
+)
 
 
-
+def _is_public_project_cover_key(key: str) -> bool:
+    return bool(_PUBLIC_PROJECT_COVER_KEY.match((key or "").lstrip("/")))
 
 
 def _mime_for_key(key: str) -> str:
@@ -101,14 +108,15 @@ def _object_key_from_url(raw: str) -> str | None:
     return None
 
 
-def _file_response(key: str) -> Response:
+def _file_response(key: str, *, public: bool = False) -> Response:
     data = get_bytes(key)
     if not data:
         raise HTTPException(status_code=404, detail="Not found")
+    cache = "public, max-age=86400" if public else "private, max-age=86400"
     return Response(
         content=data,
         media_type=_mime_for_key(key),
-        headers={"Cache-Control": "private, max-age=86400"},
+        headers={"Cache-Control": cache},
     )
 
 
@@ -253,14 +261,21 @@ def get_upload_content_by_url(
 
 @router.get("/files/{object_key:path}")
 def get_uploaded_file(
-    current_user: CurrentUser,
     object_key: str,
+    current_user: OptionalUser,
 ) -> Response:
     """
     Serve stored uploads by object key (local disk or S3/COS via get_bytes).
+
+    Project list covers (``projects/{user}/{project}/thumb-*``) are public so
+    ``<img src>`` works without Authorization. Other keys still require login + ownership.
     """
     key = (object_key or "").lstrip("/")
-    if ".." in key or not _user_owns_key(current_user.id, key):
+    if ".." in key or not key:
+        raise HTTPException(status_code=404, detail="Not found")
+    if _is_public_project_cover_key(key):
+        return _file_response(key, public=True)
+    if current_user is None or not _user_owns_key(current_user.id, key):
         raise HTTPException(status_code=404, detail="Not found")
     return _file_response(key)
 

--- a/apps/api/app/crud.py
+++ b/apps/api/app/crud.py
@@ -248,6 +248,30 @@ def update_project_if_revision(
     return int(getattr(result, "rowcount", 0) or 0) > 0
 
 
+def update_project_covers(
+    *,
+    session: Session,
+    user_id: str,
+    project_id: str,
+    thumbnail_key: str | None,
+    thumbnail_custom: bool,
+    updated_at: float,
+) -> bool:
+    """Update cover tiles only — does not bump document revision."""
+    stmt = (
+        sa_update(Project)
+        .where(Project.id == project_id, Project.user_id == user_id)
+        .values(
+            thumbnail_key=thumbnail_key,
+            thumbnail_custom=1 if thumbnail_custom else 0,
+            updated_at=updated_at,
+        )
+    )
+    result = session.execute(stmt)
+    session.commit()
+    return int(getattr(result, "rowcount", 0) or 0) > 0
+
+
 def delete_project_for_user(
     *,
     session: Session,
@@ -1037,6 +1061,7 @@ def create_asset(
     source: str,
     prompt: str | None,
     created_at: float,
+    meta_json: str | None = None,
 ) -> Asset:
     row = Asset(
         id=asset_id,
@@ -1049,9 +1074,26 @@ def create_asset(
         height=height,
         source=source,
         prompt=prompt,
-        meta_json=None,
+        meta_json=meta_json,
         created_at=created_at,
     )
+    session.add(row)
+    session.commit()
+    session.refresh(row)
+    return row
+
+
+def update_asset_meta_json(
+    *,
+    session: Session,
+    user_id: str,
+    asset_id: str,
+    meta_json: str,
+) -> Asset | None:
+    row = get_user_asset(session=session, user_id=user_id, asset_id=asset_id)
+    if not row:
+        return None
+    row.meta_json = meta_json
     session.add(row)
     session.commit()
     session.refresh(row)

--- a/apps/api/app/services/assets.py
+++ b/apps/api/app/services/assets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 import mimetypes
 import time
 import uuid
@@ -16,7 +17,9 @@ from sqlmodel import Session
 from app import crud
 from app.core.db import engine
 from app.services.db import init_schema
-from app.services.storage import delete_object, get_storage, put_bytes
+from app.services.storage import delete_object, get_bytes, get_storage, put_bytes
+
+logger = logging.getLogger(__name__)
 
 
 def _display_url(
@@ -92,6 +95,44 @@ def _normalize_asset_url(url: str | None, object_key: str | None) -> str:
     return raw
 
 
+def _parse_lottie_animation(raw: bytes | str | dict[str, Any] | None) -> dict[str, Any] | None:
+    """Bodymovin dict with layers — used inline on list items (no per-card JSON fetch)."""
+    if raw is None:
+        return None
+    data: Any = raw
+    if isinstance(raw, (bytes, bytearray)):
+        try:
+            data = json.loads(bytes(raw).decode("utf-8"))
+        except Exception:
+            return None
+    elif isinstance(raw, str):
+        try:
+            data = json.loads(raw)
+        except Exception:
+            return None
+    if not isinstance(data, dict):
+        return None
+    layers = data.get("layers")
+    if not isinstance(layers, list):
+        return None
+    return data
+
+
+def _animation_data_from_meta(meta: Any) -> dict[str, Any] | None:
+    if not isinstance(meta, dict):
+        return None
+    return _parse_lottie_animation(meta.get("animationData"))
+
+
+def _meta_json_with_animation(
+    animation: dict[str, Any],
+    existing: Any = None,
+) -> str:
+    meta: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+    meta["animationData"] = animation
+    return json.dumps(meta, ensure_ascii=False, separators=(",", ":"))
+
+
 def _row_to_asset(row: Any) -> dict[str, Any]:
     def _get(key: str) -> Any:
         return getattr(row, key) if hasattr(row, key) else row[key]
@@ -104,9 +145,10 @@ def _row_to_asset(row: Any) -> dict[str, Any]:
         except json.JSONDecodeError:
             meta = None
     object_key = _get("object_key")
-    return {
+    kind = _get("kind")
+    out: dict[str, Any] = {
         "id": _get("id"),
-        "kind": _get("kind"),
+        "kind": kind,
         "url": _normalize_asset_url(_get("url"), object_key),
         "objectKey": object_key,
         "mime": _get("mime"),
@@ -117,6 +159,44 @@ def _row_to_asset(row: Any) -> dict[str, Any]:
         "meta": meta,
         "createdAt": int(float(_get("created_at") or 0) * 1000),
     }
+    if str(kind or "").lower() == "lottie":
+        anim = _animation_data_from_meta(meta)
+        if anim is not None:
+            out["animationData"] = anim
+    return out
+
+
+def _ensure_lottie_animation_on_item(
+    user_id: str,
+    row: Any,
+    item: dict[str, Any],
+) -> dict[str, Any]:
+    """Legacy rows only stored COS JSON — inline once and persist into meta_json."""
+    if str(item.get("kind") or "").lower() != "lottie":
+        return item
+    if isinstance(item.get("animationData"), dict):
+        return item
+    key = str(item.get("objectKey") or "").strip()
+    if not key:
+        return item
+    raw = get_bytes(key)
+    anim = _parse_lottie_animation(raw)
+    if not anim:
+        return item
+    item["animationData"] = anim
+    meta = item.get("meta") if isinstance(item.get("meta"), dict) else None
+    try:
+        with Session(engine) as session:
+            crud.update_asset_meta_json(
+                session=session,
+                user_id=user_id,
+                asset_id=str(item.get("id") or ""),
+                meta_json=_meta_json_with_animation(anim, meta),
+            )
+        item["meta"] = {**(meta or {}), "animationData": anim}
+    except Exception:
+        logger.exception("persist lottie animationData failed asset=%s", item.get("id"))
+    return item
 
 
 _ASSET_KINDS = ("image", "video", "audio", "font", "lottie")
@@ -147,7 +227,9 @@ def list_assets(
             offset=offset,
             limit=page_size_n,
         )
-    items = [_row_to_asset(r) for r in rows]
+    items = [
+        _ensure_lottie_animation_on_item(user_id, r, _row_to_asset(r)) for r in rows
+    ]
     return {
         "items": items,
         "page": page_n,
@@ -303,6 +385,16 @@ def create_asset_from_stored(
     mime_n = (mime or "").split(";")[0].strip() or None
     if not mime_n:
         mime_n = _guess_ext_mime(src or key, None)[1]
+    meta_json = None
+    out_w, out_h = width, height
+    if kind_n == "lottie":
+        anim = _parse_lottie_animation(get_bytes(key))
+        if anim is not None:
+            meta_json = _meta_json_with_animation(anim)
+            if out_w is None:
+                out_w = int(anim.get("w") or 0) or None
+            if out_h is None:
+                out_h = int(anim.get("h") or 0) or None
     asset_id = f"asset_{uuid.uuid4().hex[:16]}"
     now = time.time()
     with Session(engine) as session:
@@ -314,11 +406,12 @@ def create_asset_from_stored(
             object_key=key,
             url=src,
             mime=mime_n,
-            width=width,
-            height=height,
+            width=out_w,
+            height=out_h,
             source=(source or "upload")[:32],
             prompt=(prompt or None),
             created_at=now,
+            meta_json=meta_json,
         )
     return _row_to_asset(row)
 
@@ -337,9 +430,18 @@ def create_asset_from_url(
         kind_n = "image"
     data, ctype = _fetch_bytes(url)
     ext, mime = _guess_ext_mime(url, ctype)
+    if kind_n == "lottie" and ext in ("png", "bin"):
+        ext, mime = "json", "application/json"
     width, height = (None, None)
+    meta_json = None
     if kind_n in ("image", "font"):
         width, height = _probe_image_size(data)
+    elif kind_n == "lottie":
+        anim = _parse_lottie_animation(data)
+        if anim is not None:
+            meta_json = _meta_json_with_animation(anim)
+            width = int(anim.get("w") or 0) or None
+            height = int(anim.get("h") or 0) or None
 
     asset_id = f"asset_{uuid.uuid4().hex[:16]}"
     object_key = f"assets/{user_id}/{asset_id}.{ext}"
@@ -367,6 +469,7 @@ def create_asset_from_url(
             source=(source or "ai_image")[:32],
             prompt=(prompt or None),
             created_at=now,
+            meta_json=meta_json,
         )
     return _row_to_asset(row)
 
@@ -405,16 +508,15 @@ def create_asset_from_bytes(
     out_w, out_h = width, height
     if kind_n in ("image", "font"):
         out_w, out_h = _probe_image_size(raw)
-    elif kind_n == "lottie" and (out_w is None or out_h is None):
-        try:
-            parsed = json.loads(raw.decode("utf-8"))
-            if isinstance(parsed, dict):
-                if out_w is None:
-                    out_w = int(parsed.get("w") or 0) or None
-                if out_h is None:
-                    out_h = int(parsed.get("h") or 0) or None
-        except Exception:
-            pass
+    meta_json = None
+    if kind_n == "lottie":
+        anim = _parse_lottie_animation(raw)
+        if anim is not None:
+            meta_json = _meta_json_with_animation(anim)
+            if out_w is None:
+                out_w = int(anim.get("w") or 0) or None
+            if out_h is None:
+                out_h = int(anim.get("h") or 0) or None
 
     asset_id = f"asset_{uuid.uuid4().hex[:16]}"
     object_key = f"assets/{user_id}/{asset_id}.{ext}"
@@ -441,6 +543,7 @@ def create_asset_from_bytes(
             source=(source or "ai_audio")[:32],
             prompt=(prompt or None),
             created_at=now,
+            meta_json=meta_json,
         )
     return _row_to_asset(row)
 

--- a/apps/api/app/services/projects.py
+++ b/apps/api/app/services/projects.py
@@ -200,6 +200,327 @@ def _normalize_incoming_urls(urls: list[str] | None) -> list[str]:
     return out
 
 
+_MAX_COVER_TILES = 4
+_COVER_EDGE = 360
+_MIN_COVER_EDGE = 40
+
+
+def _cov_num(value: Any, fallback: float = 0.0) -> float:
+    try:
+        n = float(value)
+        return n if n == n and abs(n) != float("inf") else fallback
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _cov_parse_rgba(raw: Any) -> tuple[int, int, int, int] | None:
+    """Parse #RGB / #RRGGBB / #RRGGBBAA / rgba() → RGBA 0–255. Skip transparent/none."""
+    text = str(raw or "").strip()
+    if not text or text.lower() in ("none", "transparent"):
+        return None
+    if text.startswith("#"):
+        h = text[1:]
+        if len(h) == 3 and all(c in "0123456789abcdefABCDEF" for c in h):
+            r, g, b = (int(c * 2, 16) for c in h)
+            return r, g, b, 255
+        if len(h) == 6 and all(c in "0123456789abcdefABCDEF" for c in h):
+            return int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16), 255
+        if len(h) == 8 and all(c in "0123456789abcdefABCDEF" for c in h):
+            return (
+                int(h[0:2], 16),
+                int(h[2:4], 16),
+                int(h[4:6], 16),
+                int(h[6:8], 16),
+            )
+        return None
+    lower = text.lower()
+    if lower.startswith("rgba(") or lower.startswith("rgb("):
+        inner = text[text.find("(") + 1 : text.rfind(")")]
+        parts = [p.strip() for p in inner.split(",")]
+        if len(parts) < 3:
+            return None
+        try:
+            r = int(float(parts[0]))
+            g = int(float(parts[1]))
+            b = int(float(parts[2]))
+            a = 255
+            if len(parts) >= 4:
+                af = float(parts[3])
+                a = int(round(af * 255)) if af <= 1.0 else int(round(af))
+            return max(0, min(255, r)), max(0, min(255, g)), max(0, min(255, b)), max(
+                0, min(255, a)
+            )
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _cov_attr_flag(attrs: dict[str, Any], key: str) -> bool:
+    v = attrs.get(key)
+    if v is True or v == 1:
+        return True
+    if isinstance(v, str) and v.strip().lower() in ("1", "true", "yes"):
+        return True
+    return False
+
+
+def _cov_has_visual(node: dict[str, Any]) -> bool:
+    if not isinstance(node, dict):
+        return False
+    attrs = node.get("attrs") if isinstance(node.get("attrs"), dict) else {}
+    if _cov_attr_flag(attrs, "hidden"):
+        return False
+    if str(attrs.get("processStatus") or "") == "running":
+        return False
+    key = str(node.get("key") or "")
+    if key == "image" and _cov_attr_flag(attrs, "imageGenerator"):
+        return False
+    if key == "video" and _cov_attr_flag(attrs, "videoGenerator"):
+        return False
+    if key == "lottie" and _cov_attr_flag(attrs, "lottieGenerator"):
+        return False
+    if key == "audio" and _cov_attr_flag(attrs, "audioGenerator"):
+        return False
+    if key in ("image", "video", "lottie"):
+        src = str(attrs.get("src") or "").strip()
+        poster = str(attrs.get("poster") or "").strip()
+        return bool(src or poster)
+    if key == "audio":
+        return bool(str(attrs.get("src") or "").strip())
+    if key in ("shape", "rect", "text", "svg", "path"):
+        return True
+    return False
+
+
+def _cov_type_rank(key: str) -> int:
+    if key in ("image", "video"):
+        return 0
+    if key in ("lottie", "audio"):
+        return 1
+    if key in ("shape", "rect", "svg", "path"):
+        return 2
+    if key == "text":
+        return 3
+    return 4
+
+
+def _cov_pick_nodes(document: dict[str, Any]) -> list[dict[str, Any]]:
+    """Up to 4 latest visual elements — image-first, then area, then z (children order)."""
+    delta = document.get("deltaSetLike")
+    if not isinstance(delta, dict):
+        return []
+    root = delta.get("ROOT")
+    children = root.get("children") if isinstance(root, dict) else None
+    if not isinstance(children, list):
+        children = []
+    ranked: list[tuple[int, float, int, dict[str, Any]]] = []
+    for z, nid in enumerate(children):
+        node = delta.get(str(nid))
+        if not isinstance(node, dict) or not _cov_has_visual(node):
+            continue
+        w = max(1.0, _cov_num(node.get("width"), 1))
+        h = max(1.0, _cov_num(node.get("height"), 1))
+        if min(w, h) < _MIN_COVER_EDGE and w * h < _MIN_COVER_EDGE * _MIN_COVER_EDGE:
+            continue
+        key = str(node.get("key") or "")
+        ranked.append((_cov_type_rank(key), w * h, z, {**node, "id": str(nid)}))
+    # Prefer media, then larger, then later z (newer / on top).
+    ranked.sort(key=lambda t: (t[0], -t[1], -t[2]))
+    return [t[3] for t in ranked[:_MAX_COVER_TILES]]
+
+
+def _cov_media_src(node: dict[str, Any]) -> str | None:
+    attrs = node.get("attrs") if isinstance(node.get("attrs"), dict) else {}
+    for key in ("src", "poster"):
+        s = str(attrs.get(key) or "").strip()
+        if s and not s.startswith("data:"):
+            return s
+    return None
+
+
+def _cov_put_tile_bytes(
+    user_id: str, project_id: str, blob: bytes | None, *, index: int, ext: str = "webp"
+) -> str | None:
+    if not blob:
+        return None
+    stamp = int(time.time() * 1000)
+    suffix = f"-{index}" if index else ""
+    content_type = "image/webp" if ext == "webp" else f"image/{ext}"
+    thumb_key = f"projects/{user_id}/{project_id}/thumb-{stamp}{suffix}.{ext}"
+    try:
+        put_bytes(
+            thumb_key,
+            blob,
+            content_type=content_type,
+            cache_control="no-cache, max-age=0, must-revalidate",
+        )
+        return thumb_key
+    except Exception:
+        return None
+
+
+def _cov_raster_shape(node: dict[str, Any]) -> bytes | None:
+    """Pillow tile for shape/rect — white board, real fill/stroke (not gray plates)."""
+    try:
+        from io import BytesIO
+
+        from PIL import Image, ImageDraw
+    except Exception:
+        return None
+
+    attrs = node.get("attrs") if isinstance(node.get("attrs"), dict) else {}
+    w = max(1.0, _cov_num(node.get("width"), 1))
+    h = max(1.0, _cov_num(node.get("height"), 1))
+    scale = min(1.0, float(_COVER_EDGE) / max(w, h))
+    out_w = max(32, int(round(w * scale)))
+    out_h = max(32, int(round(h * scale)))
+    pad = max(4, int(round(max(out_w, out_h) * 0.06)))
+    canvas_w = out_w + pad * 2
+    canvas_h = out_h + pad * 2
+
+    fill = _cov_parse_rgba(attrs.get("fill") or attrs.get("fill-color"))
+    stroke = _cov_parse_rgba(
+        attrs.get("stroke") or attrs.get("border-color") or attrs.get("borderColor")
+    )
+    sw_raw = attrs.get("borderWidth")
+    if sw_raw is None:
+        sw_raw = attrs.get("border-width")
+    if sw_raw is None:
+        sw_raw = attrs.get("strokeWidth")
+    stroke_w = max(0.0, _cov_num(sw_raw, 0)) * scale
+    if stroke is None and stroke_w <= 0:
+        stroke = (51, 51, 51, 255)
+        stroke_w = max(1.5, 2.0 * scale)
+
+    key = str(node.get("key") or "")
+    shape_type = str(attrs.get("shapeType") or attrs.get("type") or "").lower()
+    if not shape_type and key == "rect":
+        shape_type = "rect"
+    if not shape_type:
+        shape_type = "rect"
+
+    img = Image.new("RGBA", (canvas_w, canvas_h), (255, 255, 255, 255))
+    draw = ImageDraw.Draw(img)
+    x0, y0 = float(pad), float(pad)
+    x1, y1 = float(pad + out_w), float(pad + out_h)
+    fill_c = fill  # may be None → outline only
+    stroke_c = stroke if stroke_w > 0 else None
+    outline_w = max(1, int(round(stroke_w))) if stroke_c else 0
+
+    is_ellipse = shape_type in ("circle", "ellipse", "oval")
+    if is_ellipse:
+        if fill_c:
+            draw.ellipse([x0, y0, x1, y1], fill=fill_c)
+        if stroke_c and outline_w:
+            draw.ellipse([x0, y0, x1, y1], outline=stroke_c, width=outline_w)
+        if not fill_c and not stroke_c:
+            draw.ellipse([x0, y0, x1, y1], outline=(51, 51, 51, 255), width=2)
+    else:
+        # rect / polygon / triangle / star → bounding rect (best-effort)
+        if fill_c:
+            draw.rectangle([x0, y0, x1, y1], fill=fill_c)
+        if stroke_c and outline_w:
+            draw.rectangle([x0, y0, x1, y1], outline=stroke_c, width=outline_w)
+        if not fill_c and not stroke_c:
+            draw.rectangle([x0, y0, x1, y1], outline=(51, 51, 51, 255), width=2)
+
+    buf = BytesIO()
+    img.convert("RGB").save(buf, format="WEBP", quality=82, method=4)
+    return buf.getvalue()
+
+
+def _cov_raster_text(node: dict[str, Any]) -> bytes | None:
+    try:
+        from io import BytesIO
+
+        from PIL import Image, ImageDraw, ImageFont
+    except Exception:
+        return None
+    attrs = node.get("attrs") if isinstance(node.get("attrs"), dict) else {}
+    text = str(
+        attrs.get("text") or attrs.get("content") or node.get("text") or ""
+    ).strip()
+    if not text:
+        return None
+    w = max(64.0, _cov_num(node.get("width"), 160))
+    h = max(40.0, _cov_num(node.get("height"), 48))
+    scale = min(1.0, float(_COVER_EDGE) / max(w, h))
+    out_w = max(48, int(round(w * scale)))
+    out_h = max(32, int(round(h * scale)))
+    fill = _cov_parse_rgba(attrs.get("fill") or attrs.get("color")) or (30, 30, 30, 255)
+    img = Image.new("RGB", (out_w, out_h), (255, 255, 255))
+    draw = ImageDraw.Draw(img)
+    try:
+        font = ImageFont.load_default()
+    except Exception:
+        font = None
+    draw.text((8, 8), text[:80], fill=fill[:3], font=font)
+    buf = BytesIO()
+    img.save(buf, format="WEBP", quality=82, method=4)
+    return buf.getvalue()
+
+
+def _cov_tile_for_node(
+    user_id: str, project_id: str, node: dict[str, Any], *, index: int
+) -> str | None:
+    """Return hosted URL or uploaded thumb key for one element tile."""
+    key = str(node.get("key") or "")
+    if key in ("image", "video", "lottie", "audio"):
+        src = _cov_media_src(node)
+        return src
+    if key in ("shape", "rect", "path"):
+        return _cov_put_tile_bytes(user_id, project_id, _cov_raster_shape(node), index=index)
+    if key == "text":
+        return _cov_put_tile_bytes(user_id, project_id, _cov_raster_text(node), index=index)
+    if key == "svg":
+        return _cov_put_tile_bytes(
+            user_id,
+            project_id,
+            _cov_raster_shape(
+                {
+                    **node,
+                    "attrs": {
+                        **(node.get("attrs") if isinstance(node.get("attrs"), dict) else {}),
+                        "shapeType": "rect",
+                        "fill": "#E8E8E8",
+                    },
+                }
+            ),
+            index=index,
+        )
+    return None
+
+
+def _build_auto_cover_key(
+    user_id: str,
+    project_id: str,
+    document: dict[str, Any] | None,
+    existing_key: str | None,
+) -> str | None:
+    """Build ≤4 cover tiles from the latest visual elements in ``document``."""
+    if not isinstance(document, dict):
+        return None
+    nodes = _cov_pick_nodes(document)
+    if not nodes:
+        return None
+    entries: list[str] = []
+    for i, node in enumerate(nodes):
+        entry = _cov_tile_for_node(user_id, project_id, node, index=i)
+        if entry and entry not in entries:
+            entries.append(entry)
+        if len(entries) >= _MAX_COVER_TILES:
+            break
+    if not entries:
+        return None
+    _delete_thumb_entries(existing_key)
+    encoded = _encode_thumb_entries(entries)
+    print(
+        f"[projects.thumb] auto ok project={project_id} n={len(entries)}",
+        flush=True,
+    )
+    return encoded
+
+
 def _next_thumbnail(
     user_id: str,
     project_id: str,
@@ -210,23 +531,57 @@ def _next_thumbnail(
     mark_custom: bool | None,
     thumbnail_data_urls: list[str] | None = None,
     thumbnail_urls: list[str] | None = None,
+    document: dict[str, Any] | None = None,
 ) -> tuple[str | None, bool]:
     """Resolve next thumbnail_key (+ JSON array) and custom flag.
 
-    Priority: hosted ``thumbnail_urls`` → raster ``thumbnail_data_urls`` /
-    ``thumbnail_data_url`` → keep existing.
+    Priority: custom client urls/data → keep custom lock → server auto from
+    document elements → legacy client urls/data → keep existing.
     """
+    # User-uploaded / explicit custom cover.
+    if mark_custom is True:
+        hosted = _normalize_incoming_urls(thumbnail_urls)
+        if hosted:
+            _delete_thumb_entries(existing_key)
+            return _encode_thumb_entries(hosted), True
+        data_list = [
+            str(x).strip()
+            for x in (thumbnail_data_urls or [])
+            if str(x or "").strip().startswith("data:image/")
+        ]
+        if not data_list and thumbnail_data_url:
+            one = str(thumbnail_data_url).strip()
+            if one.startswith("data:image/"):
+                data_list = [one]
+        if data_list:
+            uploaded: list[str] = []
+            for i, data_url in enumerate(data_list[:4]):
+                key = _thumb_key_from_data_url(user_id, project_id, data_url, index=i)
+                if key:
+                    uploaded.append(key)
+            if uploaded:
+                _delete_thumb_entries(existing_key)
+                return _encode_thumb_entries(uploaded), True
+
+    if existing_custom and mark_custom is not False:
+        return existing_key, True
+
+    # Server: ≤4 tiles from latest document elements (image URL + shape rasters).
+    if document is not None and mark_custom is not True:
+        auto = _build_auto_cover_key(user_id, project_id, document, existing_key)
+        if auto:
+            return auto, False
+
+    # Legacy client thumbs (optional).
     hosted = _normalize_incoming_urls(thumbnail_urls)
-    if hosted:
+    if hosted and mark_custom is not True:
         _delete_thumb_entries(existing_key)
-        custom = True if mark_custom is True else False
         encoded = _encode_thumb_entries(hosted)
         print(
-            f"[projects.thumb] urls ok project={project_id} "
-            f"n={len(hosted)} custom={custom}",
+            f"[projects.thumb] urls ok project={project_id} n={len(hosted)} custom=False",
             flush=True,
         )
-        return encoded, custom
+        return encoded, False
 
     data_list = [
         str(x).strip()
@@ -237,44 +592,22 @@ def _next_thumbnail(
         one = str(thumbnail_data_url).strip()
         if one.startswith("data:image/"):
             data_list = [one]
-
-    if data_list:
-        from concurrent.futures import ThreadPoolExecutor
-
-        batch = list(enumerate(data_list[:4]))
-
-        def _one(item: tuple[int, str]) -> str | None:
-            i, data_url = item
-            return _thumb_key_from_data_url(user_id, project_id, data_url, index=i)
-
-        uploaded: list[str] = []
-        with ThreadPoolExecutor(max_workers=min(4, len(batch))) as pool:
-            for key in pool.map(_one, batch):
-                if key:
-                    uploaded.append(key)
+    if data_list and mark_custom is not True:
+        uploaded = []
+        for i, data_url in enumerate(data_list[:4]):
+            key = _thumb_key_from_data_url(user_id, project_id, data_url, index=i)
+            if key:
+                uploaded.append(key)
         if uploaded:
             _delete_thumb_entries(existing_key)
-            custom = True if mark_custom is True else False
-            encoded = _encode_thumb_entries(uploaded)
             print(
-                f"[projects.thumb] upload ok project={project_id} "
-                f"n={len(uploaded)} custom={custom} prev_custom={existing_custom}",
+                f"[projects.thumb] upload ok project={project_id} n={len(uploaded)}",
                 flush=True,
             )
-            return encoded, custom
+            return _encode_thumb_entries(uploaded), False
 
-    # No new bytes — keep key; explicit False clears the custom lock.
     if mark_custom is False:
-        print(
-            f"[projects.thumb] keep key, clear custom project={project_id} key={existing_key}",
-            flush=True,
-        )
         return existing_key, False
-    if existing_custom and (thumbnail_data_url or thumbnail_data_urls or thumbnail_urls):
-        print(
-            f"[projects.thumb] payload rejected project={project_id} keep={existing_key}",
-            flush=True,
-        )
     return existing_key, bool(existing_custom)
 
 
@@ -429,6 +762,7 @@ def patch_project(
             if name is not None and str(name).strip()
             else str(existing.name or "Untitled")
         )
+        # Incremental patch: keep existing covers; Publish / full upsert rebuilds.
         thumb_key, thumb_custom = _next_thumbnail(
             user_id,
             pid,
@@ -620,6 +954,7 @@ def upsert_project(
                 mark_custom=thumbnail_custom,
                 thumbnail_data_urls=thumbnail_data_urls,
                 thumbnail_urls=thumbnail_urls,
+                document=document,
             )
             old_doc_key = existing.document_key
             ok = crud.update_project_if_revision(
@@ -669,6 +1004,7 @@ def upsert_project(
                 mark_custom=thumbnail_custom,
                 thumbnail_data_urls=thumbnail_data_urls,
                 thumbnail_urls=thumbnail_urls,
+                document=document,
             )
             crud.create_project(
                 session=session,
@@ -707,6 +1043,72 @@ def upsert_project(
         "revision": revision,
         "updatedAt": int(now * 1000),
         "createdAt": int(created * 1000),
+    }
+
+
+def extract_project_covers(
+    user_id: str,
+    project_id: str,
+    *,
+    document: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build ≤4 cover tiles from document elements. Does not bump revision."""
+    from sqlmodel import Session
+
+    from app import crud
+    from app.core.db import engine
+
+    init_schema()
+    pid = (project_id or "").strip()
+    if not pid:
+        raise ProjectNotFoundError("")
+
+    with Session(engine) as session:
+        existing = crud.get_project_for_user(
+            session=session, user_id=user_id, project_id=pid
+        )
+        if not existing:
+            raise ProjectNotFoundError(pid)
+
+        name_n = str(existing.name or "Untitled")
+        created_at = float(existing.created_at)
+        revision = int(existing.revision or 1)
+        custom = _row_thumb_custom(existing)
+        thumb_key = existing.thumbnail_key
+        now = float(existing.updated_at)
+
+        if not custom:
+            doc = document if isinstance(document, dict) else _decode_document_row(existing)
+            now = time.time()
+            next_key, next_custom = _next_thumbnail(
+                user_id,
+                pid,
+                None,
+                existing.thumbnail_key,
+                existing_custom=False,
+                mark_custom=False,
+                document=doc,
+            )
+            if next_key and next_key != (existing.thumbnail_key or "").strip():
+                thumb_key = next_key
+                custom = bool(next_custom)
+                crud.update_project_covers(
+                    session=session,
+                    user_id=user_id,
+                    project_id=pid,
+                    thumbnail_key=thumb_key,
+                    thumbnail_custom=bool(next_custom),
+                    updated_at=now,
+                )
+
+    return {
+        "id": pid,
+        "name": name_n,
+        "thumbnailUrl": _thumbnail_urls_out(thumb_key),
+        "thumbnailCustom": bool(custom),
+        "revision": revision,
+        "updatedAt": int(now * 1000),
+        "createdAt": int(created_at * 1000),
     }
 
 
@@ -754,15 +1156,24 @@ def _url(key: str | None) -> str | None:
     text = str(key).strip()
     if not text:
         return None
-    # Already a public / absolute URL (image-node collage tiles).
-    if text.startswith("http://") or text.startswith("https://") or text.startswith("/"):
+    # Absolute http(s) — image-node collage tiles / CDN.
+    if text.startswith("http://") or text.startswith("https://"):
         return text
     # JSON array stored by mistake in a single-key call site.
     if text.startswith("["):
         urls = _thumbnail_urls_out(text)
         return urls[0] if urls else None
+    # Legacy rows sometimes stored the download path; peel to object key.
+    api_prefix = "/api/v1/uploads/files/"
+    if text.startswith(api_prefix):
+        text = text[len(api_prefix) :].lstrip("/")
+    elif text.startswith("/"):
+        return text
+    if not text:
+        return None
     storage = get_storage()
-    # Local disk keys need the authenticated download route (not a bare relative path).
+    # Local disk: browser loads via public project-thumb route (or auth for other keys).
     if not storage.enabled_remote():
         return f"/api/v1/uploads/files/{text}"
+    # COS/S3: return public object URL so list cards use bare <img src>.
     return storage.url_for(text)

--- a/apps/web/src/apis/assets.ts
+++ b/apps/web/src/apis/assets.ts
@@ -17,6 +17,8 @@ export type UserAsset = {
   source?: string | null;
   prompt?: string | null;
   meta?: Record<string, unknown> | null;
+  /** Bodymovin JSON for lottie — list API inlines this; do not refetch .json url. */
+  animationData?: Record<string, unknown> | null;
   createdAt?: number | null;
 };
 

--- a/apps/web/src/apis/projects.ts
+++ b/apps/web/src/apis/projects.ts
@@ -56,59 +56,34 @@ export type PatchProjectBody = {
   canvas?: Record<string, unknown>;
 };
 
-const PROJECTS_LIST_TTL_MS = 60_000;
-let _projectsPage1Cache: {
-  key: string;
-  at: number;
-  data: PaginatedProjects;
-} | null = null;
-
-export function invalidateProjectsListCache() {
-  _projectsPage1Cache = null;
-}
-
-export async function fetchProjects(params: {
-  page: number;
-  pageSize: number;
-}): Promise<PaginatedProjects> {
-  const key = `${params.page}:${params.pageSize}`;
-  if (
-    params.page === 1 &&
-    _projectsPage1Cache &&
-    _projectsPage1Cache.key === key &&
-    Date.now() - _projectsPage1Cache.at < PROJECTS_LIST_TTL_MS
-  ) {
-    return _projectsPage1Cache.data;
-  }
-  const data = await request<PaginatedProjects>({
-    url: '/api/v1/projects',
-    method: 'get',
-    params,
-  });
-  if (params.page === 1) {
-    _projectsPage1Cache = { key, at: Date.now(), data };
-  }
-  return data;
-}
-
 export const fetchProject = (id: string) =>
   request<{ project: ProjectDto }>({
     url: `/api/v1/projects/${encodeURIComponent(id)}`,
     method: 'get',
   });
 
+/** Ask server to rebuild ≤4 cover tiles from document elements (no revision bump). */
+export async function extractProjectCoversApi(
+  id: string,
+  document?: unknown
+): Promise<{ project: ProjectSummaryDto }> {
+  return request<{ project: ProjectSummaryDto }>({
+    url: `/api/v1/projects/${encodeURIComponent(id)}/covers`,
+    method: 'post',
+    data: document != null ? { document } : {},
+  });
+}
+
 export async function upsertProjectApi(
   data: UpsertProjectBody,
   headers?: Record<string, string>
 ): Promise<{ project: ProjectSummaryDto }> {
-  const res = await request<{ project: ProjectSummaryDto }>({
+  return request<{ project: ProjectSummaryDto }>({
     url: '/api/v1/projects',
     method: 'put',
     headers,
     data,
   });
-  invalidateProjectsListCache();
-  return res;
 }
 
 /** Node-level incremental sync — server merges under the same revision lock. */
@@ -117,34 +92,28 @@ export async function patchProjectApi(
   data: PatchProjectBody,
   headers?: Record<string, string>
 ): Promise<{ project: ProjectSummaryDto }> {
-  const res = await request<{ project: ProjectSummaryDto }>({
+  return request<{ project: ProjectSummaryDto }>({
     url: `/api/v1/projects/${encodeURIComponent(id)}`,
     method: 'patch',
     headers,
     data,
   });
-  invalidateProjectsListCache();
-  return res;
 }
 
 export async function deleteProjectApi(id: string): Promise<{ ok: boolean }> {
-  const res = await request<{ ok: boolean }>({
+  return request<{ ok: boolean }>({
     url: `/api/v1/projects/${encodeURIComponent(id)}`,
     method: 'delete',
   });
-  invalidateProjectsListCache();
-  return res;
 }
 
 /** Batch delete — one request for many project ids. */
 export async function deleteProjectsApi(
   ids: string[]
 ): Promise<{ ok: boolean; deleted: number }> {
-  const res = await request<{ ok: boolean; deleted: number }>({
+  return request<{ ok: boolean; deleted: number }>({
     url: '/api/v1/projects/batch-delete',
     method: 'post',
     data: { ids },
   });
-  invalidateProjectsListCache();
-  return res;
 }

--- a/apps/web/src/components/base/colorPanel/index.tsx
+++ b/apps/web/src/components/base/colorPanel/index.tsx
@@ -47,8 +47,8 @@ export const FILL_SOLID_PRESETS = [
 /** Same grid + transparent (artboard / alpha-capable pickers). */
 export const FILL_ALPHA_PRESETS = ['transparent', ...FILL_SOLID_PRESETS];
 
-/** Fixed panel width. */
-export const COLOR_PANEL_WIDTH = 250;
+/** Fixed panel width — same as opacity / eraser / font / blend popovers. */
+export const COLOR_PANEL_WIDTH = 240;
 /** Preset grid: 9 square swatches per row (2×9). */
 export const COLOR_PANEL_PRESET_COLS = 9;
 export const COLOR_PANEL_SWATCH_PX = 20;
@@ -216,7 +216,8 @@ function ColorPanel({
     <div
       data-color-panel
       className={cn(
-        'rounded bg-[var(--surface)] shadow-[0_12px_40px_rgba(15,23,42,0.16)] ring-1 ring-[var(--line)]',
+        // Same chrome as Fill/Stroke StylePanelShell (rounded-xl).
+        'rounded-xl bg-[var(--surface)] shadow-[0_12px_40px_rgba(15,23,42,0.16)] ring-1 ring-[var(--line)]',
         className
       )}
       style={{ width: fillWidth ? '100%' : COLOR_PANEL_WIDTH }}
@@ -258,64 +259,56 @@ function ColorPanel({
         )}
 
         {presetList.length > 0 ? (
-          <div className="flex w-full flex-col gap-1 pt-0.5">
-            {Array.from(
-              { length: Math.ceil(presetList.length / COLOR_PANEL_PRESET_COLS) },
-              (_, rowIndex) => {
-                const row = presetList.slice(
-                  rowIndex * COLOR_PANEL_PRESET_COLS,
-                  (rowIndex + 1) * COLOR_PANEL_PRESET_COLS
-                );
-                return (
-                  <div key={rowIndex} className="flex w-full justify-between">
-                    {row.map((c) => {
-                      const p = normalizeHex(c, c);
-                      const isTransparent = p === 'transparent';
-                      const active = isTransparent
-                        ? hex === 'transparent' || opacityPct === 0
-                        : hex === p && opacityPct > 0;
-                      return (
-                        <button
-                          key={String(c)}
-                          type="button"
-                          aria-label={isTransparent ? '透明' : p}
-                          onClick={() => {
-                            if (isTransparent) {
-                              onChange(solidHex);
-                              setOpacity(0);
-                              return;
-                            }
-                            onChange(p);
-                            setHsv(rgbToHsv(hexToRgba(p)));
-                            setDraft(p.replace(/^#/, ''));
-                            if (showAlpha && opacityPct === 0) setOpacity(100);
-                          }}
-                          className={cn(
-                            'rounded-[3px] transition-opacity hover:opacity-90',
-                            active && 'outline outline-2 outline-[var(--ink)] outline-offset-1'
-                          )}
-                          style={{
-                            width: COLOR_PANEL_SWATCH_PX,
-                            height: COLOR_PANEL_SWATCH_PX,
-                            ...(isTransparent
-                              ? {
-                                  backgroundImage: CHECKER,
-                                  backgroundSize: '5px 5px',
-                                  backgroundPosition: '0 0, 0 2.5px, 2.5px -2.5px, -2.5px 0',
-                                  boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.08)',
-                                }
-                              : {
-                                  background: p,
-                                  boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.08)',
-                                }),
-                          }}
-                        />
-                      );
-                    })}
-                  </div>
-                );
-              }
-            )}
+          <div
+            className="grid w-full pt-0.5"
+            style={{
+              gridTemplateColumns: `repeat(${COLOR_PANEL_PRESET_COLS}, minmax(0, 1fr))`,
+              gap: COLOR_PANEL_SWATCH_GAP_PX,
+            }}
+          >
+            {presetList.map((c) => {
+              const p = normalizeHex(c, c);
+              const isTransparent = p === 'transparent';
+              const active = isTransparent
+                ? hex === 'transparent' || opacityPct === 0
+                : hex === p && opacityPct > 0;
+              return (
+                <button
+                  key={String(c)}
+                  type="button"
+                  aria-label={isTransparent ? '透明' : p}
+                  onClick={() => {
+                    if (isTransparent) {
+                      onChange(solidHex);
+                      setOpacity(0);
+                      return;
+                    }
+                    onChange(p);
+                    setHsv(rgbToHsv(hexToRgba(p)));
+                    setDraft(p.replace(/^#/, ''));
+                    if (showAlpha && opacityPct === 0) setOpacity(100);
+                  }}
+                  className={cn(
+                    // Same radius as hex / opacity / eyedropper chips in this panel.
+                    'aspect-square w-full rounded transition-opacity hover:opacity-90',
+                    active && 'outline outline-2 outline-[var(--ink)] outline-offset-1'
+                  )}
+                  style={
+                    isTransparent
+                      ? {
+                          backgroundImage: CHECKER,
+                          backgroundSize: '5px 5px',
+                          backgroundPosition: '0 0, 0 2.5px, 2.5px -2.5px, -2.5px 0',
+                          boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.08)',
+                        }
+                      : {
+                          background: p,
+                          boxShadow: 'inset 0 0 0 1px rgba(0,0,0,0.08)',
+                        }
+                  }
+                />
+              );
+            })}
           </div>
         ) : null}
 

--- a/apps/web/src/components/editor/canvas/drop/useChatImageDrop.ts
+++ b/apps/web/src/components/editor/canvas/drop/useChatImageDrop.ts
@@ -6,10 +6,8 @@ import { rcbCenterOnPoint, type RcbCamera } from '@/components/rcb';
 import {
   beginNodeUpload,
   finishNodeUpload,
-  imageSrcToFile,
   isUploadAbortError,
-  mediaSrcNeedsAuthFetch,
-  readFileAsDataUrl,
+  toDisplayMediaUrl,
   uploadImageFromSrc,
   waitForImageReady,
 } from '@/utils/uploadImage';
@@ -83,47 +81,13 @@ async function hydrateAssetSrcForCanvas(
   if (!src) return { src, uploadKey };
 
   if (payload.kind === 'lottie') {
-    const file = await imageSrcToFile(src, 'asset-lottie.json', {
-      uploadKey,
-      fallbackMime: 'application/json',
-    });
-    const text = await file.text();
-    const animationData = parseLottieAnimationData(text);
-    if (!animationData) throw new Error('invalid lottie json');
-    return { src, uploadKey, animationData };
+    const fromList = parseLottieAnimationData(payload.animationData);
+    if (fromList) return { src, uploadKey, animationData: fromList };
+    throw new Error('lottie asset missing animationData');
   }
 
-  if (payload.kind === 'image') {
-    // List API already gives data: thumbs (local) — place as-is, no /uploads round-trip.
-    if (src.startsWith('data:') || src.startsWith('blob:')) {
-      return { src, uploadKey };
-    }
-    // Public CDN / COS https — also canvas-ready.
-    if (/^https?:\/\//i.test(src) && !mediaSrcNeedsAuthFetch(src)) {
-      return { src, uploadKey };
-    }
-    // Auth-gated path or bare storage key — hydrate via upload API.
-    const file = await imageSrcToFile(
-      uploadKey ? `/api/v1/uploads/files/${uploadKey}` : src,
-      'asset-image.png',
-      { uploadKey }
-    );
-    return { src: await readFileAsDataUrl(file), uploadKey };
-  }
-
-  if (payload.kind === 'video' || payload.kind === 'audio') {
-    if (!mediaSrcNeedsAuthFetch(src) && /^https?:\/\//i.test(src)) {
-      return { src, uploadKey };
-    }
-    if (mediaSrcNeedsAuthFetch(src)) return { src, uploadKey };
-    if (uploadKey && /^(assets|uploads|projects|font-tasks)\//.test(src)) {
-      return { src: `/api/v1/uploads/files/${uploadKey}`, uploadKey };
-    }
-    if (/^(assets|uploads|projects|font-tasks)\//.test(src)) {
-      return { src: `/api/v1/uploads/files/${src}`, uploadKey: uploadKey || src };
-    }
-  }
-  return { src, uploadKey };
+  // Place with the URL we got — no auth-fetch / blob round-trip.
+  return { src: toDisplayMediaUrl(src, uploadKey), uploadKey };
 }
 
 /** Drag chat gallery images / Assets dock media onto the canvas. */

--- a/apps/web/src/components/editor/collab/CollabRoomProvider.tsx
+++ b/apps/web/src/components/editor/collab/CollabRoomProvider.tsx
@@ -649,13 +649,14 @@ export function CollabRoomProvider({
         const scene = sceneFromYDoc(ydoc);
         if (!id || !scene) return;
         if (id.startsWith('share_')) {
-          void (async () => {
+          async function persistShareDocument() {
             try {
               await updateShareDocumentApi(id, scene);
             } catch {
               /* ignore */
             }
-          })();
+          }
+          void persistShareDocument();
           return;
         }
         const ed = store.getState().editor as {

--- a/apps/web/src/components/editor/nodes/AudioNode/AudioNodeOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/AudioNode/AudioNodeOverlay.tsx
@@ -24,7 +24,7 @@ import {
 import { radiiFromAttrs } from '@/components/rcb/scene/document/sceneRadii';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import { useHtmlMediaMount } from '@/components/editor/nodes/useHtmlMediaMount';
-import { imageSrcToFile, isOurStoredImageUrl, mediaSrcNeedsAuthFetch } from '@/utils/uploadImage';
+import { toDisplayMediaUrl } from '@/utils/uploadImage';
 import AudioWaveform, { type AudioWaveformHandle } from './AudioWaveform';
 
 export type AudioGeomOverride = {
@@ -123,77 +123,9 @@ function formatClock(seconds: number, opts?: { round?: boolean }): string {
   return `${String(m).padStart(2, '0')}:${String(r).padStart(2, '0')}`;
 }
 
-function audioSrcNeedsAuthFetch(src: string, uploadKey?: string | null): boolean {
-  const s = String(src || '').trim();
-  if (!s || s.startsWith('data:') || s.startsWith('blob:')) return false;
-  if (mediaSrcNeedsAuthFetch(s) || isOurStoredImageUrl(s)) return true;
-  return Boolean(uploadKey) && !/^https?:\/\//i.test(s);
-}
-
-function revokeBlobUrl(ref: { current: string | null }) {
-  if (!ref.current) return;
-  URL.revokeObjectURL(ref.current);
-  ref.current = null;
-}
-
-/** Auth-gated uploads → blob URL with audio/* mime (never image/png fallback). */
+/** Audio `src` → browser-playable URL (no auth blob round-trip). */
 function usePlayableAudioSrc(src: string, uploadKey?: string | null): string {
-  const [playSrc, setPlaySrc] = useState(() => {
-    if (audioSrcNeedsAuthFetch(src, uploadKey)) return '';
-    return String(src || '').trim();
-  });
-  const blobRef = useRef<string | null>(null);
-  const cacheKeyRef = useRef('');
-
-  useEffect(() => {
-    const s = String(src || '').trim();
-    if (!s) {
-      revokeBlobUrl(blobRef);
-      cacheKeyRef.current = '';
-      setPlaySrc('');
-      return;
-    }
-    if (!audioSrcNeedsAuthFetch(s, uploadKey)) {
-      revokeBlobUrl(blobRef);
-      cacheKeyRef.current = '';
-      setPlaySrc(s);
-      return;
-    }
-    const cacheKey = `${s}::${uploadKey || ''}`;
-    if (cacheKeyRef.current === cacheKey && blobRef.current) {
-      setPlaySrc(blobRef.current);
-      return;
-    }
-    let cancelled = false;
-    async function resolvePlaySrc() {
-      try {
-        const file = await imageSrcToFile(s, 'play.mp3', {
-          uploadKey,
-          fallbackMime: 'audio/mpeg',
-        });
-        if (cancelled) return;
-        let playable = file;
-        if (!String(file.type || '').startsWith('audio/')) {
-          playable = new File([file], 'play.mp3', { type: 'audio/mpeg' });
-        }
-        const next = URL.createObjectURL(playable);
-        revokeBlobUrl(blobRef);
-        blobRef.current = next;
-        cacheKeyRef.current = cacheKey;
-        setPlaySrc(next);
-      } catch (err) {
-        console.warn('[audio] auth src resolve failed', err);
-      }
-    }
-    void resolvePlaySrc();
-    return () => {
-      cancelled = true;
-    };
-  }, [src, uploadKey]);
-
-  useEffect(() => () => revokeBlobUrl(blobRef), []);
-
-  return playSrc;
+  return toDisplayMediaUrl(src, uploadKey);
 }
 
 function resolveTrimWindow(

--- a/apps/web/src/components/editor/nodes/AudioNode/AudioWaveform.tsx
+++ b/apps/web/src/components/editor/nodes/AudioNode/AudioWaveform.tsx
@@ -182,13 +182,14 @@ function AudioWaveformInner(
       }),
     ];
 
-    void (async () => {
+    async function loadWaveform() {
       try {
         await ws.load(src);
       } catch (err) {
         if (!cancelled) console.warn('[AudioWaveform] load failed', err);
       }
-    })();
+    }
+    void loadWaveform();
 
     return () => {
       cancelled = true;

--- a/apps/web/src/components/editor/nodes/VideoNode/VideoJsPlayer.tsx
+++ b/apps/web/src/components/editor/nodes/VideoNode/VideoJsPlayer.tsx
@@ -8,7 +8,7 @@ import {
   memo,
 } from 'react';
 import { cn } from '@/utils/classnames';
-import { imageSrcToFile, isOurStoredImageUrl, mediaSrcNeedsAuthFetch } from '@/utils/uploadImage';
+import { toDisplayMediaUrl } from '@/utils/uploadImage';
 import VideoPlaybackBar, {
   videoChromeLayout,
   videoMediaFromElement,
@@ -16,15 +16,6 @@ import VideoPlaybackBar, {
   type VideoMediaControl,
 } from '@/components/editor/nodes/VideoNode/VideoPlaybackBar';
 import './VideoJsPlayer.css';
-
-/** Upload files are public-read — use plain <video src>. */
-function videoSrcNeedsAuthFetch(src: string, uploadKey?: string | null): boolean {
-  const s = String(src || '').trim();
-  if (!s || s.startsWith('data:') || s.startsWith('blob:')) return false;
-  if (mediaSrcNeedsAuthFetch(s) || isOurStoredImageUrl(s)) return true;
-  // Bare key stored as src while object key is on the node.
-  return Boolean(uploadKey) && !/^https?:\/\//i.test(s);
-}
 
 function resolveAbsoluteHref(href: string): string {
   try {
@@ -44,75 +35,9 @@ function resolveVideoElementAbsSrc(el: HTMLVideoElement): string {
   }
 }
 
-/**
- * Resolve a canvas / upload video `src` into something the player can play.
- * Auth-gated uploads → blob URL; public / data / blob URLs pass through.
- * Keeps the last good URL while re-resolving so the player is not unmounted.
- * Never revoke/recreate a blob for the same src+key (avoids reload → frame 0).
- */
+/** Canvas / upload video `src` → browser-playable URL (no auth blob round-trip). */
 export function usePlayableVideoSrc(src: string, uploadKey?: string | null): string {
-  const [playSrc, setPlaySrc] = useState(() =>
-    videoSrcNeedsAuthFetch(src, uploadKey) ? '' : String(src || '').trim()
-  );
-  const blobRef = useRef<string | null>(null);
-  const cacheKeyRef = useRef<string>('');
-
-  useEffect(() => {
-    const s = String(src || '').trim();
-    if (!s) {
-      if (blobRef.current) {
-        URL.revokeObjectURL(blobRef.current);
-        blobRef.current = null;
-      }
-      cacheKeyRef.current = '';
-      setPlaySrc('');
-      return;
-    }
-    if (!videoSrcNeedsAuthFetch(s, uploadKey)) {
-      if (blobRef.current) {
-        URL.revokeObjectURL(blobRef.current);
-        blobRef.current = null;
-      }
-      cacheKeyRef.current = '';
-      setPlaySrc(s);
-      return;
-    }
-    const cacheKey = `${s}::${uploadKey || ''}`;
-    if (cacheKeyRef.current === cacheKey && blobRef.current) {
-      setPlaySrc(blobRef.current);
-      return;
-    }
-    let cancelled = false;
-    async function resolvePlaySrc() {
-      try {
-        const file = await imageSrcToFile(s, 'play.mp4', { uploadKey });
-        if (cancelled) return;
-        const next = URL.createObjectURL(file);
-        if (blobRef.current) URL.revokeObjectURL(blobRef.current);
-        blobRef.current = next;
-        cacheKeyRef.current = cacheKey;
-        setPlaySrc(next);
-      } catch (err) {
-        console.warn('[video] auth src resolve failed', err);
-      }
-    }
-    void resolvePlaySrc();
-    return () => {
-      cancelled = true;
-    };
-  }, [src, uploadKey]);
-
-  useEffect(
-    () => () => {
-      if (blobRef.current) {
-        URL.revokeObjectURL(blobRef.current);
-        blobRef.current = null;
-      }
-    },
-    []
-  );
-
-  return playSrc;
+  return toDisplayMediaUrl(src, uploadKey);
 }
 
 export type VideoCropNorm = { x: number; y: number; w: number; h: number };

--- a/apps/web/src/components/editor/nodes/VideoNode/VideoTrimSessionHost.tsx
+++ b/apps/web/src/components/editor/nodes/VideoNode/VideoTrimSessionHost.tsx
@@ -383,7 +383,7 @@ function VideoTrimSessionHost({ document }: { document: any }): ReactNode {
       restoreKeepTime();
     }
 
-    void (async () => {
+    async function extractVideoFilmstrip() {
       try {
         await extractFilmstrip(src, total, uploadKey, {
           knownDuration: known || undefined,
@@ -405,7 +405,8 @@ function VideoTrimSessionHost({ document }: { document: any }): ReactNode {
         console.warn('[video trim filmstrip]', err);
         if (!cancelled) setFrames(Array.from({ length: total }, () => ''));
       }
-    })();
+    }
+    void extractVideoFilmstrip();
 
     return () => {
       cancelled = true;

--- a/apps/web/src/components/editor/panels/AgentDock.tsx
+++ b/apps/web/src/components/editor/panels/AgentDock.tsx
@@ -1249,13 +1249,14 @@ function AgentDock({
     if (opts?.purgeUploads) {
       for (const c of contextChips) {
         if (c.kind === 'attachment' && c.uploadKey) {
-          void (async () => {
+          async function purgeContextAttachment() {
             try {
               await deleteUploadedFile(c.uploadKey);
             } catch {
               /* ignore */
             }
-          })();
+          }
+          void purgeContextAttachment();
         }
       }
     }
@@ -1271,13 +1272,14 @@ function AgentDock({
       pinnedContextKeysRef.current.delete(c.key);
       contextDismissedKeyRef.current = c.key;
       if (c.kind === 'attachment' && c.uploadKey) {
-        void (async () => {
+        async function deleteRemovedAttachmentUpload() {
           try {
             await deleteUploadedFile(c.uploadKey);
           } catch {
             /* ignore */
           }
-        })();
+        }
+        void deleteRemovedAttachmentUpload();
       }
     }
     setContextChips(next);
@@ -1421,13 +1423,14 @@ function AgentDock({
           setContextChips((prev) => {
             if (!prev.some((c) => c.key === key)) {
               if (uploaded.uploadKey) {
-                void (async () => {
+                async function purgeOrphanUpload() {
                   try {
                     await deleteUploadedFile(uploaded.uploadKey);
                   } catch {
                     /* ignore */
                   }
-                })();
+                }
+                void purgeOrphanUpload();
               }
               return prev;
             }
@@ -1671,24 +1674,26 @@ function AgentDock({
     const tid = liveDesignTaskRef.current;
     pauseRequestedRef.current = true;
     if (tid) {
-      void (async () => {
+      async function pauseLiveDesignRun() {
         try {
           await pauseDesignRun(tid);
         } catch {
           /* ignore */
         }
-      })();
+      }
+      void pauseLiveDesignRun();
     }
     abortRef.current?.abort();
     if (desktopShell && engineMode === 'cli') {
-      void (async () => {
+      async function killCodingCliOnStop() {
         try {
           const { invoke } = await import('@tauri-apps/api/core');
           await invoke('kill_coding_cli');
         } catch {
           /* ignore */
         }
-      })();
+      }
+      void killCodingCliOnStop();
     }
     dispatch(setAgentBusy(false));
     setSending(false);
@@ -2742,14 +2747,15 @@ function AgentDock({
   const handleHeaderClose = () => {
     abortRef.current?.abort();
     if (desktopShell && engineMode === 'cli') {
-      void (async () => {
+      async function killCodingCliOnClose() {
         try {
           const { invoke } = await import('@tauri-apps/api/core');
           await invoke('kill_coding_cli');
         } catch {
           /* ignore */
         }
-      })();
+      }
+      void killCodingCliOnClose();
     }
     dispatch(setAgentBusy(false));
     setSending(false);

--- a/apps/web/src/components/editor/panels/AssetPanel.tsx
+++ b/apps/web/src/components/editor/panels/AssetPanel.tsx
@@ -229,6 +229,9 @@ function AssetPanel({
       prompt: prompt || undefined,
       name: prompt.slice(0, 40) || undefined,
       duration: assetDurationSeconds(asset),
+      ...(asset.kind === 'lottie' && asset.animationData
+        ? { animationData: asset.animationData }
+        : {}),
     });
   };
 

--- a/apps/web/src/components/editor/panels/ShareDialog.tsx
+++ b/apps/web/src/components/editor/panels/ShareDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, memo } from 'react';
+import { useCallback, useEffect, useRef, useState, memo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { HiChevronDown, HiOutlineInformationCircle } from 'react-icons/hi2';
@@ -16,7 +16,7 @@ import { Dialog, Dropdown, Switch, message } from '@/components/base';
 import { UserAvatar } from '@/components/layout/UserAccountPanel';
 import { PlazaPublishForm } from '@/components/templates/PlazaPublishDialog';
 import { submitToPlaza } from '@/apis/plaza';
-import { fetchProject } from '@/apis/projects';
+import { extractProjectCoversApi } from '@/apis/projects';
 import { coverDocumentHasContent } from '@/utils/plazaCover';
 import { normalizeProjectThumbnailUrls } from '@/utils/projectThumb';
 import { cn } from '@/utils/classnames';
@@ -39,18 +39,10 @@ function shareUrl(id: string, origin = typeof window !== 'undefined' ? window.lo
 }
 
 async function copyText(text: string) {
-  if (navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text);
-    return;
-  }
-  const ta = document.createElement('textarea');
-  ta.value = text;
-  ta.style.position = 'fixed';
-  ta.style.left = '-9999px';
-  document.body.appendChild(ta);
-  ta.select();
-  document.execCommand('copy');
-  document.body.removeChild(ta);
+  const value = String(text || '');
+  if (!value) throw new Error('copy_empty');
+  if (!navigator.clipboard?.writeText) throw new Error('clipboard_unavailable');
+  await navigator.clipboard.writeText(value);
 }
 
 function permissionFromLinkAccess(access: LinkAccess): SharePermission {
@@ -196,6 +188,8 @@ function ShareDialog({ open, onClose }: Props) {
   const noDocWarnedRef = useRef(false);
   /** Shared create promise — StrictMode remount must not fire /shares twice. */
   const createShareInflightRef = useRef<Promise<{ share: ShareDto }> | null>(null);
+  /** Dedupe cover extract (StrictMode / rapid Publish tab clicks). */
+  const coversInflightRef = useRef<Promise<void> | null>(null);
   /** Only the latest open-session applies results / clears busy. */
   const createGenRef = useRef(0);
 
@@ -205,14 +199,13 @@ function ShareDialog({ open, onClose }: Props) {
 
   const accessLabel = (access: LinkAccess) => t(accessLabelKey(access));
 
-  // Parent mounts this dialog only when Share is opened (click) — hydrate once here.
-  useEffect(() => {
-    if (!currentId || !getToken()) return;
-    let cancelled = false;
-    async function hydrateProjectThumbnail() {
+  /** Server builds ≤4 element cover tiles from the live document (Publish tab). */
+  const refreshCoversFromApi = useCallback(() => {
+    if (!currentId || !getToken() || !document) return;
+    if (coversInflightRef.current) return;
+    async function refreshCovers() {
       try {
-        const res = await fetchProject(currentId);
-        if (cancelled) return;
+        const res = await extractProjectCoversApi(currentId, document);
         const thumbs = normalizeProjectThumbnailUrls(
           res.project?.thumbnailUrl,
           res.project?.updatedAt
@@ -226,15 +219,13 @@ function ShareDialog({ open, onClose }: Props) {
           })
         );
       } catch {
-        /* keep in-memory collage if list fetch fails */
+        /* keep current collage */
+      } finally {
+        coversInflightRef.current = null;
       }
     }
-    void hydrateProjectThumbnail();
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- first enter Share panel only
-  }, []);
+    coversInflightRef.current = refreshCovers();
+  }, [currentId, dispatch, document]);
 
   useEffect(() => {
     if (!document) {
@@ -277,7 +268,7 @@ function ShareDialog({ open, onClose }: Props) {
         // Older rows were created with linkPublic:false while the UI still showed
         // "anyone with the link". Promote so Copy link actually works for viewers.
         if (enabled && access !== 'edit' && s.linkPublic === false) {
-          void (async () => {
+          async function persistShareLinkPublic() {
             try {
               const patched = await updateShareMetaApi(s.id, { linkPublic: true });
               if (createGenRef.current !== gen) return;
@@ -285,14 +276,15 @@ function ShareDialog({ open, onClose }: Props) {
             } catch {
               /* keep local UI; copy still works for owner */
             }
-          })();
+          }
+          void persistShareLinkPublic();
         }
       } catch {
         if (createGenRef.current !== gen) return;
         createShareInflightRef.current = null;
         setRecord(null);
         setLinkEnabled(false);
-        message.error(t('editor.shareCopyFailed'));
+        message.error(t('editor.shareCreateFailed'));
       } finally {
         if (createGenRef.current === gen) setBusy(false);
       }
@@ -341,7 +333,7 @@ function ShareDialog({ open, onClose }: Props) {
     }
     setSearching(true);
     searchTimer.current = window.setTimeout(() => {
-      void (async () => {
+      async function runUserSearch() {
         try {
           const res = await searchUsersApi({ q, limit: 12 });
           setSearchHits(res.items || []);
@@ -350,7 +342,8 @@ function ShareDialog({ open, onClose }: Props) {
         } finally {
           setSearching(false);
         }
-      })();
+      }
+      void runUserSearch();
     }, 280);
     return () => {
       if (searchTimer.current) window.clearTimeout(searchTimer.current);
@@ -539,7 +532,10 @@ function ShareDialog({ open, onClose }: Props) {
                 onClick={() => {
                   if (publishing) return;
                   setTab(item.id);
-                  if (item.id === 'publish') setPublishPhase('confirm');
+                  if (item.id === 'publish') {
+                    setPublishPhase('confirm');
+                    refreshCoversFromApi();
+                  }
                 }}
                 className={cn(
                   'relative pb-2 text-[15px] font-medium transition-colors',

--- a/apps/web/src/components/editor/panels/agent/AgentDockComposerFooter.tsx
+++ b/apps/web/src/components/editor/panels/agent/AgentDockComposerFooter.tsx
@@ -89,7 +89,7 @@ function AgentDockComposerFooter({
                     type="button"
                     className="rounded bg-[var(--accent)] px-1.5 py-0.5 text-[11px] font-medium text-white hover:opacity-90"
                     onClick={() => {
-                      void (async () => {
+                      async function saveLongMemorySuggestion() {
                         try {
                           await fetch(resolveApiUrl('/api/v1/design/memory/long'), {
                             method: 'POST',
@@ -102,7 +102,8 @@ function AgentDockComposerFooter({
                         } catch {
                           /* silently ignore */
                         }
-                      })();
+                      }
+                      void saveLongMemorySuggestion();
                       onSavedLongSuggestion?.(i);
                     }}
                   >

--- a/apps/web/src/components/editor/panels/agent/AgentModelsPanel.tsx
+++ b/apps/web/src/components/editor/panels/agent/AgentModelsPanel.tsx
@@ -449,7 +449,7 @@ function AddPlatformModelFields(props: {
 
   const onUploadIcon = (file: File | null) => {
     if (!file || !file.type.startsWith('image/')) return;
-    void (async () => {
+    async function applyUploadedIcon() {
       try {
         const dataUrl = await readFileAsDataUrl(file);
         onIconKey('');
@@ -457,7 +457,8 @@ function AddPlatformModelFields(props: {
       } catch {
         /* ignore read errors */
       }
-    })();
+    }
+    void applyUploadedIcon();
   };
 
   return (
@@ -705,6 +706,12 @@ function submenuSelectedIdOf(
   return routePrefs.preset;
 }
 
+type SharedRouteCatalog = {
+  text: LlmModel[];
+  image: LlmModel[];
+  openrouterAvailable: boolean | null;
+};
+
 type AgentRoutePrefsEditorProps = {
   /** Popover in agent dock / home — Lovart-style card (not account form). */
   compact?: boolean;
@@ -713,6 +720,11 @@ type AgentRoutePrefsEditorProps = {
   className?: string;
   /** Fired after prefs are written to localStorage. */
   onChanged?: (prefs: AgentRoutePrefs) => void;
+  /**
+   * When set (Account Agent tab), parent owns GET /chat/models + BYOK hydrate —
+   * do not fetch again. `null` = still loading; object = ready.
+   */
+  sharedCatalog?: SharedRouteCatalog | null;
 };
 
 /**
@@ -724,9 +736,11 @@ function AgentRoutePrefsEditor({
   modeLabel,
   className,
   onChanged,
+  sharedCatalog,
 }: AgentRoutePrefsEditorProps): ReactNode {
   const { t } = useTranslation();
   const desktopLocal = isDesktopLocal();
+  const catalogFromParent = sharedCatalog !== undefined;
   const [routePrefs, setRoutePrefs] = useState<AgentRoutePrefs>(() =>
     desktopLocal ? emptyCustomRoutePrefs() : { preset: 'platform' }
   );
@@ -741,6 +755,8 @@ function AgentRoutePrefsEditor({
 
   useEffect(() => {
     setRoutePrefs(loadAgentRoutePrefs());
+    // Account Agent tab loads catalog once on the parent — skip duplicate design fetch there.
+    if (catalogFromParent) return;
     let cancelled = false;
     async function loadDesignCatalog() {
       try {
@@ -757,9 +773,20 @@ function AgentRoutePrefsEditor({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [catalogFromParent]);
 
   useEffect(() => {
+    if (catalogFromParent) {
+      if (!sharedCatalog) return;
+      setTextModels(sharedCatalog.text);
+      setImageModels(sharedCatalog.image);
+      setOpenrouterAvailable(sharedCatalog.openrouterAvailable);
+      if (sharedCatalog.openrouterAvailable != null) {
+        cachedOpenrouterAvailable = sharedCatalog.openrouterAvailable;
+      }
+      setRoutePrefs(loadAgentRoutePrefs(cachedPresetRules));
+      return;
+    }
     let cancelled = false;
     async function loadRouteModels() {
       try {
@@ -780,11 +807,11 @@ function AgentRoutePrefsEditor({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [catalogFromParent, sharedCatalog]);
 
-  // Refresh BYOK lane options when providers change (local desktop).
+  // Standalone popover on local desktop: refresh BYOK lanes (Account tab parent hydrates).
   useEffect(() => {
-    if (!desktopLocal) return;
+    if (!desktopLocal || catalogFromParent) return;
     let cancelled = false;
     async function refreshByokRouteModels() {
       await hydrateCustomLlmProviders();
@@ -797,7 +824,7 @@ function AgentRoutePrefsEditor({
     return () => {
       cancelled = true;
     };
-  }, [desktopLocal]);
+  }, [desktopLocal, catalogFromParent]);
 
   const commit = (next: AgentRoutePrefs) => {
     setRoutePrefs(next);
@@ -1314,6 +1341,8 @@ function AgentModelsPanel({
   const canCustom = isDesktopLocal() || planAllowsCustomModels(planId);
   const [providers, setProviders] = useState<CustomLlmProvider[]>([]);
   const [platforms, setPlatforms] = useState<ByokPlatform[]>([]);
+  /** Shared with RoutePrefsEditor — one GET /chat/models for the whole Agent tab. */
+  const [sharedCatalog, setSharedCatalog] = useState<SharedRouteCatalog | null>(null);
   // '' = nothing picked yet; MANUAL_PROVIDER_ID = free-text; else a platform id.
   const [presetId, setPresetId] = useState('');
   const [name, setName] = useState('');
@@ -1347,31 +1376,44 @@ function AgentModelsPanel({
 
   useEffect(() => {
     let cancelled = false;
-    async function loadProviderData() {
-      try {
-        const list = await hydrateCustomLlmProviders();
-        if (!cancelled) setProviders(list);
-      } catch {
-        /* ignore */
-      }
-      try {
-        const res = await listModels();
-        if (cancelled) return;
-        const list = res.byokPlatforms?.length
+    async function loadAgentTabData() {
+      // One parallel round: BYOK list + models (platforms + route catalog).
+      const [list, res] = await Promise.all([
+        hydrateCustomLlmProviders().catch(() => [] as CustomLlmProvider[]),
+        listModels().catch(() => null),
+      ]);
+      if (cancelled) return;
+      setProviders(list);
+      if (res) {
+        const plat = res.byokPlatforms?.length
           ? res.byokPlatforms
           : (res.byokPresets as ByokPlatform[] | undefined) ?? [];
         setPlatforms(
-          list.map((p) => ({
+          plat.map((p) => ({
             ...p,
             rowId: p.rowId || `platform:${p.id}`,
             kinds: p.kinds?.length ? p.kinds : ['text'],
           }))
         );
+        const orOk = res.openrouterAvailable !== false;
+        warmOpenrouterAvailability(orOk);
+        const { text, image } = routeCatalogFromListModels(res);
+        setSharedCatalog({ text, image, openrouterAvailable: orOk });
+      } else if (isDesktopLocal()) {
+        const { text, image } = splitByokRouteModels(customProvidersAsModels(list));
+        setSharedCatalog({ text, image, openrouterAvailable: cachedOpenrouterAvailable });
+      } else {
+        setSharedCatalog({ text: [], image: [], openrouterAvailable: null });
+      }
+      try {
+        const cat = await fetchDesignCatalog();
+        if (cancelled) return;
+        cachedPresetRules = cat.global_rules || {};
       } catch {
-        /* platforms optional — manual form still works */
+        /* route presets keep fallbacks */
       }
     }
-    void loadProviderData();
+    void loadAgentTabData();
     return () => {
       cancelled = true;
     };
@@ -1499,7 +1541,7 @@ function AgentModelsPanel({
         return;
       }
     }
-    void (async () => {
+    async function saveProvider() {
       try {
         const saved = await persistCustomLlmProvider(draft);
         let next = [saved, ...providers.filter((p) => p.id !== saved.id)];
@@ -1530,7 +1572,8 @@ function AgentModelsPanel({
       } catch {
         setError(t('agent.providerSaveFailed', { defaultValue: 'Failed to save provider' }));
       }
-    })();
+    }
+    void saveProvider();
   };
 
   const onRemove = (id: string) => {
@@ -1542,11 +1585,12 @@ function AgentModelsPanel({
     if (isPlatformByokId(id) || providers.find((p) => p.id === id)?.modelKind === 'platform') {
       for (const child of childModelsOf(id)) removeIds.add(child.id);
     }
-    void (async () => {
+    async function removeProviders() {
       await Promise.all([...removeIds].map((rid) => removeCustomLlmProvider(rid)));
       persistProviders(providers.filter((p) => !removeIds.has(p.id)));
       if (addModelForId === id) closeAddModel();
-    })();
+    }
+    void removeProviders();
   };
 
   const openAddModel = (platformRowId: string) => {
@@ -1617,7 +1661,7 @@ function AgentModelsPanel({
       iconUrl,
       createdAt: Date.now(),
     };
-    void (async () => {
+    async function savePlatformModel() {
       try {
         const saved = await persistCustomLlmProvider(draft);
         persistProviders([saved, ...providers.filter((p) => p.id !== saved.id)]);
@@ -1625,7 +1669,8 @@ function AgentModelsPanel({
       } catch {
         setAddModelError(t('agent.providerPlatformModelFailed'));
       }
-    })();
+    }
+    void savePlatformModel();
   };
 
   const platformRows = providers.filter(
@@ -1650,7 +1695,7 @@ function AgentModelsPanel({
     <>
       <div className="space-y-5">
         <section className="rounded-xl bg-[var(--account-card)] p-6 ring-1 ring-[var(--line)]">
-          <AgentRoutePrefsEditor />
+          <AgentRoutePrefsEditor sharedCatalog={sharedCatalog} />
         </section>
 
         <section className="rounded-xl bg-[var(--account-card)] p-6 ring-1 ring-[var(--line)]">

--- a/apps/web/src/components/editor/panels/agent/codingCli.ts
+++ b/apps/web/src/components/editor/panels/agent/codingCli.ts
@@ -216,17 +216,18 @@ export async function runCodingCliDesktop(opts: {
       fn();
     };
     const onAbort = () => {
-      void (async () => {
+      async function killCliOnAbort() {
         try {
           await invoke('kill_coding_cli');
         } catch {
           /* ignore */
         }
-      })();
+      }
+      void killCliOnAbort();
       finish(() => reject(new DOMException('Aborted', 'AbortError')));
     };
 
-    void (async () => {
+    async function startCodingCliRun() {
       try {
         unsubs.push(
           await listen<{ text?: string }>('coding-cli-chunk', (ev) => {
@@ -258,7 +259,8 @@ export async function runCodingCliDesktop(opts: {
       } catch (err) {
         finish(() => reject(err instanceof Error ? err : new Error(String(err))));
       }
-    })();
+    }
+    void startCodingCliRun();
   });
 }
 

--- a/apps/web/src/components/editor/panels/agent/customLlmProviders.ts
+++ b/apps/web/src/components/editor/panels/agent/customLlmProviders.ts
@@ -336,8 +336,24 @@ export async function removeCustomLlmProvider(id: string): Promise<void> {
   writeLocalEncrypted(loadCustomLlmProviders().filter((p) => p.id !== id));
 }
 
+/** Single-flight — Account Agent mounts RoutePrefs + panel both used to call this. */
+let _hydrateProvidersInflight: Promise<CustomLlmProvider[]> | null = null;
+
 /** Pull server vault + migrate legacy plaintext local keys. */
 export async function hydrateCustomLlmProviders(): Promise<CustomLlmProvider[]> {
+  if (_hydrateProvidersInflight) return _hydrateProvidersInflight;
+  const pending = (async () => {
+    try {
+      return await hydrateCustomLlmProvidersBody();
+    } finally {
+      if (_hydrateProvidersInflight === pending) _hydrateProvidersInflight = null;
+    }
+  })();
+  _hydrateProvidersInflight = pending;
+  return pending;
+}
+
+async function hydrateCustomLlmProvidersBody(): Promise<CustomLlmProvider[]> {
   const token = getToken();
   let local = readLocalRaw();
 

--- a/apps/web/src/components/editor/panels/agent/useChatSessions.ts
+++ b/apps/web/src/components/editor/panels/agent/useChatSessions.ts
@@ -232,7 +232,7 @@ export function useChatSessions(documentId: string | null | undefined) {
     if (!pending || !isChatLoggedIn() || apiDisabledRef.current) return;
     if (pending.payloadJson === lastSyncedJson.current) return;
     pendingSyncRef.current = null;
-    void (async () => {
+    async function upsertPendingSession() {
       try {
         await upsertChatSessionApi({
           projectId: pending.projectId || '__none__',
@@ -246,7 +246,8 @@ export function useChatSessions(documentId: string | null | undefined) {
         if (err?.response?.status === 401) apiDisabledRef.current = true;
         if (!pendingSyncRef.current) pendingSyncRef.current = pending;
       }
-    })();
+    }
+    void upsertPendingSession();
   }, []);
 
   useEffect(() => {
@@ -405,13 +406,14 @@ export function useChatSessions(documentId: string | null | undefined) {
     (id: string) => {
       setSessions((prev) => prev.filter((sess) => sess.id !== id));
       if (isChatLoggedIn()) {
-        void (async () => {
+        async function deleteRemoteSession() {
           try {
             await deleteChatSessionApi(id);
           } catch {
             /* ignore */
           }
-        })();
+        }
+        void deleteRemoteSession();
       }
       if (id === sessionId) {
         const nid = chatUid();

--- a/apps/web/src/components/editor/useProjectCloudSync.ts
+++ b/apps/web/src/components/editor/useProjectCloudSync.ts
@@ -1,7 +1,6 @@
 /**
  * Debounced project sync: IndexedDB draft → incremental PATCH (or PUT) for document.
- * Cover tiles rebuild only on force leave / first save — existing thumbnailUrl is reused
- * so edits do not re-fetch scene PNGs or re-upload COS thumbs every debounce.
+ * Covers are generated on the API from the saved document (≤4 element tiles).
  */
 
 import { useCallback, useEffect, useRef } from 'react';
@@ -23,7 +22,6 @@ import {
 } from '@/store/modules/editor';
 import { isOwnedTemplate } from '@/utils/templatesStorage';
 import { getToken } from '@/utils/token';
-import { buildProjectCoverTiles } from '@/utils/renderProjectThumbnail';
 import { normalizeProjectThumbnailUrls } from '@/utils/projectThumb';
 import {
   buildProjectDocumentPatch,
@@ -126,22 +124,6 @@ type ThumbUpload = {
   thumbnailUrls?: string[];
 };
 
-function thumbPayloadFromTiles(tiles: {
-  dataUrls?: string[];
-  urls?: string[];
-}): ThumbUpload {
-  // Up to 4 tiles in one projects request (not separate cover PATCHes).
-  if (tiles.urls?.length) return { thumbnailUrls: tiles.urls.slice(0, 4) };
-  const dataUrls = (tiles.dataUrls || [])
-    .map((u) => String(u || '').trim())
-    .filter((u) => u.startsWith('data:image/'))
-    .slice(0, 4);
-  if (!dataUrls.length) return {};
-  return dataUrls.length === 1
-    ? { thumbnailDataUrl: dataUrls[0], thumbnailDataUrls: dataUrls }
-    : { thumbnailDataUrls: dataUrls };
-}
-
 function applyThumbUpload(
   data: { thumbnailDataUrl?: string | null; thumbnailDataUrls?: string[] | null; thumbnailUrls?: string[] | null },
   thumb: ThumbUpload
@@ -155,69 +137,6 @@ function ackThumbnail(url: string | string[] | null | undefined, version?: numbe
   const list = normalizeProjectThumbnailUrls(url, version);
   if (!list.length) return null;
   return list.length === 1 ? list[0] : list;
-}
-
-async function buildSyncCoverThumb(
-  document: unknown,
-  dispatch: ReturnType<typeof useDispatch>,
-  projectId: string
-): Promise<ThumbUpload> {
-  try {
-    const tiles = await buildProjectCoverTiles(document);
-    const thumb = thumbPayloadFromTiles(tiles);
-    const localPreview =
-      tiles.urls?.length ? tiles.urls : tiles.dataUrls?.length ? tiles.dataUrls : null;
-    if (import.meta.env.DEV) {
-      console.info('[project-sync] cover tiles', {
-        id: projectId,
-        urls: tiles.urls?.length || 0,
-        dataUrls: tiles.dataUrls?.length || 0,
-      });
-    }
-    if (localPreview) {
-      dispatch(
-        setTemplateThumbnail({
-          id: projectId,
-          thumbnail: localPreview.length === 1 ? localPreview[0] : localPreview,
-          custom: false,
-        })
-      );
-    }
-    return thumb;
-  } catch (err) {
-    if (import.meta.env.DEV) console.warn('[project-sync] cover tiles failed', err);
-    return {};
-  }
-}
-
-/** Prefer already-hosted cover URLs — skip raster + scene image fetches. */
-function existingCoverThumb(template: { thumbnail?: unknown } | null | undefined): ThumbUpload {
-  const urls = normalizeProjectThumbnailUrls(template?.thumbnail as string | string[] | null);
-  return urls.length ? { thumbnailUrls: urls.slice(0, 4) } : {};
-}
-
-/**
- * Rebuild covers only when forced (leave / Ctrl+S force) or the project has no cover yet.
- * Incremental edits keep server thumbnailUrl as-is (omit thumb payload).
- */
-async function resolveSyncCoverThumb(opts: {
-  force: boolean;
-  document: unknown;
-  template: { thumbnail?: unknown } | null | undefined;
-  dispatch: ReturnType<typeof useDispatch>;
-  projectId: string;
-}): Promise<ThumbUpload> {
-  const existing = existingCoverThumb(opts.template);
-  if (!opts.force && existing.thumbnailUrls?.length) {
-    if (import.meta.env.DEV) {
-      console.info('[project-sync] reuse thumbnailUrl', {
-        id: opts.projectId,
-        n: existing.thumbnailUrls.length,
-      });
-    }
-    return {};
-  }
-  return buildSyncCoverThumb(opts.document, opts.dispatch, opts.projectId);
 }
 
 /** Push one owned project to the API (no-op when logged out). */
@@ -545,14 +464,8 @@ export function useProjectCloudSync() {
         return;
       }
 
-      // Cover: reuse stored thumbnailUrl on normal debounce; rebuild ≤4 only on force / first save.
-      const thumb = await resolveSyncCoverThumb({
-        force,
-        document: pushedDoc,
-        template: tpl,
-        dispatch,
-        projectId: id,
-      });
+      // Covers: API builds ≤4 tiles from the saved document (not client raster).
+      const thumb: ThumbUpload = {};
 
       // Logged out: local draft (+ optional in-memory cover on first/force) is enough.
       if (!getToken()) {
@@ -757,11 +670,11 @@ export function useProjectCloudSync() {
     };
   }, []);
 
-  // Flush when tab hides (if dirty); unmount always force-saves doc + cover.
+  // Leave / hide: force doc + cover once (not every debounce). Unmount same.
   useEffect(() => {
     const onHide = () => {
       if (!dirtyRef.current) return;
-      void flushCurrentProjectNow();
+      void flushCurrentProjectNow({ force: true });
     };
     const onVisibility = () => {
       if (window.document.visibilityState === 'hidden') onHide();

--- a/apps/web/src/components/home/HomeAgentComposer.tsx
+++ b/apps/web/src/components/home/HomeAgentComposer.tsx
@@ -785,13 +785,14 @@ function HomeAgentComposer({
           setContexts((prev) => {
             if (!prev.some((c) => c.key === key)) {
               if (uploaded.uploadKey) {
-                void (async () => {
+                async function purgeOrphanUpload() {
                   try {
                     await deleteUploadedFile(uploaded.uploadKey!);
                   } catch {
                     /* ignore */
                   }
-                })();
+                }
+                void purgeOrphanUpload();
               }
               return prev;
             }
@@ -819,13 +820,14 @@ function HomeAgentComposer({
     const removed = contexts.filter((c) => !next.some((n) => n.key === c.key));
     for (const c of removed) {
       if (c.kind === 'attachment' && c.uploadKey) {
-        void (async () => {
+        async function deleteRemovedAttachment() {
           try {
             await deleteUploadedFile(c.uploadKey!);
           } catch {
             /* ignore */
           }
-        })();
+        }
+        void deleteRemovedAttachment();
       }
     }
     setContexts(next);

--- a/apps/web/src/components/home/InspirationSection.tsx
+++ b/apps/web/src/components/home/InspirationSection.tsx
@@ -218,13 +218,14 @@ function InspirationCaseCard({
       const ok = await copyTextToClipboard(prompt);
       if (ok) {
         message.success(t('home.cases.promptCopied'));
-        void (async () => {
+        async function recordPlazaUseAfterPromptCopy() {
           try {
             await recordPlazaUse(meta.id);
           } catch {
             /* ignore */
           }
-        })();
+        }
+        void recordPlazaUseAfterPromptCopy();
       } else {
         message.error(t('home.cases.copyFailed'));
       }
@@ -239,13 +240,14 @@ function InspirationCaseCard({
       const ok = await copyImageToClipboard(url);
       if (ok) {
         message.success(t('home.cases.imageCopied'));
-        void (async () => {
+        async function recordPlazaUseAfterImageCopy() {
           try {
             await recordPlazaUse(meta.id);
           } catch {
             /* ignore */
           }
-        })();
+        }
+        void recordPlazaUseAfterImageCopy();
       } else {
         message.error(t('home.cases.copyFailed'));
       }
@@ -496,7 +498,7 @@ function InspirationSection({ onOpenCase, disabled }: Props): ReactNode {
     if (disabled || openingId) return;
     setOpeningId(meta.id);
     try {
-      void (async () => {
+      async function trackRemixUse() {
         try {
           const res = await recordPlazaUse(meta.id);
           const n = Number(res.useCount);
@@ -507,7 +509,8 @@ function InspirationSection({ onOpenCase, disabled }: Props): ReactNode {
         } catch {
           /* ignore */
         }
-      })();
+      }
+      void trackRemixUse();
       setPreviewId(null);
       // Skill chip → chat; blank canvas (handled by HomePage). No document clone.
       onOpenCase(meta);

--- a/apps/web/src/components/home/MePage.tsx
+++ b/apps/web/src/components/home/MePage.tsx
@@ -25,7 +25,6 @@ import { buildLoginUrl } from '@/utils/authReturnTo';
 import { deleteAsset, listAssets, type UserAsset } from '@/apis/assets';
 import {
   fetchMyLiked,
-  fetchMyLikedIds,
   likePlazaItem,
   syncMyLiked,
   unlikePlazaItem,
@@ -231,32 +230,13 @@ function MePage({ onOpenCase }: Props): ReactNode {
     setPublishedReady(false);
     setAssetsReady(false);
     setLiked([]);
+    setLikedIds(new Set());
     setPublishedAll([]);
     setAssets([]);
     setAssetPreview(null);
     setAssetDeleteTarget(null);
     likedMigratedRef.current = false;
   }, [userId]);
-
-  useEffect(() => {
-    if (!authed || !userId) {
-      setLikedIds(new Set());
-      return;
-    }
-    let cancelled = false;
-    async function hydrateLikedIds() {
-      try {
-        const res = await fetchMyLikedIds();
-        if (!cancelled) setLikedIds(new Set(res.ids || []));
-      } catch {
-        if (!cancelled) setLikedIds(new Set());
-      }
-    }
-    void hydrateLikedIds();
-    return () => {
-      cancelled = true;
-    };
-  }, [authed, userId]);
 
   const loadLikedOnce = useCallback(async () => {
     if (!authed || !userId) {
@@ -572,13 +552,14 @@ function MePage({ onOpenCase }: Props): ReactNode {
     if (remixingId) return;
     setRemixingId(meta.id);
     try {
-      void (async () => {
+      async function trackRemixUse() {
         try {
           await recordPlazaUse(meta.id);
         } catch {
           /* ignore */
         }
-      })();
+      }
+      void trackRemixUse();
       setPreviewId(null);
       onOpenCase(meta);
     } catch {

--- a/apps/web/src/components/home/ProjectCoverCollage.tsx
+++ b/apps/web/src/components/home/ProjectCoverCollage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode, memo } from 'react';
+import { useMemo, type ReactNode, memo } from 'react';
 import TemplateThumbnail from '@/components/templates/TemplateThumbnail';
 import LazyTemplateThumb from '@/components/home/LazyTemplateThumb';
 import {
@@ -104,62 +104,45 @@ function ProjectCoverCollage({
   );
 }
 
-/** Multi-tile collage — CSS grid keeps row/column gutters equal. */
-function ImgCollage({
-  urls,
-  fallbackDocument,
-}: {
-  urls: string[];
-  fallbackDocument?: unknown;
-}) {
-  const [failed, setFailed] = useState(() => new Set<string>());
-  const visible = urls.filter((u) => !failed.has(u));
+/** Grid cell: min-h-0 so tall imgs cannot blow past the 170px frame; overflow clips. */
+function ImgTile({ src, className }: { src: string; className?: string }) {
+  return (
+    <div className={cn('relative min-h-0 min-w-0 overflow-hidden', className)}>
+      {/* object-contain keeps shape tiles uncropped; white fill matches tile board. */}
+      <img
+        src={src}
+        alt=""
+        className="absolute inset-0 h-full w-full bg-white object-contain"
+        loading="lazy"
+      />
+    </div>
+  );
+}
 
-  const onError = (src: string) => {
-    setFailed((prev) => {
-      if (prev.has(src)) return prev;
-      const next = new Set(prev);
-      next.add(src);
-      return next;
-    });
-  };
+/** Multi-tile collage — always map ``thumbnailUrl`` list to ``<img>`` (max 4). */
+function ImgCollage({ urls }: { urls: string[]; fallbackDocument?: unknown }) {
+  const list = urls.filter(Boolean).slice(0, MAX_TILES);
+  if (!list.length) return null;
 
-  if (!visible.length) {
-    if (fallbackDocument) {
-      return (
-        <div className="absolute inset-0 overflow-hidden">
-          <TemplateThumbnail document={fallbackDocument} fit="cover" />
-        </div>
-      );
-    }
-    return null;
-  }
-
-  const n = visible.length;
+  const n = list.length;
   if (n <= 1) {
     return (
-      <img
-        src={visible[0]}
-        alt=""
-        className="absolute inset-0 h-full w-full object-cover"
-        loading="lazy"
-        onError={() => onError(visible[0])}
-      />
+      <div className="absolute inset-0 overflow-hidden">
+        <img
+          src={list[0]}
+          alt=""
+          className="absolute inset-0 h-full w-full object-cover"
+          loading="lazy"
+        />
+      </div>
     );
   }
 
   if (n === 2) {
     return (
-      <div className="absolute inset-0 grid grid-cols-2 gap-1">
-        {visible.map((src) => (
-          <img
-            key={src}
-            src={src}
-            alt=""
-            className="h-full w-full object-cover"
-            loading="lazy"
-            onError={() => onError(src)}
-          />
+      <div className="absolute inset-0 grid grid-cols-2 gap-1 overflow-hidden">
+        {list.map((src) => (
+          <ImgTile key={src} src={src} />
         ))}
       </div>
     );
@@ -167,44 +150,18 @@ function ImgCollage({
 
   if (n === 3) {
     return (
-      <div className="absolute inset-0 grid grid-cols-2 grid-rows-2 gap-1">
-        <img
-          src={visible[0]}
-          alt=""
-          className="row-span-2 h-full w-full object-cover"
-          loading="lazy"
-          onError={() => onError(visible[0])}
-        />
-        <img
-          src={visible[1]}
-          alt=""
-          className="h-full w-full object-cover"
-          loading="lazy"
-          onError={() => onError(visible[1])}
-        />
-        <img
-          src={visible[2]}
-          alt=""
-          className="h-full w-full object-cover"
-          loading="lazy"
-          onError={() => onError(visible[2])}
-        />
+      <div className="absolute inset-0 grid grid-cols-2 grid-rows-2 gap-1 overflow-hidden">
+        <ImgTile src={list[0]} className="row-span-2" />
+        <ImgTile src={list[1]} />
+        <ImgTile src={list[2]} />
       </div>
     );
   }
 
-  // 2×2 — CSS grid so row/column gutters stay equal (h-1/2 + gap overflows and squeezes rows).
   return (
-    <div className="absolute inset-0 grid grid-cols-2 grid-rows-2 gap-1">
-      {visible.slice(0, 4).map((src) => (
-        <img
-          key={src}
-          src={src}
-          alt=""
-          className="h-full w-full object-cover"
-          loading="lazy"
-          onError={() => onError(src)}
-        />
+    <div className="absolute inset-0 grid grid-cols-2 grid-rows-2 gap-1 overflow-hidden">
+      {list.slice(0, 4).map((src) => (
+        <ImgTile key={src} src={src} />
       ))}
     </div>
   );

--- a/apps/web/src/components/home/UserAssetMediaCard.tsx
+++ b/apps/web/src/components/home/UserAssetMediaCard.tsx
@@ -28,7 +28,7 @@ import type { UserAsset } from '@/apis/assets';
 import { FLOW_ITEM_CLASS, FLOW_SKELETON_COUNT } from '@/components/home/FlowScrollSection';
 import { parseLottieAnimationData } from '@/components/rcb/scene/document/sceneDocument';
 import { cn } from '@/utils/classnames';
-import { imageSrcToFile, mediaSrcNeedsAuthFetch } from '@/utils/uploadImage';
+import { toDisplayMediaUrl } from '@/utils/uploadImage';
 
 /** Varied aspects for flow skeletons (same rhythm as plaza). */
 const ASSET_SKELETON_RATIOS = ['3 / 4', '4 / 5', '1 / 1', '4 / 3', '5 / 6', '2 / 3', '5 / 4'] as const;
@@ -110,22 +110,10 @@ function clearAssetCardDragging(el: HTMLElement | null) {
   if (card instanceof HTMLElement) card.removeAttribute('data-dragging');
 }
 
-/** Load Bodymovin JSON from asset url / auth upload key. */
-async function loadAssetLottieData(
-  src: string,
-  uploadKey?: string | null
-): Promise<Record<string, unknown> | null> {
-  const url = String(src || '').trim();
-  if (!url) return null;
-  try {
-    const file = await imageSrcToFile(url, 'asset-lottie.json', {
-      uploadKey,
-      fallbackMime: 'application/json',
-    });
-    return parseLottieAnimationData(await file.text());
-  } catch {
-    return null;
-  }
+/** Prefer list-inlined ``animationData``; never refetch `.json` when present. */
+function resolveAssetLottieData(asset: UserAsset): Record<string, unknown> | null {
+  const embedded = asset.animationData ?? asset.meta?.animationData;
+  return parseLottieAnimationData(embedded);
 }
 
 function mountLottieOnHost(
@@ -145,46 +133,15 @@ function mountLottieOnHost(
 
 // ─── hooks ──────────────────────────────────────────────────────────────────
 
-/** Auth-gated local URLs → blob; public / data URLs pass through. */
-function useAuthMediaSrc(
+/** Display URL as-is (bare storage keys → /api/v1/uploads/files/…). */
+function useDisplayMediaSrc(
   url: string,
   uploadKey: string | undefined,
-  fileName: string,
+  _fileName?: string,
   enabled = true
 ): string {
-  const [src, setSrc] = useState(() =>
-    enabled && url && !mediaSrcNeedsAuthFetch(url) ? url : ''
-  );
-
-  useEffect(() => {
-    if (!enabled || !url) {
-      setSrc('');
-      return;
-    }
-    if (!mediaSrcNeedsAuthFetch(url)) {
-      setSrc(url);
-      return;
-    }
-    let cancelled = false;
-    let blobUrl: string | null = null;
-    async function loadSrc() {
-      try {
-        const file = await imageSrcToFile(url, fileName, { uploadKey });
-        if (cancelled) return;
-        blobUrl = URL.createObjectURL(file);
-        setSrc(blobUrl);
-      } catch {
-        if (!cancelled) setSrc('');
-      }
-    }
-    void loadSrc();
-    return () => {
-      cancelled = true;
-      if (blobUrl) URL.revokeObjectURL(blobUrl);
-    };
-  }, [enabled, url, uploadKey, fileName]);
-
-  return src;
+  if (!enabled || !url) return '';
+  return toDisplayMediaUrl(url, uploadKey);
 }
 
 function useEscapeToClose(open: boolean, onClose: () => void) {
@@ -270,8 +227,7 @@ function LottieAssetThumb({
 }): ReactNode {
   const [hostEl, setHostEl] = useState<HTMLDivElement | null>(null);
   const [failed, setFailed] = useState(false);
-  const url = String(asset.url || '').trim();
-  const uploadKey = String(asset.objectKey || '').trim() || undefined;
+  const lottieData = resolveAssetLottieData(asset);
 
   useEffect(() => {
     const aspect = aspectFromAsset(asset);
@@ -279,39 +235,32 @@ function LottieAssetThumb({
   }, [asset.width, asset.height, onNaturalAspect]);
 
   useEffect(() => {
-    if (!hostEl || !url) {
-      setFailed(!url);
+    if (!hostEl) return undefined;
+    if (!lottieData) {
+      setFailed(true);
       return undefined;
     }
     let cancelled = false;
     let anim: AnimationItem | null = null;
     setFailed(false);
-    void (async () => {
-      const data = await loadAssetLottieData(url, uploadKey);
-      if (cancelled) return;
-      if (!data) {
-        setFailed(true);
-        return;
-      }
-      const aw = Number(data.w);
-      const ah = Number(data.h);
-      if (aw > 0 && ah > 0) onNaturalAspect?.(`${aw} / ${ah}`);
-      try {
-        anim = mountLottieOnHost(hostEl, data);
-        requestAnimationFrame(() => {
-          if (cancelled || !hostEl.isConnected) return;
-          if (!lottieHostHasInk(hostEl)) setFailed(true);
-        });
-      } catch {
-        setFailed(true);
-      }
-    })();
+    const aw = Number(lottieData.w);
+    const ah = Number(lottieData.h);
+    if (aw > 0 && ah > 0) onNaturalAspect?.(`${aw} / ${ah}`);
+    try {
+      anim = mountLottieOnHost(hostEl, lottieData);
+      requestAnimationFrame(() => {
+        if (cancelled || !hostEl.isConnected) return;
+        if (!lottieHostHasInk(hostEl)) setFailed(true);
+      });
+    } catch {
+      setFailed(true);
+    }
     return () => {
       cancelled = true;
       anim?.destroy();
       hostEl.innerHTML = '';
     };
-  }, [hostEl, url, uploadKey, onNaturalAspect]);
+  }, [hostEl, lottieData, onNaturalAspect]);
 
   return (
     <div className="relative h-full w-full bg-transparent" aria-hidden>
@@ -334,7 +283,7 @@ function UserAssetThumb({
 }): ReactNode {
   const url = String(asset.url || '').trim();
   const uploadKey = String(asset.objectKey || '').trim() || undefined;
-  const thumbSrc = useAuthMediaSrc(url, uploadKey, 'user-asset-thumb.bin');
+  const thumbSrc = useDisplayMediaSrc(url, uploadKey, 'user-asset-thumb.bin');
 
   const reportNatural = (w: number, h: number) => {
     if (w > 0 && h > 0) onNaturalAspect?.(`${w} / ${h}`);
@@ -574,7 +523,7 @@ function ImageAssetLightbox({
 }): ReactNode {
   const url = String(asset.url || '').trim();
   const uploadKey = String(asset.objectKey || '').trim() || undefined;
-  const src = useAuthMediaSrc(url, uploadKey, 'user-asset-preview.bin');
+  const src = useDisplayMediaSrc(url, uploadKey, 'user-asset-preview.bin');
   if (!src) return null;
   return (
     <Image
@@ -612,7 +561,7 @@ function AudioAssetPreview({
   onClose: () => void;
 }): ReactNode {
   const { t } = useTranslation();
-  const playSrc = useAuthMediaSrc(
+  const playSrc = useDisplayMediaSrc(
     src,
     uploadKey || undefined,
     'asset-audio.bin',
@@ -658,38 +607,31 @@ function AudioAssetPreview({
 
 function LottieAssetPreview({
   open,
-  src,
-  uploadKey,
+  asset,
   onClose,
 }: {
   open: boolean;
-  src: string;
-  uploadKey?: string | null;
+  asset: UserAsset;
   onClose: () => void;
 }): ReactNode {
   const { t } = useTranslation();
   const [hostEl, setHostEl] = useState<HTMLDivElement | null>(null);
+  const lottieData = resolveAssetLottieData(asset);
   useEscapeToClose(open, onClose);
 
   useEffect(() => {
-    if (!open || !src || !hostEl) return undefined;
-    let cancelled = false;
+    if (!open || !hostEl || !lottieData) return undefined;
     let anim: AnimationItem | null = null;
-    void (async () => {
-      const data = await loadAssetLottieData(src, uploadKey);
-      if (cancelled || !data) return;
-      try {
-        anim = mountLottieOnHost(hostEl, data);
-      } catch {
-        /* empty */
-      }
-    })();
+    try {
+      anim = mountLottieOnHost(hostEl, lottieData);
+    } catch {
+      /* empty */
+    }
     return () => {
-      cancelled = true;
       anim?.destroy();
       hostEl.innerHTML = '';
     };
-  }, [open, src, uploadKey, hostEl]);
+  }, [open, hostEl, lottieData]);
 
   if (!open || typeof document === 'undefined') return null;
   return createPortal(
@@ -755,9 +697,8 @@ function UserAssetMediaPreview({
         onClose={onClose}
       />
       <LottieAssetPreview
-        open={asset.kind === 'lottie' && Boolean(url)}
-        src={url}
-        uploadKey={asset.objectKey}
+        open={asset.kind === 'lottie' && Boolean(resolveAssetLottieData(asset) || url)}
+        asset={asset}
         onClose={onClose}
       />
     </>

--- a/apps/web/src/components/layout/AccountNotificationsPanel.tsx
+++ b/apps/web/src/components/layout/AccountNotificationsPanel.tsx
@@ -1,9 +1,10 @@
 /**
  * Account settings — announcements & notifications inbox.
  * Content from admin-managed API; read state stays local.
+ * Each tab loads its own list via GET /notices?kind=…
  */
 
-import { useCallback, useEffect, useMemo, useState, type ReactNode, memo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { HiOutlineCheck, HiOutlineMegaphone } from 'react-icons/hi2';
 import { fetchNotices, type NoticeDto } from '@/apis/notices';
@@ -61,49 +62,53 @@ function AccountNotificationsPanel(): ReactNode {
   const { t, i18n } = useTranslation();
   const [tab, setTab] = useState<NoticeTab>('announcement');
   const [readIds, setReadIds] = useState<Set<string>>(() => loadReadIds());
-  const [itemsAll, setItemsAll] = useState<NoticeDto[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [itemsByTab, setItemsByTab] = useState<Record<NoticeTab, NoticeDto[]>>({
+    announcement: [],
+    notification: [],
+  });
+  const [loading, setLoading] = useState(false);
+  const [loadedTabs, setLoadedTabs] = useState<Partial<Record<NoticeTab, boolean>>>({});
+  const loadGenRef = useRef(0);
 
-  const load = useCallback(async () => {
+  const loadTab = useCallback(async (kind: NoticeTab) => {
+    const gen = ++loadGenRef.current;
     setLoading(true);
     try {
-      const res = await fetchNotices();
-      setItemsAll(res.items || []);
+      const res = await fetchNotices({ kind });
+      if (gen !== loadGenRef.current) return;
+      const list = (res.items || [])
+        .filter((n) => n.kind === kind)
+        .sort((a, b) => toMs(b.createdAt) - toMs(a.createdAt));
+      setItemsByTab((prev) => ({ ...prev, [kind]: list }));
+      setLoadedTabs((prev) => ({ ...prev, [kind]: true }));
     } catch {
-      setItemsAll([]);
+      if (gen !== loadGenRef.current) return;
+      setItemsByTab((prev) => ({ ...prev, [kind]: [] }));
+      setLoadedTabs((prev) => ({ ...prev, [kind]: true }));
     } finally {
-      setLoading(false);
+      if (gen === loadGenRef.current) setLoading(false);
     }
   }, []);
 
+  // Enter panel / switch tab → request that kind (no prefetch of the other tab).
   useEffect(() => {
-    void load();
-  }, [load]);
+    void loadTab(tab);
+  }, [loadTab, tab]);
 
-  const items = useMemo(
-    () =>
-      itemsAll
-        .filter((n) => n.kind === tab)
-        .sort((a, b) => toMs(b.createdAt) - toMs(a.createdAt)),
-    [itemsAll, tab]
-  );
+  const items = itemsByTab[tab];
 
   const unreadByTab = useMemo(() => {
-    let announcement = 0;
-    let notification = 0;
-    for (const n of itemsAll) {
-      if (readIds.has(n.id)) continue;
-      if (n.kind === 'announcement') announcement += 1;
-      else if (n.kind === 'notification') notification += 1;
-    }
-    return { announcement, notification };
-  }, [itemsAll, readIds]);
+    const count = (kind: NoticeTab) =>
+      itemsByTab[kind].reduce((n, item) => (readIds.has(item.id) ? n : n + 1), 0);
+    return {
+      announcement: count('announcement'),
+      notification: count('notification'),
+    };
+  }, [itemsByTab, readIds]);
 
   const markAllRead = () => {
     const next = new Set(readIds);
-    for (const n of itemsAll) {
-      if (n.kind === tab) next.add(n.id);
-    }
+    for (const n of itemsByTab[tab]) next.add(n.id);
     setReadIds(next);
     saveReadIds(next);
   };
@@ -123,13 +128,14 @@ function AccountNotificationsPanel(): ReactNode {
 
   const unreadInTab = unreadByTab[tab];
   const lang = i18n.resolvedLanguage || i18n.language || 'zh-CN';
+  const showLoading = loading && !loadedTabs[tab];
 
   return (
     <div className="flex min-h-[360px] flex-col">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <SegmentedControl
           value={tab}
-          onChange={setTab}
+          onChange={(next) => setTab(next as NoticeTab)}
           options={tabs.map((item) => ({
             value: item.id,
             label: item.label,
@@ -154,7 +160,7 @@ function AccountNotificationsPanel(): ReactNode {
       </div>
 
       <div className="mt-5 min-h-0 flex-1">
-        {loading ? (
+        {showLoading ? (
           <div className="flex h-[280px] items-center justify-center text-[13px] text-[var(--muted)]">
             {t('common.loading')}
           </div>

--- a/apps/web/src/components/layout/DesktopTitlebar.tsx
+++ b/apps/web/src/components/layout/DesktopTitlebar.tsx
@@ -94,7 +94,7 @@ function DesktopTitlebar() {
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     let cancelled = false;
-    void (async () => {
+    async function subscribeWindowResize() {
       const win = await getWin();
       if (!win || cancelled) return;
       const sync = async () => {
@@ -108,7 +108,8 @@ function DesktopTitlebar() {
       unlisten = await win.onResized(() => {
         void sync();
       });
-    })();
+    }
+    void subscribeWindowResize();
     return () => {
       cancelled = true;
       unlisten?.();

--- a/apps/web/src/components/layout/HomeBody.tsx
+++ b/apps/web/src/components/layout/HomeBody.tsx
@@ -15,8 +15,9 @@ import { LuUserRound } from 'react-icons/lu';
 import { Dropdown, Tooltip } from '@/components/base';
 import AppLogo from '@/components/base/AppLogo';
 import { Icon } from '@/components/base/icon';
-import { fetchProjects } from '@/apis/projects';
+import type { PaginatedProjects } from '@/apis/projects';
 import HomeHero from '@/components/home/HomeHero';
+import { request } from '@/utils/request';
 import InspirationSection from '@/components/home/InspirationSection';
 import MePage from '@/components/home/MePage';
 import RecentProjectsSection from '@/components/home/RecentProjectsSection';
@@ -189,6 +190,9 @@ function RailHelpMenu() {
   );
 }
 
+/** Side rail click → HomeTemplateList force-refetch (same file; avoid prop drilling). */
+let openProjectsListHandler: (() => void) | null = null;
+
 /** Side rail — logo, Add, nav icons; help (?) stays at the bottom. */
 function HomeSidebar({
   nav,
@@ -210,6 +214,11 @@ function HomeSidebar({
   const goNav = (id: 'home' | 'mine' | 'account' | 'skills') => {
     if ((id === 'mine' || id === 'account' || id === 'skills') && !authed) {
       navigate(buildLoginUrl('/home'));
+      return;
+    }
+    // Already on Projects — effect won't re-run; force list refresh on click.
+    if (id === 'mine' && nav === 'mine') {
+      openProjectsListHandler?.();
       return;
     }
     setNav(id);
@@ -341,7 +350,7 @@ function HomeTemplateList({
   const [projectsTotal, setProjectsTotal] = useState(0);
   const [projectsLoadingMore, setProjectsLoadingMore] = useState(false);
   const projectsFetchGen = useRef(0);
-  /** Skip re-fetch when toggling Home ↔ Projects; Me/Skills must not pull projects. */
+  /** Home「最近」：同一登录会话只自动 hydrate 一次；进 Projects 点侧栏会 force 再拉. */
   const projectsHydratedForUserRef = useRef<string | null>(null);
 
   /** Guest must not stay on Projects / Me — bounce home + open login. */
@@ -360,8 +369,57 @@ function HomeTemplateList({
   const showMine = nav === 'mine' && Boolean(authed);
   const showSkills = nav === 'skills' && Boolean(authed);
   const showHome = !showAccount && !showMine && !showSkills;
-  /** GET /projects — Home recent + Projects only (never Me / Skills / plaza). */
-  const needsProjectsList = showHome || showMine;
+
+  const loadProjectsFirstPage = useCallback(
+    async (opts?: { force?: boolean }) => {
+      if (!authed) return;
+      const hydrateKey = userId || 'authed';
+      // Home「最近」同一会话只拉一次；进 Projects / 侧栏点击 force 再拉。
+      if (!opts?.force && projectsHydratedForUserRef.current === hydrateKey) return;
+
+      const gen = ++projectsFetchGen.current;
+      const showSkeleton = !projectsHydratedForUserRef.current;
+      if (showSkeleton) setProjectsReady(false);
+      setProjectsLoadingMore(false);
+      try {
+        await flushCurrentProjectNow({ force: true });
+      } catch {
+        /* list anyway */
+      }
+      if (gen !== projectsFetchGen.current) return;
+      try {
+        const res = await request<PaginatedProjects>({
+          url: '/api/v1/projects',
+          method: 'get',
+          params: { page: 1, pageSize: PROJECT_PAGE_SIZE },
+        });
+        if (gen !== projectsFetchGen.current) return;
+        dispatch(hydrateRemoteProjects(res.projects || []));
+        setProjectsPage(1);
+        setProjectsHasMore(Boolean(res.hasMore));
+        setProjectsTotal(Number(res.total) || (res.projects || []).length);
+        projectsHydratedForUserRef.current = hydrateKey;
+      } catch {
+        if (gen === projectsFetchGen.current) {
+          dispatch(hydrateRemoteProjects([]));
+          setProjectsHasMore(false);
+          setProjectsTotal(0);
+        }
+      } finally {
+        if (gen === projectsFetchGen.current) setProjectsReady(true);
+      }
+    },
+    [authed, dispatch, userId]
+  );
+
+  useEffect(() => {
+    openProjectsListHandler = () => {
+      void loadProjectsFirstPage({ force: true });
+    };
+    return () => {
+      if (openProjectsListHandler) openProjectsListHandler = null;
+    };
+  }, [loadProjectsFirstPage]);
 
   useEffect(() => {
     if (!authed) {
@@ -374,46 +432,16 @@ function HomeTemplateList({
       setProjectsTotal(0);
       return;
     }
-    // Me / Skills: do not hit GET /projects.
-    if (!needsProjectsList) return;
-    const hydrateKey = userId || 'authed';
-    if (projectsHydratedForUserRef.current === hydrateKey) return;
+    // Home recent strip — first enter only (Me / Skills never hit GET /projects).
+    if (!showHome) return;
+    void loadProjectsFirstPage();
+  }, [authed, dispatch, loadProjectsFirstPage, showHome]);
 
-    let cancelled = false;
-    const gen = ++projectsFetchGen.current;
-    setProjectsReady(false);
-    setProjectsLoadingMore(false);
-    async function loadProjects() {
-      // Wait for editor leave-flush (doc + cover) so list thumbs are not one revision behind.
-      try {
-        await flushCurrentProjectNow({ force: true });
-      } catch {
-        /* list anyway */
-      }
-      if (cancelled || gen !== projectsFetchGen.current) return;
-      try {
-        const res = await fetchProjects({ page: 1, pageSize: PROJECT_PAGE_SIZE });
-        if (cancelled || gen !== projectsFetchGen.current) return;
-        dispatch(hydrateRemoteProjects(res.projects || []));
-        setProjectsPage(1);
-        setProjectsHasMore(Boolean(res.hasMore));
-        setProjectsTotal(Number(res.total) || (res.projects || []).length);
-        projectsHydratedForUserRef.current = hydrateKey;
-      } catch {
-        if (!cancelled && gen === projectsFetchGen.current) {
-          dispatch(hydrateRemoteProjects([]));
-          setProjectsHasMore(false);
-          setProjectsTotal(0);
-        }
-      } finally {
-        if (!cancelled && gen === projectsFetchGen.current) setProjectsReady(true);
-      }
-    }
-    void loadProjects();
-    return () => {
-      cancelled = true;
-    };
-  }, [authed, dispatch, needsProjectsList, userId]);
+  // View all / deep-link into Projects (sidebar click also calls openProjectsListHandler).
+  useEffect(() => {
+    if (!showMine || !authed) return;
+    void loadProjectsFirstPage({ force: true });
+  }, [authed, loadProjectsFirstPage, showMine]);
 
   const loadMoreProjects = useCallback(() => {
     if (!authed || !projectsHasMore || projectsLoadingMore || !projectsReady) return;
@@ -422,7 +450,11 @@ function HomeTemplateList({
     setProjectsLoadingMore(true);
     async function loadNextPage() {
       try {
-        const res = await fetchProjects({ page: nextPage, pageSize: PROJECT_PAGE_SIZE });
+        const res = await request<PaginatedProjects>({
+          url: '/api/v1/projects',
+          method: 'get',
+          params: { page: nextPage, pageSize: PROJECT_PAGE_SIZE },
+        });
         if (gen !== projectsFetchGen.current) return;
         dispatch(appendRemoteProjects(res.projects || []));
         setProjectsPage(nextPage);
@@ -516,7 +548,8 @@ function HomeTemplateList({
                     navigate(buildLoginUrl('/home'));
                     return;
                   }
-                  setNav('mine');
+                  if (nav === 'mine') openProjectsListHandler?.();
+                  else setNav('mine');
                 }}
               />
               {!isDesktopLocal() ? (

--- a/apps/web/src/components/layout/LoginDialog.tsx
+++ b/apps/web/src/components/layout/LoginDialog.tsx
@@ -578,7 +578,7 @@ function LoginDialog({ open, onClose, returnTo, onSuccess }: LoginDialogProps) {
             setShowCaptcha(false);
             setCaptchaResume(null);
             setBusy(true);
-            void (async () => {
+            async function retrySendCodeAfterCaptcha() {
               try {
                 await trySendCode(token);
               } catch (err: unknown) {
@@ -587,7 +587,8 @@ function LoginDialog({ open, onClose, returnTo, onSuccess }: LoginDialogProps) {
               } finally {
                 setBusy(false);
               }
-            })();
+            }
+            void retrySendCodeAfterCaptcha();
           }}
         />
       ) : null}

--- a/apps/web/src/components/layout/UserAccountPanel.tsx
+++ b/apps/web/src/components/layout/UserAccountPanel.tsx
@@ -406,13 +406,14 @@ function UserAccountPanel({ open, onOpenChange, children }: Props) {
     dispatch(clearWallet());
     dispatch(clearProjectsLibrary());
     clearSessionCaches();
-    void (async () => {
+    async function logoutRemoteSession() {
       try {
         await logoutRemote();
       } catch {
         /* ignore */
       }
-    })();
+    }
+    void logoutRemoteSession();
     message.success(t('home.loggedOut'));
     close();
     navigate('/home', { replace: true });

--- a/apps/web/src/components/rcb/scene/paint/exportImage.ts
+++ b/apps/web/src/components/rcb/scene/paint/exportImage.ts
@@ -828,13 +828,14 @@ export function exportFabricImage(options: ExportImageOptions = {}): boolean {
     if (options.selectionOnly && !(options.nodeIds || []).length) {
       return false;
     }
-    void (async () => {
+    async function runExportOnce() {
       try {
         await exportOnce(options);
       } catch (err) {
         console.error(err);
       }
-    })();
+    }
+    void runExportOnce();
     return true;
   } catch (err) {
     console.error(err);

--- a/apps/web/src/components/rcb/selection/HostPathChrome.tsx
+++ b/apps/web/src/components/rcb/selection/HostPathChrome.tsx
@@ -82,7 +82,7 @@ export type ShapeOutlineItem = {
   showRotate?: boolean;
   /** When false, handles/edges only. */
   showPath?: boolean;
-  /** Multi-select union AABB; mirrors `mirrorHostId` viewport. */
+  /** Multi-select union control box; mirrors `mirrorHostId` viewport. */
   unionChrome?: boolean;
   mirrorHostId?: string;
   cornerHandlesOnly?: boolean;
@@ -582,7 +582,7 @@ function syncHostSelHandles(
   }
 }
 
-/** Multi-select union AABB; twin member host viewport. */
+/** Multi-select union control box; twin member host viewport. */
 function syncHostSelUnionChrome(
   o: ShapeOutlineItem,
   stroke: number,
@@ -643,9 +643,14 @@ function syncHostSelUnionChrome(
     chrome.setAttribute('pointer-events', 'none');
     root.appendChild(chrome);
   }
-  // Scene-absolute union box — translate to union origin for local handle math.
-  chrome.setAttribute('transform', `translate(${o.box.left} ${o.box.top})`);
-  syncHostSelHandlesIfNeeded(chrome, { ...o, showRotate: false }, stroke, inv, '');
+  const angle = Number(o.angle) || 0;
+  chrome.setAttribute(
+    'transform',
+    Math.abs(angle) > 0.01
+      ? `translate(${o.box.left} ${o.box.top}) rotate(${angle} ${w / 2} ${h / 2})`
+      : `translate(${o.box.left} ${o.box.top})`
+  );
+  syncHostSelHandlesIfNeeded(chrome, o, stroke, inv, '');
   return mirrored;
 }
 

--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -41,7 +41,14 @@ import CornerRadiusHandlesOverlay from './chrome/CornerRadiusHandlesOverlay';
 import PolygonShapeHandlesOverlay from './chrome/PolygonShapeHandlesOverlay';
 import StarShapeHandlesOverlay from './chrome/StarShapeHandlesOverlay';
 import CircleShapeHandlesOverlay from './chrome/CircleShapeHandlesOverlay';
-import { resizeFromHandle, rotateBoxesAround, scaleBoxesToUnion, unionOfBoxes, type ResizeHandle } from './resizeGeometry';
+import {
+  resizeFromHandle,
+  rotateBoxesAround,
+  rotatedAabbBox,
+  scaleBoxesToOrientedUnion,
+  unionOfBoxes,
+  type ResizeHandle,
+} from './resizeGeometry';
 import {
   HEAVY_PATH_D_CHARS,
   pathStrokeHitsSceneBox,
@@ -465,6 +472,152 @@ function unionBoxes(boxes: SceneBox[]): SceneBox | null {
   return { left, top, width: Math.max(1, right - left), height: Math.max(1, bottom - top) };
 }
 
+type ChromeOrigin = { nodeId: string; box: SceneBox; angle?: number };
+
+function rotAroundOrigin(x: number, y: number, deg: number): { x: number; y: number } {
+  const rad = (deg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  return { x: x * cos - y * sin, y: x * sin + y * cos };
+}
+
+function memberAngle(document: any, o: ChromeOrigin): number {
+  if (o.angle != null && Number.isFinite(o.angle)) return Number(o.angle);
+  if (parseFrameSelId(o.nodeId)) return 0;
+  return readNodeAngle(document, o.nodeId);
+}
+
+/** Common member angle, or 0 when the selection is mixed. */
+function getSelectionSharedRotation(document: any, nodeIds: string[]): number {
+  let found = false;
+  let rotation = 0;
+  for (const id of nodeIds) {
+    if (parseFrameSelId(id)) continue;
+    const a = readNodeAngle(document, id);
+    if (!found) {
+      found = true;
+      rotation = a;
+    } else if (Math.abs(a - rotation) > 0.05) {
+      return 0;
+    }
+  }
+  return found ? rotation : 0;
+}
+
+function multiMembersKey(origins: Array<{ nodeId: string; box: SceneBox }>): string {
+  return origins
+    .map((o) => {
+      const b = o.box;
+      return `${o.nodeId}:${b.left.toFixed(1)}:${b.top.toFixed(1)}:${b.width.toFixed(1)}:${b.height.toFixed(1)}`;
+    })
+    .join('|');
+}
+
+/** Oriented control box when angles match; else page AABB of painted bounds. */
+function getSelectionRotatedUnion(
+  document: any,
+  origins: ChromeOrigin[],
+  sharedRotationDeg: number
+): SceneBox | null {
+  if (!origins.length) return null;
+  if (Math.abs(sharedRotationDeg) < 0.01) {
+    return unionBoxes(
+      origins.map((o) =>
+        parseFrameSelId(o.nodeId) ? o.box : rotatedAabbBox(o.box, memberAngle(document, o))
+      )
+    );
+  }
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  const rad = (-sharedRotationDeg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  for (const o of origins) {
+    const ang = memberAngle(document, o);
+    const { left, top, width, height } = o.box;
+    const cx = left + width / 2;
+    const cy = top + height / 2;
+    const ar = (ang * Math.PI) / 180;
+    const ac = Math.cos(ar);
+    const as = Math.sin(ar);
+    for (const [lx, ly] of [
+      [left, top],
+      [left + width, top],
+      [left + width, top + height],
+      [left, top + height],
+    ] as const) {
+      const dx = lx - cx;
+      const dy = ly - cy;
+      const px = Math.abs(ang) < 0.01 ? lx : cx + dx * ac - dy * as;
+      const py = Math.abs(ang) < 0.01 ? ly : cy + dx * as + dy * ac;
+      const ux = px * cos - py * sin;
+      const uy = px * sin + py * cos;
+      minX = Math.min(minX, ux);
+      minY = Math.min(minY, uy);
+      maxX = Math.max(maxX, ux);
+      maxY = Math.max(maxY, uy);
+    }
+  }
+  const w = Math.max(1, maxX - minX);
+  const h = Math.max(1, maxY - minY);
+  const centerPage = rotAroundOrigin(minX + w / 2, minY + h / 2, sharedRotationDeg);
+  return {
+    left: centerPage.x - w / 2,
+    top: centerPage.y - h / 2,
+    width: w,
+    height: h,
+  };
+}
+
+/** Prefer live tilted chrome; else derive from shared member angles. */
+function resolveControlChrome(
+  document: any,
+  origins: ChromeOrigin[],
+  liveUnion?: SceneBox | null,
+  liveAngle?: number
+): { box: SceneBox; angle: number } {
+  const fallback = unionBoxes(origins.map((o) => o.box)) || {
+    left: 0,
+    top: 0,
+    width: 1,
+    height: 1,
+  };
+  if (!origins.length) return { box: fallback, angle: 0 };
+  if (origins.length === 1) {
+    const id = origins[0].nodeId;
+    return {
+      box: { ...(liveUnion || origins[0].box) },
+      angle:
+        liveAngle ||
+        (parseFrameSelId(id) ? 0 : readNodeAngle(document, id)),
+    };
+  }
+  if (liveUnion && Math.abs(Number(liveAngle) || 0) > 0.01) {
+    return { box: { ...liveUnion }, angle: Number(liveAngle) };
+  }
+  const angle =
+    Number(liveAngle) ||
+    getSelectionSharedRotation(
+      document,
+      origins.map((o) => o.nodeId)
+    );
+  return {
+    box: getSelectionRotatedUnion(document, origins, angle) || fallback,
+    angle,
+  };
+}
+
+function patchesAsOrigins(
+  patches: Array<{ nodeId: string; left: number; top: number; width: number; height: number }>
+): ChromeOrigin[] {
+  return patches.map((pt) => ({
+    nodeId: pt.nodeId,
+    box: { left: pt.left, top: pt.top, width: pt.width, height: pt.height },
+  }));
+}
+
 /**
  * Line/arrow nodes use a tall hit AABB (`STROKE_HIT` ≈ 24). Docking the
  * floating toolbar to that box's top puts it half a hit-height above the shaft
@@ -730,11 +883,23 @@ function buildMoveOriginsForHit(opts: {
   selectedIds: string[];
   expandedHit: string[];
   liveOriginsNow: Array<{ nodeId: string; box: SceneBox }> | null | undefined;
+  /** Current control box — keep oriented multi chrome instead of local AABB union. */
+  liveUnionNow?: SceneBox | null;
+  liveAngleNow?: number;
   getNodeBox: (id: string) => SceneBox | null | undefined;
   fallbackPoint: { x: number; y: number };
 }): { origins: Array<{ nodeId: string; box: SceneBox }>; union: SceneBox } {
-  const { document, hitId, selectedIds, expandedHit, liveOriginsNow, getNodeBox, fallbackPoint } =
-    opts;
+  const {
+    document,
+    hitId,
+    selectedIds,
+    expandedHit,
+    liveOriginsNow,
+    liveUnionNow,
+    liveAngleNow,
+    getNodeBox,
+    fallbackPoint,
+  } = opts;
   const moveNodeIds = expandSelectionWithGroups(
     document,
     selectedIds.includes(hitId) ? selectedIds.filter((id) => !parseFrameSelId(id)) : expandedHit
@@ -752,13 +917,21 @@ function buildMoveOriginsForHit(opts: {
       .filter(Boolean),
     ...frameOrigins.map((o) => ({ nodeId: o.nodeId, box: { ...o.box } })),
   ] as Array<{ nodeId: string; box: SceneBox }>;
-  const union = unionOfBoxes(origins.map((o) => o.box)) || {
-    left: fallbackPoint.x,
-    top: fallbackPoint.y,
-    width: 1,
-    height: 1,
+  if (!origins.length) {
+    return {
+      origins,
+      union: {
+        left: fallbackPoint.x,
+        top: fallbackPoint.y,
+        width: 1,
+        height: 1,
+      },
+    };
+  }
+  return {
+    origins,
+    union: resolveControlChrome(document, origins, liveUnionNow, liveAngleNow).box,
   };
-  return { origins, union };
 }
 
 function filterMarqueeContentHits(document: any, rawHits: string[], frameHitSet: Set<string>) {
@@ -1186,10 +1359,38 @@ function isStrokeShapeType(t: string) {
   return t === 'line' || t === 'arrow';
 }
 
+/** Point inside an oriented control box (local AABB + angle about center). */
+function pointInOrientedBox(
+  p: { x: number; y: number },
+  box: SceneBox,
+  angleDeg: number
+): boolean {
+  if (Math.abs(angleDeg) < 0.01) {
+    return (
+      p.x >= box.left &&
+      p.x <= box.left + box.width &&
+      p.y >= box.top &&
+      p.y <= box.top + box.height
+    );
+  }
+  const cx = box.left + box.width / 2;
+  const cy = box.top + box.height / 2;
+  const rad = (-angleDeg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const dx = p.x - cx;
+  const dy = p.y - cy;
+  const lx = dx * cos - dy * sin;
+  const ly = dx * sin + dy * cos;
+  return Math.abs(lx) <= box.width / 2 && Math.abs(ly) <= box.height / 2;
+}
+
 /** Live angle while rotating / free-angle stroke resize; otherwise stored attrs. */
 function resolveChromeAngle(opts: {
   enabled: boolean;
   singleNode: boolean;
+  /** Multi-select: shared member angle (0 when angles differ). */
+  multiSelected: boolean;
   selectedNodeId: string | undefined;
   document: any;
   transforming: boolean;
@@ -1197,7 +1398,9 @@ function resolveChromeAngle(opts: {
   hasPathEndpoints: boolean;
   liveAngle: number;
 }): number {
-  if (!opts.enabled || !opts.singleNode || !opts.selectedNodeId) return 0;
+  if (!opts.enabled) return 0;
+  if (opts.multiSelected) return opts.liveAngle;
+  if (!opts.singleNode || !opts.selectedNodeId) return 0;
   const fromDoc = readNodeAngle(opts.document, opts.selectedNodeId);
   if (!opts.transforming) return fromDoc;
   if (opts.dragMode === 'rotate') return opts.liveAngle;
@@ -1326,6 +1529,9 @@ function buildShapeOutlines(opts: {
   selectedIsVideoGen: boolean;
   selectedIsLottieGen?: boolean;
   liveOrigins: Array<{ nodeId: string; box: SceneBox }> | null | undefined;
+  /** Oriented multi-select control box (session); falls back to member AABB union. */
+  multiUnionBox?: SceneBox | null;
+  multiUnionAngle?: number;
   getNodeBox: (id: string) => SceneBox | null;
 }): ShapeOutlineItem[] {
   if (!opts.enabled || opts.suppressChrome) return [];
@@ -1503,39 +1709,43 @@ function buildShapeOutlines(opts: {
     }
   }
 
-  // Multi path-only: union AABB + corner handles via host-mirrored chrome
+  // Multi path-only: oriented union box + corner handles via host-mirrored chrome
   // (same method as single — world SelectionChrome drifts at high zoom).
   const multiPathOnly =
     !opts.inspectDev &&
     !opts.readOnly &&
-    !opts.transforming &&
     opts.selectedFrameIds.length === 0 &&
     opts.selectedNodeIds.length > 1 &&
     opts.selectedNodeIds.every((id) => nodeUsesPathChrome(opts.document?.deltaSetLike?.[id]));
   if (multiPathOnly) {
-    const memberBoxes: SceneBox[] = [];
-    for (const id of opts.selectedNodeIds) {
-      const node = opts.document?.deltaSetLike?.[id];
-      const live = liveShapeGeomBox(id);
-      const fallback = opts.getNodeBox(id);
-      const geom =
-        live || (fallback ? deflateSelectionBox(fallback, node) : null);
-      if (geom) memberBoxes.push(inflateSelectionBox(geom, node));
+    let union = opts.multiUnionBox || null;
+    if (!union) {
+      const memberBoxes: SceneBox[] = [];
+      for (const id of opts.selectedNodeIds) {
+        const node = opts.document?.deltaSetLike?.[id];
+        const live = liveShapeGeomBox(id);
+        const fallback = opts.getNodeBox(id);
+        const geom =
+          live || (fallback ? deflateSelectionBox(fallback, node) : null);
+        if (geom) memberBoxes.push(inflateSelectionBox(geom, node));
+      }
+      union = unionBoxes(memberBoxes);
     }
-    const union = unionBoxes(memberBoxes);
     if (union) {
       out.push({
         id: '__rcb_sel_union__',
         mirrorHostId: opts.selectedNodeIds[0],
         pathD: '',
         box: union,
-        angle: 0,
+        angle: Number(opts.multiUnionAngle) || 0,
         color: '#3388ff',
+        // Keep the control box mounted while rotating (handles-key draws the stroke).
         withHandles: true,
         showPath: false,
         unionChrome: true,
         cornerHandlesOnly: true,
-        showRotate: false,
+        // Same multi-rotate as world chrome (orbit about union center).
+        showRotate: !opts.transforming,
       });
     }
   }
@@ -1562,9 +1772,19 @@ function resolveChromeUnion(opts: {
   selectedNodeIds: string[];
   selectedFrameIds: string[];
   document: any;
+  /** Multi session group angle — keep oriented liveUnion, do not swap in AABB. */
+  multiGroupAngle?: number;
 }): SceneBox | null {
-  const base = opts.transforming ? opts.liveUnion : opts.selectionUnion;
-  if (!base || opts.transforming) return base;
+  // Oriented multi control box (or any in-flight transform) uses liveUnion as-is.
+  if (opts.transforming) return opts.liveUnion;
+  if (
+    opts.selectedNodeIds.length > 1 &&
+    Math.abs(Number(opts.multiGroupAngle) || 0) > 0.01
+  ) {
+    return opts.liveUnion || opts.selectionUnion;
+  }
+  const base = opts.selectionUnion;
+  if (!base) return opts.liveUnion;
   // Prefer live host → path chrome (single + multi) so the box tracks remounts.
   if (opts.selectedFrameIds.length === 0 && opts.selectedNodeIds.length >= 1) {
     const lives: SceneBox[] = [];
@@ -1574,7 +1794,8 @@ function resolveChromeUnion(opts: {
       lives.push(inflateSelectionBox(live, opts.document?.deltaSetLike?.[id]));
     }
     if (lives.length === opts.selectedNodeIds.length) {
-      const liveUnion = opts.selectedNodeIds.length === 1 ? lives[0] : unionBoxes(lives);
+      const liveUnion =
+        opts.selectedNodeIds.length === 1 ? lives[0] : unionBoxes(lives);
       if (
         liveUnion &&
         Math.abs(liveUnion.left - base.left) < 2 &&
@@ -1688,6 +1909,28 @@ function SelectionFeature({
   const liveUnionRef = useRef<SceneBox | null>(null);
   const liveOriginsRef = useRef<Array<{ nodeId: string; box: SceneBox }> | null>(null);
   const liveAngleRef = useRef(0);
+  /** Held multi control pose until doc shared-angle catches up or members move (undo). */
+  const multiChromeRef = useRef<{
+    selKey: string;
+    box: SceneBox;
+    angle: number;
+    membersKey: string;
+  } | null>(null);
+  const idsKeyRef = useRef('');
+  const frameIdsKeyRef = useRef('');
+  const holdMultiChrome = (
+    box: SceneBox,
+    angle: number,
+    origins: Array<{ nodeId: string; box: SceneBox }>
+  ) => {
+    if (origins.length < 2 || Math.abs(angle) < 0.01) return;
+    multiChromeRef.current = {
+      selKey: `${idsKeyRef.current}#${frameIdsKeyRef.current}`,
+      box: { ...box },
+      angle,
+      membersKey: multiMembersKey(origins),
+    };
+  };
   /** Soft-click double-tap on text (counted on pointerup; native dblclick is the primary path). */
   const lastTextClickRef = useRef<{ id: string; at: number } | null>(null);
   const lastNodeTapRef = useRef<{ id: string; t: number; x: number; y: number } | null>(null);
@@ -1768,6 +2011,8 @@ function SelectionFeature({
 
   const idsKey = selectedNodeIds.join('|');
   const frameIdsKey = selectedFrameIds.join('|');
+  idsKeyRef.current = idsKey;
+  frameIdsKeyRef.current = frameIdsKey;
   /** Bust chrome memo when stroke band attrs change (align / width). */
   const strokeChromeKey = selectedNodeIds
     .map((id) => {
@@ -1823,24 +2068,78 @@ function SelectionFeature({
     return [...nodeOrigins, ...frameOrigins];
   }, [document, idsKey, frameIdsKey, getNodeBox, strokeChromeKey]);
 
-  /** Same-render selection bounds — avoids one-frame chrome flash when switching. */
-  const selectionUnion = useMemo(
-    () => unionBoxes(baseOrigins.map((o) => o.box)),
-    [baseOrigins]
-  );
+  const selectionSharedRotation = useMemo(() => {
+    if (selectedNodeIds.length <= 1) return 0;
+    return getSelectionSharedRotation(document, selectedNodeIds);
+  }, [document, selectedNodeIds]);
+
+  const selectionUnion = useMemo(() => {
+    if (!baseOrigins.length) return null;
+    return resolveControlChrome(
+      document,
+      baseOrigins,
+      null,
+      baseOrigins.length > 1 ? selectionSharedRotation : undefined
+    ).box;
+  }, [baseOrigins, document, selectionSharedRotation]);
 
   useEffect(() => {
     if (dragRef.current) return;
-    setLiveUnion(selectionUnion);
     setLiveOrigins(baseOrigins);
     const onlyNodeId =
       !frameIdsKey && idsKey && !idsKey.includes('|') ? idsKey : null;
     if (onlyNodeId) {
+      multiChromeRef.current = null;
+      setLiveUnion(selectionUnion);
       setLiveAngle(readNodeAngle(document, onlyNodeId));
-    } else {
-      setLiveAngle(0);
+      return;
     }
-  }, [baseOrigins, document, idsKey, frameIdsKey, selectionUnion]);
+    if (!selectionUnion || !idsKey) {
+      multiChromeRef.current = null;
+      setLiveUnion(selectionUnion);
+      setLiveAngle(0);
+      return;
+    }
+    const selKey = `${idsKey}#${frameIdsKey}`;
+    const membersKey = multiMembersKey(baseOrigins);
+    const shared = selectionSharedRotation;
+    if (Math.abs(shared) > 0.01) {
+      multiChromeRef.current = {
+        selKey,
+        box: { ...selectionUnion },
+        angle: shared,
+        membersKey,
+      };
+      setLiveUnion(selectionUnion);
+      setLiveAngle(shared);
+      return;
+    }
+    const prev = multiChromeRef.current;
+    if (
+      prev?.selKey === selKey &&
+      Math.abs(prev.angle) > 0.01 &&
+      prev.membersKey === membersKey
+    ) {
+      setLiveUnion(prev.box);
+      setLiveAngle(prev.angle);
+      return;
+    }
+    multiChromeRef.current = {
+      selKey,
+      box: { ...selectionUnion },
+      angle: 0,
+      membersKey,
+    };
+    setLiveUnion(selectionUnion);
+    setLiveAngle(0);
+  }, [
+    baseOrigins,
+    document,
+    idsKey,
+    frameIdsKey,
+    selectionUnion,
+    selectionSharedRotation,
+  ]);
 
   // Inspect: keep prior selection as pair target when clicking another element.
   useEffect(() => {
@@ -2074,15 +2373,16 @@ function SelectionFeature({
         if (readOnly || lockedSelection) return;
         e.preventDefault();
         e.stopPropagation();
+        const { box: union, angle: angle0 } = resolveControlChrome(
+          sceneDoc,
+          liveOriginsNow,
+          liveUnionNow,
+          liveAngleNow
+        );
         const center = {
-          x: liveUnionNow.left + liveUnionNow.width / 2,
-          y: liveUnionNow.top + liveUnionNow.height / 2,
+          x: union.left + union.width / 2,
+          y: union.top + union.height / 2,
         };
-        const angle0 =
-          liveAngleNow ||
-          (liveOriginsNow.length === 1
-            ? readNodeAngle(sceneDoc, liveOriginsNow[0].nodeId)
-            : 0);
         const pointerAngle0 = (Math.atan2(p.y - center.y, p.x - center.x) * 180) / Math.PI;
         dragRef.current = seed('rotate', e, p, {
           origins: liveOriginsNow.map((o) => ({
@@ -2090,11 +2390,13 @@ function SelectionFeature({
             box: { ...o.box },
             angle0: readNodeAngle(sceneDoc, o.nodeId),
           })),
-          union: { ...liveUnionNow },
+          union: { ...union },
           angle0,
           center,
           pointerAngle0,
         });
+        setLiveUnion(union);
+        setLiveAngle(angle0);
         setTransformingNotify(true);
         capture(e.pointerId);
         return;
@@ -2111,10 +2413,12 @@ function SelectionFeature({
         const singleId = liveOriginsNow.length === 1 ? liveOriginsNow[0].nodeId : '';
         const singleNode = singleId ? sceneDoc?.deltaSetLike?.[singleId] : null;
         const shapeType = singleNode ? String(singleNode.attrs?.shapeType || '') : '';
-        const angle0 =
-          liveOriginsNow.length === 1 && !parseFrameSelId(liveOriginsNow[0].nodeId)
-            ? liveAngleNow || readNodeAngle(sceneDoc, liveOriginsNow[0].nodeId)
-            : 0;
+        const { box: union, angle: shared } = resolveControlChrome(
+          sceneDoc,
+          liveOriginsNow,
+          liveUnionNow,
+          liveAngleNow
+        );
         let pathEpLocal0: [number, number] | undefined;
         let pathEpLocal1: [number, number] | undefined;
         // Open stroke tips: record path-local ends so resize tracks the grabbed tip.
@@ -2133,14 +2437,15 @@ function SelectionFeature({
         }
         dragRef.current = seed('resize', e, p, {
           origins: liveOriginsNow.map((o) => ({ nodeId: o.nodeId, box: { ...o.box } })),
-          union: { ...liveUnionNow },
+          union: { ...union },
           handle,
-          // Multi-select union is axis-aligned; single keeps node angle for local resize.
-          angle0,
-          aspectRatio: liveUnionNow.width / Math.max(1, liveUnionNow.height),
+          angle0: shared,
+          aspectRatio: union.width / Math.max(1, union.height),
           pathEpLocal0,
           pathEpLocal1,
         });
+        setLiveUnion(union);
+        setLiveAngle(shared);
         setTransformingNotify(true);
         capture(e.pointerId);
         return;
@@ -2164,11 +2469,7 @@ function SelectionFeature({
       };
 
       const pointInLiveUnion =
-        liveUnionNow &&
-        p.x >= liveUnionNow.left &&
-        p.x <= liveUnionNow.left + liveUnionNow.width &&
-        p.y >= liveUnionNow.top &&
-        p.y <= liveUnionNow.top + liveUnionNow.height;
+        liveUnionNow && pointInOrientedBox(p, liveUnionNow, liveAngleNow || 0);
       const selectionHasFrame = Boolean(
         liveOriginsNow?.some((o) => parseFrameSelId(o.nodeId))
       );
@@ -2275,6 +2576,8 @@ function SelectionFeature({
           selectedIds,
           expandedHit,
           liveOriginsNow,
+          liveUnionNow,
+          liveAngleNow,
           getNodeBox,
           fallbackPoint: p,
         });
@@ -2292,6 +2595,14 @@ function SelectionFeature({
         // Keep chrome rotation in sync ??transforming flips chromeAngle onto liveAngle.
         if (origins.length === 1 && !parseFrameSelId(origins[0].nodeId)) {
           setLiveAngle(readNodeAngle(sceneDoc, origins[0].nodeId));
+        } else if (origins.length > 1) {
+          const shared =
+            liveAngleNow ||
+            getSelectionSharedRotation(
+              sceneDoc,
+              origins.map((o) => o.nodeId)
+            );
+          setLiveAngle(shared);
         }
         // Locked layers stay selectable but cannot start a drag.
         if (isSelectionOriginsLocked(sceneDoc, origins)) {
@@ -2397,9 +2708,9 @@ function SelectionFeature({
           box: moved[i],
           angle0: o.angle0,
         }));
-        const nextUnion = unionOfBoxes(moved) || drag.union;
+        // Keep oriented control box (do not expand to AABB of orbited members).
         setLiveOrigins(nextOrigins.map((o) => ({ nodeId: o.nodeId, box: o.box })));
-        setLiveUnion(nextUnion);
+        setLiveUnion(drag.union);
         onGeometryPreview?.(
           nextOrigins.map((o) => ({
             nodeId: o.nodeId,
@@ -2523,10 +2834,11 @@ function SelectionFeature({
           );
           return;
         }
-        const scaled = scaleBoxesToUnion(
+        const scaled = scaleBoxesToOrientedUnion(
           drag.origins.map((o) => o.box),
           drag.union,
-          next
+          next,
+          drag.angle0 || 0
         );
         const nextOrigins = drag.origins.map((o, i) => ({
           nodeId: o.nodeId,
@@ -2705,18 +3017,18 @@ function SelectionFeature({
           width: moved[i].width,
           height: moved[i].height,
         }));
-        const nextUnion = unionOfBoxes(moved) || drag.union;
-        setLiveUnion(nextUnion);
-        setLiveOrigins(patches.map((pt) => ({ nodeId: pt.nodeId, box: pt })));
+        const origins = patchesAsOrigins(patches);
+        setLiveUnion(drag.union);
+        setLiveAngle(next);
+        setLiveOrigins(origins);
+        holdMultiChrome(drag.union, next, origins);
         if (Math.abs(delta) > 0.01) {
-          // One history entry for the whole multi-rotate (geometry + angles).
-          onGeometryCommit(patches);
+          // Angles first so geometry commit's document snapshot already carries them.
           drag.origins.forEach((o) => {
             onAngleCommit?.(o.nodeId, Number(o.angle0 || 0) + delta, { skipHistory: true });
           });
+          onGeometryCommit(patches);
         }
-        // Multi chrome is axis-aligned; reset visual group angle after commit.
-        setLiveAngle(0);
         endTransform();
         return;
       }
@@ -2767,8 +3079,10 @@ function SelectionFeature({
           width: o.box.width,
           height: o.box.height,
         }));
+        const origins = patchesAsOrigins(patches);
         setLiveUnion(nextUnion);
-        setLiveOrigins(patches.map((pt) => ({ nodeId: pt.nodeId, box: pt })));
+        setLiveOrigins(origins);
+        holdMultiChrome(nextUnion, liveAngleRef.current, origins);
         if (Math.hypot(sdx, sdy) > 0.01) {
           lastTextClickRef.current = null;
           onGeometryCommit(patches);
@@ -2844,10 +3158,11 @@ function SelectionFeature({
           endTransform();
           return;
         }
-        const scaled = scaleBoxesToUnion(
+        const scaled = scaleBoxesToOrientedUnion(
           drag.origins.map((o) => o.box),
           drag.union,
-          next
+          next,
+          drag.angle0 || 0
         );
         const patches = drag.origins.map((o, i) => ({
           nodeId: o.nodeId,
@@ -2856,8 +3171,12 @@ function SelectionFeature({
           width: scaled[i].width,
           height: scaled[i].height,
         }));
+        const groupAngle = drag.angle0 || 0;
+        const origins = patchesAsOrigins(patches);
         setLiveUnion(next);
-        setLiveOrigins(patches.map((pt) => ({ nodeId: pt.nodeId, box: pt })));
+        setLiveAngle(groupAngle);
+        setLiveOrigins(origins);
+        holdMultiChrome(next, groupAngle, origins);
         onGeometryCommit(patches);
       }
       endTransform();
@@ -3023,6 +3342,7 @@ function SelectionFeature({
   const chromeAngle = resolveChromeAngle({
     enabled,
     singleNode,
+    multiSelected: !single,
     selectedNodeId: selectedNodeIds[0],
     document,
     transforming,
@@ -3086,6 +3406,8 @@ function SelectionFeature({
     selectedIsVideoGen,
     selectedIsLottieGen,
     liveOrigins,
+    multiUnionBox: !single ? liveUnion || selectionUnion : null,
+    multiUnionAngle: !single ? chromeAngle : 0,
     getNodeBox,
   });
 
@@ -3135,6 +3457,7 @@ function SelectionFeature({
     selectedNodeIds,
     selectedFrameIds,
     document,
+    multiGroupAngle: !single ? chromeAngle : 0,
   });
 
   /** Radius / ellipse knobs sit on path geom (host-local), not visual-outer chrome. */
@@ -3171,24 +3494,27 @@ function SelectionFeature({
         sizeBox={measureSizeBox}
       />
 
-      {/* World SelectionChrome when idle — path single/multi use host-mirrored chrome. */}
+      {/* World SelectionChrome — path single/multi use host-mirrored chrome instead.
+          Multi non-path keeps chrome while rotating so the control box can tilt. */}
       {chromeUnion &&
       !suppressChrome &&
       selectionCount > 0 &&
-      !transforming &&
-      !skipWorldSelectionChrome ? (
+      !skipWorldSelectionChrome &&
+      (!transforming || !single) ? (
         <SelectionChrome
           box={chromeUnion}
           angle={chromeAngle}
-          showHandles={!inspectDev && !readOnly && !selectedIsMediaGen}
+          showHandles={!inspectDev && !readOnly && !selectedIsMediaGen && !transforming}
           cornerHandlesOnly={!single}
           variant={lineChrome ? 'line' : 'box'}
           showRotate={
             !inspectDev &&
             !readOnly &&
             !lineChrome &&
-            singleNode &&
-            !selectedIsMediaGen
+            !selectedIsMediaGen &&
+            !transforming &&
+            selectedNodeIds.length >= 1 &&
+            selectedFrameIds.length === 0
           }
           showBoxStroke={!lineChrome}
           interactiveBox={selectedFrameIds.length > 0}

--- a/apps/web/src/components/rcb/selection/resizeGeometry.ts
+++ b/apps/web/src/components/rcb/selection/resizeGeometry.ts
@@ -208,6 +208,91 @@ export function scaleBoxesToUnion(
   }));
 }
 
+/**
+ * Scale child boxes with `from`→`to` in the local frame of a rotated control box.
+ * When angle≈0, identical to {@link scaleBoxesToUnion}.
+ */
+export function scaleBoxesToOrientedUnion(
+  origins: SceneBox[],
+  from: SceneBox,
+  to: SceneBox,
+  angleDeg: number
+): SceneBox[] {
+  if (Math.abs(angleDeg) < 0.01) return scaleBoxesToUnion(origins, from, to);
+
+  const sx = to.width / Math.max(1e-4, from.width);
+  const sy = to.height / Math.max(1e-4, from.height);
+  const rad = (angleDeg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const ic = Math.cos(-rad);
+  const isn = Math.sin(-rad);
+  const fromCx = from.left + from.width / 2;
+  const fromCy = from.top + from.height / 2;
+  const toCx = to.left + to.width / 2;
+  const toCy = to.top + to.height / 2;
+
+  return origins.map((o) => {
+    const ocx = o.left + o.width / 2;
+    const ocy = o.top + o.height / 2;
+    const dx = ocx - fromCx;
+    const dy = ocy - fromCy;
+    const lx = dx * ic - dy * isn;
+    const ly = dx * isn + dy * ic;
+    const nlx = lx * sx;
+    const nly = ly * sy;
+    const nw = Math.max(1, o.width * sx);
+    const nh = Math.max(1, o.height * sy);
+    const nx = toCx + nlx * cos - nly * sin;
+    const ny = toCy + nlx * sin + nly * cos;
+    return {
+      left: nx - nw / 2,
+      top: ny - nh / 2,
+      width: nw,
+      height: nh,
+    };
+  });
+}
+
+/** Axis-aligned bounds of a box after rotating about its center. */
+export function rotatedAabbBox(box: SceneBox, angleDeg: number): SceneBox {
+  if (Math.abs(angleDeg) < 0.01) {
+    return { left: box.left, top: box.top, width: box.width, height: box.height };
+  }
+  const w = Math.max(1, box.width);
+  const h = Math.max(1, box.height);
+  const cx = box.left + w / 2;
+  const cy = box.top + h / 2;
+  const rad = (angleDeg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const [px, py] of [
+    [box.left, box.top],
+    [box.left + w, box.top],
+    [box.left + w, box.top + h],
+    [box.left, box.top + h],
+  ] as const) {
+    const dx = px - cx;
+    const dy = py - cy;
+    const rx = cx + dx * cos - dy * sin;
+    const ry = cy + dx * sin + dy * cos;
+    minX = Math.min(minX, rx);
+    minY = Math.min(minY, ry);
+    maxX = Math.max(maxX, rx);
+    maxY = Math.max(maxY, ry);
+  }
+  return {
+    left: minX,
+    top: minY,
+    width: Math.max(1, maxX - minX),
+    height: Math.max(1, maxY - minY),
+  };
+}
+
 /** Rotate box centers around a point; sizes unchanged. Returns new boxes. */
 export function rotateBoxesAround(
   origins: SceneBox[],

--- a/apps/web/src/components/templates/PlazaPublishDialog.tsx
+++ b/apps/web/src/components/templates/PlazaPublishDialog.tsx
@@ -5,19 +5,14 @@ import { Button, Dialog, message } from '@/components/base';
 import ProjectCoverCollage from '@/components/home/ProjectCoverCollage';
 import { checkPlazaCoverForPublish, coverDocumentHasContent } from '@/utils/plazaCover';
 import { normalizeProjectThumbnailUrls } from '@/utils/projectThumb';
-import { buildProjectCoverTiles, PREVIEW_PNG_MAX_EDGE } from '@/utils/renderProjectThumbnail';
 
-/** Publish modal preview — sharper than list-card 360px JPEG thumbs. */
-const PUBLISH_PREVIEW_TILE_EDGE = Math.max(960, Math.round(PREVIEW_PNG_MAX_EDGE / 2));
-
-/** `<img src>` cannot send Bearer — skip auth-only upload routes. */
 function canUseAsImgSrc(url: string): boolean {
   const raw = String(url || '').trim();
   if (!raw) return false;
   if (raw.startsWith('data:') || raw.startsWith('blob:')) return true;
+  if (raw.startsWith('/')) return true;
   try {
     const u = new URL(raw, typeof window !== 'undefined' ? window.location.origin : 'http://local');
-    if (u.pathname.startsWith('/api/v1/uploads/')) return false;
     return u.protocol === 'http:' || u.protocol === 'https:';
   } catch {
     return false;
@@ -75,53 +70,11 @@ function PlazaPublishForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId]);
 
-  // Same source as Share / homepage: prefer saved collage URLs.
-  // Only live-raster when nothing is stored yet (or regenerate failed to
-  // load). Live element crops of white frames look blank in a 2×2 grid.
+  // Prefer server cover URLs (from /covers). Fallback: live document collage.
   useEffect(() => {
-    let cancelled = false;
-
-    const run = async () => {
-      if (propUrls.length) {
-        if (!cancelled) {
-          setResolvedUrls(propUrls);
-          setResolvingCover(false);
-        }
-        return;
-      }
-      if (!document) {
-        if (!cancelled) {
-          setResolvedUrls([]);
-          setResolvingCover(false);
-        }
-        return;
-      }
-      if (!cancelled) setResolvingCover(true);
-      try {
-        const tiles = await buildProjectCoverTiles(document, {
-          maxEdge: PUBLISH_PREVIEW_TILE_EDGE,
-          fullBoardMaxEdge: PREVIEW_PNG_MAX_EDGE,
-          format: 'png',
-          compress: false,
-        });
-        if (cancelled) return;
-        const next = (tiles.dataUrls || tiles.urls || [])
-          .map((u) => String(u || '').trim())
-          .filter(Boolean)
-          .slice(0, 4);
-        setResolvedUrls(next);
-      } catch {
-        if (!cancelled) setResolvedUrls([]);
-      } finally {
-        if (!cancelled) setResolvingCover(false);
-      }
-    };
-
-    void run();
-    return () => {
-      cancelled = true;
-    };
-  }, [propUrls, document, projectId]);
+    setResolvedUrls(propUrls);
+    setResolvingCover(false);
+  }, [propUrls]);
 
   const goPhase = (next: 'confirm' | 'success') => {
     setPhase(next);
@@ -191,14 +144,13 @@ function PlazaPublishForm({
         <div className="aspect-[680/385] w-full overflow-hidden bg-[var(--canvas)]">
           {resolvingCover && !hasThumbCollage ? (
             <div className="h-full w-full animate-pulse bg-[var(--accent-soft)]" />
-          ) : hasThumbCollage ? (
+          ) : (
             <ProjectCoverCollage
               urls={resolvedUrls}
               version={coverVersion}
+              document={document}
               className="!h-full !rounded-none !border-0 !shadow-none"
             />
-          ) : (
-            <div className="h-full w-full bg-[var(--accent-soft)]" />
           )}
         </div>
       </div>

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -27,7 +27,7 @@ function detectLngFromUrl(): string | undefined {
   return DEFAULT_I18N_LANG;
 }
 
-void (async () => {
+async function initI18n() {
   await i18n
     .use(LanguageDetector)
     .use(initReactI18next)
@@ -52,7 +52,8 @@ void (async () => {
     document.documentElement.lang =
       i18n.resolvedLanguage || i18n.language || DEFAULT_I18N_LANG;
   }
-})();
+}
+void initI18n();
 
 i18n.on('languageChanged', (lng) => {
   if (typeof document !== 'undefined') {

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -880,6 +880,8 @@ const en = {
     shareMe: 'Me',
     shareRemoveCollaborator: 'Remove',
     shareUpdateFailed: 'Failed to update share settings',
+    shareCreateFailed: 'Failed to create share link',
+    shareOpenFailed: 'Failed to open shared file',
     shareQrSoon: 'QR code coming soon',
     shareLink: 'Share link',
     shareLinkPlaceholder: 'Generating…',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -859,6 +859,8 @@ const ja = {
     shareMe: '自分',
     shareRemoveCollaborator: '削除',
     shareUpdateFailed: '共有設定の更新に失敗しました',
+    shareCreateFailed: '共有リンクの作成に失敗しました',
+    shareOpenFailed: '共有ファイルを開けませんでした',
     shareQrSoon: 'QRコードは近日公開',
     shareLink: '共有リンク',
     shareLinkPlaceholder: '生成中…',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -873,6 +873,8 @@ const zhCN = {
     shareMe: '我',
     shareRemoveCollaborator: '移除',
     shareUpdateFailed: '更新分享设置失败',
+    shareCreateFailed: '创建分享链接失败',
+    shareOpenFailed: '打开分享文件失败',
     shareQrSoon: '二维码即将开放',
     shareLink: '分享链接',
     shareLinkPlaceholder: '生成中…',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -852,6 +852,8 @@ const zhTW = {
     shareMe: '我',
     shareRemoveCollaborator: '移除',
     shareUpdateFailed: '更新分享設定失敗',
+    shareCreateFailed: '建立分享連結失敗',
+    shareOpenFailed: '開啟分享檔案失敗',
     shareQrSoon: '二維碼即將開放',
     shareLink: '分享連結',
     shareLinkPlaceholder: '產生中…',

--- a/apps/web/src/pages/EditorPage.tsx
+++ b/apps/web/src/pages/EditorPage.tsx
@@ -381,7 +381,7 @@ async function hydrateShareTarget(
     dispatch(setWorkspaceMode('design'));
   } catch {
     if (isCancelled()) return;
-    message.error(t('editor.shareCopyFailed'));
+    message.error(t('editor.shareOpenFailed'));
     navigate(`/s/${encodeURIComponent(targetId)}`, { replace: true });
   }
 }
@@ -604,13 +604,14 @@ function EditorPage() {
     if (shareSaveTimer.current) window.clearTimeout(shareSaveTimer.current);
     const id = currentId;
     shareSaveTimer.current = window.setTimeout(() => {
-      void (async () => {
+      async function persistShareDocument() {
         try {
           await updateShareDocumentApi(id, document);
         } catch {
           /* ignore */
         }
-      })();
+      }
+      void persistShareDocument();
     }, 700);
     return () => {
       if (shareSaveTimer.current) window.clearTimeout(shareSaveTimer.current);

--- a/apps/web/src/theme/index.ts
+++ b/apps/web/src/theme/index.ts
@@ -27,14 +27,15 @@ function isTauriShell(): boolean {
 /** Match Windows/macOS title-bar chrome to the app theme (Tauri only). */
 function syncDesktopWindowTheme(resolved: 'light' | 'dark') {
   if (!isTauriShell()) return;
-  void (async () => {
+  async function applyTauriWindowTheme() {
     try {
       const { getCurrentWindow } = await import('@tauri-apps/api/window');
       await getCurrentWindow().setTheme(resolved);
     } catch {
       /* ignore */
     }
-  })();
+  }
+  void applyTauriWindowTheme();
 }
 
 /** Apply resolved theme via data-theme (CSS files own the tokens). */

--- a/apps/web/src/utils/chatImageDrag.ts
+++ b/apps/web/src/utils/chatImageDrag.ts
@@ -13,6 +13,8 @@ export type MediaAssetDragPayload = {
   prompt?: string | null;
   name?: string | null;
   duration?: number | null;
+  /** Inlined Bodymovin from list API — canvas drop must not refetch .json. */
+  animationData?: Record<string, unknown> | null;
 };
 
 /**
@@ -108,6 +110,8 @@ export function setMediaAssetDragData(
     prompt: payload.prompt || undefined,
     name: payload.name || undefined,
     duration: payload.duration || undefined,
+    // Keep in memory only — too large for DataTransfer JSON.
+    ...(payload.animationData ? { animationData: payload.animationData } : {}),
   };
 
   const slimSrc = slimDragSrc(pendingMediaAssetDrag);

--- a/apps/web/src/utils/goEditor.ts
+++ b/apps/web/src/utils/goEditor.ts
@@ -70,8 +70,15 @@ export function useGoEditor() {
           if (!opened) navigate(dest);
           return;
         }
-        const win = window.open(dest, '_blank', 'noopener,noreferrer');
-        if (!win) navigate(dest);
+        // Do not pass `noopener` to window.open — it makes the return value null in
+        // Chromium even when the tab opens, and we would wrongly navigate this window.
+        const win = window.open(dest, '_blank');
+        if (win) {
+          win.opener = null;
+          return;
+        }
+        // Popup blocked — fall back to same-tab navigation.
+        navigate(dest);
         return;
       }
       if (opts?.homeAgentBoot) saveHomeAgentBoot(opts.homeAgentBoot);

--- a/apps/web/src/utils/renderProjectThumbnail.ts
+++ b/apps/web/src/utils/renderProjectThumbnail.ts
@@ -1,6 +1,6 @@
 /**
- * Rasterize project covers for list cards / cloud sync.
- * Save path: up to 4 per-element snapshots (not full-page, not raw image src).
+ * Rasterize project covers for list cards / Publish / cloud sync.
+ * Up to 4 tiles: per-artboard or per-element snapshots — never raw node src.
  */
 
 import { inlineSvgImages, renderExport } from '@/components/rcb/scene/paint/exportImage';
@@ -62,8 +62,6 @@ function canvasToDataUrl(canvas: HTMLCanvasElement, format: 'webp' | 'png' | 'jp
 /** Build a full-board WebP for project list / publish preview (contain, not cropped). */
 export async function renderProjectThumbnail(document: unknown): Promise<string | null> {
   if (!document || typeof document !== 'object') return null;
-  // Content-fit the artboard so list/publish covers center the design, not empty margins.
-  // Empty boards still render (paper / frame background) so list covers stay in sync.
   const cover = extractPlazaCoverDocument(document, { contentFit: true }) || document;
   return renderDocumentThumbnail(cover, { allowEmpty: true });
 }
@@ -84,9 +82,10 @@ function nodeOverlapsFrame(node: Record<string, unknown>, frame: PlazaCoverFrame
   return ow * oh >= w * h * 0.12;
 }
 
-/** image → shape/svg → text → other (collage prefers visual tiles). */
+/** Media → shape/svg → text → other (collage prefers visual tiles). */
 function coverElementTypeRank(key: string): number {
-  if (key === 'image') return 0;
+  if (key === 'image' || key === 'video') return 0;
+  if (key === 'lottie' || key === 'audio') return 1;
   if (
     key === 'svg' ||
     key === 'path' ||
@@ -96,10 +95,26 @@ function coverElementTypeRank(key: string): number {
     key === 'circle' ||
     key === 'line'
   ) {
-    return 1;
+    return 2;
   }
-  if (key === 'text') return 2;
-  return 3;
+  if (key === 'text') return 3;
+  return 4;
+}
+
+/** Skip empty media plates (#E5E7EB placeholders) — they steal collage slots from real shapes. */
+function coverElementHasVisual(node: Record<string, unknown>): boolean {
+  const key = String(node.key || '');
+  const attrs =
+    node.attrs && typeof node.attrs === 'object'
+      ? (node.attrs as Record<string, unknown>)
+      : {};
+  if (key === 'image' || key === 'video' || key === 'lottie') {
+    const src = String(attrs.src || '').trim();
+    const poster = String(attrs.poster || '').trim();
+    return Boolean(src || poster);
+  }
+  if (key === 'audio') return Boolean(String(attrs.src || '').trim());
+  return true;
 }
 
 /**
@@ -119,6 +134,7 @@ export function pickCoverElementIds(document: unknown): string[] {
   nodes.forEach(({ id, node }, z) => {
     if (!id || !node || typeof node !== 'object') return;
     if (!isExportableSceneNode(node)) return;
+    if (!coverElementHasVisual(node)) return;
     if (frame && !nodeOverlapsFrame(node, frame)) return;
     const w = Math.max(1, num(node.width, 1));
     const h = Math.max(1, num(node.height, 1));
@@ -141,33 +157,87 @@ export function pickCoverElementIds(document: unknown): string[] {
   return ranked.slice(0, MAX_TILES).map((r) => r.id);
 }
 
+/**
+ * Mini document with one element on a white board — same finite-board path as list thumbs.
+ * Avoids infinite-canvas selection export (shapes often rasterized to empty/gray tiles).
+ */
+function extractElementCoverDocument(document: unknown, nodeId: string): unknown | null {
+  const dsl = (document as { deltaSetLike?: Record<string, unknown> })?.deltaSetLike;
+  const raw = dsl?.[nodeId];
+  if (!raw || typeof raw !== 'object') return null;
+  const node = raw as Record<string, unknown>;
+  if (!isExportableSceneNode(node) || !coverElementHasVisual(node)) return null;
+
+  const w = Math.max(1, num(node.width, 1));
+  const h = Math.max(1, num(node.height, 1));
+  const pad = Math.max(12, Math.round(Math.max(w, h) * 0.08));
+  const boardW = Math.max(32, Math.round(w + pad * 2));
+  const boardH = Math.max(32, Math.round(h + pad * 2));
+  const id = String(nodeId);
+
+  return {
+    width: boardW,
+    height: boardH,
+    backgroundColor: '#ffffff',
+    backgroundFillType: 'solid',
+    frames: [
+      {
+        id: 'element-cover',
+        x: 0,
+        y: 0,
+        width: boardW,
+        height: boardH,
+        backgroundColor: '#ffffff',
+      },
+    ],
+    deltaSetLike: {
+      ROOT: { id: 'ROOT', key: 'entry', children: [id] },
+      [id]: {
+        ...node,
+        id,
+        x: pad,
+        y: pad,
+        width: w,
+        height: h,
+      },
+    },
+  };
+}
+
 /** Rasterize one element (cropped to its bbox) for a collage tile. */
 async function rasterizeElementTile(
   document: unknown,
   nodeId: string,
   opts?: { maxEdge?: number; format?: 'webp' | 'png' | 'jpeg'; compress?: boolean }
 ): Promise<string | null> {
-  const dsl = (document as { deltaSetLike?: Record<string, unknown> })?.deltaSetLike;
-  const node = dsl?.[nodeId];
-  if (!node || typeof node !== 'object') return null;
-  const w = Math.max(1, num((node as Record<string, unknown>).width, 1));
-  const h = Math.max(1, num((node as Record<string, unknown>).height, 1));
+  const slice = extractElementCoverDocument(document, nodeId);
+  if (!slice) return null;
+
   const maxEdge = Math.max(64, Math.round(opts?.maxEdge || TILE_MAX_EDGE));
-  // Allow >1× so small scene boxes still fill the tile sharply on retina.
-  const multiplier = Math.max(0.25, Math.min(2, maxEdge / Math.max(w, h)));
-  const format = opts?.format || 'jpeg';
-  // renderExport only accepts png|jpeg|svg — map webp tiles to png.
-  const exportFormat = format === 'webp' ? 'png' : format;
-  const compress = opts?.compress ?? exportFormat === 'jpeg';
+  let format: 'webp' | 'png' | 'jpeg' = 'webp';
+  if (opts?.format === 'png' || opts?.format === 'jpeg') format = opts.format;
 
   try {
+    const viaThumb = await renderDocumentThumbnail(slice, {
+      allowEmpty: true,
+      format,
+      maxEdge,
+    });
+    if (viaThumb) return viaThumb;
+  } catch {
+    /* fall through to export */
+  }
+
+  // Fallback: selection export (images with remote src sometimes need inline pass).
+  try {
+    const exportFormat = format === 'webp' ? 'png' : format;
     const result = await renderExport({
-      document,
+      document: slice,
       selectionOnly: true,
       nodeIds: [nodeId],
-      multiplier,
+      multiplier: 1,
       format: exportFormat,
-      compress,
+      compress: opts?.compress ?? exportFormat === 'jpeg',
       backgroundColor: '#ffffff',
     });
     if (result?.kind === 'raster' && result.dataUrl) return result.dataUrl;
@@ -180,7 +250,7 @@ async function rasterizeElementTile(
 export type ProjectCoverTiles = {
   /** Already-hosted image URLs — rare passthrough. */
   urls?: string[];
-  /** Raster data URLs to upload as project thumbs (preferred). */
+  /** Raster data URLs to upload as project thumbs. */
   dataUrls?: string[];
 };
 
@@ -210,9 +280,7 @@ function resolveCoverTileRasterOpts(opts?: ProjectCoverTileOptions) {
 
 /**
  * Up to 4 cover tiles for list collage / Publish / cloud sync.
- * Prefer one snapshot per artboard when there are 2+ boards;
- * else per-element crops; else one full-board cover.
- * Tile rasters run in parallel so sync sends all four in one request.
+ * 2+ artboards → one snapshot each; else up to 4 per-element rasters; else full board.
  */
 export async function buildProjectCoverTiles(
   document: unknown,
@@ -220,9 +288,9 @@ export async function buildProjectCoverTiles(
 ): Promise<ProjectCoverTiles> {
   if (!document || typeof document !== 'object') return {};
 
-  const { format: thumbFormat, tileMax, fullMax } = resolveCoverTileRasterOpts(opts);
-
+  const { format: thumbFormat, tileMax } = resolveCoverTileRasterOpts(opts);
   const frames = listArtboardFrames(document).slice(0, MAX_TILES);
+
   if (frames.length >= 2) {
     const slices = frames
       .map((frame) => extractFrameDocument(document, frame, { contentFit: true }))
@@ -240,13 +308,14 @@ export async function buildProjectCoverTiles(
     if (dataUrls.length) return { dataUrls };
   }
 
+  // Single board: up to 4 element tiles (square / image / circle each as one cover).
   const ids = pickCoverElementIds(document);
   if (ids.length) {
     const rendered = await Promise.all(
       ids.map((id) =>
         rasterizeElementTile(document, id, {
-          maxEdge: opts?.maxEdge,
-          format: opts?.format,
+          maxEdge: opts?.maxEdge ?? tileMax,
+          format: opts?.format ?? thumbFormat,
           compress: opts?.compress,
         })
       )
@@ -322,8 +391,6 @@ export async function renderDocumentThumbnail(
       omitNonExportable: true,
     });
 
-    // Same as export: blob-URL SVG→canvas cannot load external <image> hrefs.
-    // Inline rasters (auth/COS-aware) before rasterizing the cover.
     const xml = new XMLSerializer().serializeToString(root);
     const inlined = await inlineSvgImages(xml, previewDoc, { failClosed: false });
     const blob = new Blob([inlined], { type: 'image/svg+xml;charset=utf-8' });

--- a/apps/web/src/utils/uploadImage.ts
+++ b/apps/web/src/utils/uploadImage.ts
@@ -162,14 +162,15 @@ export function waitForImageReady(
     opts?.signal?.addEventListener('abort', onAbort, { once: true });
     img.onload = () => {
       if (typeof img.decode === 'function') {
-        void (async () => {
+        async function decodeAndFinish() {
           try {
             await img.decode!();
           } catch {
             /* decode optional — still treat as loaded */
           }
           finish(true);
-        })();
+        }
+        void decodeAndFinish();
         return;
       }
       finish(true);
@@ -191,12 +192,9 @@ export function isOurStoredImageUrl(src: string): boolean {
   }
 }
 
-/** Local storage keys / auth download routes cannot be used as raw <img>/<video> src. */
-export function mediaSrcNeedsAuthFetch(src: string): boolean {
-  const s = String(src || '').trim();
-  if (!s || s.startsWith('data:') || s.startsWith('blob:')) return false;
-  if (isOurStoredImageUrl(s)) return true;
-  return /^(assets|uploads|projects|font-tasks)\//.test(s);
+/** Display whatever URL the API/item already gave — no rewrite. */
+export function toDisplayMediaUrl(src: string, _uploadKey?: string | null): string {
+  return String(src || '').trim();
 }
 
 export function resolveUploadObjectKey(src: string): string | null {


### PR DESCRIPTION
## Summary
- Generate project covers from document elements on the API instead of relying on client rasters
- Keep multi-select control boxes oriented with the group after rotate/move/resize, with shared chrome helpers
- Clean up related async/UI paths across home, editor panels, and asset flows

## Test plan
- [ ] Create/save a project with mixed shapes/images and confirm cover tiles appear on home
- [ ] Marquee multi-select, rotate the group — control box stays tilted after release
- [ ] Move the tilted multi-selection — control box shape/angle does not reset to AABB
- [ ] Undo after group rotate — chrome updates correctly
- [ ] Mixed-angle multi-select still uses upright AABB chrome
