### PR TITLE
fix: assets AI-only; LOD selection stays degraded

### DIFF
--- a/apps/api/app/api/routes/assets.py
+++ b/apps/api/app/api/routes/assets.py
@@ -23,7 +23,7 @@ class RegisterAssetIn(BaseModel):
     prompt: str | None = Field(default=None, max_length=500)
     width: int | None = None
     height: int | None = None
-    source: str | None = Field(default="upload", max_length=32)
+    source: str | None = Field(default=None, max_length=32)
 
 
 @router.get("")
@@ -49,6 +49,13 @@ def register_my_asset(
     kind = (body.kind or "").strip().lower()
     if kind not in ("image", "video", "audio", "lottie"):
         raise HTTPException(status_code=400, detail="kind must be image|video|audio|lottie")
+    source = (body.source or "").strip().lower()
+    # Assets dock is AI-generated only — reject user canvas uploads.
+    if not source.startswith("ai_"):
+        raise HTTPException(
+            status_code=400,
+            detail="assets are AI-generated only; user uploads are not registered",
+        )
     try:
         return asset_store.create_asset_from_stored(
             current_user.id,
@@ -56,7 +63,7 @@ def register_my_asset(
             url=body.url.strip(),
             object_key=(body.objectKey or None),
             mime=body.mime,
-            source=(body.source or "upload"),
+            source=source,
             prompt=(body.prompt or None),
             width=body.width,
             height=body.height,

--- a/apps/api/app/crud.py
+++ b/apps/api/app/crud.py
@@ -1000,11 +1000,17 @@ def delete_asset(*, session: Session, asset_id: str) -> Asset | None:
 
 
 def count_user_assets(
-    *, session: Session, user_id: str, kind: str | None = None
+    *,
+    session: Session,
+    user_id: str,
+    kind: str | None = None,
+    sources: tuple[str, ...] | list[str] | None = None,
 ) -> int:
     where: list[Any] = [Asset.user_id == user_id]
     if kind:
         where.append(Asset.kind == kind)
+    if sources:
+        where.append(col(Asset.source).in_(list(sources)))
     return int(
         session.exec(select(func.count()).select_from(Asset).where(*where)).one()
         or 0
@@ -1016,12 +1022,15 @@ def list_user_assets(
     session: Session,
     user_id: str,
     kind: str | None = None,
+    sources: tuple[str, ...] | list[str] | None = None,
     offset: int = 0,
     limit: int = 24,
 ) -> list[Asset]:
     where: list[Any] = [Asset.user_id == user_id]
     if kind:
         where.append(Asset.kind == kind)
+    if sources:
+        where.append(col(Asset.source).in_(list(sources)))
     return list(
         session.exec(
             select(Asset)

--- a/apps/api/app/services/assets.py
+++ b/apps/api/app/services/assets.py
@@ -1,4 +1,4 @@
-"""User AI assets (image/video) — metadata in DB, blobs in COS/local storage."""
+"""User AI assets (image/video/audio/lottie) — AI-generated only; blobs in COS/local storage."""
 
 from __future__ import annotations
 
@@ -200,6 +200,8 @@ def _ensure_lottie_animation_on_item(
 
 
 _ASSET_KINDS = ("image", "video", "audio", "font", "lottie")
+# Assets dock is AI-generated media only — user canvas uploads must not appear.
+_AI_ASSET_SOURCES = ("ai_image", "ai_video", "ai_audio", "ai_lottie")
 
 
 def list_assets(
@@ -218,12 +220,16 @@ def list_assets(
         kind_n = None
     with Session(engine) as session:
         total = crud.count_user_assets(
-            session=session, user_id=user_id, kind=kind_n
+            session=session,
+            user_id=user_id,
+            kind=kind_n,
+            sources=_AI_ASSET_SOURCES,
         )
         rows = crud.list_user_assets(
             session=session,
             user_id=user_id,
             kind=kind_n,
+            sources=_AI_ASSET_SOURCES,
             offset=offset,
             limit=page_size_n,
         )
@@ -364,13 +370,16 @@ def create_asset_from_stored(
     url: str,
     object_key: str | None = None,
     mime: str | None = None,
-    source: str = "upload",
+    source: str = "ai_image",
     prompt: str | None = None,
     width: int | None = None,
     height: int | None = None,
 ) -> dict[str, Any]:
-    """Register an already-uploaded storage object (canvas video/audio upload)."""
+    """Register an already-stored media object into the AI assets dock."""
     init_schema()
+    source_n = (source or "").strip().lower()
+    if not source_n.startswith("ai_"):
+        raise ValueError("assets are AI-generated only; user uploads are not registered")
     kind_n = (kind or "image").strip().lower()
     if kind_n not in _ASSET_KINDS:
         kind_n = "image"
@@ -408,7 +417,7 @@ def create_asset_from_stored(
             mime=mime_n,
             width=out_w,
             height=out_h,
-            source=(source or "upload")[:32],
+            source=source_n[:32],
             prompt=(prompt or None),
             created_at=now,
             meta_json=meta_json,

--- a/apps/web/src/components/base/image/Image.tsx
+++ b/apps/web/src/components/base/image/Image.tsx
@@ -276,8 +276,11 @@ const Image: React.FC<ImageProps> = ({
                     onMouseDown={(e) => e.stopPropagation()}
                     style={{
                       display: 'block',
-                      maxWidth: '700px',
-                      maxHeight: '700px',
+                      width: 'auto',
+                      height: 'auto',
+                      maxWidth: 'min(92vw, 960px)',
+                      maxHeight: 'min(88vh, 960px)',
+                      objectFit: 'contain',
                       transform: `rotate(${transform.rotate}deg) scale(${transform.scale}) scaleX(${transform.flipX ? -1 : 1}) scaleY(${transform.flipY ? -1 : 1})`,
                       transformOrigin: 'center center',
                     }}

--- a/apps/web/src/components/editor/canvas/SvgCanvas.tsx
+++ b/apps/web/src/components/editor/canvas/SvgCanvas.tsx
@@ -66,7 +66,6 @@ import {
   readFileAsDataUrl,
   waitForImageReady,
 } from '@/utils/uploadImage';
-import { registerAsset } from '@/service/assets';
 import { getHttpErrorMessage } from '@/service/client';
 import store from '@/store';
 import { message } from '@/components/base';
@@ -1679,20 +1678,6 @@ function SvgCanvas({
           },
         })
       );
-      try {
-        await registerAsset({
-          kind: 'video',
-          url: String(uploaded.url || '').trim(),
-          objectKey: uploaded.key || null,
-          mime: file.type || 'video/mp4',
-          prompt: prepared.name || null,
-          width,
-          height,
-          source: 'upload',
-        });
-      } catch {
-        /* ignore asset registration errors */
-      }
     } catch (err: any) {
       dispatch(failImageProcess({}));
       message.error(getHttpErrorMessage(err, '视频上传失败'));
@@ -1765,18 +1750,6 @@ function SvgCanvas({
             },
           })
         );
-        try {
-          await registerAsset({
-            kind: 'audio',
-            url,
-            objectKey: uploaded.key || null,
-            mime: file.type || 'audio/mpeg',
-            prompt: file.name?.replace(/\.[^.]+$/, '') || null,
-            source: 'upload',
-          });
-        } catch {
-          /* ignore asset registration errors */
-        }
       } finally {
         finishNodeUpload(spawnedId);
       }
@@ -1929,6 +1902,14 @@ function SvgCanvas({
     return out;
   }, [ids, editingTextId, editingPenId]);
 
+  /** Editors need full SVG; selection alone must stay LOD while zoomed out. */
+  const forceFullIds = useMemo(() => {
+    const out: string[] = [];
+    if (editingTextId) out.push(editingTextId);
+    if (editingPenId) out.push(editingPenId);
+    return out;
+  }, [editingTextId, editingPenId]);
+
   // Path-edit stays open on empty selection (blank click must not dismiss).
   // Only leave when the user selects a *different* node.
   useEffect(() => {
@@ -2017,6 +1998,7 @@ function SvgCanvas({
             lastPatchedNodeIds={lastPatchedNodeIds}
             hiddenNodeId={editingTextId || editingPenId}
             keepVisibleIds={keepVisibleIds}
+            forceFullIds={forceFullIds}
             spatialIndex={nodeSpatialIndex}
           />
         ) : null}

--- a/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
@@ -30,11 +30,15 @@ type Props = {
   hiddenNodeId?: string | null;
   /** Never cull these (selection / inline editors) even if off-screen. */
   keepVisibleIds?: readonly string[];
+  /** Must stay as full SVG hosts (inline editors only — selection stays LOD). */
+  forceFullIds?: readonly string[];
   /** Shared scene index from SvgCanvas — drives viewport visible set. */
   spatialIndex?: RcbSpatialIndex | null;
 };
 
 const EMPTY_KEEP: readonly string[] = [];
+const EMPTY_FORCE_FULL: readonly string[] = [];
+const EMPTY_FORCE_FULL_SET = new Set<string>();
 
 /** Screen-px margin so shapes entering the view aren't blank for a frame. */
 const CULL_PAD_SCREEN_PX = 96;
@@ -248,11 +252,14 @@ export function pickFullAndProxyIds(opts: {
   document: SceneDocument;
   visibleIds: string[];
   keepSet: Set<string>;
+  /** Only these force full SVG (e.g. text/pen editors). Selection uses keepSet for cull only. */
+  forceFullSet?: Set<string>;
   zoom: number;
   moving: boolean;
   maxProxies?: number;
 }): { fullIds: string[]; proxyIds: string[] } {
-  const { document, visibleIds, keepSet, zoom, moving } = opts;
+  const { document, visibleIds, zoom, moving } = opts;
+  const forceFullSet = opts.forceFullSet ?? EMPTY_FORCE_FULL_SET;
   const maxProxies = opts.maxProxies ?? MAX_PROXY_PAINT;
   const budget = hostBudget({ zoom, moving, visibleCount: visibleIds.length });
   const far = zoom < LOD_ZOOM_FAR;
@@ -266,7 +273,8 @@ export function pickFullAndProxyIds(opts: {
   const scored: Array<{ id: string; score: number; force: boolean }> = [];
   for (const id of visibleIds) {
     const node = document?.deltaSetLike?.[id];
-    const force = keepSet.has(id);
+    // Selection must not promote proxy → full while LOD is active.
+    const force = forceFullSet.has(id);
     let score = screenAreaPx(node, zoom);
     if (isHeavyPathNode(node) && forceLod) score *= 0.05;
     // Far zoom: demote media-heavy nodes (image/video/lottie/text) so cheap shapes
@@ -400,8 +408,9 @@ function paintLodProxiesCanvas(opts: {
 /**
  * Renders each ROOT child as its own SVG shape host (sharp under CSS camera zoom).
  * Canvas Path2D is only used by selection indicators / draw-tool overlays.
- * Off-viewport nodes are not mounted (lazy paint); selected/editing stay alive.
+ * Off-viewport nodes are not mounted (lazy paint); selection/editing stay culled-alive.
  * Far zoom / dense views: one Canvas2D LOD batch (stroke for pencil; AABB for fills).
+ * Selection does not promote proxies back to full SVG — only inline editors do.
  * z-index comes from document.stackOrder so shapes can interleave with artboards.
  */
 function RcbShapesLayer({
@@ -411,6 +420,7 @@ function RcbShapesLayer({
   lastPatchedNodeIds = [],
   hiddenNodeId = null,
   keepVisibleIds = EMPTY_KEEP,
+  forceFullIds = EMPTY_FORCE_FULL,
   spatialIndex = null,
 }: Props) {
   const camera = useRcbCamera();
@@ -457,6 +467,10 @@ function RcbShapesLayer({
   const keepSet = useMemo(
     () => new Set(keepVisibleIds.filter(Boolean)),
     [keepVisibleIds]
+  );
+  const forceFullSet = useMemo(
+    () => new Set(forceFullIds.filter(Boolean)),
+    [forceFullIds]
   );
 
   /** Mount only in-view (+ keep) ids — never `ids.filter` over 100k after spatial hits. */
@@ -511,10 +525,11 @@ function RcbShapesLayer({
         document,
         visibleIds,
         keepSet,
+        forceFullSet,
         zoom: cullCam.zoom || 1,
         moving,
       }),
-    [document, visibleIds, keepSet, cullCam.zoom, moving]
+    [document, visibleIds, keepSet, forceFullSet, cullCam.zoom, moving]
   );
 
   const patched = useMemo(() => new Set(lastPatchedNodeIds.filter(Boolean)), [lastPatchedNodeIds]);

--- a/apps/web/src/components/rcb/shapes/__tests__/lodHostBudget.test.ts
+++ b/apps/web/src/components/rcb/shapes/__tests__/lodHostBudget.test.ts
@@ -68,10 +68,10 @@ describe('pickFullAndProxyIds', () => {
       document: doc,
       visibleIds: ids,
       keepSet: new Set(['n0']),
-      zoom: 0.2,
+      zoom: 0.15,
       moving: true,
     });
-    expect(fullIds).toContain('n0');
+    // Selection keepSet must not force full SVG while LOD is active.
     expect(fullIds.length).toBeLessThanOrEqual(24);
     expect(proxyIds.length).toBeGreaterThan(0);
     expect(fullIds.length + proxyIds.length).toBe(120);
@@ -86,14 +86,47 @@ describe('pickFullAndProxyIds', () => {
       document: doc,
       visibleIds: ids,
       keepSet: new Set(['n0']),
-      zoom: 0.2,
+      zoom: 0.15,
       moving: true,
       maxProxies: 128,
     });
-    expect(fullIds).toContain('n0');
     expect(fullIds.length).toBeLessThanOrEqual(24);
     expect(proxyIds.length).toBeLessThanOrEqual(128);
     expect(fullIds.length + proxyIds.length).toBeLessThan(5000);
+  });
+
+  it('forceFullSet keeps editors as full SVG under LOD', () => {
+    const nodes: Record<string, any> = {};
+    for (let i = 0; i < 120; i += 1) nodes[`n${i}`] = rect(`n${i}`);
+    const doc = makeDoc(nodes);
+    const ids = Object.keys(nodes);
+    const { fullIds, proxyIds } = pickFullAndProxyIds({
+      document: doc,
+      visibleIds: ids,
+      keepSet: new Set(['n0']),
+      forceFullSet: new Set(['n0']),
+      zoom: 0.15,
+      moving: false,
+    });
+    expect(fullIds).toContain('n0');
+    expect(proxyIds).not.toContain('n0');
+  });
+
+  it('selection keepSet alone does not promote under far LOD', () => {
+    // Tiny n0 loses the host budget to large siblings unless keepSet forces it.
+    const nodes: Record<string, any> = { n0: rect('n0', 2, 2) };
+    for (let i = 1; i < 120; i += 1) nodes[`n${i}`] = rect(`n${i}`, 400, 400);
+    const doc = makeDoc(nodes);
+    const ids = Object.keys(nodes);
+    const { fullIds, proxyIds } = pickFullAndProxyIds({
+      document: doc,
+      visibleIds: ids,
+      keepSet: new Set(['n0']),
+      zoom: 0.15,
+      moving: false,
+    });
+    expect(proxyIds).toContain('n0');
+    expect(fullIds).not.toContain('n0');
   });
 
   it('demotes heavy paths when force-lod', () => {
@@ -108,7 +141,7 @@ describe('pickFullAndProxyIds', () => {
       document: doc,
       visibleIds: ids,
       keepSet: new Set(),
-      zoom: 0.2,
+      zoom: 0.15,
       moving: true,
     });
     expect(fullIds).toContain('big');

--- a/apps/web/src/service/assets.ts
+++ b/apps/web/src/service/assets.ts
@@ -5,7 +5,7 @@
 import { apiClient } from '@/service/client';
 import type { AssetKind, UserAsset } from '@/models/assets';
 
-/** POST /api/v1/assets/register — canvas upload → Assets dock */
+/** POST /api/v1/assets/register — AI-generated media only (source must be ai_*). */
 export const registerAsset = (data: {
   kind: Exclude<AssetKind, 'font'>;
   url: string;
@@ -25,7 +25,7 @@ export const registerAsset = (data: {
       ...(data.prompt ? { prompt: data.prompt } : {}),
       ...(data.width != null ? { width: data.width } : {}),
       ...(data.height != null ? { height: data.height } : {}),
-      source: data.source || 'upload',
+      ...(data.source ? { source: data.source } : {}),
     },
   }) as Promise<UserAsset>;
 


### PR DESCRIPTION
## Summary

- Assets dock is AI-generated only: canvas uploads no longer register; list/register reject non-`ai_*` sources.
- Image preview lightbox keeps natural aspect (`width/height: auto`, `object-fit: contain`).
- LOD: selecting shapes no longer promotes them back to full SVG; only text/pen editors force full hosts.

## Test plan

- [ ] Upload image/video/audio to canvas — does not appear under Me → Assets
- [ ] AI-generated image/video still appears in Assets
- [ ] Open image preview — no horizontal stretch
- [ ] Zoom canvas to ≤20%, select shapes — stay as LOD proxies (same look as unselected)
- [ ] Inline text/pen edit still works at any zoom
