### PR TITLE
Move GitHub Star CTA above Canvas in README

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -30,6 +30,12 @@ Docker Compose で数分でセルフホストできます（既定は **MySQL** 
 
 ---
 
+## GitHub で ⭐ Star を
+
+オープンソースは時間がかかります。Recombyn が役に立ったら、右上の **⭐ Star** をお願いします。
+
+→ [https://github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)
+
 ## キャンバス
 
 自作 **RCB**（Resume Canvas）無限キャンバス：`SceneDocument` + CSS カメラ（約 5%–10000%）。確定図元は **ノード単位 SVG host**、**Path2D** はヒットテスト / 選択オーバーレイ用。ビューポート cull + **LOD**（遠景 AABB プロキシ）で大きなドキュメントも編集可能。
@@ -180,9 +186,3 @@ e2e/               Playwright
 - Issue / PR テンプレートは `.github/`
 
 公式: [recombyn.com](https://recombyn.com) · Docs: [recombyn.github.io/recombyn](https://recombyn.github.io/recombyn/) · Source: [github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)
-
-## GitHub で ⭐ Star を
-
-オープンソースは時間がかかります。Recombyn が役に立ったら、右上の **⭐ Star** をお願いします。
-
-→ [https://github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Self-host in minutes with Docker Compose (default **MySQL** + Redis + web + API 
 
 ---
 
+## Star us on GitHub ⭐
+
+Open source takes time. If Recombyn helps your work, please hit **⭐ Star** in the top-right of the GitHub repo — your support is the best fuel for making it better.
+
+→ [https://github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)
+
 ## Canvas
 
 Custom **RCB** (Resume Canvas) infinite editor: `SceneDocument` + CSS camera (~5%–10000%). Committed nodes paint as **per-node SVG hosts**; **Path2D** powers hit-testing and selection/tool overlays. Viewport cull + **LOD** (far AABB proxies; capped full hosts on screen) keeps large docs editable.
@@ -194,9 +200,3 @@ User-facing help **source** is private; CI publishes only the built static site 
 - **Security** — report privately per [SECURITY.md](SECURITY.md)
 
 Official: [recombyn.com](https://recombyn.com) · Docs: [recombyn.github.io/recombyn](https://recombyn.github.io/recombyn/) · Source: [github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)
-
-## Star us on GitHub ⭐
-
-Open source takes time. If Recombyn helps your work, please hit **⭐ Star** in the top-right of the GitHub repo — your support is the best fuel for making it better.
-
-→ [https://github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,6 +29,12 @@
 
 ---
 
+## 帮忙点个 ⭐ Star
+
+开源不易，如果觉得 Recombyn 对您的工作还有帮助，请帮忙在 GitHub 仓库右上角点个 ⭐ Star。您的支持是让 Recombyn 变得更好最大的动力。
+
+→ [https://github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)
+
 ## 画布
 
 自研 **RCB**（Resume Canvas）无限画布：`SceneDocument` 场景图 + CSS 相机（约 5%–10000%）；已提交图元以 **逐节点 SVG host** 绘制，**Path2D** 负责命中检测与选区/工具叠加；视口裁剪 + **LOD**（远景 AABB 代理，同屏全量 host 有上限），大文档仍可编辑。
@@ -182,9 +188,3 @@ e2e/               Playwright
 - [贡献](CONTRIBUTING.md) · [安全](SECURITY.md) · [行为准则](CODE_OF_CONDUCT.md)
 - Issue / PR 模板见 `.github/`
 官网：[recombyn.com](https://recombyn.com) · 文档：[recombyn.github.io/recombyn](https://recombyn.github.io/recombyn/) · 源码：[github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)
-
-## 帮忙点个 ⭐ Star
-
-开源不易，如果觉得 Recombyn 对您的工作还有帮助，请帮忙在 GitHub 仓库右上角点个 ⭐ Star。您的支持是让 Recombyn 变得更好最大的动力。
-
-→ [https://github.com/recombyn/recombyn](https://github.com/recombyn/recombyn)


### PR DESCRIPTION
## Summary
- Move Star CTA above the Canvas section in en / zh-CN / ja READMEs.
- Commit has no Cursor Co-authored-by trailer.

## Test plan
- [ ] GitHub README shows Star block before Canvas


Made with [Cursor](https://cursor.com)