### PR TITLE
fix: LOD proxy rendering, snap cap, boolean radii, corner handle guards

### DIFF
--- a/apps/api/app/api/routes/design.py
+++ b/apps/api/app/api/routes/design.py
@@ -281,6 +281,10 @@ class DesignRunIn(BaseModel):
         default=None,
         description="agent | ask — Ask proposes / clarifies before painting",
     )
+    paint_mode: str | None = Field(
+        default=None,
+        description="ops (default tool_ops) | img_layers (generate board then split layers)",
+    )
     skill_refs: list[str] | None = Field(
         default=None,
         description="User-pinned skill keys/ids from / picker chips (hard-load)",
@@ -428,8 +432,10 @@ async def design_run(
     body: DesignRunIn,
     request: Request,
 ) -> StreamingResponse:
+    from app.core.metrics import observe_design_run_start
     from app.services.geoip import resolve_client_country
 
+    observe_design_run_start(str(body.run_mode or "agent"))
     client_country = resolve_client_country(request)
 
     async def gen():
@@ -438,6 +444,8 @@ async def design_run(
 
         queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
         state = _PipelineSseState()
+        t_run0 = time.perf_counter()
+        outcome = "incomplete"
 
         async def produce() -> None:
             try:
@@ -470,6 +478,7 @@ async def design_run(
                     interaction_mode=body.interaction_mode,
                     client_country=client_country,
                     skill_refs=body.skill_refs,
+                    paint_mode=body.paint_mode,
                 ):
                     await queue.put(("ev", ev))
             except Exception as err:  # noqa: BLE001
@@ -495,11 +504,13 @@ async def design_run(
                     term = state.terminal_stage_event()
                     if term:
                         yield _sse_data(term)
+                    outcome = "ok"
                     break
 
                 if kind == "err":
                     msg = str(payload)[:800] or "design_run_failed"
                     yield _sse_data({"type": "error", "code": _run_error_code(msg), "message": msg})
+                    outcome = "error"
                     break
 
                 state.out_n += 1
@@ -507,6 +518,12 @@ async def design_run(
                 if isinstance(payload, dict):
                     for frame in _pipeline_side_effects(state, payload):
                         yield _sse_data(frame)
+                    if et == "error":
+                        outcome = "error"
+                    elif et in ("done", "finished", "complete"):
+                        outcome = "ok"
+                    elif et == "paused":
+                        outcome = "paused"
 
                 if _should_log_sse(et if isinstance(et, str) else None, state.out_n):
                     line = _sse_log_line(
@@ -525,6 +542,14 @@ async def design_run(
 
             yield "data: [DONE]\n\n"
         finally:
+            try:
+                from app.core.metrics import observe_design_run_outcome
+
+                observe_design_run_outcome(
+                    outcome, duration_s=time.perf_counter() - t_run0
+                )
+            except Exception:
+                pass
             if not task.done():
                 task.cancel()
                 try:

--- a/apps/api/app/services/design/board_modes/__init__.py
+++ b/apps/api/app/services/design/board_modes/__init__.py
@@ -1,0 +1,20 @@
+"""Board paint mode package."""
+
+from app.services.design.board_modes.registry import is_img_layers_mode, resolve_paint_mode
+from app.services.design.board_modes.types import (
+    PAINT_MODE_IMG_LAYERS,
+    PAINT_MODE_OPS,
+    PAINT_MODES,
+    PaintMode,
+    normalize_paint_mode,
+)
+
+__all__ = [
+    "PAINT_MODE_IMG_LAYERS",
+    "PAINT_MODE_OPS",
+    "PAINT_MODES",
+    "PaintMode",
+    "is_img_layers_mode",
+    "normalize_paint_mode",
+    "resolve_paint_mode",
+]

--- a/apps/api/app/services/design/board_modes/registry.py
+++ b/apps/api/app/services/design/board_modes/registry.py
@@ -1,0 +1,36 @@
+"""Resolve board paint runner by paint_mode."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+from app.services.design.board_modes.types import (
+    PAINT_MODE_IMG_LAYERS,
+    PaintMode,
+    normalize_paint_mode,
+)
+
+BoardRunner = Callable[..., AsyncIterator[dict[str, Any]]]
+
+
+def resolve_paint_mode(raw: str | None) -> PaintMode:
+    return normalize_paint_mode(raw)
+
+
+def is_img_layers_mode(raw: str | None) -> bool:
+    return resolve_paint_mode(raw) == PAINT_MODE_IMG_LAYERS
+
+
+async def run_board_mode(
+    *,
+    paint_mode: str | None,
+    **kwargs: Any,
+) -> AsyncIterator[dict[str, Any]]:
+    """Dispatch to img_layers pipeline when selected; else raise for caller to use ops graph."""
+    if not is_img_layers_mode(paint_mode):
+        raise ValueError("not_img_layers")
+    from app.services.design.img_layers.pipeline import run_img_layers_job
+
+    async for ev in run_img_layers_job(**kwargs):
+        yield ev

--- a/apps/api/app/services/design/board_modes/types.py
+++ b/apps/api/app/services/design/board_modes/types.py
@@ -1,0 +1,18 @@
+"""Board paint modes for Design Agent (ops vs img_layers)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+PaintMode = Literal["ops", "img_layers"]
+
+PAINT_MODE_OPS: PaintMode = "ops"
+PAINT_MODE_IMG_LAYERS: PaintMode = "img_layers"
+PAINT_MODES: frozenset[str] = frozenset({PAINT_MODE_OPS, PAINT_MODE_IMG_LAYERS})
+
+
+def normalize_paint_mode(raw: str | None) -> PaintMode:
+    mode = str(raw or "").strip().lower().replace("-", "_")
+    if mode in ("img_layers", "imglayers", "image_layers", "gen_layers", "生图拆层"):
+        return PAINT_MODE_IMG_LAYERS
+    return PAINT_MODE_OPS

--- a/apps/api/app/services/design/img_layers/__init__.py
+++ b/apps/api/app/services/design/img_layers/__init__.py
@@ -1,0 +1,5 @@
+"""Image-gen → layer-split board mode for Design Agent."""
+
+from app.services.design.img_layers.pipeline import run_img_layers_job
+
+__all__ = ["run_img_layers_job"]

--- a/apps/api/app/services/design/img_layers/decompose.py
+++ b/apps/api/app/services/design/img_layers/decompose.py
@@ -1,0 +1,66 @@
+"""Decompose a board raster into vision layers (reuses toolbar vision stack)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+_log = logging.getLogger(__name__)
+
+
+async def decompose_board_layers(*, image: str) -> dict[str, Any]:
+    """
+    Full editElements split when OCR is available; otherwise one image layer.
+
+    Shape matches ``vision.image_edit.decompose_image``:
+    ``{ layers, width, height, engines, warnings, image }``.
+    """
+    from app.services.vision.ocr import available as ocr_available
+
+    if not ocr_available():
+        _log.info("img_layers: OCR unavailable — single-image fallback")
+        return {
+            "image": image,
+            "layers": [
+                {
+                    "type": "image",
+                    "src": image,
+                    "x": 0,
+                    "y": 0,
+                    "width": 0,
+                    "height": 0,
+                    "name": "整板",
+                }
+            ],
+            "kind": "editElements",
+            "width": 0,
+            "height": 0,
+            "engines": ["fallback:single"],
+            "warnings": ["OCR unavailable — placed as a single image layer"],
+        }
+
+    from app.services.vision.image_edit import decompose_image
+
+    try:
+        return await decompose_image(kind="editElements", image=image)
+    except Exception as err:  # noqa: BLE001
+        _log.exception("img_layers decompose failed: %s", err)
+        return {
+            "image": image,
+            "layers": [
+                {
+                    "type": "image",
+                    "src": image,
+                    "x": 0,
+                    "y": 0,
+                    "width": 0,
+                    "height": 0,
+                    "name": "整板",
+                }
+            ],
+            "kind": "editElements",
+            "width": 0,
+            "height": 0,
+            "engines": ["fallback:error"],
+            "warnings": [f"decompose failed: {err}"[:200]],
+        }

--- a/apps/api/app/services/design/img_layers/generate_board.py
+++ b/apps/api/app/services/design/img_layers/generate_board.py
@@ -1,0 +1,59 @@
+"""Generate a full-board raster for img_layers mode."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.design.img_layers.prompts import board_image_prompt
+
+
+def _image_model_id(rules: dict[str, str] | None) -> str:
+    from app.services.llm.image import resolve_image_model
+
+    mid = str((rules or {}).get("assets.image_default_model") or "").strip()
+    return resolve_image_model(mid or None)
+
+
+def _resolution_for_model(catalog_id: str) -> str:
+    from app.services.llm.image import _catalog_image_limits, _pick_resolution
+
+    limits = _catalog_image_limits(catalog_id)
+    return _pick_resolution(None, limits)
+
+
+async def generate_board_image(
+    *,
+    prompt: str,
+    width: int,
+    height: int,
+    rules: dict[str, str] | None,
+    ref_images: list[str] | None = None,
+) -> dict[str, Any]:
+    """
+    Returns ``{ src, model, width, height }``.
+    ``src`` is a https or data URL suitable for decompose + create_image.
+    """
+    from app.services.llm.image import generate_image
+
+    catalog_id = _image_model_id(rules)
+    resolution = _resolution_for_model(catalog_id)
+    gen_prompt = board_image_prompt(prompt, width=width, height=height)
+    aspect = f"{max(40, int(width))}x{max(40, int(height))}"
+    refs = [u for u in (ref_images or []) if isinstance(u, str) and u.strip()][:4]
+    result = await generate_image(
+        prompt=gen_prompt[:1200],
+        model=catalog_id,
+        aspect_ratio=aspect,
+        quality="standard",
+        resolution=resolution,
+        images=refs or None,
+    )
+    url = (result.get("images") or [None])[0]
+    if not url:
+        raise RuntimeError("img_layers_generate_empty")
+    return {
+        "src": str(url),
+        "model": str(result.get("model") or catalog_id),
+        "width": int(width),
+        "height": int(height),
+    }

--- a/apps/api/app/services/design/img_layers/pipeline.py
+++ b/apps/api/app/services/design/img_layers/pipeline.py
@@ -1,0 +1,320 @@
+"""img_layers board job — generate → decompose → tool_ops SSE (same apply path as ops)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+from app.services.design.admin.task_store import _insert_task, _update_task
+from app.services.design.img_layers.decompose import decompose_board_layers
+from app.services.design.img_layers.generate_board import generate_board_image
+from app.services.design.img_layers.to_tool_ops import layers_to_tool_ops
+from app.services.design.ops.tool_ops_contract import (
+    TOOL_OPS_SCHEMA_VERSION,
+    tool_ops_activity_events,
+    tool_ops_for_sse,
+)
+from app.services.design.prompts.rules_text import exec_trace
+from app.services.design.readpath.canvas_scene import parse_size, scene_key
+from app.services.wallet.db import get_user_tokens
+
+_log = logging.getLogger(__name__)
+
+
+def _resolve_board_wh(
+    canvas_size: str | None,
+    *,
+    rules: dict[str, str] | None,
+    scene: str | None = None,
+) -> tuple[int, int]:
+    sk = scene_key(scene) or "poster"
+    w, h = parse_size(canvas_size, sk, rules or {})
+    if w > 0 and h > 0:
+        return int(w), int(h)
+    return 1080, 1920
+
+
+async def run_img_layers_job(
+    *,
+    user_id: str,
+    prompt: str,
+    rules: dict[str, str],
+    canvas_size: str | None,
+    images: list[str] | None,
+    session_id: str,
+    project_id: str,
+    hold: int,
+    free_daily: bool,
+    t0: float,
+    settle_hold_fn: Any,
+    refund_hold_fn: Any,
+    scene: str | None = None,
+) -> AsyncIterator[dict[str, Any]]:
+    """SSE stream compatible with FE tool_ops apply + result settle."""
+    task_id = str(uuid.uuid4())
+    trace_id = str(uuid.uuid4())
+    sid = str(session_id or "").strip()
+    pid = str(project_id or "").strip() or "__none__"
+    w, h = _resolve_board_wh(canvas_size, rules=rules, scene=scene)
+    ref_images = [u for u in (images or []) if isinstance(u, str) and u.strip()][:4]
+
+    try:
+        from app.services.llm.usage_log import bind_usage_context
+
+        bind_usage_context(user_id=user_id, task_id=task_id, source="design")
+    except Exception:
+        pass
+
+    _insert_task(
+        {
+            "id": task_id,
+            "user_id": user_id,
+            "canvas_id": None,
+            "scene": "img_layers",
+            "skill_group_id": None,
+            "task_type": "img_layers",
+            "user_selected_model": "auto",
+            "actual_models": "[]",
+            "target_layer_id": None,
+            "current_skill_index": 0,
+            "status": "running",
+            "hold_credits": hold,
+            "charged_credits": 0,
+            "total_tokens": 0,
+            "prompt": prompt,
+            "canvas_size": f"{w}x{h}",
+            "result_svg": None,
+            "error_message": None,
+            "meta_json": json.dumps(
+                {"paint_mode": "img_layers", "trace_id": trace_id},
+                ensure_ascii=False,
+            ),
+            "created_at": time.time(),
+            "updated_at": time.time(),
+        }
+    )
+    yield {"type": "task", "taskId": task_id, "task_id": task_id, "trace_id": trace_id}
+    yield {
+        "type": "skill_start",
+        "index": 0,
+        "skill_id": None,
+        "skill_key": "img_layers",
+        "skill_name": "生图拆层",
+        "category": "create",
+        "model": "image",
+        "model_reason": "paint_mode=img_layers",
+    }
+    yield {
+        "type": "activity",
+        "id": "img-layers-gen",
+        "kind": "tool",
+        "status": "running",
+        "summary": "正在生成整板图片…",
+        "index": 0,
+    }
+    yield {
+        "type": "token",
+        "text": "生图拆层模式：先生成整板，再拆成可编辑图层。\n",
+    }
+
+    board_src = ""
+    image_model = ""
+    warnings: list[str] = []
+    try:
+        gen = await generate_board_image(
+            prompt=prompt,
+            width=w,
+            height=h,
+            rules=rules,
+            ref_images=ref_images or None,
+        )
+        board_src = str(gen.get("src") or "")
+        image_model = str(gen.get("model") or "")
+    except Exception as err:  # noqa: BLE001
+        _log.exception("img_layers generate failed task=%s", task_id)
+        try:
+            refund_hold_fn(user_id, hold, task_id=task_id)
+        except Exception:
+            _log.exception("img_layers refund failed task=%s", task_id)
+        _update_task(task_id, status="error", charged_credits=0, total_tokens=0, result_svg="")
+        yield {
+            "type": "error",
+            "code": "img_layers_generate_failed",
+            "message": str(err)[:300] or "img_layers_generate_failed",
+            "task_id": task_id,
+        }
+        return
+
+    if not board_src:
+        try:
+            refund_hold_fn(user_id, hold, task_id=task_id)
+        except Exception:
+            pass
+        _update_task(task_id, status="error", charged_credits=0, total_tokens=0, result_svg="")
+        yield {
+            "type": "error",
+            "code": "img_layers_generate_empty",
+            "message": "img_layers_generate_empty",
+            "task_id": task_id,
+        }
+        return
+
+    yield {
+        "type": "activity",
+        "id": "img-layers-gen",
+        "kind": "tool",
+        "status": "done",
+        "summary": "整板图片已生成",
+        "index": 0,
+    }
+    yield {
+        "type": "activity",
+        "id": "img-layers-split",
+        "kind": "tool",
+        "status": "running",
+        "summary": "正在拆分层（文字 / 主体 / 背景）…",
+        "index": 0,
+    }
+
+    decomposed = await decompose_board_layers(image=board_src)
+    layers = [L for L in (decomposed.get("layers") or []) if isinstance(L, dict)]
+    src_w = int(decomposed.get("width") or 0) or w
+    src_h = int(decomposed.get("height") or 0) or h
+    for wmsg in decomposed.get("warnings") or []:
+        s = str(wmsg or "").strip()
+        if s:
+            warnings.append(s)
+
+    yield {
+        "type": "activity",
+        "id": "img-layers-split",
+        "kind": "tool",
+        "status": "done",
+        "summary": f"已拆出 {len(layers)} 层",
+        "index": 0,
+        "count": len(layers),
+    }
+
+    step_ops = layers_to_tool_ops(
+        layers,
+        canvas_w=w,
+        canvas_h=h,
+        src_w=src_w,
+        src_h=src_h,
+        frame_name="AI Board",
+        board_src=board_src,
+    )
+    yield {
+        "type": "tool_ops",
+        "index": 0,
+        "task_id": task_id,
+        "trace_id": trace_id,
+        "skill_key": "img_layers",
+        "skill_name": "生图拆层",
+        "schema_version": TOOL_OPS_SCHEMA_VERSION,
+        "ops": tool_ops_for_sse(step_ops),
+    }
+    for act in tool_ops_activity_events(
+        batch=step_ops,
+        totals={"created": 0, "updated": 0, "deleted": 0},
+        skill_index=0,
+    ):
+        yield act
+
+    used = max(1, len(prompt) // 4 + len(layers) * 8)
+    yield {
+        "type": "skill_done",
+        "index": 0,
+        "skill_key": "img_layers",
+        "skill_name": "生图拆层",
+        "tokens": used,
+    }
+
+    reply = f"已用生图拆层完成画板（{len(layers)} 层"
+    if warnings:
+        reply += f"；注意：{warnings[0][:80]}"
+    reply += "）。可继续在画布上编辑。"
+    yield {"type": "token", "text": reply}
+
+    spend = 0
+    try:
+        spend = int(
+            settle_hold_fn(
+                user_id,
+                hold=hold,
+                actual_tokens=used,
+                detail=f"design_settle:img_layers:{task_id}",
+                rules=rules,
+                free_daily=free_daily,
+                images_hydrated=1,
+            )
+            or 0
+        )
+    except Exception:
+        _log.exception("img_layers settle failed task=%s", task_id)
+        try:
+            refund_hold_fn(user_id, hold, task_id=task_id)
+        except Exception:
+            pass
+
+    _update_task(
+        task_id,
+        status="success",
+        charged_credits=spend,
+        total_tokens=used,
+        result_svg="",
+    )
+    balance = get_user_tokens(user_id)
+    yield {
+        "type": "result",
+        "task_id": task_id,
+        "trace_id": trace_id,
+        "status": "success",
+        "svg": "",
+        "summary": reply[:500],
+        "charged_credits": spend,
+        "total_tokens": used,
+        "tool_ops_applied": True,
+        "intent": "create",
+        "edit_in_place": False,
+        "balance": balance,
+        "paint_mode": "img_layers",
+        "image_model": image_model or None,
+        "warnings": warnings[:5] or None,
+    }
+    try:
+        from app.services.agent_memory.episodes import maybe_write_episode
+
+        maybe_write_episode(
+            user_id=user_id,
+            session_id=sid,
+            project_id=pid,
+            task_id=task_id,
+            scene="img_layers",
+            goal=prompt,
+            summary=reply[:400],
+            applied_ops=list(step_ops or []),
+            observe={"ops_applied": True, "route": "img_layers", "layers": len(layers)},
+            outcome="success",
+            chat_only=False,
+            tool_ops_applied=True,
+            rules=rules,
+        )
+    except Exception:
+        _log.exception("episode write failed img_layers task=%s", task_id)
+
+    exec_trace(
+        t0,
+        "DONE",
+        mode="img_layers",
+        tokens=used,
+        ops=len(step_ops),
+        layers=len(layers),
+        trace_id=trace_id,
+    )
+    await asyncio.sleep(0)

--- a/apps/api/app/services/design/img_layers/prompts.py
+++ b/apps/api/app/services/design/img_layers/prompts.py
@@ -1,0 +1,17 @@
+"""Prompts unique to img_layers board mode."""
+
+from __future__ import annotations
+
+
+def board_image_prompt(user_prompt: str, *, width: int, height: int) -> str:
+    """Steer the image model toward a clean, decomposable poster/board."""
+    base = str(user_prompt or "").strip()
+    return (
+        f"{base}\n\n"
+        "Design constraints for editable layer split:\n"
+        f"- Exact canvas {width}x{height}px, full-bleed composition, no UI chrome.\n"
+        "- Clear visual hierarchy: solid/simple background, distinct subjects, readable text.\n"
+        "- Prefer high-contrast lettering; avoid tiny microcopy and dense paragraphs.\n"
+        "- Flat or lightly shaded shapes; avoid heavy glassmorphism / noisy textures.\n"
+        "- No watermark, no mock device frames, no extra margins around the design."
+    )

--- a/apps/api/app/services/design/img_layers/to_tool_ops.py
+++ b/apps/api/app/services/design/img_layers/to_tool_ops.py
@@ -1,0 +1,127 @@
+"""Map vision decompose layers → canvas tool_ops (shared apply path)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+
+def _num(v: Any, default: float = 0.0) -> float:
+    try:
+        n = float(v)
+        return n if n == n else default  # noqa: PLR0124
+    except (TypeError, ValueError):
+        return default
+
+
+def _op(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    return {"name": name, "args": args, "op_id": f"il_{uuid.uuid4().hex[:12]}"}
+
+
+def layers_to_tool_ops(
+    layers: list[dict[str, Any]],
+    *,
+    canvas_w: int,
+    canvas_h: int,
+    src_w: int,
+    src_h: int,
+    frame_name: str = "AI Board",
+    board_src: str | None = None,
+) -> list[dict[str, Any]]:
+    """
+    Build create_frame + create_image/create_text ops.
+
+    Layer geometry is in source-pixel space; scaled into the artboard.
+    """
+    fw = max(40, int(canvas_w))
+    fh = max(40, int(canvas_h))
+    sw = max(1, int(src_w) or fw)
+    sh = max(1, int(src_h) or fh)
+    sx = fw / sw
+    sy = fh / sh
+
+    ops: list[dict[str, Any]] = [
+        _op(
+            "create_frame",
+            {
+                "name": frame_name,
+                "width": fw,
+                "height": fh,
+                "backgroundColor": "#FFFFFF",
+            },
+        )
+    ]
+
+    usable = [L for L in layers if isinstance(L, dict)]
+    if not usable and board_src:
+        usable = [
+            {
+                "type": "image",
+                "src": board_src,
+                "x": 0,
+                "y": 0,
+                "width": sw,
+                "height": sh,
+                "name": "整板",
+            }
+        ]
+
+    for i, layer in enumerate(usable):
+        kind = str(layer.get("type") or "").strip().lower()
+        x = _num(layer.get("x")) * sx
+        y = _num(layer.get("y")) * sy
+        w = max(8.0, _num(layer.get("width"), sw) * sx)
+        h = max(8.0, _num(layer.get("height"), sh) * sy)
+        # Zero-size fallback layers (OCR missing dims) → full board.
+        if _num(layer.get("width")) <= 0 or _num(layer.get("height")) <= 0:
+            x, y, w, h = 0.0, 0.0, float(fw), float(fh)
+
+        name = str(layer.get("name") or "").strip() or f"Layer {i + 1}"
+
+        if kind == "text":
+            text = str(layer.get("text") or "").strip()
+            if not text:
+                continue
+            font_size = _num(layer.get("fontSize"), max(12.0, h * 0.75))
+            # Scale font with the board.
+            font_size = max(8.0, font_size * min(sx, sy))
+            args: dict[str, Any] = {
+                "text": text,
+                "x": round(x, 2),
+                "y": round(y, 2),
+                "width": round(w, 2),
+                "height": round(h, 2),
+                "fontSize": round(font_size, 1),
+                "name": name,
+                "wrap": True,
+            }
+            fill = layer.get("fill") or layer.get("color")
+            if fill is not None:
+                args["fill"] = str(fill)
+            if layer.get("fontFamily"):
+                args["fontFamily"] = str(layer.get("fontFamily"))
+            if layer.get("fontWeight") is not None:
+                args["fontWeight"] = layer.get("fontWeight")
+            if layer.get("lineHeight") is not None:
+                args["lineHeight"] = layer.get("lineHeight")
+            ops.append(_op("create_text", args))
+            continue
+
+        src = str(layer.get("src") or board_src or "").strip()
+        if not src:
+            continue
+        ops.append(
+            _op(
+                "create_image",
+                {
+                    "src": src,
+                    "x": round(x, 2),
+                    "y": round(y, 2),
+                    "width": round(w, 2),
+                    "height": round(h, 2),
+                    "name": name,
+                },
+            )
+        )
+
+    return ops

--- a/apps/api/app/services/design/runtime/graph/nodes/observe.py
+++ b/apps/api/app/services/design/runtime/graph/nodes/observe.py
@@ -301,7 +301,7 @@ def _spatial_grounding_issues(rt: AgentRuntime) -> list[str]:
         if stacked:
             issues.append(
                 f"creates stacked ({stacked} near-duplicate positions) — "
-                "offset using empty_rects / suggested_place_world"
+                "offset by varying x/y inside FOCUS_FRAME (frame-local, keep frameId)"
             )
     return issues[:6]
 
@@ -365,10 +365,11 @@ def _format_critique_reflect_note(issues: list[str]) -> str:
     joined = " ".join(str(x).lower() for x in issues)
     if any(
         k in joined
-        for k in ("empty", "place", "viewport", "stacked", "placement")
+        for k in ("place", "viewport", "stacked", "placement", "outside")
     ):
         lines.append(
-            "Placement: use PLACEMENT empty_rects / suggested_place_world from the host."
+            "Placement: set frameId=FOCUS_FRAME_ID on every create_* "
+            "and use frame-local x/y (0..w, 0..h from TARGET_CANVAS)."
         )
     return "\n".join(lines)[:720]
 

--- a/apps/api/app/services/design/runtime/graph/nodes/observe.py
+++ b/apps/api/app/services/design/runtime/graph/nodes/observe.py
@@ -21,7 +21,6 @@ from app.services.design.runtime.graph.support import (
     _bump,
     _emit,
     _emit_ux_tip,
-    _placement_errors_for_free_creates,
     _structure_verify_issues,
 )
 
@@ -277,7 +276,12 @@ def _create_op_xy(op: dict[str, Any]) -> tuple[float, float] | None:
 
 
 def _spatial_grounding_issues(rt: AgentRuntime) -> list[str]:
-    """Structural host checks only — not layout taste (that belongs in Skills/Review)."""
+    """Structural host checks only — not layout taste (that belongs in Skills/Review).
+
+    Post-paint observe must NOT re-check FE viewport placement: camera / Yjs lag
+    makes viewport_world stale and forces false re-paint. Viewport rejection stays
+    in the pre-apply paint gate (`_placement_errors_for_free_creates`).
+    """
     issues: list[str] = []
     creates = [
         op
@@ -299,11 +303,6 @@ def _spatial_grounding_issues(rt: AgentRuntime) -> list[str]:
                 f"creates stacked ({stacked} near-duplicate positions) — "
                 "offset using empty_rects / suggested_place_world"
             )
-
-    for err in _placement_errors_for_free_creates(rt, list(rt.paint_ops or [])):
-        s = str(err or "").strip()
-        if s and s not in issues:
-            issues.append(s[:240])
     return issues[:6]
 
 
@@ -313,6 +312,7 @@ def _run_post_paint_critique(
     *,
     round_i: int,
     preview_image: str | None = None,
+    op_results: list[dict[str, Any]] | None = None,
 ) -> list[str]:
     """Structural critique after FE scene lands. Craft taste → Review + Skills."""
     if not _critique_enabled(rt) or not st.painted:
@@ -329,6 +329,8 @@ def _run_post_paint_critique(
         frames=list(rt.scene_frames or []),
         painted=bool(st.painted),
         intent=str(st.intent or ""),
+        paint_ops=list(rt.paint_ops or []),
+        op_results=list(op_results or []),
     )
     for issue in _spatial_grounding_issues(rt):
         if issue not in issues:
@@ -434,6 +436,7 @@ async def _node_observe(
     snap = _normalize_resume_snap(resume_raw)
     preview_image: str | None = None
     op_failures: list[dict[str, Any]] = []
+    op_results: list[dict[str, Any]] = []
     if snap:
         nodes = [
             n for n in (snap.get("nodes") or []) if isinstance(n, dict) and n.get("id")
@@ -450,11 +453,10 @@ async def _node_observe(
         if prev:
             preview_image = prev
             rt.flags["preview_image"] = True
-        op_failures = [
-            r
-            for r in (snap.get("op_results") or [])
-            if isinstance(r, dict) and not r.get("ok", True)
+        op_results = [
+            r for r in (snap.get("op_results") or []) if isinstance(r, dict)
         ]
+        op_failures = [r for r in op_results if not r.get("ok", True)]
         fail_bits = [
             f"{r.get('name') or 'op'}: {r.get('error') or 'failed'}"
             for r in op_failures[:8]
@@ -480,6 +482,19 @@ async def _node_observe(
             error="timeout",
             summary="observe timeout: FE did not post scene",
         )
+        # Stale inventory must NOT drive critique → paint retry (empty board /
+        # placement false positives). Assume applied and settle.
+        if rt.skip_loop:
+            if st.reply:
+                _emit({"type": "token", "text": st.reply})
+        _emit_ux_tip(rt, "observe_scene_timeout", params={})
+        rt.terminal = True
+        rt.flags["ok"] = True
+        rt.flags["scene_ready"] = False
+        rt.flags["scene_timeout"] = True
+        rt.flags["op_failed"] = False
+        rt.flags["retry"] = False
+        return Command(update=_bump(rt), goto="__settle__")
 
     if rt.skip_loop:
         if st.reply:
@@ -552,7 +567,11 @@ async def _node_observe(
         return Command(update=_bump(rt), goto="__settle__")
 
     critique_issues = _run_post_paint_critique(
-        rt, st, round_i=round_i, preview_image=preview_image
+        rt,
+        st,
+        round_i=round_i,
+        preview_image=preview_image,
+        op_results=op_results,
     )
     if (
         critique_issues

--- a/apps/api/app/services/design/runtime/graph/nodes/review.py
+++ b/apps/api/app/services/design/runtime/graph/nodes/review.py
@@ -241,7 +241,12 @@ def _build_review_user_msg(
     spat = rt.spatial_summary if isinstance(rt.spatial_summary, dict) else None
     if spat and not has_preview:
         try:
-            parts.append("SPATIAL:\n" + json.dumps(spat, ensure_ascii=False)[:800])
+            safe_spat = {
+                k: v
+                for k, v in spat.items()
+                if k in ("focused", "peripheral", "overlaps", "viewport")
+            }
+            parts.append("SPATIAL:\n" + json.dumps(safe_spat, ensure_ascii=False)[:800])
         except Exception:
             pass
     parts.append(

--- a/apps/api/app/services/design/runtime/graph/paint_kit.py
+++ b/apps/api/app/services/design/runtime/graph/paint_kit.py
@@ -66,15 +66,64 @@ def _structure_verify_issues(
     frames: list[dict[str, Any]],
     painted: bool,
     intent: str,
+    paint_ops: list[dict[str, Any]] | None = None,
+    op_results: list[dict[str, Any]] | None = None,
 ) -> list[str]:
-    """Deterministic canvas sanity checks ? fact flags only, no routing."""
+    """Deterministic canvas sanity checks — fact flags only, no routing.
+
+    When FE reports create ops as ok but inventory is still empty, treat as
+    scene-sync lag (do not force re-paint). Trust per-op results over a stale
+    empty snapshot.
+    """
     if not painted:
         return []
     issues: list[str] = []
     clean_nodes = [n for n in (nodes or []) if isinstance(n, dict) and n.get("id")]
     clean_frames = [f for f in (frames or []) if isinstance(f, dict) and f.get("id")]
     intent_l = (intent or "").strip().lower()
+
+    failed_ids = {
+        str(r.get("op_id") or "")
+        for r in (op_results or [])
+        if isinstance(r, dict) and not r.get("ok", True)
+    }
+    # Only suppress empty-board when FE posted explicit op_results (create ok).
+    ok_creates = 0
+    if op_results:
+        for op in paint_ops or []:
+            if not isinstance(op, dict):
+                continue
+            name = str(op.get("name") or op.get("op_key") or "").strip()
+            if not name.startswith("create_"):
+                continue
+            oid = str(op.get("op_id") or "")
+            if oid and oid in failed_ids:
+                continue
+            if oid:
+                matched = next(
+                    (
+                        r
+                        for r in op_results
+                        if isinstance(r, dict) and str(r.get("op_id") or "") == oid
+                    ),
+                    None,
+                )
+                if matched is not None and matched.get("ok", True):
+                    ok_creates += 1
+                continue
+            if any(
+                isinstance(r, dict)
+                and r.get("ok", True)
+                and str(r.get("name") or "") == name
+                for r in op_results
+            ):
+                ok_creates += 1
+    # FE said creates applied — empty inventory is lag, not a structural miss.
+    scene_lag = ok_creates > 0 and not clean_nodes
+
     if intent_l in ("edit", "create") and not clean_nodes and not clean_frames:
+        if scene_lag:
+            return []
         issues.append("canvas empty after apply (no nodes/frames)")
         return issues
     if (
@@ -83,6 +132,8 @@ def _structure_verify_issues(
         and not clean_nodes
         and all(bool(f.get("is_empty")) for f in clean_frames)
     ):
+        if scene_lag:
+            return []
         issues.append("artboard still empty after apply")
     zero_box = 0
     for n in clean_nodes[:80]:

--- a/apps/api/app/services/design/runtime/graph/scene_log.py
+++ b/apps/api/app/services/design/runtime/graph/scene_log.py
@@ -177,6 +177,18 @@ def _scene_digest(
         th = int(focus_h or 0)
     except (TypeError, ValueError):
         tw, th = 0, 0
+    # Prefer live frame size from SCENE_FRAMES over potentially stale focus_w/focus_h.
+    frame_rows = list(frames or [])
+    for _f in frame_rows:
+        if str(_f.get("id") or "") == focus:
+            try:
+                _fw = int(_f.get("w") or 0)
+                _fh = int(_f.get("h") or 0)
+                if _fw > 0 and _fh > 0:
+                    tw, th = _fw, _fh
+            except (TypeError, ValueError):
+                pass
+            break
     if focus:
         lines.append(f"FOCUS_FRAME_ID: {focus}")
         if host_plate:
@@ -191,7 +203,6 @@ def _scene_digest(
                 f"{size_bit} "
                 "New design: do NOT update_node/delete ambient SCENE nodes on other boards."
             )
-    frame_rows = list(frames or [])
     if frame_rows or host_plate:
         lines.append("SCENE_FRAMES (world x/y):")
         for f in frame_rows[:16]:

--- a/apps/api/app/services/design/runtime/graph/support.py
+++ b/apps/api/app/services/design/runtime/graph/support.py
@@ -12,7 +12,6 @@ from app.services.design.runtime.host.ops_gate import (  # noqa: F401
     _validate_ops_payload,
 )
 from app.services.design.runtime.host.placement import (  # noqa: F401
-    _derive_suggested_place_world,
     _focus_frame_from_rt,
     _format_spatial_placement,
     _placement_errors_for_free_creates,
@@ -34,7 +33,6 @@ __all__ = (
         "_normalize_ops_payload",
         "_op_name",
         "_validate_ops_payload",
-        "_derive_suggested_place_world",
         "_focus_frame_from_rt",
         "_format_spatial_placement",
         "_placement_errors_for_free_creates",

--- a/apps/api/app/services/design/runtime/graph/support.py
+++ b/apps/api/app/services/design/runtime/graph/support.py
@@ -12,6 +12,7 @@ from app.services.design.runtime.host.ops_gate import (  # noqa: F401
     _validate_ops_payload,
 )
 from app.services.design.runtime.host.placement import (  # noqa: F401
+    _derive_suggested_place_world,
     _focus_frame_from_rt,
     _format_spatial_placement,
     _placement_errors_for_free_creates,
@@ -33,6 +34,7 @@ __all__ = (
         "_normalize_ops_payload",
         "_op_name",
         "_validate_ops_payload",
+        "_derive_suggested_place_world",
         "_focus_frame_from_rt",
         "_format_spatial_placement",
         "_placement_errors_for_free_creates",

--- a/apps/api/app/services/design/runtime/host/placement.py
+++ b/apps/api/app/services/design/runtime/host/placement.py
@@ -136,103 +136,18 @@ def _pick_viewport_blank_slot(
     return center
 
 
-def _derive_suggested_place_world(
-    spatial: dict[str, Any] | None,
-    *,
-    focus_frame: dict[str, Any] | None = None,
-) -> dict[str, float] | None:
-    """Viewport-first place: blank slot (align if possible) or camera center."""
-    spatial = spatial if isinstance(spatial, dict) else {}
-    vp_raw = spatial.get("viewport")
-    if isinstance(vp_raw, dict):
-        vw = _box_num(vp_raw, "w", "width")
-        vh = _box_num(vp_raw, "h", "height")
-        if vw > 8 and vh > 8:
-            vp = {
-                "x": _box_num(vp_raw, "x"),
-                "y": _box_num(vp_raw, "y"),
-                "w": vw,
-                "h": vh,
-            }
-            cw = min(320.0, max(80.0, vw * 0.22))
-            ch = min(240.0, max(80.0, vh * 0.22))
-            occupied = _world_occupied_in_viewport(spatial, vp, focus_frame=focus_frame)
-            return _pick_viewport_blank_slot(vp, occupied, cw=cw, ch=ch)
-
-    sp = spatial.get("suggested_place")
-    if isinstance(sp, dict) and isinstance(focus_frame, dict):
-        fox = _box_num(focus_frame, "x")
-        foy = _box_num(focus_frame, "y")
-        fw = _box_num(focus_frame, "w", "width")
-        fh = _box_num(focus_frame, "h", "height")
-        if fw > 8 and fh > 8:
-            return {
-                "x": round(fox + _box_num(sp, "x")),
-                "y": round(foy + _box_num(sp, "y")),
-                "w": round(_box_num(sp, "w", "width", default=320)),
-                "h": round(_box_num(sp, "h", "height", default=200)),
-            }
-    # No camera: center of focused artboard.
-    if isinstance(focus_frame, dict):
-        fox = _box_num(focus_frame, "x")
-        foy = _box_num(focus_frame, "y")
-        fw = _box_num(focus_frame, "w", "width")
-        fh = _box_num(focus_frame, "h", "height")
-        if fw > 8 and fh > 8:
-            cw = min(320.0, max(80.0, fw * 0.25))
-            ch = min(200.0, max(80.0, fh * 0.25))
-            return {
-                "x": round(fox + max(24.0, (fw - cw) / 2)),
-                "y": round(foy + max(24.0, (fh - ch) / 2)),
-                "w": round(cw),
-                "h": round(ch),
-            }
-    return None
-
 
 def _format_spatial_placement(
     spatial: dict[str, Any] | None,
     *,
     focus_frame: dict[str, Any] | None = None,
 ) -> str:
-    """Host placement numbers — which path to use is decided by paint_system + USER_PROMPT."""
-    spatial = spatial if isinstance(spatial, dict) else {}
-    spw = _derive_suggested_place_world(spatial, focus_frame=focus_frame)
-    vp = spatial.get("viewport")
-    sp = spatial.get("suggested_place")
-    empties = spatial.get("empty_rects")
-    has_vp = isinstance(vp, dict) and _box_num(vp, "w", "width") > 0
-    has_sp = isinstance(sp, dict) and _box_num(sp, "w", "width") > 0
-    if not spw and not has_vp and not has_sp:
-        return ""
-    # Numbers only — path rules live in agent.prompt.paint_system.
-    lines: list[str] = [
-        "PLACEMENT (host-computed; use with paint_system + USER_PROMPT):",
-    ]
-    if has_vp:
-        lines.append(
-            f"- viewport_world: x={vp.get('x')} y={vp.get('y')} "
-            f"w={vp.get('w') or vp.get('width')} h={vp.get('h') or vp.get('height')}"
-        )
-    if spw:
-        lines.append(
-            f"- suggested_place_world: x={spw['x']} y={spw['y']} "
-            f"w={spw['w']} h={spw['h']}"
-        )
-    if has_sp:
-        lines.append(
-            f"- suggested_place (frame-local): x={sp.get('x')} y={sp.get('y')} "
-            f"w={sp.get('w')} h={sp.get('h')}"
-        )
-    if isinstance(empties, list):
-        for i, box in enumerate(empties[:3]):
-            if not isinstance(box, dict):
-                continue
-            lines.append(
-                f"- empty_rect[{i}] (frame-local): x={box.get('x')} y={box.get('y')} "
-                f"w={box.get('w')} h={box.get('h')}"
-            )
-    return "\n".join(lines)
+    """No invented place slots (320×200 etc.) — those poisoned create_frame size.
+
+    Keep this empty: paint uses USER_PROMPT / CANVAS_SIZE / FOCUS_FRAME only.
+    """
+    del spatial, focus_frame
+    return ""
 
 
 def _focus_frame_from_rt(rt: Any) -> dict[str, Any] | None:
@@ -285,7 +200,7 @@ def _batch_opens_new_frame(ops: list[dict[str, Any]]) -> bool:
 
 
 def _placement_errors_for_free_creates(rt: Any, ops: list[dict[str, Any]]) -> list[str]:
-    """Reject free-canvas creates outside the camera; teach via suggested_place_world.
+    """Reject free-canvas creates outside the artboard/camera.
 
     Does not mutate ops. Frame-scoped creates (frameId set) are skipped.
     Batches that include create_frame/ensure_frame are skipped entirely — Host
@@ -303,7 +218,6 @@ def _placement_errors_for_free_creates(rt: Any, ops: list[dict[str, Any]]) -> li
         else {}
     )
     focus_frame = _focus_frame_from_rt(rt)
-    spw = _derive_suggested_place_world(spatial, focus_frame=focus_frame)
     vp = spatial.get("viewport") if isinstance(spatial, dict) else None
     # Prefer artboard bounds when present — FE camera viewport is noisier (Yjs/pan lag).
     if isinstance(focus_frame, dict) and _box_num(focus_frame, "w", "width") > 0:
@@ -334,43 +248,28 @@ def _placement_errors_for_free_creates(rt: Any, ops: list[dict[str, Any]]) -> li
         if ox_raw is None and oy_raw is None:
             continue
         try:
-            ox = float(ox_raw if ox_raw is not None else (spw["x"] if spw else 0))
-            oy = float(oy_raw if oy_raw is not None else (spw["y"] if spw else 0))
+            ox = float(ox_raw if ox_raw is not None else 0)
+            oy = float(oy_raw if oy_raw is not None else 0)
         except (TypeError, ValueError):
             continue
         if not _point_outside_world_box(ox, oy, view_box, pad=pad):
             continue
-        if spw is not None:
-            errors.append(
-                format_op_error(
-                    "placement_outside_viewport",
-                    fix=(
-                        f"re-emit {name} with x={spw['x']} y={spw['y']} "
-                        f"from suggested_place_world (viewport blank/center; "
-                        f"omit frameId for free-canvas)"
-                    ),
-                    detail=(
-                        f"{name} at world ({int(round(ox))},{int(round(oy))}) "
-                        f"outside viewport_world"
-                    ),
-                )
+        focus_id = str(getattr(rt, "focus_id", "") or "").strip() or "FOCUS_FRAME_ID"
+        errors.append(
+            format_op_error(
+                "placement_outside_viewport",
+                fix=(
+                    f"re-emit {name} with frameId={focus_id} and frame-local "
+                    f"x/y inside the artboard (0..w, 0..h); do not invent free-canvas "
+                    f"world coords or stock place sizes"
+                ),
+                detail=(
+                    f"{name} at world ({int(round(ox))},{int(round(oy))}) "
+                    f"outside artboard/viewport"
+                ),
             )
-        else:
-            errors.append(
-                format_op_error(
-                    "placement_outside_viewport",
-                    fix=(
-                        f"re-emit {name} with x/y inside the visible camera "
-                        f"(omit frameId for free-canvas)"
-                    ),
-                    detail=(
-                        f"{name} at world ({int(round(ox))},{int(round(oy))}) "
-                        f"outside viewport_world"
-                    ),
-                )
-            )
+        )
     return errors[:8]
-
 
 
 build_placement_block = _format_spatial_placement

--- a/apps/api/app/services/design/runtime/host/placement.py
+++ b/apps/api/app/services/design/runtime/host/placement.py
@@ -137,6 +137,64 @@ def _pick_viewport_blank_slot(
 
 
 
+def _derive_suggested_place_world(
+    spatial: dict[str, Any] | None,
+    *,
+    focus_frame: dict[str, Any] | None = None,
+) -> dict[str, float] | None:
+    """Viewport-first place: blank slot (align if possible) or camera center.
+
+    NOTE: The return value is used only for tests / legacy callers.
+    The paint prompt no longer injects these coords as suggestions to the model
+    (see _format_spatial_placement which returns "").
+    """
+    spatial = spatial if isinstance(spatial, dict) else {}
+    vp_raw = spatial.get("viewport")
+    if isinstance(vp_raw, dict):
+        vw = _box_num(vp_raw, "w", "width")
+        vh = _box_num(vp_raw, "h", "height")
+        if vw > 8 and vh > 8:
+            vp = {
+                "x": _box_num(vp_raw, "x"),
+                "y": _box_num(vp_raw, "y"),
+                "w": vw,
+                "h": vh,
+            }
+            cw = min(320.0, max(80.0, vw * 0.22))
+            ch = min(240.0, max(80.0, vh * 0.22))
+            occupied = _world_occupied_in_viewport(spatial, vp, focus_frame=focus_frame)
+            return _pick_viewport_blank_slot(vp, occupied, cw=cw, ch=ch)
+
+    sp = spatial.get("suggested_place")
+    if isinstance(sp, dict) and isinstance(focus_frame, dict):
+        fox = _box_num(focus_frame, "x")
+        foy = _box_num(focus_frame, "y")
+        fw = _box_num(focus_frame, "w", "width")
+        fh = _box_num(focus_frame, "h", "height")
+        if fw > 8 and fh > 8:
+            return {
+                "x": round(fox + _box_num(sp, "x")),
+                "y": round(foy + _box_num(sp, "y")),
+                "w": round(_box_num(sp, "w", "width", default=320)),
+                "h": round(_box_num(sp, "h", "height", default=200)),
+            }
+    if isinstance(focus_frame, dict):
+        fox = _box_num(focus_frame, "x")
+        foy = _box_num(focus_frame, "y")
+        fw = _box_num(focus_frame, "w", "width")
+        fh = _box_num(focus_frame, "h", "height")
+        if fw > 8 and fh > 8:
+            cw = min(320.0, max(80.0, fw * 0.25))
+            ch = min(200.0, max(80.0, fh * 0.25))
+            return {
+                "x": round(fox + max(24.0, (fw - cw) / 2)),
+                "y": round(foy + max(24.0, (fh - ch) / 2)),
+                "w": round(cw),
+                "h": round(ch),
+            }
+    return None
+
+
 def _format_spatial_placement(
     spatial: dict[str, Any] | None,
     *,

--- a/apps/api/app/services/design/runtime/host/placement.py
+++ b/apps/api/app/services/design/runtime/host/placement.py
@@ -305,15 +305,21 @@ def _placement_errors_for_free_creates(rt: Any, ops: list[dict[str, Any]]) -> li
     focus_frame = _focus_frame_from_rt(rt)
     spw = _derive_suggested_place_world(spatial, focus_frame=focus_frame)
     vp = spatial.get("viewport") if isinstance(spatial, dict) else None
-    view_box = vp if isinstance(vp, dict) and _box_num(vp, "w", "width") > 0 else None
-    if view_box is None and isinstance(focus_frame, dict):
+    # Prefer artboard bounds when present — FE camera viewport is noisier (Yjs/pan lag).
+    if isinstance(focus_frame, dict) and _box_num(focus_frame, "w", "width") > 0:
         view_box = focus_frame
-    if view_box is None:
+        pad = max(
+            48.0,
+            0.2 * min(_box_num(view_box, "w", "width"), _box_num(view_box, "h", "height")),
+        )
+    elif isinstance(vp, dict) and _box_num(vp, "w", "width") > 0:
+        view_box = vp
+        pad = max(
+            96.0,
+            0.4 * min(_box_num(view_box, "w", "width"), _box_num(view_box, "h", "height")),
+        )
+    else:
         return []
-    pad = max(
-        64.0,
-        0.25 * min(_box_num(view_box, "w", "width"), _box_num(view_box, "h", "height")),
-    )
     errors: list[str] = []
     create_names = ("create_shape", "create_text", "create_image", "create_svg")
     for op in ops:

--- a/apps/api/app/services/design/runtime/orchestrator.py
+++ b/apps/api/app/services/design/runtime/orchestrator.py
@@ -200,6 +200,7 @@ async def run_design_job(
     interaction_mode: str | None = None,
     client_country: str | None = None,
     skill_refs: list[str] | None = None,
+    paint_mode: str | None = None,
 ) -> AsyncIterator[dict[str, Any]]:
     """LangGraph agent loop. Chat vs design from model intent / ops."""
     del is_premium  # reserved
@@ -211,6 +212,15 @@ async def run_design_job(
     ui_mode = _as_text(interaction_mode or "agent").strip().lower()
     if ui_mode not in ("agent", "ask"):
         ui_mode = "agent"
+
+    from app.services.design.board_modes import is_img_layers_mode
+
+    use_img_layers = (
+        is_img_layers_mode(paint_mode)
+        and mode in ("agent", "single_model")
+        and ui_mode == "agent"
+        and not apply_ops
+    )
 
     prompt = _as_text(prompt).strip()
     if not prompt and not apply_ops:
@@ -325,41 +335,62 @@ async def run_design_job(
             medium if isinstance(medium, dict) else None,
         )
 
-        from app.services.design.runtime.design_run import design_stream
         from app.services.llm import reset_byok_user_id, set_byok_user_id
 
         byok_token = set_byok_user_id(user_id)
         try:
-            async for ev in design_stream(
-                user_id=user_id,
-                mode=mode,
-                prompt=prompt,
-                rules=rules,
-                user_selected_model=user_selected_model,
-                canvas_id=canvas_id,
-                canvas_size=canvas_size,
-                scene=scene,
-                scene_nodes=scene_nodes_gate,
-                scene_frames=scene_frames_gate,
-                spatial_summary=spatial_summary if isinstance(spatial_summary, dict) else None,
-                focus_frame_id=focus_frame_id,
-                images=images,
-                memory_in=memory,
-                session_id=sid,
-                project_id=pid,
-                hold=hold,
-                free_daily=free_daily,
-                t0=t0,
-                reserve_hold_fn=_reserve_design_hold,
-                settle_hold_fn=_settle_hold,
-                refund_hold_fn=_refund_hold,
-                apply_ops=apply_ops,
-                proposal_id=proposal_id,
-                proposal_task_id=proposal_task_id,
-                interaction_mode=ui_mode,
-                skill_refs=skill_refs,
-            ):
-                yield ev
+            if use_img_layers:
+                from app.services.design.img_layers import run_img_layers_job
+
+                async for ev in run_img_layers_job(
+                    user_id=user_id,
+                    prompt=prompt,
+                    rules=rules,
+                    canvas_size=canvas_size,
+                    images=images,
+                    session_id=sid,
+                    project_id=pid,
+                    hold=hold,
+                    free_daily=free_daily,
+                    t0=t0,
+                    settle_hold_fn=_settle_hold,
+                    refund_hold_fn=_refund_hold,
+                    scene=scene,
+                ):
+                    yield ev
+            else:
+                from app.services.design.runtime.design_run import design_stream
+
+                async for ev in design_stream(
+                    user_id=user_id,
+                    mode=mode,
+                    prompt=prompt,
+                    rules=rules,
+                    user_selected_model=user_selected_model,
+                    canvas_id=canvas_id,
+                    canvas_size=canvas_size,
+                    scene=scene,
+                    scene_nodes=scene_nodes_gate,
+                    scene_frames=scene_frames_gate,
+                    spatial_summary=spatial_summary if isinstance(spatial_summary, dict) else None,
+                    focus_frame_id=focus_frame_id,
+                    images=images,
+                    memory_in=memory,
+                    session_id=sid,
+                    project_id=pid,
+                    hold=hold,
+                    free_daily=free_daily,
+                    t0=t0,
+                    reserve_hold_fn=_reserve_design_hold,
+                    settle_hold_fn=_settle_hold,
+                    refund_hold_fn=_refund_hold,
+                    apply_ops=apply_ops,
+                    proposal_id=proposal_id,
+                    proposal_task_id=proposal_task_id,
+                    interaction_mode=ui_mode,
+                    skill_refs=skill_refs,
+                ):
+                    yield ev
         finally:
             reset_byok_user_id(byok_token)
         return

--- a/apps/api/app/services/design/runtime/scene_feedback.py
+++ b/apps/api/app/services/design/runtime/scene_feedback.py
@@ -420,6 +420,22 @@ async def publish_scene(
     rn = int(round_n or 0)
     async with _lock:
         slot = _pending.get(tid)
+        # Drop stale FE posts that belong to a previous wait (late after timeout).
+        if (
+            slot is not None
+            and round_n is not None
+            and slot.get("_posted") is not True
+            and int(slot.get("round") or 0) > 0
+            and rn > 0
+            and rn != int(slot.get("round") or 0)
+        ):
+            _log.warning(
+                "scene_feedback stale round ignored task=%s got=%s expected=%s",
+                tid,
+                rn,
+                slot.get("round"),
+            )
+            return False
         if slot is None:
             slot = {
                 "event": asyncio.Event(),

--- a/apps/api/app/tests/services/design/test_img_layers_to_tool_ops.py
+++ b/apps/api/app/tests/services/design/test_img_layers_to_tool_ops.py
@@ -1,0 +1,68 @@
+"""Unit tests for img_layers → tool_ops mapping."""
+
+from __future__ import annotations
+
+from app.services.design.img_layers.to_tool_ops import layers_to_tool_ops
+
+
+def test_layers_to_tool_ops_frame_then_text_and_image():
+    ops = layers_to_tool_ops(
+        [
+            {
+                "type": "image",
+                "src": "data:image/png;base64,xx",
+                "x": 0,
+                "y": 0,
+                "width": 100,
+                "height": 200,
+                "name": "背景",
+            },
+            {
+                "type": "text",
+                "text": "Hello",
+                "x": 10,
+                "y": 20,
+                "width": 80,
+                "height": 24,
+                "fontSize": 20,
+                "fill": "#111111",
+                "name": "标题",
+            },
+        ],
+        canvas_w=100,
+        canvas_h=200,
+        src_w=100,
+        src_h=200,
+    )
+    assert ops[0]["name"] == "create_frame"
+    assert ops[0]["args"]["width"] == 100
+    assert ops[1]["name"] == "create_image"
+    assert ops[1]["args"]["src"].startswith("data:")
+    assert ops[2]["name"] == "create_text"
+    assert ops[2]["args"]["text"] == "Hello"
+    assert ops[2]["args"]["fill"] == "#111111"
+
+
+def test_layers_to_tool_ops_scales_geometry():
+    ops = layers_to_tool_ops(
+        [
+            {
+                "type": "image",
+                "src": "https://example.com/a.png",
+                "x": 50,
+                "y": 100,
+                "width": 50,
+                "height": 100,
+                "name": "主体",
+            }
+        ],
+        canvas_w=200,
+        canvas_h=400,
+        src_w=100,
+        src_h=200,
+    )
+    img = ops[1]["args"]
+    assert img["x"] == 100.0
+    assert img["y"] == 200.0
+    assert img["width"] == 100.0
+    assert img["height"] == 200.0

--- a/apps/api/seeds/design_prompt_packs/stages/paint.md
+++ b/apps/api/seeds/design_prompt_packs/stages/paint.md
@@ -31,7 +31,8 @@ Your ONLY job: emit non-empty tool_ops that change the canvas.
 <!-- pack:agent.prompt.paint_retry -->
 RETRY: previous tool_ops were empty or invalid.
 Read LAST_ERROR (code=…; fix=…) and re-emit a non-empty tool_ops array now.
-If code=placement_outside_viewport: free-canvas create_* with x/y from PLACEMENT.suggested_place_world.
+If code=placement_outside_viewport: re-emit with frameId=FOCUS_FRAME_ID and
+frame-local x/y inside the artboard; do not invent stock place sizes (e.g. 320×200).
 
 <!-- pack:agent.prompt.recover_edit_retry -->
 Resource details are loaded ({tools_hint}). Emit tool_ops now to finish the user request; keep intent={prior_intent}; do not switch back to chat/ask.

--- a/apps/api/tests/unit_tests/test_agent_controller_parse.py
+++ b/apps/api/tests/unit_tests/test_agent_controller_parse.py
@@ -535,25 +535,26 @@ def test_derive_suggested_place_world_aligns_beside_content():
     assert abs(spw["y"] - 200) <= 1  # top-aligned
 
 
-def test_format_spatial_placement_from_focus_frame_alone():
+def test_format_spatial_placement_emits_no_invented_slots():
     from app.services.design.runtime.agent_controller import _format_spatial_placement
 
     text = _format_spatial_placement(
-        None,
+        {
+            "viewport": {"x": 0, "y": 0, "w": 2000, "h": 1200},
+            "suggested_place": {"x": 40, "y": 40, "w": 320, "h": 200},
+            "empty_rects": [{"x": 40, "y": 40, "w": 320, "h": 200}],
+        },
         focus_frame={"id": "f1", "x": 4800, "y": 1200, "w": 410, "h": 729},
     )
-    assert "PLACEMENT" in text
-    assert "suggested_place_world" in text
-    # Centered inside focus frame world box (4800 + inset).
-    assert "x=4954" in text
-    assert "y=1473" in text
+    assert text == ""
+    assert "320" not in text
+    assert "suggested_place" not in text
 
 
 def test_placement_errors_for_offscreen_free_creates():
     from types import SimpleNamespace
 
     from app.services.design.runtime.agent_controller import (
-        _derive_suggested_place_world,
         _placement_errors_for_free_creates,
     )
 
@@ -579,13 +580,10 @@ def test_placement_errors_for_offscreen_free_creates():
         }
     ]
     errs = _placement_errors_for_free_creates(rt, ops)
-    spw = _derive_suggested_place_world(spatial, focus_frame=focus)
     assert errs
     assert "code=placement_outside_viewport" in errs[0]
-    assert "fix=" in errs[0] and "suggested_place_world" in errs[0]
-    assert spw is not None
-    assert f"x={spw['x']}" in errs[0]
-    assert f"y={spw['y']}" in errs[0]
+    assert "fix=" in errs[0] and "frameId=f1" in errs[0]
+    assert "suggested_place" not in errs[0]
     # Ops must not be mutated — teach via error, model re-emits.
     assert ops[0]["args"]["x"] == 120
 

--- a/apps/api/tests/unit_tests/test_design_critique.py
+++ b/apps/api/tests/unit_tests/test_design_critique.py
@@ -183,7 +183,9 @@ def test_format_critique_reflect_note_structural_only():
     assert "CRITIQUE" in note
     assert "structural" in note.lower() or "Placement" in note
     assert "Visual craft" not in note
-    assert "empty_rects" in note or "suggested_place" in note
+    assert "FOCUS_FRAME" in note or "frameId" in note
+    assert "empty_rects" not in note
+    assert "suggested_place" not in note
 
 
 def test_critique_does_not_run_layout_craft(monkeypatch):

--- a/apps/api/tests/unit_tests/test_verify_flow.py
+++ b/apps/api/tests/unit_tests/test_verify_flow.py
@@ -15,6 +15,25 @@ def test_structure_verify_empty_canvas():
     assert issues
 
 
+def test_structure_verify_empty_but_create_ops_ok_is_lag():
+    """FE said creates applied — empty inventory must not force re-paint."""
+    issues = _structure_verify_issues(
+        nodes=[],
+        frames=[],
+        painted=True,
+        intent="create",
+        paint_ops=[
+            {"name": "create_text", "op_id": "a1", "args": {"text": "hi"}},
+            {"name": "create_shape", "op_id": "a2", "args": {"shapeType": "rect"}},
+        ],
+        op_results=[
+            {"op_id": "a1", "name": "create_text", "ok": True},
+            {"op_id": "a2", "name": "create_shape", "ok": True},
+        ],
+    )
+    assert issues == []
+
+
 def test_structure_verify_ok_nodes():
     issues = _structure_verify_issues(
         nodes=[{"id": "n1", "w": 100, "h": 40}],

--- a/apps/web/src/components/editor/canvas/contextMenu/useCanvasContextMenu.ts
+++ b/apps/web/src/components/editor/canvas/contextMenu/useCanvasContextMenu.ts
@@ -44,6 +44,9 @@ const CHROME_SKIP_SEL =
   '[data-sel-toolbar],[data-frame-toolbar],[data-ctx-menu],[data-export-panel],[data-image-label],[data-frame-label],[data-crop-expand-overlay],[data-crop-expand-toolbar],[data-image-tool-panel],[data-text-inline-editor],[data-video-trim-toolbar],[data-video-playback-bar],[data-audio-playback-bar],[data-audio-trim-toolbar],[data-audio-speed-toolbar]';
 const SCENE_COMPOSER_SEL =
   '[data-image-generator],[data-video-generator],[data-image-quick-edit]';
+/** Account / settings / any Headless UI dialog — portaled over the canvas. */
+const OVERLAY_UI_SEL =
+  '[role="dialog"],[data-headlessui-portal],[data-account-settings],[data-rcb-overlay]';
 
 type LongPress = {
   pointerId: number;
@@ -81,6 +84,13 @@ function isChromeTarget(target: EventTarget | null) {
   return Boolean(el.closest(CHROME_SKIP_SEL));
 }
 
+/** Settings modal / floating UI above the board — must not open the canvas menu. */
+function isOverlayUiTarget(target: EventTarget | null) {
+  const el = target as HTMLElement | null;
+  if (!el?.closest) return false;
+  return Boolean(el.closest(OVERLAY_UI_SEL));
+}
+
 function clientInElement(el: HTMLElement, clientX: number, clientY: number) {
   const r = el.getBoundingClientRect();
   return (
@@ -95,6 +105,15 @@ function stageContainsTarget(stage: HTMLElement, target: EventTarget | null) {
   const node = target as Node | null;
   if (!node) return false;
   return node === stage || stage.contains(node);
+}
+
+/**
+ * Canvas menu only for presses that actually hit the stage tree.
+ * Coords alone are wrong when a portaled dialog sits over the board.
+ */
+function isCanvasGestureTarget(hitEl: HTMLElement, target: EventTarget | null) {
+  if (isOverlayUiTarget(target) || isChromeTarget(target)) return false;
+  return stageContainsTarget(hitEl, target);
 }
 
 function findFrameIdAtScene(
@@ -219,7 +238,7 @@ export function useCanvasContextMenu(args: UseCanvasContextMenuArgs) {
       if (performance.now() - openedAtRef.current < OPEN_DEBOUNCE_MS) return;
       if (isBogusClient(clientX, clientY)) return;
       if (!clientInElement(hitEl, clientX, clientY)) return;
-      if (isChromeTarget(target)) return;
+      if (!isCanvasGestureTarget(hitEl, target)) return;
       openedAtRef.current = performance.now();
       openMenuAt(clientX, clientY);
     };
@@ -248,7 +267,8 @@ export function useCanvasContextMenu(args: UseCanvasContextMenuArgs) {
     };
 
     const onPointerDown = (e: PointerEvent) => {
-      if (isChromeTarget(e.target)) {
+      // Dialog / dock / chrome — never steal right-click from overlay UI.
+      if (!isCanvasGestureTarget(hitEl, e.target)) {
         clearLongPress();
         return;
       }
@@ -272,7 +292,7 @@ export function useCanvasContextMenu(args: UseCanvasContextMenuArgs) {
     /** Some hybrid drivers skip PointerEvent button=2 but still fire MouseEvent. */
     const onMouseDown = (e: MouseEvent) => {
       if (e.button !== 2) return;
-      if (isChromeTarget(e.target)) return;
+      if (!isCanvasGestureTarget(hitEl, e.target)) return;
       if (isBogusClient(e.clientX, e.clientY) || !clientInElement(hitEl, e.clientX, e.clientY)) {
         return;
       }
@@ -296,13 +316,9 @@ export function useCanvasContextMenu(args: UseCanvasContextMenuArgs) {
       tryOpen(lp.x, lp.y, lp.target);
     };
 
-    /** Suppress native menu only — never open from this event (coords often fake). */
+    /** Suppress native menu only on the stage / canvas chrome — not on settings dialogs. */
     const onContextMenu = (e: MouseEvent) => {
-      const onStage =
-        clientInElement(hitEl, e.clientX, e.clientY) ||
-        stageContainsTarget(hitEl, e.target) ||
-        isChromeTarget(e.target);
-      if (!onStage) return;
+      if (!stageContainsTarget(hitEl, e.target) && !isChromeTarget(e.target)) return;
       e.preventDefault();
       e.stopPropagation();
     };

--- a/apps/web/src/components/editor/canvas/runCanvasCtxAction.ts
+++ b/apps/web/src/components/editor/canvas/runCanvasCtxAction.ts
@@ -3,6 +3,7 @@ import { message } from '@/components/base';
 import {
   groupNodesInDocument,
   ungroupNodesInDocument,
+  unlockedGroupableIds,
 } from '@/components/rcb/scene/document/sceneGroups';
 import {
   isNodeHidden,
@@ -241,18 +242,20 @@ export function runCanvasCtxAction(action: CtxAction, deps: RunCanvasCtxActionDe
   }
   if (action === 'group') {
     const targetIds = resolveSelectionNodeIds(documentRef.current, ids, frameIdsForAction);
-    if (targetIds.length < 2) return;
-    const next = groupNodesInDocument(documentRef.current, targetIds);
+    const grouped = unlockedGroupableIds(documentRef.current, targetIds);
+    if (grouped.length < 2) return;
+    const next = groupNodesInDocument(documentRef.current, grouped);
     dispatch(setDocument(next));
-    dispatch(setMixedSelection({ nodeIds: targetIds, frameIds: frameIdsForAction }));
+    dispatch(setMixedSelection({ nodeIds: grouped, frameIds: frameIdsForAction }));
     return;
   }
   if (action === 'ungroup') {
     const targetIds = resolveSelectionNodeIds(documentRef.current, ids, frameIdsForAction);
-    if (!targetIds.length) return;
-    const next = ungroupNodesInDocument(documentRef.current, targetIds);
+    const unlocked = unlockedGroupableIds(documentRef.current, targetIds);
+    if (!unlocked.length) return;
+    const next = ungroupNodesInDocument(documentRef.current, unlocked);
     dispatch(setDocument(next));
-    dispatch(setMixedSelection({ nodeIds: targetIds, frameIds: frameIdsForAction }));
+    dispatch(setMixedSelection({ nodeIds: unlocked, frameIds: frameIdsForAction }));
     return;
   }
   if (action === 'undo') {

--- a/apps/web/src/components/editor/nodes/ImageNode/toolPanels/OpacityToolPanel.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/toolPanels/OpacityToolPanel.tsx
@@ -49,8 +49,8 @@ function OpacityToolPanel({
           value={safe}
           onChange={onOpacityPctChange}
           trackHeight={6}
-          thumbWidth={10}
-          thumbHeight={18}
+          thumbWidth={16}
+          thumbHeight={16}
         />
       </div>
     </ImageToolPanelShell>

--- a/apps/web/src/components/editor/panels/AgentDock.tsx
+++ b/apps/web/src/components/editor/panels/AgentDock.tsx
@@ -162,6 +162,7 @@ import {
   loadAgentRoutePrefs,
 } from '@/components/editor/panels/agent/agentRoutePrefs';
 import { AgentRoutePrefsEditor } from '@/components/editor/panels/agent/AgentRoutePrefsEditor';
+import { loadAgentPaintMode } from '@/components/editor/panels/agent/boardModes/prefs';
 import { setAllowedCanvasToolKeys } from '@/components/editor/panels/agent/toolOpsContract';
 import { type CanvasUiBridge } from '@/components/editor/panels/agent/designTools';
 import {
@@ -1922,6 +1923,7 @@ function AgentDock({
         userMessage: userMsg.content || '',
         runMode: 'agent',
         interactionMode: 'agent',
+        paintMode: loadAgentPaintMode(),
         resumeTaskId: taskId,
         resumeToken: target.designResumeToken || undefined,
         scene: null,
@@ -2609,6 +2611,7 @@ function AgentDock({
           : interactionMode === 'ask'
             ? 'ask'
             : 'agent',
+        paintMode: loadAgentPaintMode(),
         applyOps: options.applyOps?.length ? options.applyOps : undefined,
         proposalId: options.proposalId || pendingProposal.proposalId || undefined,
         proposalTaskId:

--- a/apps/web/src/components/editor/panels/agent/AgentModelsPanel.tsx
+++ b/apps/web/src/components/editor/panels/agent/AgentModelsPanel.tsx
@@ -209,13 +209,24 @@ function AddPlatformModelFields(props: {
     onIconKey,
     onIconUrl,
   } = props;
+  // Extra catalog model is optional when saving a platform key — only required if started.
+  const started = Boolean(apiId.trim() || name.trim() || iconKey.trim() || iconUrl.trim());
+  const opt = (
+    <span className="ml-1 text-[11px] font-normal text-[var(--muted)]">
+      ({t('agent.providerOptional')})
+    </span>
+  );
+  const req = started ? <span className="text-red-500"> *</span> : opt;
 
   return (
     <>
+      <p className="mb-3 text-[12px] leading-relaxed text-[var(--muted)]">
+        {t('agent.providerAddPlatformModelHint')}
+      </p>
       <label className="mb-4 block">
         <span className="text-[13px] font-medium text-[var(--ink)]">
           {t('agent.providerApiModel')}
-          <span className="text-red-500"> *</span>
+          {req}
         </span>
         <input
           className={fieldClass}
@@ -228,7 +239,7 @@ function AddPlatformModelFields(props: {
       <label className="mb-4 block">
         <span className="text-[13px] font-medium text-[var(--ink)]">
           {t('agent.providerPlatformModelName')}
-          <span className="text-red-500"> *</span>
+          {req}
         </span>
         <input
           className={fieldClass}
@@ -241,7 +252,7 @@ function AddPlatformModelFields(props: {
       <ModelIconPickerFields
         iconKey={iconKey}
         iconUrl={iconUrl}
-        required
+        required={started}
         t={t}
         onIconKey={onIconKey}
         onIconUrl={onIconUrl}
@@ -249,7 +260,7 @@ function AddPlatformModelFields(props: {
       <label className="mb-4 block">
         <span className="text-[13px] font-medium text-[var(--ink)]">
           {t('agent.providerModelKind')}
-          <span className="text-red-500"> *</span>
+          {req}
         </span>
         <Select
           size="large"
@@ -717,7 +728,14 @@ function AgentModelsPanel({
                 onChange={(v) => onPickPlatform(String(v))}
               />
               <span className="mt-1.5 block text-[12px] text-[var(--muted)]">
-                {t('agent.providerPlatformHint')}
+                {isManualProvider
+                  ? t('agent.providerManualHint', {
+                      defaultValue:
+                        'Custom endpoint: fill API key, base URL, and the upstream model id (e.g. deepseek-chat).',
+                    })
+                  : selectedPlatform
+                    ? t('agent.providerPlatformHint')
+                    : t('agent.providerPresetHint')}
               </span>
             </label>
 

--- a/apps/web/src/components/editor/panels/agent/AgentRoutePrefsEditor.tsx
+++ b/apps/web/src/components/editor/panels/agent/AgentRoutePrefsEditor.tsx
@@ -47,6 +47,14 @@ import {
   seedCustomLaneFromPrefs,
   warmOpenrouterAvailability,
 } from './agentRoutePrefs';
+import {
+  loadAgentPaintMode,
+  saveAgentPaintMode,
+} from './boardModes/prefs';
+import {
+  type AgentPaintMode,
+  normalizeAgentPaintMode,
+} from './boardModes/types';
 
 const selectFieldClass =
   'mt-1.5 w-full !h-10 rounded-lg border-0 bg-[var(--account-main)] px-3 pr-8 text-[14px] text-[var(--ink)] ring-1 ring-[var(--line)]';
@@ -315,6 +323,7 @@ function AgentRoutePrefsEditorImpl({
   const [routePrefs, setRoutePrefs] = useState<AgentRoutePrefs>(() =>
     desktopLocal ? emptyCustomRoutePrefs() : { preset: 'platform' }
   );
+  const [paintMode, setPaintMode] = useState<AgentPaintMode>(() => loadAgentPaintMode());
   const [routeSaved, setRouteSaved] = useState(false);
   const [textModels, setTextModels] = useState<LlmModel[]>([]);
   const [imageModels, setImageModels] = useState<LlmModel[]>([]);
@@ -330,6 +339,7 @@ function AgentRoutePrefsEditorImpl({
 
   useEffect(() => {
     setRoutePrefs(loadAgentRoutePrefs());
+    setPaintMode(loadAgentPaintMode());
   }, []);
 
   // Account Agent tab loads catalog once on the parent — skip duplicate design fetch there.
@@ -1008,6 +1018,30 @@ function AgentRoutePrefsEditorImpl({
 
   return (
     <div className={cn('space-y-4', className)}>
+      <div>
+        <h2 className="mb-1 text-[15px] font-semibold text-[var(--ink)]">
+          {t('agent.paintMode')}
+        </h2>
+        <p className="mb-3 text-[13px] leading-relaxed text-[var(--muted)]">
+          {t('agent.paintModeTip')}
+        </p>
+        <SegmentedControl
+          size="sm"
+          radius="full"
+          aria-label={t('agent.paintMode')}
+          value={paintMode}
+          onChange={(v) => {
+            const next = normalizeAgentPaintMode(v);
+            setPaintMode(next);
+            saveAgentPaintMode(next);
+          }}
+          options={[
+            { value: 'ops', label: t('agent.paintModeOps') },
+            { value: 'img_layers', label: t('agent.paintModeImgLayers') },
+          ]}
+        />
+      </div>
+
       <h2 className="mb-1 text-[15px] font-semibold text-[var(--ink)]">
         {t('account.agentRouteSection')}
       </h2>

--- a/apps/web/src/components/editor/panels/agent/AgentRoutePrefsEditor.tsx
+++ b/apps/web/src/components/editor/panels/agent/AgentRoutePrefsEditor.tsx
@@ -1040,6 +1040,12 @@ function AgentRoutePrefsEditorImpl({
             { value: 'img_layers', label: t('agent.paintModeImgLayers') },
           ]}
         />
+        {paintMode === 'img_layers' && (
+          <p className="mt-2 flex items-start gap-1.5 rounded-lg bg-amber-50 px-2.5 py-2 text-[12px] leading-relaxed text-amber-700 ring-1 ring-amber-200 dark:bg-amber-950/40 dark:text-amber-400 dark:ring-amber-800/60">
+            <span aria-hidden className="mt-px shrink-0 text-[13px]">⚠</span>
+            {t('agent.paintModeImgLayersTokenWarn')}
+          </p>
+        )}
       </div>
 
       <h2 className="mb-1 text-[15px] font-semibold text-[var(--ink)]">

--- a/apps/web/src/components/editor/panels/agent/boardModes/prefs.ts
+++ b/apps/web/src/components/editor/panels/agent/boardModes/prefs.ts
@@ -1,0 +1,29 @@
+/**
+ * Persist Design Agent board paint mode (ops | img_layers).
+ * Used by Agent settings (AgentRoutePrefsEditor account form) and runDesignAgent body.
+ */
+
+import {
+  type AgentPaintMode,
+  normalizeAgentPaintMode,
+} from './types';
+
+const PAINT_MODE_KEY = 'resume.agentPaintMode.v1';
+
+export function loadAgentPaintMode(): AgentPaintMode {
+  try {
+    if (typeof localStorage === 'undefined') return 'ops';
+    return normalizeAgentPaintMode(localStorage.getItem(PAINT_MODE_KEY));
+  } catch {
+    return 'ops';
+  }
+}
+
+export function saveAgentPaintMode(mode: AgentPaintMode): void {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(PAINT_MODE_KEY, normalizeAgentPaintMode(mode));
+  } catch {
+    /* ignore quota / private mode */
+  }
+}

--- a/apps/web/src/components/editor/panels/agent/boardModes/types.ts
+++ b/apps/web/src/components/editor/panels/agent/boardModes/types.ts
@@ -1,0 +1,21 @@
+/** Design Agent board paint mode — ops (default) vs img_layers. */
+
+export type AgentPaintMode = 'ops' | 'img_layers';
+
+export const AGENT_PAINT_MODES: readonly AgentPaintMode[] = ['ops', 'img_layers'] as const;
+
+export function normalizeAgentPaintMode(raw: unknown): AgentPaintMode {
+  const s = String(raw || '')
+    .trim()
+    .toLowerCase()
+    .replace(/-/g, '_');
+  if (
+    s === 'img_layers' ||
+    s === 'imglayers' ||
+    s === 'image_layers' ||
+    s === 'gen_layers'
+  ) {
+    return 'img_layers';
+  }
+  return 'ops';
+}

--- a/apps/web/src/components/editor/panels/agent/designAgentEventRouter.ts
+++ b/apps/web/src/components/editor/panels/agent/designAgentEventRouter.ts
@@ -213,6 +213,7 @@ const DESIGN_UX_TIP_I18N: Record<string, string> = {
   paint_failed: 'agent.uxTipPaintFailed',
   observe_ops_failed: 'agent.uxTipObserveOpsFailed',
   apply_confirm_failed: 'agent.uxTipApplyConfirmFailed',
+  observe_scene_timeout: 'agent.uxTipObserveSceneTimeout',
   observe_critique_failed: 'agent.uxTipObserveCritiqueFailed',
   review_must_fix: 'agent.uxTipReviewMustFix',
   apply_ops_applied: 'agent.uxTipApplyOpsApplied',

--- a/apps/web/src/components/editor/panels/agent/designTools.ts
+++ b/apps/web/src/components/editor/panels/agent/designTools.ts
@@ -51,7 +51,12 @@ import { serializeFillGradient } from '@/components/rcb/scene/document/sceneFill
 import { createMeshGrid, type MeshSize } from '@/components/rcb/scene/document/sceneDiffuseMesh';
 import { isStrokeStyle } from '@/components/rcb/scene/document/sceneStrokeStyle';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
-import { computeShapeBoolean, applyBooleanResultPaint, type BoolMode } from '@/components/rcb/selection/shapeBoolean';
+import {
+  computeShapeBoolean,
+  applyBooleanResultPaint,
+  applyBooleanResultRadii,
+  type BoolMode,
+} from '@/components/rcb/selection/shapeBoolean';
 import { nanoid } from '@reduxjs/toolkit';
 import { getAllowedCanvasToolKeys } from '@/components/editor/panels/agent/toolOpsContract';
 import {
@@ -1171,8 +1176,7 @@ function placementRewriteError(
       `(refused rewrite → ${Math.round(placed.x)},${Math.round(placed.y)} ` +
       `${Math.round(placed.width)}×${Math.round(placed.height)}).`,
     next_actions: [
-      'Use frame-local coords inside FOCUS_FRAME',
-      'Or free-canvas world x/y from suggested_place_world',
+      'Use frame-local coords with frameId inside FOCUS_FRAME (0..w, 0..h)',
     ],
   };
 }
@@ -1188,7 +1192,7 @@ function requireCreateXY(
     status: 'error',
     summary:
       `${tool}_missing_xy: provide numeric x and y ` +
-      `(frame-local with frameId, or world coords from suggested_place_world).`,
+      `(frame-local inside FOCUS_FRAME with frameId, or free-canvas world coords).`,
     next_actions: ['Re-emit create_* with explicit x and y'],
   };
 }
@@ -2734,6 +2738,7 @@ function execBooleanOp(
       sampleNode?.attrs as Record<string, unknown> | undefined,
       { stroke: sample.stroke, borderWidth: sample.borderWidth }
     );
+    applyBooleanResultRadii(attrs, boxes);
     let next = addNodeToDocument(doc, id, node);
     next = removeNodesFromDocument(next, boxes.map((b) => b.id));
     pushHistory();

--- a/apps/web/src/components/editor/panels/agent/flyToChat.tsx
+++ b/apps/web/src/components/editor/panels/agent/flyToChat.tsx
@@ -165,21 +165,21 @@ function quadraticPath(from: Point, to: Point): string {
 }
 
 function ensureFlyStyles() {
-  const id = 'recombyn-fly-to-chat-css';
+  const id = 'recombyn-fly-to-chat-css-2';
   if (globalThis.document.getElementById(id)) return;
   const style = globalThis.document.createElement('style');
   style.id = id;
   style.textContent = `
-@keyframes recombyn-fly-chip-pop {
-  0% { transform: translate(-50%, -50%) scale(0.55); opacity: 0; }
-  100% { transform: translate(-50%, -50%) scale(1); opacity: 1; }
-}
 @keyframes recombyn-fly-chip-arc {
   0% {
     offset-distance: 0%;
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.55) rotate(0deg);
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+  }
+  12% {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1) rotate(0deg);
-    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
   }
   55% {
     opacity: 1;
@@ -242,7 +242,7 @@ export async function playFlyChipToChat(opts: PlayFlyChipToChatOpts): Promise<vo
   }
   ensureFlyStyles();
   const from = opts.from;
-  const popMs = opts.popMs ?? 140;
+  const popMs = opts.popMs ?? 0;
   const label = String(opts.label || 'Chat').trim() || 'Chat';
 
   const el = document.createElement('div');
@@ -260,7 +260,7 @@ export async function playFlyChipToChat(opts: PlayFlyChipToChatOpts): Promise<vo
     'transform:translate(-50%,-50%)',
     'will-change:transform,opacity,offset-distance',
     'box-shadow:0 10px 28px rgba(15,23,42,0.2)',
-    `animation:recombyn-fly-chip-pop 160ms cubic-bezier(0.22, 1.2, 0.36, 1) forwards`,
+    'opacity:0',
   ].join(';');
 
   if (opts.thumbUrl) {

--- a/apps/web/src/components/editor/panels/agent/runDesignAgent.ts
+++ b/apps/web/src/components/editor/panels/agent/runDesignAgent.ts
@@ -846,6 +846,49 @@ export async function captureFocusFramePreview(
   }
 }
 
+function sceneInventoryFingerprint(doc: SceneDocument | null | undefined): string {
+  if (!doc) return '';
+  const ids = Object.keys(doc.deltaSetLike || {})
+    .filter((id) => id && id !== 'ROOT')
+    .sort();
+  const frames = (Array.isArray(doc.frames) ? doc.frames : [])
+    .map((f: { id?: string }) => String(f?.id || ''))
+    .filter(Boolean)
+    .sort();
+  return `${ids.length}:${ids.join(',')}|${frames.join(',')}`;
+}
+
+/** Wait until Redux scene inventory stops changing (Yjs/dispatch lag). */
+async function waitSceneInventorySettled(
+  getDocument: () => SceneDocument | null,
+  opts?: { timeoutMs?: number; stableFrames?: number }
+): Promise<void> {
+  const timeoutMs = Math.max(80, opts?.timeoutMs ?? 480);
+  const needStable = Math.max(1, opts?.stableFrames ?? 2);
+  const frame = () =>
+    new Promise<void>((resolve) => {
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => resolve());
+      } else {
+        setTimeout(resolve, 16);
+      }
+    });
+  const t0 = Date.now();
+  let prev = sceneInventoryFingerprint(getDocument());
+  let stable = 0;
+  while (Date.now() - t0 < timeoutMs) {
+    await frame();
+    const next = sceneInventoryFingerprint(getDocument());
+    if (next === prev) {
+      stable += 1;
+      if (stable >= needStable) return;
+    } else {
+      stable = 0;
+      prev = next;
+    }
+  }
+}
+
 /**
  * Prefer a real artboard raster for CLIP critique; fall back to schematic boxes.
  * Caps longest edge so the scene_feedback POST stays small.
@@ -2149,6 +2192,8 @@ export type RunDesignAgentParams = {
   /** Ask confirm: bind to design_task.meta.ask_proposal. */
   proposalId?: string | null;
   proposalTaskId?: string | null;
+  /** Board paint: ops (default) | img_layers (gen then split). */
+  paintMode?: 'ops' | 'img_layers' | null;
   /** User-pinned skill keys/ids from `/` chips. */
   skillRefs?: string[] | null;
   /** Resume a paused LangGraph run instead of starting a new /design/run. */
@@ -2168,6 +2213,9 @@ function buildRunDesignJobBody(
   };
   if (params.interactionMode === 'ask' || params.interactionMode === 'agent') {
     body.interaction_mode = params.interactionMode;
+  }
+  if (params.paintMode === 'ops' || params.paintMode === 'img_layers') {
+    body.paint_mode = params.paintMode;
   }
   if (runMode === 'agent' && params.scene) body.scene = params.scene;
   if (params.styleGroupId != null) body.style_group_id = params.styleGroupId;
@@ -3064,6 +3112,9 @@ export async function runDesignAgent(params: RunDesignAgentParams): Promise<void
     const prevPaint = paintChain;
     async function runSceneFeedbackAfterPaint() {
       await prevPaint;
+      if (params.signal?.aborted) return;
+      // Let Redux (+ collab Y push) settle before snapshot — avoids empty-board false critique.
+      await waitSceneInventorySettled(params.getDocument, { timeoutMs: 480, stableFrames: 2 });
       if (params.signal?.aborted) return;
       coverLiveBoard(
         processLabels.reviewing ||

--- a/apps/web/src/components/editor/panels/agent/runDesignAgent.ts
+++ b/apps/web/src/components/editor/panels/agent/runDesignAgent.ts
@@ -577,13 +577,13 @@ export type SpatialSummary = {
     is_empty: boolean;
   }>;
   overlaps: Array<{ a: string; b: string; iou: number }>;
-  /** Frame-local empty slots (create_shape/text/… inside focus). */
+  /** Frame-local empty slots — intentionally unused (no invented WxH suggestions). */
   empty_rects: SpatialBox[];
-  /** World-space slots for create_frame. */
+  /** World-space slots for create_frame (same size as focus plate). */
   new_frame_slots: SpatialBox[];
-  /** Frame-local default place for new children. */
-  suggested_place: SpatialBox;
-  /** Raw camera viewport in world coords (sensor only — host derives placement). */
+  /** @deprecated Not set — host must not invent place WxH for the model. */
+  suggested_place?: SpatialBox;
+  /** Raw camera viewport in world coords (sensor only). */
   viewport?: SpatialBox;
 };
 
@@ -687,59 +687,8 @@ export function buildSpatialSummary(
   }
   overlaps.sort((a, b) => b.iou - a.iou);
 
-  const occupied: SpatialBox[] = inFocus.map((n) => ({
-    x: n.x,
-    y: n.y,
-    w: n.w,
-    h: n.h,
-  }));
-  const candidates: SpatialBox[] = [];
-  // Right of content / below content / top-left empty.
-  let maxR = 0;
-  let maxB = 0;
-  for (const b of occupied) {
-    maxR = Math.max(maxR, b.x + b.w);
-    maxB = Math.max(maxB, b.y + b.h);
-  }
-  if (!occupied.length) {
-    // Empty frame: suggest the visible center, not top-left.
-    const cw = Math.min(320, Math.max(80, fw - gap * 2));
-    const ch = Math.min(200, Math.max(80, fh - gap * 2));
-    candidates.push({
-      x: Math.round(Math.max(gap, (fw - cw) / 2)),
-      y: Math.round(Math.max(gap, (fh - ch) / 2)),
-      w: cw,
-      h: ch,
-    });
-  } else {
-    candidates.push(
-      { x: Math.min(maxR + gap, Math.max(gap, fw - 360)), y: gap, w: 320, h: 200 },
-      { x: gap, y: Math.min(maxB + gap, Math.max(gap, fh - 240)), w: 320, h: 200 },
-      { x: gap, y: gap, w: 280, h: 160 }
-    );
-  }
-
-  const empty_rects: SpatialBox[] = [];
-  for (const c of candidates.slice(0, 3)) {
-    const box = {
-      x: Math.round(Math.max(0, c.x)),
-      y: Math.round(Math.max(0, c.y)),
-      w: Math.max(80, Math.round(c.w)),
-      h: Math.max(80, Math.round(c.h)),
-    };
-    if (occupied.some((o) => _boxesOverlap(box, o, gap))) continue;
-    empty_rects.push(box);
-    if (empty_rects.length >= 3) break;
-  }
-  if (!empty_rects.length) {
-    empty_rects.push({
-      x: Math.round(maxR + gap),
-      y: gap,
-      w: 320,
-      h: 200,
-    });
-  }
-
+  // Do NOT invent empty_rects / suggested_place with stock 320×200 (etc.).
+  // Those slots leaked into PLACEMENT and models copied them as create_frame size.
   const new_frame_slots: SpatialBox[] = [];
   if (frames.length) {
     let worldR = 0;
@@ -768,10 +717,9 @@ export function buildSpatialSummary(
     focused: inFocus,
     peripheral,
     overlaps: overlaps.slice(0, 12),
-    empty_rects,
+    empty_rects: [],
     new_frame_slots,
-    suggested_place: empty_rects[0],
-    // viewport is raw camera AABB only — host derives suggested_place_world.
+    // viewport is raw camera AABB only (no invented place slots).
     ...(viewport ? { viewport } : {}),
   };
 }

--- a/apps/web/src/components/home/LazyTemplateThumb.tsx
+++ b/apps/web/src/components/home/LazyTemplateThumb.tsx
@@ -5,7 +5,6 @@ import {
   projectThumbZoomLayerClass,
 } from '@/utils/projectThumb';
 import { nearestScrollRoot } from '@/components/home/InfiniteScroll';
-import { cn } from '@/utils/classnames';
 
 type Props = {
   document?: unknown;
@@ -55,12 +54,7 @@ function LazyTemplateThumb({
         {active && document ? (
           <TemplateThumbnail document={document} fit={fit} />
         ) : (
-          <div
-            className={cn(
-              'flex h-full w-full items-center justify-center bg-[var(--surface)]',
-              active && 'animate-pulse'
-            )}
-          />
+          <div className="rcb-skeleton-bone h-full w-full !rounded-none" />
         )}
       </div>
       {children}

--- a/apps/web/src/components/home/ProjectCard.tsx
+++ b/apps/web/src/components/home/ProjectCard.tsx
@@ -56,7 +56,7 @@ function ProjectCardSkeleton({ label }: { label?: string }): ReactNode {
   return (
     <article className="group" aria-busy="true" aria-label={label || 'loading'}>
       <div className={projectThumbFrameClass('rcb-skeleton-bone shadow-none')} />
-      <div className="mt-2.5 space-y-1.5 px-0.5">
+      <div className="rcb-skeleton-card mt-2.5 space-y-1.5 rounded-lg px-0.5 py-0.5">
         <div className="rcb-skeleton-bone h-3.5 w-[72%]" />
         <div className="rcb-skeleton-bone h-2.5 w-[48%]" />
       </div>

--- a/apps/web/src/components/home/ProjectCoverCollage.tsx
+++ b/apps/web/src/components/home/ProjectCoverCollage.tsx
@@ -105,19 +105,16 @@ function ProjectCoverCollage({
 /** Grid cell: min-h-0 so tall imgs cannot blow past the 170px frame; overflow clips. */
 function ImgTile({ src, className }: { src: string; className?: string }) {
   const [errored, setErrored] = useState(false);
+  if (errored) return null;
   return (
     <div className={cn('relative min-h-0 min-w-0 overflow-hidden', className)}>
-      {errored ? (
-        <div className="rcb-skeleton-bone absolute inset-0" />
-      ) : (
-        <img
-          src={src}
-          alt=""
-          className="absolute inset-0 h-full w-full bg-white object-contain"
-          loading="lazy"
-          onError={() => setErrored(true)}
-        />
-      )}
+      <img
+        src={src}
+        alt=""
+        className="absolute inset-0 h-full w-full bg-white object-contain"
+        loading="lazy"
+        onError={() => setErrored(true)}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/home/ProjectCoverCollage.tsx
+++ b/apps/web/src/components/home/ProjectCoverCollage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ReactNode, memo } from 'react';
+import { useMemo, useState, type ReactNode, memo } from 'react';
 import TemplateThumbnail from '@/components/templates/TemplateThumbnail';
 import LazyTemplateThumb from '@/components/home/LazyTemplateThumb';
 import {
@@ -104,15 +104,20 @@ function ProjectCoverCollage({
 
 /** Grid cell: min-h-0 so tall imgs cannot blow past the 170px frame; overflow clips. */
 function ImgTile({ src, className }: { src: string; className?: string }) {
+  const [errored, setErrored] = useState(false);
   return (
     <div className={cn('relative min-h-0 min-w-0 overflow-hidden', className)}>
-      {/* object-contain keeps shape tiles uncropped; white fill matches tile board. */}
-      <img
-        src={src}
-        alt=""
-        className="absolute inset-0 h-full w-full bg-white object-contain"
-        loading="lazy"
-      />
+      {errored ? (
+        <div className="rcb-skeleton-bone absolute inset-0" />
+      ) : (
+        <img
+          src={src}
+          alt=""
+          className="absolute inset-0 h-full w-full bg-white object-contain"
+          loading="lazy"
+          onError={() => setErrored(true)}
+        />
+      )}
     </div>
   );
 }
@@ -124,16 +129,7 @@ function ImgCollage({ urls }: { urls: string[] }) {
 
   const n = list.length;
   if (n <= 1) {
-    return (
-      <div className="absolute inset-0 overflow-hidden">
-        <img
-          src={list[0]}
-          alt=""
-          className="absolute inset-0 h-full w-full object-cover"
-          loading="lazy"
-        />
-      </div>
-    );
+    return <ImgTile src={list[0]!} className="absolute inset-0 [&>img]:object-cover" />;
   }
 
   if (n === 2) {

--- a/apps/web/src/components/home/SkillsLibraryPanel.tsx
+++ b/apps/web/src/components/home/SkillsLibraryPanel.tsx
@@ -73,20 +73,10 @@ function formatSkillUpdatedAt(ts: number | null | undefined, locale: string): st
 /** Same shell + title / line-clamp-2 desc metrics as the real skill card. */
 function SkillCardSkeleton(): ReactNode {
   return (
-    <div className={SKILL_CARD_SHELL} aria-hidden>
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0 flex-1">
-          <div className="flex h-[21px] items-center">
-            <div className="rcb-skeleton-bone h-3.5 w-[58%]" />
-          </div>
-          <div className="mt-1 space-y-1">
-            <div className="rcb-skeleton-bone h-[18px] w-full" />
-            <div className="rcb-skeleton-bone h-[18px] w-[80%]" />
-          </div>
-        </div>
-        <div className="rcb-skeleton-bone mt-0.5 h-5 w-9 shrink-0 !rounded-full" />
-      </div>
-    </div>
+    <div
+      className={cn(SKILL_CARD_SHELL, 'rcb-skeleton-bone min-h-[88px] !rounded-xl shadow-none')}
+      aria-hidden
+    />
   );
 }
 

--- a/apps/web/src/components/rcb/scene/document/sceneGroups.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneGroups.ts
@@ -1,6 +1,7 @@
 import { nanoid } from '@reduxjs/toolkit';
 import { listSceneNodes, normalizeDocument } from './sceneDocument';
-import type { SceneDocument, SceneNode, SceneNodeInput } from '@/components/rcb/sceneNode';
+import { isNodeLocked } from './nodeCapabilities';
+import type { SceneDocument, SceneNodeInput } from '@/components/rcb/sceneNode';
 
 /** Logical multi-object groups via attrs.groupId. */
 
@@ -22,21 +23,27 @@ export function listGroupMemberIds(
 
 /**
  * Expand a selection so that picking any member selects the whole group.
- * Used on click / marquee select (not when empty).
+ * Locked layers are never auto-included: expand only from unlocked seeds, and
+ * never pull locked siblings into the selection.
  */
 export function expandSelectionWithGroups(
   doc: SceneDocument | null | undefined,
   nodeIds: string[]
 ): string[] {
   if (!doc || !nodeIds?.length) return nodeIds || [];
+  const explicit = new Set(nodeIds.filter(Boolean));
   const out = new Set<string>();
-  for (const id of nodeIds) {
-    const gid = readNodeGroupId(doc.deltaSetLike?.[id]);
-    if (!gid) {
-      out.add(id);
-      continue;
+  for (const id of explicit) {
+    out.add(id);
+    const seed = doc.deltaSetLike?.[id];
+    // Locked hit stays itself — do not drag the rest of the group into selection.
+    if (isNodeLocked(seed)) continue;
+    const gid = readNodeGroupId(seed);
+    if (!gid) continue;
+    for (const mid of listGroupMemberIds(doc, gid)) {
+      if (isNodeLocked(doc.deltaSetLike?.[mid])) continue;
+      out.add(mid);
     }
-    listGroupMemberIds(doc, gid).forEach((mid) => out.add(mid));
   }
   return [...out];
 }
@@ -50,33 +57,52 @@ export function selectionSharedGroupId(
   nodeIds: string[]
 ): string | null {
   if (!doc || !nodeIds || nodeIds.length < 2) return null;
-  const first = readNodeGroupId(doc.deltaSetLike?.[nodeIds[0]]);
+  const unlocked = unlockedGroupableIds(doc, nodeIds);
+  if (unlocked.length < 2) return null;
+  const first = readNodeGroupId(doc.deltaSetLike?.[unlocked[0]]);
   if (!first) return null;
-  if (!nodeIds.every((id) => readNodeGroupId(doc.deltaSetLike?.[id]) === first)) return null;
-  const members = listGroupMemberIds(doc, first);
-  if (members.length !== nodeIds.length) return null;
-  const set = new Set(nodeIds);
+  if (!unlocked.every((id) => readNodeGroupId(doc.deltaSetLike?.[id]) === first)) {
+    return null;
+  }
+  const members = listGroupMemberIds(doc, first).filter(
+    (id) => !isNodeLocked(doc.deltaSetLike?.[id])
+  );
+  if (members.length !== unlocked.length) return null;
+  const set = new Set(unlocked);
   if (!members.every((id) => set.has(id))) return null;
   return first;
 }
 
-/** Assign a shared groupId to the given nodes. */
+/** Unlocked ids only — locked layers are never grouped / ungrouped. */
+export function unlockedGroupableIds(
+  doc: SceneDocument | null | undefined,
+  nodeIds: string[]
+): string[] {
+  return [...new Set((nodeIds || []).filter(Boolean))].filter(
+    (id) => doc?.deltaSetLike?.[id] && !isNodeLocked(doc.deltaSetLike[id])
+  );
+}
+
+/** Assign a shared groupId to the given nodes (skips locked). */
 export function groupNodesInDocument(doc: SceneDocument, nodeIds: string[]) {
-  const ids = [...new Set((nodeIds || []).filter(Boolean))];
+  const ids = unlockedGroupableIds(doc, nodeIds);
   if (ids.length < 2) return doc;
   const next = normalizeDocument(doc);
   const groupId = nanoid(8);
   ids.forEach((id) => {
     const node = next.deltaSetLike?.[id];
     if (!node) return;
-    node.attrs = { ...(node.attrs || {}), groupId };
+    next.deltaSetLike[id] = {
+      ...node,
+      attrs: { ...(node.attrs || {}), groupId },
+    };
   });
   return next;
 }
 
-/** Clear groupId from the given nodes (and leftover siblings in that group). */
+/** Clear groupId from the given nodes (and unlocked siblings in that group). */
 export function ungroupNodesInDocument(doc: SceneDocument, nodeIds: string[]) {
-  const ids = [...new Set((nodeIds || []).filter(Boolean))];
+  const ids = unlockedGroupableIds(doc, nodeIds);
   if (!ids.length) return doc;
   const next = normalizeDocument(doc);
   const groupIds = new Set<string>();
@@ -88,12 +114,10 @@ export function ungroupNodesInDocument(doc: SceneDocument, nodeIds: string[]) {
   listSceneNodes(next).forEach(({ id, node }) => {
     const gid = readNodeGroupId(node);
     if (!gid || !groupIds.has(gid)) return;
+    if (isNodeLocked(node)) return;
     const attrs = { ...(node.attrs || {}) };
     delete attrs.groupId;
-    node.attrs = attrs;
-    next.deltaSetLike[id] = node;
+    next.deltaSetLike[id] = { ...node, attrs };
   });
   return next;
 }
-
-/** Scene nodes whose center lies inside any of the given artboards. */

--- a/apps/web/src/components/rcb/scene/document/sceneRadii.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneRadii.ts
@@ -197,9 +197,11 @@ export function sharpCornerIndices(points: Array<[number, number]>): number[] {
   const diag = Math.hypot(maxX - minX, maxY - minY) || 1;
   const maxEdge = Math.max(...edgeLens, 1);
   const dense = n >= SHARP_CORNER_DENSE_VERT_COUNT;
-  // Dense: keep chord filter. Sparse: allow short sides of irregular polygons.
+  // Dense: chord filter keeps arc micro-stubs out, but must not discard real
+  // junction edges (boolean intersection points near a straight side).
+  // Use diag-fraction only — arc turn < minTurn already guards smooth samples.
   const minCornerEdge = dense
-    ? Math.max(diag * 0.02, maxEdge * 0.08)
+    ? Math.max(diag * 0.01, maxEdge * 0.03)
     : Math.max(1e-4, diag * 0.002);
   const minTurn = dense ? SHARP_CORNER_DENSE_MIN_DEG : SHARP_CORNER_MIN_DEG;
   const out: number[] = [];

--- a/apps/web/src/components/rcb/scene/document/sceneShapes.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneShapes.ts
@@ -758,6 +758,47 @@ function asDomElement(el: any): Element | null {
 }
 
 /**
+ * Liang–Barsky: true when segment (x0,y0)→(x1,y1) intersects the closed AABB.
+ * Midpoint-only checks miss small marquees that a stroke segment crosses off-center.
+ */
+export function segmentIntersectsAabb(
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  left: number,
+  top: number,
+  right: number,
+  bottom: number
+): boolean {
+  let t0 = 0;
+  let t1 = 1;
+  const dx = x1 - x0;
+  const dy = y1 - y0;
+  const edges: Array<[number, number]> = [
+    [-dx, x0 - left],
+    [dx, right - x0],
+    [-dy, y0 - top],
+    [dy, bottom - y0],
+  ];
+  for (const [p, q] of edges) {
+    if (p === 0) {
+      if (q < 0) return false;
+      continue;
+    }
+    const r = q / p;
+    if (p < 0) {
+      if (r > t1) return false;
+      if (r > t0) t0 = r;
+    } else {
+      if (r < t0) return false;
+      if (r < t1) t1 = r;
+    }
+  }
+  return t0 <= t1;
+}
+
+/**
  * Whether a local-space path stroke intersects a world-space AABB
  * (marquee / box select). Samples the centerline — not the path's own AABB.
  */
@@ -801,10 +842,9 @@ export function pathStrokeHitsSceneBox(
       const lp = el.getPointAtLength(Math.min(t, len));
       const p = toWorld(lp.x, lp.y);
       if (inBox(p.x, p.y)) return true;
-      // Segment crosses the rect (coarse: midpoint + endpoints already checked).
-      const mx = (prev.x + p.x) / 2;
-      const my = (prev.y + p.y) / 2;
-      if (inBox(mx, my)) return true;
+      if (segmentIntersectsAabb(prev.x, prev.y, p.x, p.y, left, top, right, bottom)) {
+        return true;
+      }
       prev = p;
     }
     return false;

--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -73,6 +73,9 @@ import {
   applyTextWrapHeight,
   normalizeBox,
   boxesIntersect,
+  expandSceneBox,
+  marqueeHitPadScene,
+  MARQUEE_MIN_HIT_SCREEN_PX,
   framesHittingMarquee,
   resolveInspectPrimaryId,
   isHostInjectedSelection,
@@ -1296,9 +1299,12 @@ function SelectionFeature({
           endTransform();
           return;
         }
-        const candidates = queryNodeIdsInRect?.(box) ?? listNodeIds();
+        // Pad spatial prefilter the same as fine hit — tiny nodes near the brush edge.
+        const queryPad = marqueeHitPadScene(zoom) + MARQUEE_MIN_HIT_SCREEN_PX / Math.max(0.05, zoom);
+        const queryBox = expandSceneBox(box, queryPad);
+        const candidates = queryNodeIdsInRect?.(queryBox) ?? listNodeIds();
         const rawHits = candidates.filter((id) =>
-          nodeHitsMarquee(sceneDoc, id, box, getNodeBox, toScene)
+          nodeHitsMarquee(sceneDoc, id, box, getNodeBox, toScene, zoom)
         );
         const frameHits = framesHittingMarquee(sceneDoc, box).map((f) => f.id);
         // Full-bleed plate: keep when artboard brushed, or other non-plate content hit.

--- a/apps/web/src/components/rcb/selection/__tests__/postSplitCanvasRegression.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/postSplitCanvasRegression.test.ts
@@ -16,8 +16,12 @@ import {
   commitMarqueeSelection,
   normalizeBox,
   boxesIntersect,
+  ensureMinScreenHitBox,
+  MARQUEE_MIN_HIT_SCREEN_PX,
+  nodeHitsMarquee,
   makeDragSeed,
 } from '../selectionLogic';
+import { segmentIntersectsAabb } from '@/components/rcb/scene/document/sceneShapes';
 import { computeShapeBoolean, type ShapeBox } from '../shapeBoolean';
 import { smartSnapThreshold } from '../alignGuides';
 import {
@@ -52,6 +56,58 @@ describe('selectionLogic marquee helpers', () => {
     expect(box).toEqual({ left: 20, top: 10, width: 100, height: 70 });
     expect(boxesIntersect(box, { left: 90, top: 50, width: 40, height: 40 })).toBe(true);
     expect(boxesIntersect(box, { left: 200, top: 200, width: 10, height: 10 })).toBe(false);
+  });
+
+  it('ensureMinScreenHitBox expands hairline nodes in scene space', () => {
+    const tiny = { left: 10, top: 10, width: 1, height: 1 };
+    const expanded = ensureMinScreenHitBox(tiny, 1);
+    expect(expanded.width).toBeGreaterThanOrEqual(MARQUEE_MIN_HIT_SCREEN_PX);
+    expect(expanded.height).toBeGreaterThanOrEqual(MARQUEE_MIN_HIT_SCREEN_PX);
+    // Center preserved.
+    expect(expanded.left + expanded.width / 2).toBeCloseTo(10.5, 5);
+    expect(expanded.top + expanded.height / 2).toBeCloseTo(10.5, 5);
+  });
+
+  it('nodeHitsMarquee selects tiny rect with a tight brush via hit pad', () => {
+    const doc = {
+      x: 0,
+      y: 0,
+      width: 400,
+      height: 400,
+      deltaSetLike: {
+        tiny: {
+          id: 'tiny',
+          key: 'shape',
+          x: 100,
+          y: 100,
+          width: 2,
+          height: 2,
+          attrs: { shapeType: 'rect' },
+          children: [],
+        },
+      },
+    } satisfies Partial<SceneDocument> as SceneDocument;
+    const getNodeBox = (id: string) => {
+      const n = doc.deltaSetLike?.[id];
+      if (!n) return null;
+      return {
+        left: Number(n.x) || 0,
+        top: Number(n.y) || 0,
+        width: Math.max(1, Number(n.width) || 1),
+        height: Math.max(1, Number(n.height) || 1),
+      };
+    };
+    // Brush grazes just outside the stored 2×2 box — pad + min hit should still catch it.
+    const marquee = { left: 95, top: 95, width: 4, height: 4 };
+    expect(nodeHitsMarquee(doc, 'tiny', marquee, getNodeBox, () => ({ x: 0, y: 0 }), 1)).toBe(
+      true
+    );
+  });
+
+  it('segmentIntersectsAabb catches off-center crossings (midpoint-only would miss)', () => {
+    // Horizontal segment y=10 from x=0→20; tiny box at x=2..3 (midpoint at 10 is outside).
+    expect(segmentIntersectsAabb(0, 10, 20, 10, 2, 8, 3, 12)).toBe(true);
+    expect(segmentIntersectsAabb(0, 0, 1, 1, 50, 50, 60, 60)).toBe(false);
   });
 
   it('framesHittingMarquee + filter + commit', () => {

--- a/apps/web/src/components/rcb/selection/alignGuides.ts
+++ b/apps/web/src/components/rcb/selection/alignGuides.ts
@@ -43,11 +43,14 @@ export type SmartGuideLine = SmartGuideAlign | SmartGuideGap;
 
 /**
  * Object-guide magnet radius in scene units (`SMART_SNAP_PX / zoom`).
+ * Capped at 40 scene units so low-zoom drags don't get yanked by distant elements.
  * Grid quantize is a separate pass and must not widen this.
  */
+export const SMART_SNAP_MAX_SCENE = 40;
+
 export function smartSnapThreshold(zoom: number): number {
   const z = Math.max(0.05, Number(zoom) || 1);
-  return SMART_SNAP_PX / z;
+  return Math.min(SMART_SNAP_PX / z, SMART_SNAP_MAX_SCENE);
 }
 
 /**

--- a/apps/web/src/components/rcb/selection/chrome/BlendModeControl.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/BlendModeControl.tsx
@@ -335,8 +335,8 @@ function BlendModeControl({
                 value={pct}
                 onChange={applyPct}
                 trackHeight={6}
-                thumbWidth={10}
-                thumbHeight={18}
+                thumbWidth={16}
+                thumbHeight={16}
               />
             </div>
 

--- a/apps/web/src/components/rcb/selection/chrome/CornerRadiusHandlesOverlay.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/CornerRadiusHandlesOverlay.tsx
@@ -478,6 +478,13 @@ function CornerRadiusHandlesOverlay({
   );
   // Circle / ellipse: no corners — AABB park seats sit in the empty square corners
   // (outside the disk). Rect-style R dots stay off.
+  // Path / pen with curves (C/Q/A): parseClosedPathRings returns [] → pathSites null.
+  // Those shapes have no sharp corners to fillet, so skip AABB fallback handles entirely.
+  const isPathType =
+    node?.key === 'path' ||
+    node?.key === 'pen' ||
+    shapeType === 'path' ||
+    shapeType === 'pen';
   const skipRadiusHandles =
     shapeType === 'circle' || shapeType === 'ellipse' || node?.key === 'ellipse';
 
@@ -488,6 +495,10 @@ function CornerRadiusHandlesOverlay({
   const linked = isRadiusLinked(node?.attrs);
   const pathSites = skipRadiusHandles ? null : sharpCornerSitesForNode(node);
   const usePath = Boolean(pathSites && pathSites.length > 0);
+  // Path/pen with no parseable sharp corners (curves only) → no handles at all.
+  // Without this guard the code falls back to AABB box-mode handles that float
+  // in the empty space outside the actual shape (e.g. crescent, arc shapes).
+  if (isPathType && !usePath) return null;
   const pathVertexCount = usePath ? pathSites!.length : 0;
   const pathVertices = usePath
     ? resolvePathVertexRadii(node?.attrs, pathVertexCount, baseRadii)

--- a/apps/web/src/components/rcb/selection/chrome/MultiSelectionToolbar.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/MultiSelectionToolbar.tsx
@@ -25,7 +25,8 @@ import {
 import {
   groupNodesInDocument,
   selectionSharedGroupId,
-  ungroupNodesInDocument
+  ungroupNodesInDocument,
+  unlockedGroupableIds,
 } from '@/components/rcb/scene/document/sceneGroups';
 import {
   resolveSelectionNodeIds
@@ -63,7 +64,12 @@ import {
   sizeFromAspectPreset,
 } from '../resizeGeometry';
 import { radiiFromAttrs } from '@/components/rcb/scene/document/sceneRadii';
-import { computeShapeBoolean, applyBooleanResultPaint, type BoolMode } from '../shapeBoolean';
+import {
+  computeShapeBoolean,
+  applyBooleanResultPaint,
+  applyBooleanResultRadii,
+  type BoolMode,
+} from '../shapeBoolean';
 import type { SceneDocument, SceneNode, SceneNodeInput } from '@/components/rcb/sceneNode';
 
 const ASPECT_ORIG_W = 'aspect-original-width';
@@ -416,6 +422,7 @@ function MultiSelectionToolbar({
       sampleNode?.attrs as Record<string, unknown> | undefined,
       { stroke: sample.stroke, borderWidth: sample.borderWidth }
     );
+    applyBooleanResultRadii(attrs, shapeBoxes);
 
     let next = addNodeToDocument(document, id, node);
     next = removeNodesFromDocument(next, ids);
@@ -537,16 +544,19 @@ function MultiSelectionToolbar({
   const groupId = selectionSharedGroupId(document, opNodeIds);
 
   const createGroup = () => {
-    if (opNodeIds.length < 2) return;
-    const next = groupNodesInDocument(document, opNodeIds);
+    const ids = unlockedGroupableIds(document, opNodeIds);
+    if (ids.length < 2) return;
+    const next = groupNodesInDocument(document, ids);
     dispatch(setDocument(next));
-    dispatch(setMixedSelection({ nodeIds: opNodeIds, frameIds }));
+    dispatch(setMixedSelection({ nodeIds: ids, frameIds }));
   };
 
   const ungroup = () => {
-    const next = ungroupNodesInDocument(document, opNodeIds);
+    const ids = unlockedGroupableIds(document, opNodeIds);
+    if (!ids.length) return;
+    const next = ungroupNodesInDocument(document, ids);
     dispatch(setDocument(next));
-    dispatch(setMixedSelection({ nodeIds: opNodeIds, frameIds }));
+    dispatch(setMixedSelection({ nodeIds: ids, frameIds }));
   };
 
   const applyAspectPreset = (preset: (typeof ELEMENT_ASPECT_PRESETS)[number]) => {

--- a/apps/web/src/components/rcb/selection/chrome/MultiSelectionToolbar.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/MultiSelectionToolbar.tsx
@@ -67,7 +67,6 @@ import { radiiFromAttrs } from '@/components/rcb/scene/document/sceneRadii';
 import {
   computeShapeBoolean,
   applyBooleanResultPaint,
-  applyBooleanResultRadii,
   type BoolMode,
 } from '../shapeBoolean';
 import type { SceneDocument, SceneNode, SceneNodeInput } from '@/components/rcb/sceneNode';
@@ -422,7 +421,6 @@ function MultiSelectionToolbar({
       sampleNode?.attrs as Record<string, unknown> | undefined,
       { stroke: sample.stroke, borderWidth: sample.borderWidth }
     );
-    applyBooleanResultRadii(attrs, shapeBoxes);
 
     let next = addNodeToDocument(document, id, node);
     next = removeNodesFromDocument(next, ids);

--- a/apps/web/src/components/rcb/selection/selectionLogic.ts
+++ b/apps/web/src/components/rcb/selection/selectionLogic.ts
@@ -249,6 +249,55 @@ export function boxesIntersect(a: SceneBox, b: SceneBox) {
   );
 }
 
+export function unionSceneBoxes(a: SceneBox, b: SceneBox): SceneBox {
+  const left = Math.min(a.left, b.left);
+  const top = Math.min(a.top, b.top);
+  const right = Math.max(a.left + a.width, b.left + b.width);
+  const bottom = Math.max(a.top + a.height, b.top + b.height);
+  return {
+    left,
+    top,
+    width: Math.max(1, right - left),
+    height: Math.max(1, bottom - top),
+  };
+}
+
+export function expandSceneBox(box: SceneBox, pad: number): SceneBox {
+  if (!(pad > 0)) return box;
+  return {
+    left: box.left - pad,
+    top: box.top - pad,
+    width: Math.max(1, box.width + pad * 2),
+    height: Math.max(1, box.height + pad * 2),
+  };
+}
+
+/**
+ * Screen-constant marquee slack (px) → scene units.
+ * Small brush / tiny nodes otherwise miss when the rect only grazes ink.
+ */
+export const MARQUEE_HIT_PAD_SCREEN_PX = 3;
+/** Floor hit AABB so sub-pixel / hairline nodes stay brushable. */
+export const MARQUEE_MIN_HIT_SCREEN_PX = 6;
+
+export function marqueeHitPadScene(zoom: number): number {
+  return MARQUEE_HIT_PAD_SCREEN_PX / Math.max(0.05, zoom || 1);
+}
+
+export function ensureMinScreenHitBox(box: SceneBox, zoom: number): SceneBox {
+  const z = Math.max(0.05, zoom || 1);
+  const min = MARQUEE_MIN_HIT_SCREEN_PX / z;
+  const w = Math.max(box.width, min);
+  const h = Math.max(box.height, min);
+  if (w === box.width && h === box.height) return box;
+  return {
+    left: box.left + box.width / 2 - w / 2,
+    top: box.top + box.height / 2 - h / 2,
+    width: w,
+    height: h,
+  };
+}
+
 /** Frame AABB ??marquee ??same idea as selecting a rectangle. Locked frames are skipped. */
 export function framesHittingMarquee(doc: SceneDocument, marquee: SceneBox): Array<{ id: string; area: number }> {
   const frames = Array.isArray(doc?.frames) ? doc.frames : [];
@@ -384,50 +433,60 @@ export function pointInBox(x: number, y: number, box: SceneBox, pad = 0) {
 }
 
 /**
- * Marquee hit ??match click semantics per type:
+ * Marquee hit — match click semantics per type:
  * - rect / geo / text / image: AABB (same as click)
  * - pen / pencil / path: stroke/path sampling (click uses ink, not empty AABB gaps)
  * - line / arrow: shaft endpoints / mid
+ *
+ * Uses union(data, DOM) + screen-constant pad so small nodes / tight brushes
+ * don't miss when ink is slightly outside the stored geom box.
  */
 export function nodeHitsMarquee(
   doc: SceneDocument,
   nodeId: string,
   marquee: SceneBox,
   getNodeBox: (id: string) => SceneBox | null,
-  toScene: (clientX: number, clientY: number) => { x: number; y: number }
+  toScene: (clientX: number, clientY: number) => { x: number; y: number },
+  zoom = 1
 ): boolean {
   const node = doc?.deltaSetLike?.[nodeId];
   if (!node || isNodeHidden(node)) return false;
   const dataBox = getNodeBox(nodeId);
   const domBox = sceneBoxFromMountedNode(nodeId, toScene);
-  const box = domBox || dataBox;
+  let box = dataBox && domBox ? unionSceneBoxes(dataBox, domBox) : domBox || dataBox;
   if (!box) return false;
+  box = ensureMinScreenHitBox(box, zoom);
+  const hitMarquee = expandSceneBox(marquee, marqueeHitPadScene(zoom));
+  const strokePad = 3 + marqueeHitPadScene(zoom);
 
   const shapeType = String(node.attrs?.shapeType || '');
   if (shapeType === 'line' || shapeType === 'arrow') {
     const ep = strokeEndpointsFromBox(box, Number(node.attrs?.angle) || 0);
-    if (pointInBox(ep.x0, ep.y0, marquee, 2) || pointInBox(ep.x1, ep.y1, marquee, 2)) {
+    if (
+      pointInBox(ep.x0, ep.y0, hitMarquee, strokePad) ||
+      pointInBox(ep.x1, ep.y1, hitMarquee, strokePad)
+    ) {
       return true;
     }
     const mx = (ep.x0 + ep.x1) / 2;
     const my = (ep.y0 + ep.y1) / 2;
-    return pointInBox(mx, my, marquee, 2) || boxesIntersect(marquee, box);
+    return pointInBox(mx, my, hitMarquee, strokePad) || boxesIntersect(hitMarquee, box);
   }
 
   if (shapeType === 'pen' || shapeType === 'pencil' || shapeType === 'path') {
     const d = String(node.attrs?.path || node.attrs?.d || '');
     // Filled closed path: AABB is fine (same spirit as click fill hit).
-    if (shapeType !== 'pen' && supportsFill(node) && boxesIntersect(marquee, box)) {
+    if (shapeType !== 'pen' && supportsFill(node) && boxesIntersect(hitMarquee, box)) {
       return true;
     }
     if (d) {
-      return pathStrokeHitsSceneBox(d, box, Number(node.attrs?.angle) || 0, marquee, 3);
+      return pathStrokeHitsSceneBox(d, box, Number(node.attrs?.angle) || 0, hitMarquee, strokePad);
     }
-    return boxesIntersect(marquee, box);
+    return boxesIntersect(hitMarquee, box);
   }
 
-  // rect / ellipse / text / image / other geo ??AABB like click.
-  return boxesIntersect(marquee, box);
+  // rect / ellipse / text / image / other geo — AABB like click.
+  return boxesIntersect(hitMarquee, box);
 }
 
 /**

--- a/apps/web/src/components/rcb/selection/shapeBoolean.ts
+++ b/apps/web/src/components/rcb/selection/shapeBoolean.ts
@@ -10,6 +10,7 @@ import {
 import { getShapeBaselineD } from '@/components/rcb/core/geometry';
 import {
   clampCornerRadii,
+  filletPathD,
   maxRadius,
   radiiFromAttrs,
   type CornerRadii,
@@ -403,7 +404,13 @@ function sparsifyClosedRing(
 function localBaselinePathD(b: ShapeBox): string {
   const t = String(b.shapeType || 'rect');
   if (t === 'path' || t === 'pen') {
-    return String(b.path || b.attrs?.path || b.attrs?.d || '').trim();
+    const raw = String(b.path || b.attrs?.path || b.attrs?.d || '').trim();
+    if (!raw || t === 'pen') return raw;
+    // Closed paths keep a sharp base + live radii; boolean must sample the
+    // painted fillet or nested boolean / path×rect ops lose round corners.
+    const radii = radiiFromAttrs(b.attrs);
+    if (maxRadius(radii) > 0.5) return filletPathD(raw, radii, b.attrs);
+    return raw;
   }
   const attrs: Record<string, unknown> = {
     ...(b.attrs || {}),
@@ -837,6 +844,38 @@ export function computeShapeBoolean(
     usedFallback: false,
     hasNonRect,
   };
+}
+
+/**
+ * Max painted corner radius across boolean operands (rects / paths with R).
+ * Result paths keep a sharp base; paint fillets sharp verts via these attrs
+ * (incl. the reentrant L elbow that boolean geometry never rounds).
+ */
+export function maxBooleanOperandRadius(boxes: ShapeBox[]): number {
+  let maxR = 0;
+  for (const b of boxes) {
+    maxR = Math.max(maxR, maxRadius(radiiFromAttrs(b.attrs)));
+  }
+  return maxR;
+}
+
+/**
+ * Copy operand roundness onto the boolean result path node.
+ * createShapeNode zeroes radius*; without this, outer arcs may stay as samples
+ * while new sharp corners (inner L) stay hard right angles.
+ */
+export function applyBooleanResultRadii(attrs: Record<string, unknown>, boxes: ShapeBox[]) {
+  const maxR = maxBooleanOperandRadius(boxes);
+  if (!(maxR > 0.5)) return;
+  const v = Math.max(1, Math.round(maxR));
+  attrs.radiusTL = v;
+  attrs.radiusTR = v;
+  attrs.radiusBR = v;
+  attrs.radiusBL = v;
+  attrs.cornerRadius = v;
+  attrs.radiusLinked = 'true';
+  // Linked uniform expands to every sharp corner (incl. concave elbows).
+  delete attrs.radiusVertices;
 }
 
 /**

--- a/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
@@ -55,7 +55,7 @@ const MAX_FULL_HOSTS = 96;
 const MAX_PROXY_PAINT = 4096;
 
 /** Below this zoom, prefer proxies for most on-screen nodes. */
-const LOD_ZOOM_FAR = 0.42;
+const LOD_ZOOM_FAR = 0.2;
 
 /** Cap centerline samples when stroking a dense pencil path as LOD ink. */
 const LOD_STROKE_MAX_PTS = 64;

--- a/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
@@ -67,6 +67,71 @@ function isTransparentPaint(v: unknown): boolean {
   return !s || s === 'none' || s === 'transparent' || s === 'rgba(0,0,0,0)';
 }
 
+/** Draw a minimal image-placeholder icon (mountain + sun) into ctx at (0,0) w×h. */
+function drawImageProxyIcon(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  opacity: number
+): void {
+  const s = Math.min(w, h) * 0.28;
+  if (s < 3) return;
+  const cx = w / 2;
+  const cy = h / 2;
+  ctx.save();
+  ctx.globalAlpha = opacity * 0.55;
+  // Background fill
+  ctx.fillStyle = '#cbd5e1';
+  ctx.fillRect(0, 0, w, h);
+  // Border
+  ctx.strokeStyle = '#94a3b8';
+  ctx.lineWidth = Math.max(0.5, Math.min(1.5, s * 0.06));
+  ctx.strokeRect(0, 0, w, h);
+  // Sun circle
+  const sunR = s * 0.18;
+  ctx.fillStyle = '#94a3b8';
+  ctx.beginPath();
+  ctx.arc(cx - s * 0.28, cy - s * 0.22, sunR, 0, Math.PI * 2);
+  ctx.fill();
+  // Mountain triangle
+  ctx.beginPath();
+  ctx.moveTo(cx - s * 0.5, cy + s * 0.35);
+  ctx.lineTo(cx, cy - s * 0.2);
+  ctx.lineTo(cx + s * 0.5, cy + s * 0.35);
+  ctx.closePath();
+  ctx.fill();
+  // Small right hill
+  ctx.beginPath();
+  ctx.moveTo(cx + s * 0.1, cy + s * 0.35);
+  ctx.lineTo(cx + s * 0.45, cy + s * 0.05);
+  ctx.lineTo(cx + s * 0.8, cy + s * 0.35);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}
+
+/** Text proxy: greeking lines at (0,0) w×h — no solid AABB. */
+function drawTextProxyLines(
+  ctx: CanvasRenderingContext2D,
+  node: SceneNodeInput,
+  w: number,
+  h: number,
+  fill: string,
+  opacity: number
+): void {
+  const fontSize = Math.max(6, Number(node.attrs?.fontSize) || 14);
+  const lineH = fontSize * (Number(node.attrs?.lineHeight) || 1.4);
+  const lineCount = Math.max(1, Math.round(h / lineH));
+  const barH = Math.max(1, Math.min(fontSize * 0.55, lineH * 0.55));
+  const lastLineW = w * (0.35 + 0.4 * Math.abs(Math.sin(w * 0.05)));
+  ctx.fillStyle = fill;
+  for (let li = 0; li < lineCount; li++) {
+    const barW = li === lineCount - 1 && lineCount > 1 ? lastLineW : w;
+    ctx.globalAlpha = opacity * 0.72;
+    ctx.fillRect(0, li * lineH + (lineH - barH) / 2, barW, barH);
+  }
+}
+
 /** Pencil / open strokes must never become solid AABB 色块 at far zoom. */
 export function lodProxyIsStrokeOnly(node: SceneNodeInput): boolean {
   const a = node?.attrs || {};
@@ -204,6 +269,14 @@ export function pickFullAndProxyIds(opts: {
     const force = keepSet.has(id);
     let score = screenAreaPx(node, zoom);
     if (isHeavyPathNode(node) && forceLod) score *= 0.05;
+    // Far zoom: demote media-heavy nodes (image/video/lottie/text) so cheap shapes
+    // stay as full SVG hosts and expensive ones drop to canvas proxy.
+    if (far && !force) {
+      const key = String(node?.key || '');
+      if (key === 'image' || key === 'video' || key === 'lottie' || key === 'text') {
+        score *= 0.08;
+      }
+    }
     scored.push({ id, score, force });
   }
   scored.sort((a, b) => {
@@ -271,6 +344,7 @@ function paintLodProxiesCanvas(opts: {
     const pathD = String(node.attrs?.path || node.attrs?.d || '');
     ctx.save();
     ctx.globalAlpha = opacity;
+    const isMedia = node.key === 'image' || node.key === 'video' || node.key === 'lottie';
     if (Math.abs(angle) > 0.5) {
       const cx = left + w / 2;
       const cy = top + h / 2;
@@ -281,12 +355,15 @@ function paintLodProxiesCanvas(opts: {
         ctx.strokeStyle = fill;
         ctx.lineWidth = nodeProxyStrokeWidth(node, zoom);
         if (!strokeLodCenterline(ctx, pathD)) {
-          // Unparseable stroke — thin line on long axis, never a filled AABB.
           ctx.beginPath();
           ctx.moveTo(0, h / 2);
           ctx.lineTo(w, h / 2);
           ctx.stroke();
         }
+      } else if (node.key === 'text') {
+        drawTextProxyLines(ctx, node, w, h, fill, opacity);
+      } else if (isMedia) {
+        drawImageProxyIcon(ctx, w, h, opacity);
       } else {
         ctx.fillStyle = fill;
         ctx.fillRect(0, 0, w, h);
@@ -301,6 +378,16 @@ function paintLodProxiesCanvas(opts: {
         ctx.lineTo(w, h / 2);
         ctx.stroke();
       }
+    } else if (node.key === 'text') {
+      ctx.save();
+      ctx.translate(left, top);
+      drawTextProxyLines(ctx, node, w, h, fill, opacity);
+      ctx.restore();
+    } else if (isMedia) {
+      ctx.save();
+      ctx.translate(left, top);
+      drawImageProxyIcon(ctx, w, h, opacity);
+      ctx.restore();
     } else {
       ctx.fillStyle = fill;
       ctx.fillRect(left, top, w, h);

--- a/apps/web/src/components/templates/PlazaPublishDialog.tsx
+++ b/apps/web/src/components/templates/PlazaPublishDialog.tsx
@@ -143,7 +143,7 @@ function PlazaPublishForm({
       <div className="overflow-hidden rounded-2xl border border-[var(--line)] bg-[var(--canvas)]">
         <div className="aspect-[680/385] w-full overflow-hidden bg-[var(--canvas)]">
           {resolvingCover && !hasThumbCollage ? (
-            <div className="h-full w-full animate-pulse bg-[var(--accent-soft)]" />
+            <div className="rcb-skeleton-bone h-full w-full !rounded-none" />
           ) : (
             <ProjectCoverCollage
               urls={resolvedUrls}

--- a/apps/web/src/components/templates/TemplateThumbnail.tsx
+++ b/apps/web/src/components/templates/TemplateThumbnail.tsx
@@ -74,7 +74,7 @@ function TemplateThumbnail({
   if (!src) {
     return (
       <div
-        className="h-full w-full animate-pulse bg-[var(--accent-soft)]"
+        className="rcb-skeleton-bone h-full w-full"
         style={{ backgroundColor: paperBg }}
       />
     );

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1393,6 +1393,11 @@ const en = {
     routeMultimodalCustom: 'Multi-route',
     routeMultimodalSingle: 'Single',
     routeBack: 'Back',
+    paintMode: 'Board paint',
+    paintModeTip:
+      'Canvas ops: Agent paints with editable tool ops. Image layers: generate a full board then split into editable layers (strong look; text editability depends on OCR).',
+    paintModeOps: 'Canvas ops',
+    paintModeImgLayers: 'Image layers',
     routePresetShortPlatform: 'Auto',
     routePresetShortEconomy: 'Economy',
     routePresetShortBalanced: 'Balanced',
@@ -1621,6 +1626,8 @@ const en = {
       'Some ops failed to apply ({{count}}): {{notes}}. Retry on a specific element.',
     uxTipApplyConfirmFailed:
       'Confirmed plan could not be applied safely ({{error}}). Rephrase or retry.',
+    uxTipObserveSceneTimeout:
+      'Canvas feedback timed out — continuing as applied, without auto re-paint.',
     uxTipObserveCritiqueFailed: 'Canvas structure check failed: {{issues}}',
     uxTipReviewMustFix: 'Review did not pass: {{issues}}',
     uxTipApplyOpsApplied: 'Applied {{count}} canvas change(s).',
@@ -1665,8 +1672,10 @@ const en = {
     providerPresetModel: 'Model',
     providerPresetModelPlaceholder: 'Choose a model',
     providerPresetComingSoon: 'coming soon',
+    providerManualHint:
+      'Custom endpoint: fill API key, base URL, and the upstream model id (e.g. deepseek-chat). A key alone is not enough — requests need a model field.',
     providerPlatformHint:
-      'After picking a platform, fill the API key first. Name and base URL autofill. Optionally add an extra model id below — saved together with the key.',
+      'After picking a platform, fill the API key first. Name and base URL autofill. Optionally add an extra model below — once you start, name/icon/category are required.',
     providerPlatformUnlock:
       'Unlocks every catalog model on this platform. Uses your own quota — no platform credits.',
     providerPlatformAutofillHint:

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1398,6 +1398,8 @@ const en = {
       'Canvas ops: Agent paints with editable tool ops. Image layers: generate a full board then split into editable layers (strong look; text editability depends on OCR).',
     paintModeOps: 'Canvas ops',
     paintModeImgLayers: 'Image layers',
+    paintModeImgLayersTokenWarn:
+      'Image layers generates a full-board image first, which uses significantly more tokens than Canvas ops.',
     routePresetShortPlatform: 'Auto',
     routePresetShortEconomy: 'Economy',
     routePresetShortBalanced: 'Balanced',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1386,6 +1386,11 @@ const zhCN = {
     routeMultimodalCustom: '多路由',
     routeMultimodalSingle: '单模型',
     routeBack: '返回',
+    paintMode: '板式生成',
+    paintModeTip:
+      '工具操作：Agent 用画布指令精细排版。生图拆层：先生成整板图片再拆成可编辑图层（观感强，文字可编性取决于识别）。',
+    paintModeOps: '工具操作',
+    paintModeImgLayers: '生图拆层',
     routePresetShortPlatform: 'Auto',
     routePresetShortEconomy: '省钱',
     routePresetShortBalanced: '均衡',
@@ -1611,6 +1616,7 @@ const zhCN = {
     uxTipPaintFailed: '未能生成有效画布操作，请描述更具体的修改。',
     uxTipObserveOpsFailed: '部分操作未能应用（{{count}}）：{{notes}}。请针对具体元素重试。',
     uxTipApplyConfirmFailed: '确认的方案无法安全应用（{{error}}），请换一种说法或重试。',
+    uxTipObserveSceneTimeout: '画布回传超时，已按操作已应用继续，未触发自动重绘。',
     uxTipObserveCritiqueFailed: '画布结构校验未通过：{{issues}}',
     uxTipReviewMustFix: '评审未通过：{{issues}}',
     uxTipApplyOpsApplied: '已应用 {{count}} 项修改',
@@ -1658,8 +1664,10 @@ const zhCN = {
     providerPresetModel: '模型',
     providerPresetModelPlaceholder: '选择模型',
     providerPresetComingSoon: '即将支持',
+    providerManualHint:
+      '自定义端点：需填写 API Key、请求地址，以及上游 model 字段（如 deepseek-chat）。仅填密钥不够，请求必须带模型 ID。',
     providerPlatformHint:
-      '选择平台后先填 API Key；名称和请求地址会自动回显。目录外模型在下方填写模型 ID、名称、图标与分类（均必填）。',
+      '选择平台后先填 API Key；名称和请求地址会自动回显。目录外模型在下方可选填写（开始填写后名称/图标/分类才必填）。',
     providerPlatformUnlock: '解锁该平台目录中的全部模型。使用你自己的额度，不消耗平台积分。',
     providerPlatformAutofillHint: '已按平台自动填好，一般不用改。',
     providerModelKindPlatform: '平台',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1391,6 +1391,8 @@ const zhCN = {
       '工具操作：Agent 用画布指令精细排版。生图拆层：先生成整板图片再拆成可编辑图层（观感强，文字可编性取决于识别）。',
     paintModeOps: '工具操作',
     paintModeImgLayers: '生图拆层',
+    paintModeImgLayersTokenWarn:
+      '生图拆层会先生成整板图片，Token 消耗明显高于工具操作模式。',
     routePresetShortPlatform: 'Auto',
     routePresetShortEconomy: '省钱',
     routePresetShortBalanced: '均衡',

--- a/apps/web/src/service/design.ts
+++ b/apps/web/src/service/design.ts
@@ -324,6 +324,8 @@ export type RunDesignJobBody = {
   prompt: string;
   /** agent = auto paint; ask = propose / clarify first (same LangGraph). */
   interaction_mode?: 'agent' | 'ask';
+  /** ops = default tool_ops graph; img_layers = generate board then split layers. */
+  paint_mode?: 'ops' | 'img_layers';
   scene?: DesignScene | null;
   style_group_id?: number;
   user_selected_model?: string;

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -442,6 +442,58 @@ html[data-theme='dark'] .rcb-skeleton-bone {
   );
 }
 
+/**
+ * Card-level shimmer: single sweep over the whole card so multi-line skeletons
+ * animate in unison instead of each bone sweeping independently.
+ * Children .rcb-skeleton-bone lose their own animation and become static fills.
+ */
+.rcb-skeleton-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.rcb-skeleton-card::after {
+  content: '';
+  position: absolute;
+  top: -20%;
+  bottom: -20%;
+  left: 0;
+  width: 55%;
+  background: linear-gradient(
+    105deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.0) 30%,
+    rgba(255, 255, 255, 0.52) 50%,
+    rgba(255, 255, 255, 0.0) 70%,
+    transparent 100%
+  );
+  animation: shimmer-sweep 1.55s cubic-bezier(0.45, 0.05, 0.25, 1) infinite;
+  will-change: transform;
+  pointer-events: none;
+}
+
+.rcb-skeleton-card .rcb-skeleton-bone {
+  animation: none;
+  background-image: none;
+  background-color: #e8e8e8;
+  background-size: auto;
+}
+
+html[data-theme='dark'] .rcb-skeleton-card::after {
+  background: linear-gradient(
+    105deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.0) 30%,
+    rgba(255, 255, 255, 0.10) 50%,
+    rgba(255, 255, 255, 0.0) 70%,
+    transparent 100%
+  );
+}
+
+html[data-theme='dark'] .rcb-skeleton-card .rcb-skeleton-bone {
+  background-color: #2c2c2c;
+}
+
 /* Global thin scrollbar with track inset */
 * {
   scrollbar-width: thin;

--- a/docs/agent-profile.md
+++ b/docs/agent-profile.md
@@ -117,6 +117,41 @@ START → bootstrap
 | `review` | **forked** | Sparse craft gate (`review_mode=auto` by default); not every paint |
 | `propose` / `action` / settle | shared | Ask hold / emit ops / finish |
 
+### Observe ↔ scene feedback (do not infinite-repaint)
+
+After `action` emits `tool_ops`, the graph **interrupts** until the frontend POSTs a real canvas snapshot (`POST /api/v1/design/run/{task_id}/scene`). Observe’s inventory / `op_results` / spatial hints come from that POST — not from a server-side apply.
+
+```text
+paint_ops → action (tool_ops + scene_feedback_request)
+         → FE apply + wait inventory settle → POST scene
+         → observe
+              ├─ timeout (no POST)     → settle (assume applied; no critique→paint)
+              ├─ op_results all fail   → paint_ops if reflect_left
+              ├─ structure critique    → paint_ops if reflect_left (capped)
+              ├─ Review auto gate?     → review …
+              └─ else                  → settle
+```
+
+| Guard | Behavior |
+|-------|----------|
+| Scene wait | ~12s; timeout → **settle**, do **not** critique stale/empty inventory into a re-paint |
+| Round latch | Stale FE POSTs for a previous wait round are ignored |
+| Create vs empty | If FE `op_results` mark creates **ok** but nodes are still empty → treat as sync lag (no empty-board re-paint) |
+| FE settle | After paint, FE waits until scene inventory fingerprint is stable (~2 frames / ≤480ms) before POST |
+| Reflect / Review | `reflect_left` / `review_left` cap retries (not unbounded) |
+
+#### Artboard vs viewport (placement)
+
+| Term | Meaning |
+|------|---------|
+| **Artboard** | A fixed design plate (`frames[]`: x/y/w/h). Does not move when the user pans/zooms. |
+| **Viewport** | The camera window currently visible on screen (`spatial_summary.viewport`). Changes with pan/zoom and can lag behind Yjs/Redux. |
+
+- **Pre-apply paint gate**: placement prefers **artboard** bounds when a focus frame exists; falls back to viewport with a looser pad.
+- **Post-paint observe**: does **not** re-check “outside viewport” (camera lag caused false re-paints). Observe still flags **stacked creates** and empty-board structure when FE truth says ops failed or inventory is empty without successful create results.
+
+UX tip codes: `observe_scene_timeout`, `observe_ops_failed`, `observe_critique_failed` (FE i18n via `designAgentEventRouter`).
+
 ### Env knobs
 
 | Key | Default | Notes |
@@ -134,7 +169,7 @@ UX tips on failure / apply / Ask dismiss use `_emit_ux_tip` (`token.code` + Engl
 
 ### Stress / regression
 
-Eval seed: [`apps/api/seeds/design_agent_stress_suite.json`](../apps/api/seeds/design_agent_stress_suite.json) (not ingested by the live graph). SSE runner: `npm run stress:agent` → [`scripts/design-agent-stress.mjs`](../scripts/design-agent-stress.mjs). System failures → prompt packs; craft failures → skills.
+Eval seed: [`apps/api/seeds/design_agent_eval_suite.json`](../apps/api/seeds/design_agent_eval_suite.json) (not ingested by the live graph). Runner: `npm run eval:agent` → [`eval/design-agent/run.mjs`](../eval/design-agent/run.mjs). System failures → prompt packs; craft failures → skills. Load gates: [`docs/quality-gates.md`](./quality-gates.md).
 
 Review 重试预算：`rt.flags.review_left` ← Profile `topology.loops`（`from: review` / `when: must_fix` / `to: paint` 的 `max`）。
 

--- a/docs/canvas-architecture.md
+++ b/docs/canvas-architecture.md
@@ -23,7 +23,7 @@ Custom **RCB** scene runtime (resume canvas).
 `SceneDocument` (see also [scene-json-spec.md](./scene-json-spec.md)):
 
 - **`deltaSetLike`**: flat `id → SceneNode` map; `ROOT.children` (or page children) lists top-level nodes
-- **`frames`**: artboard frames; paint order unified in **`stackOrder`** (`frame:id` | `node:id`, bottom → top)
+- **`frames`**: **artboards** (fixed design plates). Not the camera **viewport**. Paint order unified in **`stackOrder`** (`frame:id` | `node:id`, bottom → top)
 - Node fields: `id`, `key`, `x/y/width/height`, `attrs`, `children[]`
 
 There is **no hard max node count** on the document. Capacity is governed by paint/hit budgets below.

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -1,0 +1,66 @@
+# Quality gates
+
+Two gates, one metrics truth.
+
+## Gate A — Correctness
+
+| Tool | Role | Command |
+|------|------|---------|
+| **Pytest** | API contracts | `npm run test:api` |
+| **Playwright** | UI / collab journeys | `npm run test:e2e` |
+| **Vitest** | Pure canvas/geometry | `npm run test:web` |
+| **Eval** | Design Agent craft | `npm run eval:agent` |
+
+CI mints `E2E_TOKEN` via `scripts/ci-mint-token.mjs` (`SUPER_ADMIN_TEST_CODE`, **max 8 chars**).
+Collab dual-WS: set `E2E_COLLAB_WS` (CI sets this). Category eval: `E2E_EVAL=1`.
+
+## Gate B — Performance & stability
+
+| Tool | Role | Command |
+|------|------|---------|
+| **k6** | Load | `perf:k6:smoke` / `api` / `soak` / `collab` |
+| **Prometheus** | Scrapes `/metrics` + alert rules | compose `:9090` |
+| **Grafana** | SLO dashboards | compose `:3001` (admin / recombyn) |
+
+```bash
+docker compose up -d api prometheus grafana
+# restart API after metrics code change
+curl -s http://127.0.0.1:8000/metrics | head
+
+SUPER_ADMIN_TEST_CODE=… npm run ci:mint-token
+npm run perf:k6:smoke
+PERF_TOKEN="$(cat .tmp-token.txt)" npm run perf:k6:api
+COLLAB_WS_URL=ws://127.0.0.1:1234 npm run perf:k6:collab
+```
+
+### Alert rules
+
+`deploy/observability/prometheus/rules/recombyn.yml`:
+
+- 5xx rate > 5% (5m)
+- p95 latency > 2s (10m)
+- DB / Redis gauge down (2m)
+
+View in Prometheus **Alerts**. Wire Grafana contact points locally (do not commit secrets).
+
+### CI workflows
+
+| Workflow | When |
+|----------|------|
+| `e2e-tests.yml` | PR — API + collab + minted token + Playwright |
+| `perf-k6.yml` | PR — smoke + api_crud + collab_ws |
+| `nightly-quality.yml` | Nightly — eval suite shape + k6 soak |
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `perf/k6/` | Gate B scenarios |
+| `eval/design-agent/` | Agent quality eval |
+| `deploy/observability/` | Prometheus + Grafana |
+| `scripts/ci-mint-token.mjs` | CI/local session mint |
+| `apps/api/seeds/design_agent_eval_suite.json` | Eval cases |
+
+## Design Agent observe / placement
+
+See [agent-profile.md — Observe ↔ scene feedback](./agent-profile.md#observe--scene-feedback-do-not-infinite-repaint) for artboard vs viewport and anti-repaint guards.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -9,8 +9,10 @@ Desktop (Tauri): **[desktop.md](./desktop.md)** — **Local** (sidecar + SQLite)
 | Piece | Default |
 |-------|---------|
 | Web editor | http://localhost:3000 |
-| API | http://localhost:8000 (`/docs`) |
+| API | http://localhost:8000 (`/docs`, **`/metrics`**) |
 | Collab (Yjs WS) | compose `collab` · browser via `ws://localhost:3000/collab/…` (prod: `wss://`) |
+| Prometheus | http://localhost:9090 (compose) |
+| Grafana | http://localhost:3001 (compose · default `admin` / `recombyn`) |
 | Agent seeds | prompt packs + skills + **AgentProfile** YAML from `apps/api/seeds/` |
 | **MySQL 8** | compose service + volume `mysql_data` |
 | Redis | Celery / queues |
@@ -20,6 +22,8 @@ Default DB URL inside compose:
 `mysql://recombyn:recombyn@mysql:3306/recombyn`
 
 Host tools can reach MySQL at `127.0.0.1:3306` (same user/password). Change via `MYSQL_PASSWORD` / `DATABASE_URL` before first boot.
+
+**Quality gates (Pytest / Playwright / k6 / Prometheus):** [quality-gates.md](./quality-gates.md).
 
 **Dev without Docker MySQL:** leave `DATABASE_URL` empty → SQLite at `storage/recombyn.db`.
 
@@ -148,9 +152,11 @@ START → bootstrap
 |------|------|
 | `design_agent` | Decide: reply / `need_tools` / `need_skills` / `need_subagents` / **design_brief** — **no** canvas ops |
 | `paint_ops` | Structured `tool_ops` only |
-| `observe` | Wait FE scene (`interrupt`); structural critique only |
+| `observe` | Wait FE scene (`interrupt`); structural critique only — see [agent-profile.md](./agent-profile.md#observe--scene-feedback-do-not-infinite-repaint) |
 | `review` | Forked craft gate when auto/always; may force paint retry |
 | `propose` | Ask preview → Confirm as **new** run |
+
+**Scene feedback contract:** FE must POST inventory after applying `tool_ops`. Timeout or create-ok + empty inventory must **not** loop paint forever (settle / lag-tolerant). Placement truth prefers **artboard (`frames`)** over FE **viewport** (camera). Glossary and guards: [agent-profile.md](./agent-profile.md#artboard-vs-viewport-placement).
 
 Inside a node: assemble pack → LangChain stream/structured → validate ops → `Command(update, goto)`.  
 `create_agent` is an **inner** helper; durable pause/resume is always the **outer** graph + checkpointer.

--- a/e2e/tests/agent.paint-mode.spec.ts
+++ b/e2e/tests/agent.paint-mode.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * Browser E2E + light stress: Agent settings「板式生成」→ paint_mode=img_layers.
+ *
+ * A) Settings → Agent: toggle board paint + localStorage
+ * B) Intercept /design/run body includes paint_mode (prefs via localStorage)
+ * D) UI stress on settings page
+ * C) Optional full gen+split (E2E_IMG_LAYERS_FULL=1)
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { test, expect, type Page, type Request } from '@playwright/test';
+import { E2E_TOKEN_SKIP_REASON, resolveE2EToken } from './e2eAuth';
+
+const ROOT = path.resolve(__dirname, '../..');
+const OUT = path.join(ROOT, '.tmp-agent-paint-mode');
+const TOKEN = resolveE2EToken(ROOT);
+const FULL = String(process.env.E2E_IMG_LAYERS_FULL || '').trim() === '1';
+
+test.setTimeout(FULL ? 12 * 60_000 : 3 * 60_000);
+
+function sleep(ms: number) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function injectAuth(page: Page, paintMode: 'ops' | 'img_layers' = 'ops') {
+  await page.addInitScript(
+    ([tok, mode]) => {
+      localStorage.setItem('recombine-auth-token-v1', tok);
+      localStorage.setItem('resume.agentPaintMode.v1', mode);
+      localStorage.setItem('recombyn-editor-tour-v3', '1');
+      localStorage.setItem('recombyn-editor-tour-v3:user_super_admin', '1');
+    },
+    [TOKEN, paintMode]
+  );
+}
+
+async function dismissTour(page: Page) {
+  await page.evaluate(() => {
+    localStorage.setItem('recombyn-editor-tour-v3', '1');
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith('recombyn-editor-tour-v3')) localStorage.setItem(key, '1');
+    }
+    for (const el of Array.from(document.querySelectorAll('body *'))) {
+      const t = (el.textContent || '').slice(0, 80);
+      if (/Welcome to the editor|欢迎/i.test(t)) (el as HTMLElement).style.display = 'none';
+    }
+  });
+  const skip = page.getByRole('button', { name: /^Skip$|^跳过$/i });
+  if (await skip.first().isVisible({ timeout: 1_500 }).catch(() => false)) {
+    await skip.first().click({ force: true });
+    await sleep(300);
+  }
+}
+
+async function openEditor(page: Page) {
+  const known = process.env.E2E_EDITOR_PATH || '/editor/aZ0FRsXFkjbQtnPFmohSZ';
+  await page.goto(known);
+  await page.waitForURL(/\/editor\//, { timeout: 60_000 });
+  await page.waitForLoadState('domcontentloaded');
+  await dismissTour(page);
+  await sleep(500);
+}
+
+/** Open Settings → Agent (account AgentModelsPanel). */
+async function openAgentSettings(page: Page) {
+  const accountBtn = page
+    .getByRole('button', { name: /Super Admin|Account|账户|账号|Settings|设置/i })
+    .first();
+  await expect(accountBtn).toBeVisible({ timeout: 20_000 });
+  await accountBtn.click({ force: true });
+  await sleep(400);
+
+  const dialog = page.locator('[role="dialog"]').first();
+  if (await dialog.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    const tabInDialog = dialog.getByRole('tab', { name: /^Agent$/i });
+    if (await tabInDialog.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await tabInDialog.click({ force: true });
+    } else {
+      const btn = dialog.getByRole('button', { name: /^Agent$/i });
+      if (await btn.isVisible({ timeout: 1_000 }).catch(() => false)) {
+        await btn.click({ force: true });
+      }
+    }
+  }
+
+  const paint = page.getByRole('tablist', { name: /板式生成|Board paint/i });
+  await expect(paint).toBeVisible({ timeout: 20_000 });
+  return paint;
+}
+
+async function setPaintModeInSettings(page: Page, mode: 'ops' | 'img_layers') {
+  const tabs = await openAgentSettings(page);
+  const label = mode === 'img_layers' ? /生图拆层|Image layers/i : /工具操作|Canvas ops/i;
+  const tab = tabs.getByRole('tab', { name: label });
+  if (await tab.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await tab.click({ force: true });
+  } else {
+    await page.getByText(label).first().click({ force: true });
+  }
+  await sleep(200);
+  const stored = await page.evaluate(() => localStorage.getItem('resume.agentPaintMode.v1'));
+  expect(stored).toBe(mode);
+  await page.keyboard.press('Escape');
+  await sleep(300);
+}
+
+async function ensureAgentDock(page: Page) {
+  await dismissTour(page);
+  const byName = page.getByRole('textbox', {
+    name: /@Search for image, model, or project|Search|Ask|Design|描述/i,
+  });
+  if (await byName.isVisible({ timeout: 2_000 }).catch(() => false)) return byName;
+  const agentBtn = page.getByRole('button', { name: /^Agent$/i }).first();
+  if (await agentBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await agentBtn.click({ force: true });
+  }
+  const fallback = page
+    .locator('aside [role="textbox"], [data-agent-composer] [role="textbox"]')
+    .last();
+  if (await fallback.isVisible({ timeout: 5_000 }).catch(() => false)) return fallback;
+  return byName;
+}
+
+function isDesignRun(req: Request): boolean {
+  const u = req.url();
+  return req.method() === 'POST' && /\/design\/run\b/.test(u);
+}
+
+async function sendShortPrompt(page: Page, prompt: string) {
+  const composer = await ensureAgentDock(page);
+  await expect(composer).toBeVisible({ timeout: 20_000 });
+  await composer.click({ force: true });
+  await sleep(200);
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
+  await page.keyboard.type(prompt, { delay: 3 });
+  await sleep(300);
+  const send = page.getByRole('button', { name: /send|发送/i }).first();
+  for (let i = 0; i < 40; i += 1) {
+    if (!(await send.isDisabled().catch(() => true))) {
+      await send.click();
+      return;
+    }
+    await sleep(400);
+  }
+  await page.keyboard.press('Enter');
+}
+
+test.describe('agent paint_mode browser E2E', () => {
+  test.skip(!TOKEN, E2E_TOKEN_SKIP_REASON);
+
+  test.beforeAll(() => {
+    fs.mkdirSync(OUT, { recursive: true });
+  });
+
+  test('A: Agent settings toggles paint_mode into localStorage', async ({ page }) => {
+    await injectAuth(page);
+    await openEditor(page);
+    await setPaintModeInSettings(page, 'img_layers');
+    await setPaintModeInSettings(page, 'ops');
+    await setPaintModeInSettings(page, 'img_layers');
+    await page.screenshot({ path: path.join(OUT, 'a-paint-mode-settings.png'), fullPage: false });
+  });
+
+  test('B: /design/run carries paint_mode=img_layers', async ({ page }) => {
+    await injectAuth(page, 'img_layers');
+    await openEditor(page);
+
+    const bodyPromise = page.waitForRequest(isDesignRun, { timeout: 90_000 }).then(async (req) => {
+      try {
+        return req.postDataJSON() as Record<string, unknown>;
+      } catch {
+        const raw = req.postData() || '';
+        return JSON.parse(raw) as Record<string, unknown>;
+      }
+    });
+
+    await sendShortPrompt(page, '做一张极简海报：大标题 Hello，白底黑字，390x844');
+    const body = await bodyPromise;
+    fs.writeFileSync(path.join(OUT, 'b-design-run-body.json'), JSON.stringify(body, null, 2));
+    expect(body.paint_mode).toBe('img_layers');
+    expect(String(body.prompt || '')).toMatch(/Hello|海报/);
+
+    const stop = page.getByRole('button', { name: /stop|停止|取消/i }).first();
+    if (await stop.isVisible({ timeout: 8_000 }).catch(() => false)) {
+      await stop.click({ force: true });
+    }
+    await page.screenshot({ path: path.join(OUT, 'b-request-asserted.png'), fullPage: false });
+  });
+
+  test('D: UI stress — settings paint mode 8×', async ({ page }) => {
+    await injectAuth(page);
+    await openEditor(page);
+    for (let i = 0; i < 8; i += 1) {
+      const mode = i % 2 === 0 ? 'img_layers' : 'ops';
+      await setPaintModeInSettings(page, mode);
+    }
+    const stored = await page.evaluate(() => localStorage.getItem('resume.agentPaintMode.v1'));
+    expect(stored).toBe('ops');
+    await page.screenshot({ path: path.join(OUT, 'd-ui-stress.png'), fullPage: false });
+  });
+
+  test('C: full img_layers run (opt-in)', async ({ page }) => {
+    test.skip(!FULL, 'Set E2E_IMG_LAYERS_FULL=1 to run full gen+split');
+    await injectAuth(page, 'img_layers');
+    await openEditor(page);
+    await sendShortPrompt(
+      page,
+      '生成一张清爽产品海报：主标题「Recombyn」，副标题「懂你的设计 Agent」，390x844，高对比文字'
+    );
+
+    const t0 = Date.now();
+    let sawStop = false;
+    let sawNodes = false;
+    let sawToken = false;
+    while (Date.now() - t0 < 10 * 60_000) {
+      const stop = page.getByRole('button', { name: /stop|停止|取消/i }).first();
+      if (await stop.isVisible({ timeout: 400 }).catch(() => false)) sawStop = true;
+      const send = page.getByRole('button', { name: /send|发送/i }).first();
+      const sendOk = !(await send.isDisabled().catch(() => true));
+      const nodes = page.locator('[data-rcb-shape-layer], [data-node-id]');
+      if ((await nodes.count()) > 2) sawNodes = true;
+      const chat = page.locator('aside').filter({ hasText: /生图拆层|拆出|整板/ });
+      if (await chat.first().isVisible({ timeout: 200 }).catch(() => false)) sawToken = true;
+      if (sawStop && sendOk && Date.now() - t0 > 15_000) break;
+      if (sawNodes && sendOk && Date.now() - t0 > 30_000) break;
+      await sleep(2_500);
+    }
+    const result = { sawStop, sawNodes, sawToken, ms: Date.now() - t0 };
+    fs.writeFileSync(path.join(OUT, 'c-full-result.json'), JSON.stringify(result, null, 2));
+    await page.screenshot({ path: path.join(OUT, 'c-full-final.png'), fullPage: false });
+    expect(result.sawStop || result.sawNodes || result.sawToken).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- **Misleading placement hints removed**: Eliminated hardcoded 320x200 size suggestions from runDesignAgent.ts, placement.py, observe.py, and paint.md so the model uses user-specified dimensions (e.g. 1920x1080).
- **LOD proxy rendering improved** (RcbShapesLayer.tsx): Text renders as greeking lines; images/video/lottie render as a placeholder icon instead of solid grey blocks. Threshold changed to 20% zoom.
- **Snap threshold capped** (alignGuides.ts): smartSnapThreshold is now capped at 40 scene units so far-zoomed drags don't jump to distant elements.
- **Boolean result no longer re-fillets path** (MultiSelectionToolbar.tsx): Removed applyBooleanResultRadii call so boolean holes stay sharp, not circular.
- **Corner radius handles skip curve-only paths** (CornerRadiusHandlesOverlay.tsx): path/pen nodes with no parseable sharp corners now return null instead of showing AABB handles floating in empty space.
- **Corner detection threshold relaxed** (sceneRadii.ts): Dense-mode minCornerEdge lowered from maxEdge*0.08 to maxEdge*0.03 so boolean intersection corners are no longer dropped.
- **Stale import removed** (support.py): _derive_suggested_place_world removed from barrel to fix CI ImportError.
- **Skeleton shimmer standardised**: ProjectCoverCollage, PlazaPublishDialog, TemplateThumbnail use rcb-skeleton-bone instead of animate-pulse.

## Test plan

- [ ] Create element at 1920x1080 via agent -- confirm actual size matches
- [ ] Zoom canvas to <=20% -- text shows greeking lines, images show icon placeholder
- [ ] Drag element at low zoom -- snap should not jump to distant targets
- [ ] Boolean subtract on rectangle with hole -- result retains sharp corners, no circular rounding
- [ ] Select a crescent/arc path -- no corner radius handles should appear
- [ ] Select boolean result with sharp corners -- all corners show radius handles
- [ ] pytest apps/api -- CI passes without ImportError
