### PR TITLE
Rewrite design skills for intentional craft and medium choice

### DIFF
--- a/.agents/skills/garden_style/SKILL.md
+++ b/.agents/skills/garden_style/SKILL.md
@@ -2,22 +2,19 @@
 
 Deliver canvas work that looks **intentional and memorable** — not a safe AI draft.
 
-## Principles
-1. **Commit a direction** — minimal / editorial / industrial / organic / luxury / festive hand / playful geometric / retro-futurist — one only.
-2. **One memory point** — hero image **or** hero title dominates; never both fighting.
-3. **Atmosphere over flat fill** — backgrounds have depth (image, gradient, texture) matching the tone.
-4. **Anti-slop** — refuse default AI faces unless the brief demands them.
-5. **Craftsmanship** — alignments, contrast, and type mood must look labored-over.
+## Design thinking
 
-## Workflow
-1. Purpose: who sees this and what job it does.
-2. Pick **one** tone from the catalog; justify one creative risk.
-3. Lock constraints: size, required copy, whether image gen is allowed.
-4. Choose the single memory point.
-5. Build: board → atmosphere/hero → hierarchy copy → sparse decoration.
-6. Far/near self-check; fix higher failures first.
+| Ask | Aim |
+|-----|-----|
+| **Purpose** | Who sees this and what job it does |
+| **Tone** | One direction from the catalog — do not mix casually |
+| **Memory point** | Hero image **or** hero title — not both fighting |
+| **Bitmap vs vector** | Simple geometry / flat language that stays crisp → vector. Complex atmosphere, materials, faces, busy illustration → bitmap. If vectors look crude, use image |
+
+Quality bar: **intentional design** — alignments, contrast, and type mood fit this brief. Soft-avoid generic AI postcard defaults. Not a “handmade texture” mandate.
 
 ## Direction catalog (pick one)
+
 | Direction | Cues |
 |-----------|------|
 | Minimal | Few elements, precise gaps, quiet palette, one accent |
@@ -25,35 +22,38 @@ Deliver canvas work that looks **intentional and memorable** — not a safe AI d
 | Industrial | Utility type, hard edges, restrained metal/ink palette |
 | Organic | Soft forms, natural textures, muted earth/plant tones |
 | Luxury | High contrast, generous empty, refined metals/ink |
-| Festive hand | Illustrated hero + expressive lettering; shapes only as accents |
-| Playful geometric | Bold primitives, flat color blocks, friendly type |
-| Retro-futurist | Period cues + modern restraint; avoid costume-party clutter |
+| Festive hand | Expressive lettering + illustrated or rich atmosphere when complexity needs it; simple flat festive language may stay vector |
+| Playful geometric | Bold primitives, flat color blocks, friendly type — vector-friendly |
+| Retro-futurist | Period cues + modern restraint; soft-avoid costume-party clutter |
 
 ## Anti-defaults (unless brief demands)
+
 Purple→indigo gradients on white; Inter/Roboto/Arial as “design”; warm cream `#F4F1EA` + terracotta serif cliché; dense broadsheet hairlines; glow stacks; rounded-full pill spam; emoji-as-icon; Space Grotesk convergence.
 
 ## Build rules
-- Festive / illustration / atmosphere poster: real hero bitmap for the main visual; shape collage ≠ done.
-- Type: distinctive display + restrained body; do not force generic UI sans onto illustration posters.
-- Color: one dominant + sharp accent; copy must clear the background.
-- Space: generous whitespace **or** controlled density — never “everything centered, nothing focal.”
-- Background: atmosphere; put copy on quieter regions.
-- Decoration: only what serves the theme; ban generic UI chrome as festive props.
-- Motion (if allowed): 1–2 high-impact beats via `motion_lottie`, not jitter.
+
+- Atmosphere that needs depth/light/material → real bitmap; soft-avoid crude shape spam as a fake scene.
+- Simple intentional geometry is fine when that is the language (e.g. playful geometric).
+- Type: distinctive display + restrained body; soft-avoid forcing generic UI sans onto illustration posters.
+- Color: one dominant + sharp accent; copy clears the background.
+- Space: generous whitespace **or** controlled density — soft-avoid “everything centered, nothing focal.”
+- Decoration only when they serve the theme.
+- Motion (if allowed): 1–2 high-impact beats via `motion_lottie`.
 
 ## Far / near check
-- Far (~1s): theme + main title readable; hero is illustration/photo when required.
-- Near: no clipped glyphs, low contrast, emoji tofu, or unrelated icons.
+
+- Far (~1s): theme + main title readable; medium matches complexity.
+- Near: soft-avoid clipped glyphs, low contrast, emoji tofu, unrelated icons.
 - Tone: type mood matches the picture.
 
-## Do not
-- Ship a “safe” generic template that could belong to any brand
-- Mix two directions mid-board without declaring cover/merge
-- Use festive Material icons as illustration substitutes
-- Skip locking the artboard on fixed-size briefs
+## Honesty
+
+Unless the user provides them, avoid inventing board facts such as logos, slogans, trademark marks, etc.
 
 ## Related
-`poster_craft` / `landing_page` for surface playbooks; `awesome_design_md` when a brand parameter sheet exists.
+
+`poster_craft` / `landing_page` / `image_gen` for surface playbooks; `awesome_design_md` when a brand parameter sheet exists.
 
 ## Done when
+
 Direction is nameable in one phrase; one memory point; anti-defaults cleared; far/near pass.

--- a/apps/api/app/services/design/prompts/skill_store/runtime.py
+++ b/apps/api/app/services/design/prompts/skill_store/runtime.py
@@ -562,13 +562,16 @@ def format_skills_details_checked(
         head = f"## skill: {key} — {name} (v{ver}, ns={ns})"
         if when:
             head += f"\nwhen: {when}"
-        if tools:
-            head += "\npreferred_tools: " + ", ".join(str(t) for t in tools)
+        # Prefer natural-language canvas actions in craft text — never leak op ids
+        # like create_image into SKILL_DETAILS (TOOL_DETAILS already owns schemas).
+        action_hint = _preferred_tools_as_actions(tools)
+        if action_hint:
+            head += "\ncanvas_actions: " + action_hint
         out_schema = r.get("outputSchema") if isinstance(r.get("outputSchema"), dict) else None
         if out_schema and isinstance(out_schema.get("allowed_ops"), list):
-            head += "\noutput_allowed_ops: " + ", ".join(
-                str(t) for t in out_schema.get("allowed_ops") if str(t).strip()
-            )
+            allowed_actions = _preferred_tools_as_actions(out_schema.get("allowed_ops") or [])
+            if allowed_actions:
+                head += "\noutput_actions: " + allowed_actions
         block = f"{head}\n{body}".strip()
         if neg:
             block += f"\n\nforbid: {neg}"
@@ -609,6 +612,43 @@ def _iter_skills_for_keys(
         key = str(r.get("skillKey") or "").strip().lower()
         if key in keys:
             yield r
+
+_OP_TO_ACTION = {
+    "create_image": "新增图片",
+    "create_text": "新增文字",
+    "create_shape": "新增形状",
+    "create_frame": "新建画板",
+    "create_svg": "新增矢量图",
+    "create_icon": "新增图标",
+    "create_lottie": "新增动效",
+    "update_node": "修改图层",
+    "move_nodes": "移动图层",
+    "resize_nodes": "缩放图层",
+    "delete_nodes": "删除图层",
+    "delete_frame": "删除画板",
+}
+
+
+def _preferred_tools_as_actions(tools: Any) -> str:
+    """Map preferred_tools / allowed_ops ids → natural canvas actions for SKILL_DETAILS."""
+    if not isinstance(tools, (list, tuple)):
+        return ""
+    seen: set[str] = set()
+    out: list[str] = []
+    for raw in tools:
+        key = str(raw or "").strip()
+        if not key:
+            continue
+        label = _OP_TO_ACTION.get(key) or _OP_TO_ACTION.get(key.lower())
+        if not label:
+            # Skip unknown op ids — do not leak them into craft text.
+            continue
+        if label in seen:
+            continue
+        seen.add(label)
+        out.append(label)
+    return "、".join(out)
+
 
 def preferred_tools_allowlist(
     skill_keys: list[str], *, scene: str = "website"

--- a/apps/api/seeds/design_prompt_packs/stages/paint.md
+++ b/apps/api/seeds/design_prompt_packs/stages/paint.md
@@ -20,6 +20,7 @@ Your ONLY job: emit non-empty tool_ops that change the canvas.
 - **DESIGN_BRIEF** (when present) is the execution contract — emit tool_ops that implement it. Craft how-to lives in **SKILL_DETAILS**; do not invent skill keys; do not paste playbooks into reply/thought.
 - Fills: solid → fill=#RRGGBB|rgba(…); gradient → fillType=linear|radial|angular|diffuse + fill + fillEnd (+ gradientAngle?). NEVER put CSS linear-gradient()/radial-gradient()/conic-gradient() in fill (host rejects) — TOOL_DETAILS.
 - Attachments / image ops: host routing + args in TOOL_DETAILS; *what* to generate (cutout vs atmosphere, baked-text bans) → **SKILL_DETAILS** (`image_gen` / deliverable skill).
+- Medium choice: simple geometry that stays crisp → vector (`create_shape` / `create_icon` / `create_svg`); complex atmosphere / materials / faces that vectors would draw poorly → `create_image`. Follow **SKILL_DETAILS**.
 - Icons / UI glyphs / tab marks / list leading marks: use `create_icon` (non-empty svg) / `create_svg` / vector `create_shape` paths. **Never** emoji or pictograph Unicode (🏠🔍❤️🏃🧘👋等) inside `create_text` as a mark or decoration stand-in — labels are plain words only.
 
 # Edit protocol

--- a/apps/api/seeds/design_skills/banner_ad/SKILL.md
+++ b/apps/api/seeds/design_skills/banner_ad/SKILL.md
@@ -1,30 +1,52 @@
 # Banner / ad strip
 
-Playbook for **横幅 / banner / 通栏 / 顶通 / KV banner** — one message strip, not a landing page.
+Craft for **横幅 / banner / 通栏 / 顶通 / KV banner** — one claim strip, not a landing page.
 
-## Principles
-1. **One claim + one CTA** — no essay, no five competing buttons.
-2. **Mid-band safe** — keep primary copy away from edge crop; assume 5–8% side/top bleed risk.
-3. **Subject vs message** — photo/illustration owns one side (or full bleed under quiet plate); type owns the calm band.
-4. **Fixed ratio** — lock exact WxH first; common: 1920×400, 1200×628, 750×300, 1080×540.
+## Design thinking
 
-## Workflow
-1. Lock banner WxH.
-2. Hero atmosphere or subject (full bleed or subject-side); pull `image_gen` when needed.
-3. Quiet plate or calm region for title + CTA.
-4. Title: catalog face if ~≥90% match else lettering art; support line ≤1 short sentence.
-5. Single CTA — high contrast, not edge-clipped.
-6. Self-check: crop safety, contrast, no invented logo/price.
+| Ask | Aim |
+|-----|-----|
+| **Job** | One claim + one CTA a glance can catch |
+| **Tone** | One direction — clean promo, bold retail, quiet luxury, etc. |
+| **Split** | Where subject lives vs where type lives |
+| **Bitmap vs vector** | Simple geometry / flat marks → vector. Rich atmosphere / product photo → bitmap. If vectors look crude, use image |
+| **Crop risk** | Mid-band safer; edges may clip (~5–8%) |
+| **Size** | e.g. 1920×400 / 1200×628 / 750×300 / 1080×540 or user WxH |
+
+Quality bar: **intentional design** — claim readable, CTA obvious, crop-aware. Soft-avoid generic AI postcard fills.
 
 ## Layout recipes
+
 | Format | Split |
 |--------|-------|
-| Wide web banner | Left/right: subject \| copy+CTA; or full bleed + bottom/mid quiet band |
-| Tall mobile strip | Top subject → mid claim → bottom CTA |
-| Square social | Center claim; subject as atmosphere, not busy collage |
+| Wide web | Subject \| copy+CTA, or full bleed + quiet band |
+| Tall mobile | Subject → claim → CTA |
+| Square social | Center claim; subject as atmosphere |
 
-## Avoid
-- Multi-section landing rhythm on a single strip
-- Emoji / Material icon spam as decoration
-- Tiny type at edges; dual primary CTAs
-- Baked titles in the hero bitmap fighting overlay copy
+## Type & CTA
+
+- One primary claim; ≤1 supporting line, clearly smaller.
+- One primary CTA — high contrast, not flush to the edge.
+- Catalog text or lettering plate via `image_gen` when fonts fall short.
+
+## Vector vs image
+
+Simple frames, dividers, dots, flat CTA plates → vector. Complex product/scene → `image_gen`. Soft-avoid emoji spam and multi-section landing sprawl on one strip.
+
+## Honesty
+
+Unless the user provides them, avoid inventing board facts such as logos, prices, phone numbers, etc.
+
+## Place on board
+
+Load **`image_gen`** for atmosphere / product / title plates and stack.
+
+Typical stack: background → subject → structure/marks → claim → CTA.
+
+## Related
+
+`image_gen`, `garden_style`
+
+## Done when
+
+Far: claim + CTA clear. Near: mid-band safe; medium matches complexity; language matches the user.

--- a/apps/api/seeds/design_skills/banner_ad/_meta.json
+++ b/apps/api/seeds/design_skills/banner_ad/_meta.json
@@ -31,7 +31,7 @@
     }
   ],
   "mutex_group": "",
-  "prompt_negative": "Do not turn a banner into a multi-section landing; do not clip mid-band copy; do not invent logos/prices; do not spam five CTAs.",
+  "prompt_negative": "Prefer one claim strip over a multi-section landing. Prefer mid-band safe copy. Simple marks may stay vector; complex atmosphere/product that looks crude as shapes should use images. Unless the user provides them, avoid inventing board facts such as logos, prices, phone numbers, etc. Prefer one primary CTA.",
   "locales": {
     "zh-CN": {
       "displayName": "横幅 / 广告条",

--- a/apps/api/seeds/design_skills/brush_ops/SKILL.md
+++ b/apps/api/seeds/design_skills/brush_ops/SKILL.md
@@ -1,50 +1,58 @@
 # Brush / pencil
 
-Playbook for **brush / pencil / 板绘 / 线稿 / pressure drawing** — expressive freehand, not geometric shape collage.
+Craft for **brush / pencil / 板绘 / 线稿 / pressure drawing** — freehand when the brief wants drawn marks. Medium follows the job: pressure strokes vs simple vector vs complex bitmap.
 
-Host args for the pencil brush live in TOOL_DETAILS — this skill owns craft intent and tip choice.
+## Design thinking
 
-## Principles
-1. **Pressure tells the story** — light start/end, heavier mid; flat pressure reads as stamp spam.
-2. **Tip matches intent** — sketch ≠ calligraphy ≠ marker; pick one tip family per pass.
-3. **Stroke economy** — fewer confident strokes beat dozens of timid ones.
-4. **Never fake brush with geometry** — circle/ellipse piles are not drawing.
-5. **Stay inside the artboard** — all strokes clip to FOCUS.
+| Ask | Aim |
+|-----|-----|
+| **Is brush right?** | Sketch / ink / chalk — or UI chrome / photo hero / icons instead? |
+| **Tone** | One drawn language per pass |
+| **Tip family** | Sketch ≠ calligraphy ≠ marker — pick one |
+| **Bitmap vs vector vs brush** | Pressure / expressive freehand → brush. Simple precise geometry → vector. Complex photo/atmosphere → bitmap. Soft-avoid faking brush with ellipse piles |
+| **Economy** | Few confident strokes over timid spam |
 
-## Workflow
-1. Confirm the brief needs freehand (sketch, ink flourish, chalk mark) — not UI chrome or poster hero.
-2. Lock artboard if missing; keep strokes inside FOCUS.
-3. Choose tip + hardness; plan 3–12 strokes max for a mark cluster.
-4. Draw with the pencil brush tool (polyline + matching pressure samples — see TOOL_DETAILS).
-5. Far check: silhouette readable; near check: pressure varies.
-6. Refine the same stroke or add companion strokes — do not rebuild as geometry.
+Quality bar: **intentional design** — silhouette reads; pressure varies.
+
+## Stroke & composition
+
+- Keep strokes on the current artboard.
+- Plan a small budget (~3–12 strokes for a mark cluster).
+- Pressure: lighter ends, heavier mid — soft-avoid uniform stamp dots.
+- Far check silhouette; near check pressure. Refine before rebuilding as geometry.
 
 ## Tip → intent
+
 | Tip | Lean |
 |-----|------|
-| `pencil-hb` / `needle` | Sketch / 线稿; thin; vary pressure |
-| `fountain` / `calligraphy` / `brushpen` | Ink flourishes; fewer confident strokes |
-| `marker` / `highlighter` | Broad marks; opacity for wash feel |
-| `chalk` / `charcoal` / `bristle` | Texture; darker mid-stroke |
-| `soft` / `watercolor` / `airbrush` | Soft edges; lower hardness |
-| `solid` / `bold` | Graphic poster marks; still pressure-aware |
+| `pencil-hb` / `needle` | Sketch / 线稿 |
+| `fountain` / `calligraphy` / `brushpen` | Ink flourishes |
+| `marker` / `highlighter` | Broad marks / wash |
+| `chalk` / `charcoal` / `bristle` | Texture |
+| `soft` / `watercolor` / `airbrush` | Soft edges |
+| `solid` / `bold` | Graphic marks, still pressure-aware |
 
-## When NOT brush
+## When another medium fits better
+
 | Need | Prefer |
 |------|--------|
-| UI chrome / cards / buttons | `shadcn_ui` |
-| Festive / photo hero | `image_gen` / `poster_craft` |
+| Simple precise geometry / icons | shape tools / `icon_set` |
+| UI chrome | `shadcn_ui` |
+| Complex photo / rich atmosphere | `image_gen` / `poster_craft` |
 | Looping motion | `motion_lottie` |
-| Precise geometry | rect / ellipse / line shapes |
 
-## Do not
-- Rebuild brush art as ellipse/circle piles
-- Use curve commands expecting pressure sampling (polyline only)
-- Cover a poster subject with scribble noise
-- Use brush as a substitute for missing fonts or icons
+## Honesty
+
+Soft-avoid using brush as a stand-in for missing fonts or icons. Soft-avoid covering a poster subject with scribble noise.
+
+## Place on board
+
+Confirm freehand → pick tip → draw with pressure → refine. Soft-avoid deleting an artboard when only cleaning strokes.
+
+## Related
+
+`image_gen`, `poster_craft`, `icon_set`
 
 ## Done when
-Silhouette reads at a glance; pressure varies; tip matches intent; strokes stay inside FOCUS.
 
-## Edit / color intent
-When the user asks to keep one color and remove others: match via SCENE fill/stroke; never delete an artboard id (use `delete_frame`). Tool arg shapes → TOOL_DETAILS.
+Silhouette reads; pressure varies; tip matches intent; strokes stay on board.

--- a/apps/api/seeds/design_skills/brush_ops/_meta.json
+++ b/apps/api/seeds/design_skills/brush_ops/_meta.json
@@ -36,7 +36,7 @@
     }
   ],
   "mutex_group": "",
-  "prompt_negative": "Do not fake brush work with circle/ellipse piles; do not use C/Q curves when pathPressure tip-stamp is required.",
+  "prompt_negative": "Prefer real pressure strokes over circle/ellipse piles as fake brush work. Prefer polyline tip-stamp paths when pressure sampling is needed.",
   "locales": {
     "zh-CN": {
       "displayName": "笔刷 / 铅笔",

--- a/apps/api/seeds/design_skills/dashboard_ui/SKILL.md
+++ b/apps/api/seeds/design_skills/dashboard_ui/SKILL.md
@@ -1,67 +1,52 @@
 # Dashboard / admin UI
 
-Playbook for **后台 / dashboard / console** — scannable density, clear IA, honest empty states.
+Craft for **后台 / dashboard / console** — scannable density, clear IA, honest empty states. Most chrome is simple vector; complex media widgets use image when needed.
 
-## Principles
-1. **Shell before widgets** — sidebar + top bar + main; then KPIs and tables.
-2. **Scan in ~2s** — nav + KPIs + primary content readable immediately.
-3. **Honest data** — never invent KPI numbers, series, or logos; use user values or "—".
-4. **One primary per region** — Create/Apply stays obvious; rest ghost/secondary.
-5. **Density with rhythm** — base-8; section gaps > item gaps; not cramped noise.
+## Design thinking
 
-## Workflow
-1. Desktop-ish size (e.g. 1440×900) unless asked mobile (then prefer `mobile_app_ui`).
-2. Load `shadcn_ui` when crafting dense chrome from scratch.
-3. Build shell → KPI row → main (table **or** card grid) → filters.
-4. Wire loading/empty/error states as muted structures, not blank voids.
-5. Self-check alignment and role consistency.
+| Ask | Aim |
+|-----|-----|
+| **Job** | What scans in ~2s — nav + KPIs + main? |
+| **IA** | Filters+table / KPI+chart+table / master-detail / cards — pick one primary |
+| **Tone** | Dense but calm; one token system |
+| **Bitmap vs vector** | Simple shell, KPI cards, charts, marks → vector. Complex media / photo widgets → bitmap. If vectors look crude, use image |
+| **Data honesty** | Metrics from the user, or placeholders like `—` |
+| **Device** | Desktop ~1440×900; phone → prefer `mobile_app_ui` |
 
-## Shell
+Quality bar: **intentional design** — alignment and roles crisp. Soft-avoid festive poster heroes and invented analytics.
+
+## Shell & composition
+
 | Region | Compose |
 |--------|---------|
-| Sidebar | Narrow vertical; logo/mark + nav; active = weight **and** color |
-| Top bar | Title / breadcrumbs / search / user chip — quiet |
-| KPI row | 3–4 equal cards: label + value; aligned baselines |
-| Main | Table **or** card grid — pick one primary |
-| Filters | Row above table; labeled controls; one primary Apply if needed |
+| Sidebar | Mark + nav; active = weight and color |
+| Top bar | Title / search / user — quiet |
+| KPI row | 3–4 equal cards; aligned baselines |
+| Main | Table **or** card grid as primary |
+| Filters | Labeled controls; one primary Apply when needed |
 
-## Modules
-| Module | Notes |
-|--------|-------|
-| KPI card | Surface + muted label + bold value |
-| Table | Header distinct; column-aligned body |
-| Skeleton | Muted bars matching final layout |
-| Chart | Simple bar/line — no fake precision labels |
-| Primary button | Filled primary + verb from user language |
+States: loading skeleton / empty + one action / error + next step.
 
-## IA patterns
-| Pattern | When |
-|---------|------|
-| Filters + table | Operational lists, orders, users |
-| KPI + chart + table | Analytics overview |
-| List + detail | Master/detail |
-| Cards grid | Entity galleries |
+## Type
 
-## States
-- **Loading**: muted skeleton matching layout.
-- **Empty**: short message + one CTA.
-- **Error**: what failed + next step.
+Muted labels, bold values; one console type system. Primary button verb from user language.
 
-## Placeholder grammar
-| Missing | Show |
-|---------|------|
-| Metric value | `—` with label kept |
-| Chart series | Empty plot or omit series |
-| Logo | Text mark — do not invent brand marks |
+## Vector vs image
 
-## Do not
-- Marketing hero / festive illustration as the whole board
-- Five equal CTAs; rainbow accents; emoji / pictograph text as nav or KPI icons (draw real vector glyphs instead)
-- Invent analytics facts or “sample” revenue
-- Desktop-density tables as the default on phone frames
+Nav and KPI marks as real geometry when simple (`icon_set` when many). Charts as simple bar/line structure. Dense controls → `shadcn_ui`. Soft-avoid emoji as icons. Soft-avoid rebuilding the whole console as a marketing collage.
+
+## Honesty
+
+Unless the user provides them, avoid inventing board facts such as KPI numbers, chart series, logos, revenue samples, etc. Prefer `—` or empty structure.
+
+## Place on board
+
+Shell → KPI → main → filters. Load `image_gen` only when a media widget needs a real bitmap.
 
 ## Related
-`shadcn_ui` (controls), `icon_set` (glyph systems), `mobile_app_ui` (if phone console).
+
+`shadcn_ui`, `icon_set`, `mobile_app_ui`, `image_gen` (media widgets)
 
 ## Done when
-Nav + KPIs + main content readable in ~2s; alignment crisp; roles consistent; no invented metrics.
+
+Nav + KPIs + main scan quickly; roles consistent; medium matches complexity; language matches the user.

--- a/apps/api/seeds/design_skills/dashboard_ui/_meta.json
+++ b/apps/api/seeds/design_skills/dashboard_ui/_meta.json
@@ -38,7 +38,7 @@
     }
   ],
   "mutex_group": "",
-  "prompt_negative": "Do not invent metrics or chart data; do not turn a dashboard into a festive poster; do not use five competing primary buttons.",
+  "prompt_negative": "Unless the user provides them, avoid inventing board facts such as metrics, chart series, logos, etc. Prefer console density over a festive poster. Prefer one primary action per region. Simple chrome/charts may stay vector; complex media widgets that look crude as shapes should use images.",
   "locales": {
     "zh-CN": {
       "displayName": "后台 / Dashboard",

--- a/apps/api/seeds/design_skills/ecommerce_surface/SKILL.md
+++ b/apps/api/seeds/design_skills/ecommerce_surface/SKILL.md
@@ -1,55 +1,56 @@
 # Ecommerce surfaces
 
-Playbook for **电商主图 / product hero** and **商详 / PDP** — product first, modules clear, commerce facts honest.
+Craft for **电商主图 / product hero** and **商详 / PDP** — product first, modules clear, commerce facts honest.
 
-## Principles
-1. **Product is the hero** — ≥40–60% visual weight on the subject; whitespace around.
-2. **Modules have order** — hero → title/price → benefits → specs → story → CTA; do not scramble.
-3. **Honesty** — never invent % off, reviews, sold counts, phones, or prices the user did not give.
-4. **One accent** — CTA/price only; neutrals elsewhere.
-5. **Platform-aware size** — honor 1:1 / 3:4 / tall PDP when asked.
+## Design thinking
 
-## Pick surface
-| Surface | Aspect / feel | Job |
-|---------|---------------|-----|
-| **Hero** | ~1:1 or platform size | Subject largest; sparse badges; no nav/forms |
-| **PDP** | Tall scroll or multi-section board | hero → title/price → benefits → specs → rich text → CTA |
+| Ask | Aim |
+|-----|-----|
+| **Surface** | Hero card vs tall PDP |
+| **Hero** | Product owns ~40–60% visual weight |
+| **Tone** | Clean retail / soft lifestyle / luxury sparse — one only |
+| **Bitmap vs vector** | Product / lifestyle complexity → bitmap. Simple badge frames, benefit icons, dividers → vector |
+| **Facts** | Commerce numbers only from the user |
+| **Ratio** | 1:1 / 3:4 / tall as asked |
 
-## Hero workflow
-1. Lock target size (1:1, 800×800, 3:4, or user WxH).
-2. Subject: user cutout attachment **or** generated isolated product on a solid white/neutral plate with cutout so no white box remains on the board.
-3. Keep ≥40–60% weight on product; calm plate (not festive poster chaos).
-4. Badges (sale/new): ≤2, small, high contrast; never invent % off.
-5. Optional short title — do not cover the product face.
-6. Far check: product unmistakable in ~1s; no opaque white rectangle around the SKU.
+Quality bar: **intentional design** — product unmistakable; modules scannable. Soft-avoid burying the SKU under chrome.
 
-## PDP workflow
-1. Tall or sectioned boards if multi-screen.
-2. Top: product hero (cut out) + title; price **only if user provided**.
-3. Benefits: 3–5 short lines or icon+text rows (vector marks, not emoji).
-4. Specs: aligned label/value pairs.
-5. Rich text / story: calmer type; generous margins.
-6. Sticky CTA optional — one primary verb from user copy.
+## Surface recipes
 
-## Platform size cues
-| Platform feel | Size cue |
-|---------------|----------|
-| Square hero | 1:1 (e.g. 800×800 / 1080×1080) |
-| Portrait card | 3:4 |
-| Tall PDP | 750× long scroll or stacked sections |
+| Surface | Feel | Job |
+|---------|------|-----|
+| **Hero** | ~1:1 or platform size | Subject largest; sparse badges |
+| **PDP** | Tall / sections | hero → title/price → benefits → specs → story → CTA |
 
-## Edit
-Preserve module order. Refine in place; do not rebuild product hero as shape collage.
+## Type & modules
 
-## Do not
-- Bury the product under badges, stickers, or festive chrome
-- Fake reviews, sold counts, coupons, or phones
-- Five equal CTAs or rainbow accents
-- Turn hero into a lifestyle poster that hides the SKU
-- Leave uncut white/solid plate around the product on a colored board
+- Title clear of the face; price/promo only when provided.
+- Benefits: 3–5 short lines; specs as aligned label/value.
+- One accent for CTA/price; neutrals elsewhere.
+
+## Vector vs image
+
+| Prefer vector when | Prefer bitmap when |
+|--------------------|--------------------|
+| Benefit icons, thin rules, card frames | Product photo / detailed hero |
+| Sparse badge outlines | Lifestyle scene that vectors cannot carry |
+
+Real geometry for marks (`icon_set` when many); soft-avoid emoji as icons.
+
+## Honesty
+
+Unless the user provides them, avoid inventing board facts such as prices, discounts, review counts, sold numbers, phone numbers, logos, etc.
+
+## Place on board
+
+Load **`image_gen`** for product plates, titles, and cutouts.
+
+Typical stack: product cutout → vector module chrome → title/price → benefits → CTA.
 
 ## Related
-`image_gen` (product plate), `shadcn_ui` (if embedding buy-box UI chrome).
+
+`image_gen`, `icon_set`, `shadcn_ui` (buy-box chrome only)
 
 ## Done when
-Product is unmistakable at a glance; modules scannable; no invented commerce facts; copy language matches user.
+
+Product reads at a glance; modules clear; medium matches complexity; language matches the user.

--- a/apps/api/seeds/design_skills/ecommerce_surface/_meta.json
+++ b/apps/api/seeds/design_skills/ecommerce_surface/_meta.json
@@ -36,7 +36,7 @@
     }
   ],
   "mutex_group": "",
-  "prompt_negative": "Do not invent prices/discounts/SKU; do not bury the product under chrome; do not turn PDP into a festive poster with no modules; never leave uncut white product plates on the board.",
+  "prompt_negative": "Unless the user provides them, avoid inventing board facts such as prices, discounts, SKUs, review counts, etc. Prefer the product as hero over heavy chrome. Prefer modular PDP over a festive poster. Simple module chrome may stay vector; detailed product/lifestyle that looks crude as shapes should use images. Prefer cutout when white product plates would remain.",
   "locales": {
     "zh-CN": {
       "displayName": "电商表面",

--- a/apps/api/seeds/design_skills/icon_set/SKILL.md
+++ b/apps/api/seeds/design_skills/icon_set/SKILL.md
@@ -1,41 +1,48 @@
 # Icon / mark set
 
-Playbook for **图标 / icon set / favicon / UI glyph** — static vector consistency, not illustration posters.
+Craft for **图标 / icon set / favicon / UI glyph** — one system. Default to vector for simple marks; use bitmap only when texture/brand detail cannot stay crisp as geometry.
 
-## Principles
-1. **One system** — shared optical size, stroke weight, corner radius, filled vs outline rule.
-2. **Grid first** — frame each mark on the same cell (e.g. 64 / 96 / 128); align to a keyline grid.
-3. **Vector over bitmap** — prefer clean vector marks; bitmap only for textured/brand marks the user requested.
-4. **Real glyphs only** — every mark is drawn geometry. Never emoji, pictograph characters, or a lone text character as the icon.
+## Design thinking
 
-## Marks & labels
-| Role | Craft |
-|------|-------|
-| Mark | One compact vector glyph per requested icon (shared stroke / corner language) |
-| Label | Optional small plain text under the mark — labels never replace marks |
-| Sheet | One artboard / grid board for the set when creating multiple icons |
+| Ask | Aim |
+|-----|-----|
+| **Deliverable** | App icon / UI glyph set / favicon |
+| **System** | Shared optical size, stroke, corner, filled vs outline |
+| **Grid** | Same cell (e.g. 64 / 96 / 128); columns × rows |
+| **Bitmap vs vector** | Simple silhouettes / outline-filled glyphs → vector. Textured or complex brand marks the user asked for → bitmap. Soft-avoid emoji-as-icon |
+| **Scale** | Still readable ~32px for UI glyphs |
 
-Empty or placeholder marks are not allowed — each glyph must have real paths/geometry.
+Quality bar: **intentional design** — one language across the set, even optical weight. Soft-avoid rainbow-per-mark.
 
-**Budget:** one solid glyph per mark (not a pile of tiny strokes). Eight marks plus labels should stay readable and even.
+## Composition
 
-## Workflow
-1. Lock cell size + columns (e.g. 4×2 grid). Outer artboard optional for the sheet.
-2. State the system in one line (outline 2px / rounded 4 / monochrome ink).
-3. For **each** requested mark: draw the vector glyph first, then optional label.
-4. Optical balance: round glyphs slightly oversized vs square; keep equal visual weight.
-5. Self-check: N marks = N vector glyphs; no emoji; no mixed styles; labels readable.
+- Lock cell size and sheet grid (e.g. 4×2).
+- State the system in one line (stroke / corner / mono ink).
+- Optical balance: rounds slightly large, squares slightly tight.
+- Optional small labels under marks — labels never replace glyphs.
 
-## Set recipes
-| Ask | Deliver |
-|-----|---------|
-| App icon | Single mark + simple plate; avoid tiny detail that dies at 32px |
-| UI glyph set | Outline or filled family; draw larger for craft |
-| Favicon | Ultra-simple silhouette; 1–2 shapes max |
+## Vector vs image
 
-## Avoid
-- Emoji / 🏠🔍❤️ / “icon font” text as marks
-- Motion/Lottie for static icons
-- Rainbow random fills per icon in one set
-- Photoreal collage as “icon set”
-- Only labels with no vector mark
+| Ask | Prefer |
+|-----|--------|
+| App icon / UI set / favicon | Vector silhouette that survives small sizes |
+| Textured brand mark (user asked) | Bitmap via `image_gen` |
+| Static mark | Vector — soft-avoid Lottie unless motion is asked |
+
+Budget: one solid/outline glyph per mark — not stroke piles. Soft-avoid pictograph characters or lone text characters as the icon.
+
+## Honesty
+
+Unless the user provides them, avoid inventing board facts such as brand logos or trademark marks.
+
+## Place on board
+
+Draw each simple mark as real geometry; then optional labels. Load `image_gen` only for textured/complex marks the user requested.
+
+## Related
+
+`mobile_app_ui`, `dashboard_ui`, `shadcn_ui`, `image_gen`, `motion_lottie` (motion only)
+
+## Done when
+
+N marks ≈ N real glyphs (or intentional bitmap marks); one system language; labels readable.

--- a/apps/api/seeds/design_skills/icon_set/_meta.json
+++ b/apps/api/seeds/design_skills/icon_set/_meta.json
@@ -34,7 +34,7 @@
     }
   ],
   "mutex_group": "",
-  "prompt_negative": "Never use emoji or pictograph text as icons. Every mark must be real vector geometry. Do not substitute motion/Lottie for static marks; do not invent brand logos; do not mix outline and filled weights in one set.",
+  "prompt_negative": "Prefer real geometry over emoji or pictograph text as icons. Prefer simple vector marks; textured/complex brand marks the user asked for may use images. Prefer static marks over Lottie for non-moving icons. Unless the user provides them, avoid inventing brand logos, etc. Prefer one stroke/fill language across a set.",
   "locales": {
     "zh-CN": {
       "displayName": "图标 / 符号组",

--- a/apps/api/seeds/design_skills/image_gen/SKILL.md
+++ b/apps/api/seeds/design_skills/image_gen/SKILL.md
@@ -1,59 +1,69 @@
 # Image generation
 
-Craft for **bitmap heroes / materials / lettering art** — concrete prompts, honest typography gate, cutout when compositing. Tool args live in TOOL_DETAILS; this skill owns *what to ask for*, not op recipes.
+Craft for **visual plates on the board**: bitmaps, vectors, and type. Choose medium by **what draws well**, not by a fixed “vectors are only accents” rule.
 
-## Principles
-1. **Hero honesty** — festive/illustrated boards start with a real full/near-full bitmap, not shape piles.
-2. **Typography gate (~90%)** — catalog face or lettering image; never invent font names.
-3. **Concrete prompts** — subject, medium, light, composition, color, negatives.
-4. **Stacking** — image first, then type/chrome on quieter regions.
-5. **No invented facts** inside the picture (logos, prices, phones) unless asked / letteringText.
-6. **Cutout when compositing** — product / subject plates on a design bg must be transparent (no white box).
+## Design thinking
 
-## When
-- Poster / festive / illustrated hero
-- Photo / product / material / atmosphere backgrounds
-- Display lettering that fails the typography gate below
+| Ask | Aim |
+|-----|-----|
+| **What carries the eye** | Atmosphere, subject, or display type — pick the memory point |
+| **Tone** | One direction matching the brief |
+| **Bitmap vs vector** | **Simple** marks/geometry that stay crisp → vector. **Complex** scenes, lighting, materials, faces, busy illustration → bitmap (`add image`). If a vector attempt would look like crude shape spam, switch to image |
+| **Where type sits** | Quiet bands so overlay copy reads |
+| **Medium (bitmap)** | Photo, illustration, grain print, soft 3D, etc. — one craft language per plate |
 
-## Two image jobs (do not mix)
-| Job | Prompt must | Finish |
-|-----|-------------|--------|
-| **Atmosphere / full-bleed hero** | Scene only — **no titles, dates, slogans, logos, watermarks, gibberish letters**. Titles come later as editable type / letteringText. | no cutout |
-| **Product / subject plate** | Isolated subject on **plain solid plate** (white/neutral); studio light; no lifestyle collage text | cutout / removeBg |
-| **Lettering art** | Glyphs only on plain plate | letteringText + cutout |
+Quality bar: **intentional design** — light, material, and crop that fit this brief. Soft-avoid generic AI postcard defaults. This is designed specificity, not a “handmade” texture effect.
 
-## Typography gate (~90%)
-Compare needed title look to Available fonts:
-- ~**≥90%** similar → catalog editable type
-- Below — especially hero/main titles → lettering image on a plain plate (hydrate cutout). Do **not** map 书法感/手写感/国潮/艺术字 to the nearest calligraphy font.
-- Body/UI/captions: prefer catalog faces; invent no font names.
-If the user forbids image gen: skip bitmaps; plain editable type only.
+## When to use bitmap
 
-## Prompt recipe
-Include: **subject**, **style/medium**, **lighting/mood**, **composition/camera**, **color cues**, **negatives**.
-- Atmosphere negatives: **no text, no letters, no logo, no watermark, no poster title baked in**.
-- Product plate: **isolated on solid white/neutral background** + cutout.
-- Lettering: isolate glyphs; high contrast plate; no busy background behind letters.
+- Atmosphere / mood that needs depth, haze, rich light, or material.
+- Products, people, props with believable form and light.
+- Complex illustrated heroes that vectors cannot carry cleanly.
+- Lettering art when catalog fonts cannot match the gesture (~90%+).
 
-## Stacking
-Hero image first → then type / UI chrome on quieter regions. Size/transparency details → TOOL_DETAILS.
+Prompt with subject, medium, lighting, composition, color, and avoid-in-image (e.g. baked titles, watermarks — unless the user wants text in the picture).
 
-## Route
-| Brief | Also load |
-|-------|-----------|
-| Poster / roll-up | `poster_craft` |
-| Ecommerce product plate | `ecommerce_surface` |
-| Taste / anti-slop | `garden_style` |
+## When to use vector
 
-## Do not
-- Fake festive heroes with geometry
-- Bake event titles / dates / CTAs into the hero when editable type will sit on top
-- Ship product photos with a white rectangle still visible on a colored board
-- Paste finished composites that double-print baked titles
+- Simple geometry done cleanly: rules, frames, dots, discs, bars, flat badges, icons, clean silhouettes.
+- UI marks and glyphs (`icon_set` when many).
+- Structural color blocks and dividers that support hierarchy.
+
+Shared stroke / corner / ink with the board. Soft-avoid emoji as marks.
+
+**Not a ban on simple scenes in vector** — a flat night field + moon disc + a few stars can be vector if that is the intentional, simple language. Prefer bitmap when the brief wants rich atmosphere or the vector version would look unfinished.
+
+## Subject & product plates
+
+- Clear silhouette and believable light when using bitmap.
+- Studio / clean plate when the product should stay honest; lifestyle only when asked.
+- **Cutout** when a solid plate sits on a colored board (avoid leftover white boxes).
+
+## Lettering
+
+- Catalog **add text** when a face is a close match (~90%+).
+- Lettering **as image + cutout** when display / calligraphy / neon / 国潮 needs a gesture fonts cannot carry.
+- Body and captions stay catalog text.
+
+## Honesty
+
+Unless the user asks for them, avoid inventing facts inside the picture such as logos, prices, phone numbers, etc.
+
+## Place on board
+
+| Action | Use |
+|--------|-----|
+| **Add image** | Bitmap plate |
+| **Add text** | Editable catalog type |
+| **Cutout** | Drop solid plate on subjects / lettering (skip on full-bleed backgrounds) |
+| **Vector shapes / marks** | Simple geometry, rules, icons, clean accents |
+
+Typical stack: background (bitmap **or** simple vector field) → subject → structure/marks → title → support.
+
+## Related
+
+`poster_craft`, `banner_ad`, `long_scroll`, `ecommerce_surface`, `landing_page`, `icon_set`, `garden_style`
 
 ## Done when
-Hero/atmosphere exists when required; lettering path respects the 90% gate; product plates are cut out; prompt is concrete; stacking leaves quiet zones for type.
 
-## Review gate (for Review Agent / SKILL_CRAFT)
-Fail when: festive/illustrated board has no real bitmap hero; product plate still shows a white box; atmosphere genPrompt baked titles that fight overlay type; typography gate ignored for hero lettering.
-Pass when Principles + Done-when hold for the brief's image job.
+Far: tone and focal read in ~1s. Near: medium choice fits complexity; type sits on quiet ground; language matches the user.

--- a/apps/api/seeds/design_skills/image_gen/_meta.json
+++ b/apps/api/seeds/design_skills/image_gen/_meta.json
@@ -2,12 +2,12 @@
   "skill_key": "image_gen",
   "name": "image_gen",
   "displayName": "Image generation",
-  "description": "Bitmap heroes, atmosphere plates, materials, and stylized lettering — with typography gate for overlay copy",
-  "when_to_use": "Poster/hero bitmap, generated backgrounds, materials, or stylized lettering as image",
+  "description": "Bitmap atmosphere/subjects, vector accents, and lettering — design-led visual craft",
+  "when_to_use": "Hero/atmosphere bitmaps, product plates, vector accents/marks, or stylized lettering",
   "category": "image",
   "scenes": "all",
   "sort_weight": 88,
-  "version": "2.0.0",
+  "version": "3.1.0",
   "preferred_tools": [
     "create_image",
     "create_frame",
@@ -31,15 +31,15 @@
     }
   ],
   "mutex_group": "image",
-  "prompt_negative": "If the user forbids image gen, skip bitmap heroes; do not invent fontFamily; do not ship poster/festive work as shape-only geometry; do not bake titles into atmosphere heroes; do not leave white product plates uncut.",
+  "prompt_negative": "If the user forbids image gen, skip bitmap heroes. Prefer catalog fontFamily names. Simple marks may stay vector; complex scenes that look crude as shapes should use images. Prefer overlay type over baking titles into backgrounds. Prefer cutout when product/lettering plates would leave white boxes.",
   "locales": {
     "zh-CN": {
       "displayName": "图像生成",
-      "description": "英雄图 / 氛围底板 / 材质 / 艺术字；可改字标题不进图"
+      "description": "氛围图 / 主体 / 矢量点缀 / 艺术字 — 偏设计表达"
     },
     "en": {
       "displayName": "Image generation",
-      "description": "Bitmap heroes, atmosphere plates, materials, stylized lettering"
+      "description": "Atmosphere, subjects, vector accents, lettering"
     }
   }
 }

--- a/apps/api/seeds/design_skills/landing_page/SKILL.md
+++ b/apps/api/seeds/design_skills/landing_page/SKILL.md
@@ -1,54 +1,60 @@
 # Landing / website
 
-Playbook for **落地页 / 官网 / landing** — one thesis, clear section rhythm, one primary CTA.
+Craft for **落地页 / 官网 / landing** — one thesis, section rhythm, one primary CTA.
 
-## Principles
-1. **One thesis** — one headline job; supporting line clarifies; everything else serves it.
-2. **One primary CTA** — secondary actions stay ghost/quiet.
-3. **Section spine** — nav → hero → benefits → proof (optional) → CTA → footer.
-4. **Honest proof** — logos/quotes only if user provided; never invent testimonials or pricing.
-5. **Direction once** — minimal SaaS / editorial brand / product demo — one language end-to-end.
+## Design thinking
 
-## Workflow
-1. Size: desktop (e.g. 1440×900+ scroll) or mobile (390×844). Multi-screen → one artboard per screen (cap ~8).
-2. Commit direction; optionally load `garden_style`.
-3. Build section spine; dense chrome inside sections → also `shadcn_ui`.
-4. Self-check contrast, overflow, and hierarchy before done.
-5. Far check: thesis + CTA in ~1s; near: alignment and contrast.
+| Ask | Aim |
+|-----|-----|
+| **Purpose** | Conversion or story job |
+| **Tone** | One aesthetic — editorial, minimal, industrial, soft product, etc. |
+| **Thesis** | One headline + one supporting line |
+| **CTA** | One primary action; secondaries stay quiet |
+| **Bitmap vs vector** | Simple cards / icons / rules / chrome → vector. Rich hero atmosphere/product → bitmap. If vectors look crude, use image |
+| **Proof** | Only assets the user gave |
+| **Device** | Desktop ~1440 or mobile ~390 |
 
-## Hero thesis
-- One headline + one supporting line + one primary CTA.
-- Visual: product shot / atmosphere image **or** strong typographic hero — not both fighting.
-- Avoid generic “big number + purple gradient accent” unless the brief is metric-led.
+Quality bar: **intentional design** — clear IA and one memory point. Soft-avoid generic AI postcard heroes and five equal CTAs.
 
-## Sections
+## Sections & composition
+
 | Block | Notes |
 |-------|-------|
-| Nav | Logo mark + 3–6 links; quiet surface |
-| Hero | Image or display type + CTA |
-| Benefits | 3 equal cards/rows; shared radius; short titles; real vector marks — never emoji |
-| Proof | Logos/quotes **only if provided** |
-| CTA band | High contrast; single verb from user copy |
-| Footer | Muted; links + legal short |
+| Nav | Mark + few links |
+| Hero | Image or display type + primary CTA |
+| Benefits | 3 equal units; short titles |
+| Proof | User-provided logos/quotes |
+| CTA band | Single verb from user copy |
+| Footer | Muted links |
 
-## Desktop vs mobile
 | | Desktop | Mobile |
 |--|---------|--------|
 | Board | ~1440×900+ | ~390×844 |
-| Nav | Horizontal links | Compact mark + fewer links |
-| Benefits | 3-column cards | Stacked rows |
-| CTA | Inline + band | Full-width in thumb zone |
+| Benefits | 3 columns | Stacked |
+| CTA | Inline + band | Full-width thumb zone |
 
-## Cross-skill load order
-1. `landing_page` (this spine)
-2. `shadcn_ui` when forms/buttons densify
-3. `garden_style` when a strong art direction is needed
+## Type
 
-## Do not
-- Five CTAs of equal weight
-- Invent pricing tables, logos, or testimonials
-- Turn the whole page into a poster with no scannable sections
-- Mix festive hand-lettering with dense admin tables casually
+One type system page-wide. Headline owns the thesis; body stays quieter.
+
+## Vector vs image
+
+Card frames, dividers, benefit marks → vector. Complex hero scenes → `image_gen`. Soft-avoid emoji as icons (`icon_set` when many). Dense controls → `shadcn_ui`.
+
+## Honesty
+
+Unless the user provides them, avoid inventing board facts such as logos, testimonials, pricing tables, phone numbers, etc.
+
+## Place on board
+
+When the hero needs bitmaps or cutouts, load **`image_gen`**.
+
+Typical stack: hero bitmap → vector section chrome → type → CTA.
+
+## Related
+
+`image_gen`, `shadcn_ui`, `icon_set`, `garden_style`
 
 ## Done when
-Hero job is obvious in ~1s; sections align to one grid; primary CTA unmistakable; copy language matches user.
+
+Hero job is obvious quickly; sections share one grid; primary CTA clear; language matches the user.

--- a/apps/api/seeds/design_skills/landing_page/_meta.json
+++ b/apps/api/seeds/design_skills/landing_page/_meta.json
@@ -35,7 +35,7 @@
     }
   ],
   "mutex_group": "",
-  "prompt_negative": "Do not ship a landing as a single festive poster with no sections; do not invent pricing tiers or logos; do not use five competing CTAs.",
+  "prompt_negative": "Prefer scannable sections over a single festive poster. Simple cards/icons/rules may stay vector; complex hero scenes that look crude as shapes should use images. Unless the user provides them, avoid inventing board facts such as pricing tiers, logos, testimonials, etc. Prefer one primary CTA.",
   "locales": {
     "zh-CN": {
       "displayName": "落地页 / 官网",

--- a/apps/api/seeds/design_skills/long_scroll/SKILL.md
+++ b/apps/api/seeds/design_skills/long_scroll/SKILL.md
@@ -1,33 +1,54 @@
 # Long image / scroll story
 
-Playbook for **长图 / long image / 长截图 / scroll story** — one tall continuous board.
+Craft for **长图 / long image / 长截图 / scroll story** — one tall continuous board with chapter rhythm.
 
-## Principles
-1. **One board, tall rhythm** — single tall artboard (e.g. 750×3000+ or 1080×4000); not many separate boards unless user asks.
-2. **Chapter beats** — intro → 3–6 sections → close/CTA; each beat needs a visual pause.
-3. **Mobile-first width** — keep ~750–1080 width; generous vertical spacing between chapters.
-4. **Sticky thesis** — repeat the core claim lightly; do not dump all copy at the top.
+## Design thinking
 
-## Workflow
-1. Lock WxH; prefer width 750/1080; height from content (start ≥2800 if story-rich).
-2. Map chapter list before painting (title each beat in one phrase).
-3. Per chapter: optional mood band + quiet type block; pull `image_gen` sparingly (1 hero + accents).
-4. Keep left/right margins ≥ ~6% width; avoid edge-clipped titles.
-5. Closing beat: one CTA or takeaway — not a second landing page.
-6. Self-check: scroll continuity, contrast on each band, no invented metrics.
+| Ask | Aim |
+|-----|-----|
+| **Job** | A scroll story, not a short square poster |
+| **Beats** | Hook → a few chapters → close/CTA |
+| **Tone** | One visual language top to bottom |
+| **Bitmap vs vector** | Simple separators / marks → vector. Rich hook/chapter scenes → bitmap. If vectors look crude, use image |
+| **Width** | Mobile-first (~750–1080) |
+| **Height** | Real scroll when asked 长图 (often tall, e.g. ≥~2800) |
 
-## Rhythm
+Quality bar: **intentional design** — clear pauses between beats, coverage down the board. Soft-avoid empty bottoms and shape-pile fillers.
+
+## Rhythm & composition
+
 | Zone | Role |
 |------|------|
-| Hook (top ~15%) | Hook visual + one-line thesis |
-| Body chapters | Alternating image/type density; clear separators |
-| Close | Summary + CTA / share prompt |
+| Hook (~top 15%) | Visual + one-line thesis |
+| Body | Alternating image/type density; clear pauses |
+| Close | Summary + one CTA |
 
-## Avoid
-- Short 1:1 poster when user asked 长图
-- Website nav + footer chrome on a shareable long image
-- Wall of text without visual pauses
+- Side inset often ≥~6% width.
+- Prefer appending chapters below over rebuilding an empty top.
 
-## Review gate (for Review Agent / SKILL_CRAFT)
-Fail (`must_fix`) when a tall board (≥~1400px or aspect ≳2.2) leaves large empty bottom — content coverage should reach ~≥72% of height; APPEND modules below current content (no clear/rebuild top).
-Pass when chapter rhythm + coverage meet Principles above.
+## Type
+
+- One theme line per chapter; thesis repeats lightly, not a wall of text at the top.
+- Catalog text; lettering plates via `image_gen` when display needs it.
+
+## Vector vs image
+
+Separators, chapter markers, thin rules → vector. Complex chapter heroes → `image_gen`. Soft-avoid filling empty scroll with crude geometry spam.
+
+## Honesty
+
+Unless the user provides them, avoid inventing board facts such as logos, prices, phone numbers, etc.
+
+## Place on board
+
+Load **`image_gen`** for hook/chapter bitmaps, overlay type, and cutouts.
+
+Review cue: on very tall boards (e.g. ≥~1400px or aspect ≳2.2), large empty bottoms usually mean unfinished chapters — keep appending.
+
+## Related
+
+`image_gen`, `garden_style`
+
+## Done when
+
+Scroll rhythm reads; coverage reaches well down the board; type and imagery share one tone; language matches the user.

--- a/apps/api/seeds/design_skills/long_scroll/_meta.json
+++ b/apps/api/seeds/design_skills/long_scroll/_meta.json
@@ -31,7 +31,7 @@
     }
   ],
   "mutex_group": "",
-  "prompt_negative": "Do not flatten a long story into a short square poster; do not invent multi-artboard websites when user asked for one long image; do not clip chapter titles.",
+  "prompt_negative": "When the user asks for a long image, prefer one tall scroll board over a short square poster or a multi-artboard website. Prefer chapter titles with breathing room. Simple separators may stay vector; complex chapter scenes that look crude as shapes should use images.",
   "locales": {
     "zh-CN": {
       "displayName": "长图 / 滚动叙事",

--- a/apps/api/seeds/design_skills/mobile_app_ui/SKILL.md
+++ b/apps/api/seeds/design_skills/mobile_app_ui/SKILL.md
@@ -1,77 +1,54 @@
 # Mobile / H5 app UI
 
-Playbook for **手机 / H5 / App** screens — single column, thumb-first, honest chrome.
+Craft for **手机 / H5 / App** screens — single column, thumb-first, honest chrome. Medium follows complexity: simple chrome/marks → vector; complex header/hero → image.
 
-## Principles
-1. **Thumb-first** — primary CTA lives in the lower third; avoid corner-only primaries.
-2. **Single column** — stack; do not port desktop sidebars as the default.
-3. **Honest chrome** — do not invent OS battery/wifi glyphs unless asked.
-4. **Hit targets** — generous tap height; do not rely on hover.
-5. **Shared tokens across screens** — multi-board flows keep one type/color language.
-6. **Real nav / list icons** — tabs, lists, and action marks are drawn vector glyphs (shared stroke). Never use emoji or a single pictograph character as an icon — including greetings and card titles.
+## Design thinking
 
-## Workflow
-1. Phone-ish size (e.g. 390×844) or user WxH. Multi-screen → one artboard per screen (cap ~8).
-2. Pair with `shadcn_ui` for controls when needed; pair with `icon_set` when many glyphs share one stroke system.
-3. Build: top bar → content → bottom nav **or** sticky CTA. Each bottom-nav item = vector mark + short plain label.
-4. Apply safe insets; check tap sizes.
-5. Far check at phone scale; near check overflow and contrast.
+| Ask | Aim |
+|-----|-----|
+| **Job** | Login / list / detail / empty / tabs |
+| **Tone** | One product UI language across screens |
+| **Thumb** | Primary action in the lower third when possible |
+| **Bitmap vs vector** | Simple icons, lists, chrome → vector. Rich header/hero scenes → bitmap. If vectors look crude, use image |
+| **Chrome honesty** | Prefer not inventing OS status glyphs unless asked |
+| **Size** | ~390×844 or user WxH |
 
-## Marks & labels
-| Role | Craft |
-|------|-------|
-| Tab / list / KPI mark | One compact vector glyph per mark — not emoji, not a letter pretending to be an icon |
-| Label | Short plain words only under/beside the mark |
-| Bottom nav | Mark first, then label; 3–5 items max |
+Quality bar: **intentional design** — readable at phone scale, clear hierarchy. Soft-avoid desktop sidebars and festive poster chrome on product UI.
 
-Keep the screen lean: do not explode each icon into many overlapping shapes; leave room for chrome and content.
+## Patterns & composition
 
-## Safe area & insets
-| Region | Cue |
-|--------|-----|
-| Side inset | ~16–24px content padding |
-| Top | Title/logo; optional back; respect status-band calm |
-| Bottom | Nav or sticky CTA above home-indicator feel |
-| Tap height | List rows / buttons feel ≥ ~44px |
-
-## Chrome
-| Region | Notes |
-|--------|-------|
-| Top | Title or logo; optional back; quiet |
-| Content | Single column; shared radius on cards/lists |
-| Bottom nav | 3–5 items max; active = weight **and** color |
-| Sticky CTA | Full-width primary in thumb zone; one verb |
-
-## Patterns
 | Pattern | Compose |
 |---------|---------|
-| Login / form | Labels above fields; error adjacent; full-width primary |
-| Feed / list | Repeated rows; avatar + title + meta; generous height |
+| Login / form | Labels above fields; full-width primary |
+| Feed / list | Avatar + title + meta; generous row height |
 | Detail | Optional top image + title + body + bottom CTA |
 | Empty | Short line + one action |
-| Tabs | Labels; active underline; panel below |
+| Tabs | 3–5 items; mark + label; active cue |
 
-## Multi-screen flows
-- One artboard per step; reuse tokens.
-- Carry the same primary verb language across steps.
-- Do not invent intermediate marketing interstitial screens.
+Safe area: side inset ~16–24; top title/back; bottom nav or sticky CTA; tap targets feel ~≥44px.
 
-## When NOT this skill
-| Need | Prefer |
-|------|--------|
-| Desktop admin density | `dashboard_ui` |
-| Marketing multi-section site | `landing_page` |
-| Festive full-board poster | `poster_craft` |
+## Type
 
-## Do not
-- Desktop sidebar + dense tables as the default mobile layout
-- Tiny tap targets; CTA only in the top corner
-- Festive poster decoration on product chrome
-- Five bottom-nav items of equal “primary” weight
-- Emoji / pictograph text in greetings, cards, or nav (use vector marks + plain labels)
+One token set across the flow. Short labels; plain words beside marks.
+
+## Vector vs image
+
+Tab / list / KPI marks as real geometry when simple (`icon_set` when many). Soft-avoid emoji as icons. Dense controls → `shadcn_ui`. Complex photo headers → `image_gen`.
+
+## Honesty
+
+Unless the user provides them, avoid inventing board facts such as account balances, phone numbers, brand logos, etc.
+
+## Place on board
+
+Optional detail header → load **`image_gen`** when the plate needs bitmap/cutout; keep the title clear.
+
+Typical stack: optional header → vector chrome / icons → type → primary CTA.
 
 ## Related
-`shadcn_ui` for controls when needed; `icon_set` for glyph systems; `motion_lottie` only for explicit micro-motion.
+
+`image_gen`, `shadcn_ui`, `icon_set`, `motion_lottie` when motion is explicit
 
 ## Done when
-Readable at phone scale; primary action easy to reach; safe margins; hierarchy clear; tokens consistent across screens; every tab/list mark is a real vector glyph.
+
+Readable at phone scale; primary action easy to reach; medium matches complexity; language matches the user.

--- a/apps/api/seeds/design_skills/mobile_app_ui/_meta.json
+++ b/apps/api/seeds/design_skills/mobile_app_ui/_meta.json
@@ -40,7 +40,7 @@
     }
   ],
   "mutex_group": "",
-  "prompt_negative": "Do not use desktop sidebar layouts on mobile; do not invent OS status icons clutter; do not place primary CTA outside the thumb zone without reason; never use emoji or pictograph text as tab/list icons — draw real vector glyphs plus plain labels.",
+  "prompt_negative": "Prefer single-column mobile layouts over desktop sidebars. Unless asked, avoid inventing OS status clutter. Prefer primary CTA in the thumb zone. Prefer real glyphs plus plain labels over emoji/pictograph text as tab/list icons. Simple chrome may stay vector; complex headers that look crude as shapes should use images.",
   "locales": {
     "zh-CN": {
       "displayName": "移动 / H5 UI",

--- a/apps/api/seeds/design_skills/motion_lottie/SKILL.md
+++ b/apps/api/seeds/design_skills/motion_lottie/SKILL.md
@@ -1,47 +1,54 @@
 # Motion / Lottie
 
-Playbook for **Lottie / 动效 / UI motion** — calm, purposeful loops and one-shots. Tool args live in TOOL_DETAILS.
+Craft for **Lottie / 动效 / UI motion** — calm, purposeful loops and one-shots. Static simple marks stay vector; complex still scenes use image; motion only when it has a job.
 
-## Principles
-1. **Motion has a job** — loading, success, empty idle, like/favorite — not decoration for its own sake.
-2. **1–2 focal movers** — extra limbs and flicker read as noise.
-3. **Calm loops** — prefer ease and settle over seizure-level flash.
-4. **Style matches chrome** — flat UI / line / soft 3D must agree with surrounding UI tokens.
-5. **Static marks stay vector** — icons that do not move stay shapes/SVG, not Lottie.
+## Design thinking
 
-## Workflow
-1. Confirm the brief needs motion (explicit Lottie/动效/loading loop) — else skip.
-2. Place inside FOCUS; size for tap-adjacent UI (≥ ~44px feel when interactive-adjacent).
-3. Write a tight motion prompt: what moves, loop vs one-shot, tempo, style, colors, purpose.
-4. Use the Lottie tool with that prompt — never invent huge animation JSON unless the user pasted Bodymovin.
-5. Self-check: purpose clear in ~1s; no flicker; colors match UI.
-6. Refine size/position in place when only layout changed.
+| Ask | Aim |
+|-----|-----|
+| **Is motion needed?** | Explicit Lottie / 动效 / loading ask — otherwise skip |
+| **Job** | Loading / success / empty idle / like / tip pulse |
+| **Focus** | 1–2 movers; calm ease |
+| **Fit** | Style matches surrounding UI tokens |
+| **Bitmap vs vector vs motion** | Simple static marks → vector. Complex still atmosphere → bitmap. Motion only when the brief asks for it |
 
-## Prompt cues
-Say explicitly: **what moves**, **loop vs one-shot**, **tempo**, **style**, **colors**, **purpose**.
+Quality bar: **intentional design** — purpose reads in ~1s. Soft-avoid strobe, rainbow flicker, and animating every chrome piece.
 
-## Recipes
+## Recipes & composition
+
 | Intent | Lean |
 |--------|------|
-| Loading | Cyclic spinner/bar/dots; muted; infinite calm loop |
-| Success | Short check / burst then settle; often non-loop |
-| Empty state | Gentle idle; spacious; low amplitude |
-| Like / favorite | Heartbeat or pop scale; accent color; short delight |
-| Onboarding tip | Soft pulse on one affordance; do not animate whole screen |
+| Loading | Calm cyclic spinner/dots |
+| Success | Short settle; often non-loop |
+| Empty | Low-amplitude idle |
+| Like | Short accent pop |
+| Tip | Soft pulse on one affordance |
 
-## When NOT Lottie
+Place at a sensible UI size (often ~≥44px feel when interactive-adjacent). Soft-avoid oversized motion covering primary copy.
+
+## Prompt cues
+
+Say: **what moves**, **loop vs one-shot**, **tempo**, **style**, **colors**, **purpose**.
+
+## When another medium fits better
+
 | Need | Prefer |
 |------|--------|
-| Static icon / logo mark | Vector shapes / SVG / still image |
-| Full-board festive poster | `poster_craft` + `image_gen` |
-| Page transition metaphor only | Skip motion unless asked |
+| Static simple icon / logo mark | Vector / `icon_set` |
+| Complex still poster / atmosphere | `poster_craft` + `image_gen` |
 
-## Do not
-- Seizure-level flicker or rainbow strobe
-- Animate every chrome element “because we can”
-- Use Lottie as a substitute for missing static icons
-- Invent brand mascots or logos inside the motion
-- Oversized motion covering primary copy
+## Honesty
+
+Unless the user provides them, avoid inventing board facts such as brand mascots or logos inside the motion.
+
+## Place on board
+
+Confirm motion → place → generate from a tight brief → refine size/position in place when layout-only.
+
+## Related
+
+`icon_set`, `mobile_app_ui`, `shadcn_ui`, `poster_craft`, `image_gen`
 
 ## Done when
-Purpose reads in ~1s; 1–2 movers; loop/one-shot matches intent; colors agree with UI; tap-safe size when UI-adjacent.
+
+Purpose is clear quickly; 1–2 movers; loop/one-shot matches the job; colors agree with UI.

--- a/apps/api/seeds/design_skills/motion_lottie/_meta.json
+++ b/apps/api/seeds/design_skills/motion_lottie/_meta.json
@@ -35,7 +35,7 @@
     }
   ],
   "mutex_group": "",
-  "prompt_negative": "Never substitute still bitmaps, SVG marks, or shape piles for requested Lottie/motion. Do not use Lottie for static icons.",
+  "prompt_negative": "When Lottie/motion is requested, prefer real motion over still stand-ins. Prefer simple static marks as vector instead of Lottie. Complex still atmosphere belongs in image/poster skills, not motion.",
   "locales": {
     "zh-CN": {
       "displayName": "动效 / Lottie",

--- a/apps/api/seeds/design_skills/poster_craft/SKILL.md
+++ b/apps/api/seeds/design_skills/poster_craft/SKILL.md
@@ -1,71 +1,57 @@
 # Poster / roll-up
 
-Playbook for **海报 / poster / 易拉宝 / roll-up** — atmosphere first, then readable info groups.
+Craft for **海报 / poster / 易拉宝 / roll-up / 演唱会 KV** — atmosphere and hierarchy first; sparse, intentional type. Medium follows complexity: simple → vector OK; complex → image.
 
-Mature craft: name a visual philosophy, commit one focal image, treat type as sparse visual accent — never a shape collage pretending to be a poster.
+## Design thinking
 
-## Principles
-1. **Atmosphere carries meaning** — form, color, and space speak before paragraphs.
-2. **One focal hero** — full/near-full board atmosphere or photo; geometry piles are not posters.
-3. **Quiet zones for type** — place copy on calm bands; never fight busy art with hard titles.
-4. **Sparse text** — one primary line + ≤2 support clusters; type is accent, not essay.
-5. **Master craftsmanship** — alignments and contrast must look labored-over, not AI-default.
+| Ask | Aim |
+|-----|-----|
+| **Purpose** | Who sees it, and what sticks in ~1s? |
+| **Tone** | One direction — e.g. night quiet, editorial, luxury, industrial, organic, retro-futurist |
+| **Memory point** | Strong atmosphere **or** dominant title — not both fighting |
+| **Bitmap vs vector** | Simple geometry / flat language → vector. Rich light, material, photo, busy illustration → bitmap via `image_gen`. If vectors would look crude, use image |
+| **Copy budget** | Usually 1 title + ≤2 support clusters |
+| **Constraints** | Size / roll-up / language / user assets |
 
-## Workflow
-1. Lock size (common: 1080×1920, 1242×2208, 800×2000 roll-up, 1920×1080 wide).
-2. Name the tone in one phrase (festive hand / luxury ink / editorial photo / minimal print …).
-3. Deduce the subject from the brief — embed it visually; do not announce with paragraphs.
-4. Build layer order below; pull `image_gen` + `garden_style` when needed.
-5. Far/near self-check; fix contrast and clip before declaring done.
+Quality bar: **intentional design** — hierarchy and crop fit this brief. Soft-avoid generic AI postcard defaults.
 
-## Layer order
-1. **Hero** — full or near-full board scene/atmosphere only (no baked titles).
-2. **Quiet zones** — calm bands for copy (top/mid/bottom).
-3. **Title** — one primary editable line (or lettering art when catalog fonts fail the 90% gate).
-4. **Support** — date / venue / CTA / bullets — clearly smaller; ≤2 clusters.
-5. **Accents** — thin marks only; no Material icon spam; no emoji as type.
+## Atmosphere & layout
 
-## Tall vs wide
-| Format | Hierarchy |
-|--------|-----------|
-| Tall poster / roll-up | Top brand/title → mid hero focus → bottom info/CTA; side margins ≥ ~5% width |
-| Wide banner-poster | Left/right subject vs copy; mid-band safe for title; avoid edge clip |
+- Tall / roll-up: top brand/title → mid focus → bottom info/CTA; generous side margins.
+- Wide: subject vs copy left/right; mid-band safer for title.
+- Quiet bands for type on busy grounds.
+- Visual-first posters need a real scene when complexity calls for it — not a pile of random shapes pretending to be atmosphere.
 
-## Image intent
-Subject + style/medium + lighting + composition + color + **hard negatives**:
-- No titles, event names, dates, venue text, logos, watermarks, or gibberish letters in the hero bitmap.
-- Titles/dates live as editable type on quiet zones.
-- Cutout subjects on a colored board: solid plate + cutout — never leave a white rectangle.
+## Type & hierarchy
 
-## Type scale (feel)
-| Role | Relative |
-|------|----------|
-| Title | Dominates; one line preferred |
-| Support | Clearly smaller; secondary weight |
-| Meta | Smallest; date/venue/legal |
+- Title ≫ support ≫ meta.
+- Catalog text when fonts match (~90%+); lettering image + cutout when display needs it (`image_gen`).
+- Language matches the user.
 
-## Edit
-Refine type and accents in place. Do **not** rebuild the hero as shapes. Regenerate hero only when the brief's atmosphere changes.
+## Vector vs image (same rule)
 
-## Do not
-- Fake hero with rect/circle piles
-- Five equal-weight slogans
-- Hard title against the edge / low-contrast type on busy art
-- Bake the poster title/date into the hero then overlay the same copy again
-- Invent QR / phone / price / logos
-- Festive Material UI chrome as decoration
-- Composite subjects with leftover white cutout boxes
+| Prefer vector when | Prefer bitmap when |
+|--------------------|--------------------|
+| Clean discs, dots, bars, frames, hairlines, flat badges | Deep night sky with rich light/haze/material |
+| Simple geometric poster language, intentional and sparse | Photo / painted hero, complex illustration |
+| Icons and crisp marks | Faces, products, detailed props |
+
+## Honesty
+
+Unless the user provides them, avoid inventing board facts such as logos, prices, phone numbers, QR codes, review counts, etc.
+
+## Place on board
+
+Load **`image_gen`** when placing bitmaps, cutouts, or lettering plates.
+
+Typical stack: background → optional subject → simple vector structure → title → support.
+
+Second pass: refine alignment and contrast before adding more marks.
 
 ## Related
-`image_gen` (hero), `garden_style` (direction), `brush_ops` (hand accents only).
+
+`image_gen`, `garden_style`, `brush_ops` (accents only), `icon_set`
 
 ## Done when
-Far: theme + title read in ~1s. Near: no clip, contrast OK, one focal image, copy language matches user.
 
-## Review gate (for Review Agent / SKILL_CRAFT)
-Fail (`must_fix`) when any of:
-- Hero is a shape/geometry pile instead of `create_image` atmosphere
-- Hero bitmap bakes titles/dates that also appear as overlay type
-- Product/subject plates leave white cutout boxes on a colored board
-- Title clipped, low-contrast on busy art, or five equal-weight slogans
-Pass when Principles + Done-when above hold and DESIGN_BRIEF image strategy is met.
+Far: tone + title in ~1s. Near: medium matches complexity; type clear; language matches the user.

--- a/apps/api/seeds/design_skills/poster_craft/_meta.json
+++ b/apps/api/seeds/design_skills/poster_craft/_meta.json
@@ -34,7 +34,7 @@
     }
   ],
   "mutex_group": "",
-  "prompt_negative": "Do not fake a poster hero with shape/ellipse piles; do not clip titles; do not put SaaS nav/forms on a festive poster; do not invent prices/phones/QR unless the user provided them; do not bake titles/dates into the hero bitmap — keep overlay copy as editable type.",
+  "prompt_negative": "Simple geometry may stay vector; complex atmosphere/illustration that looks crude as shapes should use a background image. Prefer readable titles with margin. Prefer poster craft over SaaS nav/forms on visual posters. Unless the user provides them, avoid inventing board facts such as prices, phones, QR codes, logos, etc. Prefer overlay text or cutout lettering over baking titles into the background.",
   "locales": {
     "zh-CN": {
       "displayName": "海报 / 易拉宝",

--- a/apps/api/seeds/design_skills/resume_layout/SKILL.md
+++ b/apps/api/seeds/design_skills/resume_layout/SKILL.md
@@ -1,62 +1,57 @@
 # Resume / CV
 
-Playbook for **简历 / resume / CV** — scannable professional document, not a festive poster.
+Craft for **简历 / resume / CV** — scannable professional document, not a festive poster. Structure is mostly simple vector + type; photo only when asked.
 
-## Principles
-1. **Scan path first** — name → contact → latest role → skills in seconds.
-2. **Honesty** — never invent employers, dates, GPAs, phones, or titles; ask or leave gaps.
-3. **Document, not poster** — no festive heroes, emoji icons, or illustration chrome.
-4. **One grid** — ≤2 columns; align edges; base-8 rhythm.
-5. **One accent** — name or section rules only; rest neutral.
+## Design thinking
 
-## Workflow
-1. Size: A4-ish (e.g. 794×1123 @96dpi feel) or user WxH. Lock artboard first.
-2. Pick structure: **single column** or **sidebar + main** (≤2 columns).
-3. Inventory user facts; mark missing slots — do not invent.
-4. Type: restrained document faces from Available fonts; one display weight for **name only**.
-5. Place sections; self-check scan path and overflow.
-6. Edit in place — preserve column edges.
+| Ask | Aim |
+|-----|-----|
+| **Scan path** | Name → contact → latest role → skills in seconds |
+| **Tone** | Professional document; one restrained accent |
+| **Layout** | ≤2 columns — single / left rail / top name band |
+| **Bitmap vs vector** | Hairlines, columns, section marks → vector. Photo / complex portrait → bitmap when requested. Soft-avoid decorative shape spam |
+| **Facts** | Only what the user gave |
+| **Size** | A4-ish (e.g. 794×1123) or user WxH |
 
-## Structure recipes
-| Pattern | Use when | Notes |
-|---------|----------|-------|
-| Single column | Dense content, ATS-like clarity | Stack section titles + body |
-| Left sidebar | Skills/languages/contact rail | Narrow sidebar + main column |
-| Top header band | Strong name block | Header surface + contacts row; body below |
+Quality bar: **intentional design** — clear scan path and even margins. Soft-avoid festive heroes and emoji section icons.
 
-## Section order (default)
-Name / title → contacts → summary (optional, ≤3 lines) → experience → education → skills → extras.
+## Structure & composition
 
-## Type roles
+| Pattern | When |
+|---------|------|
+| Single column | Dense, ATS-like clarity |
+| Left sidebar | Skills / contact rail |
+| Top header band | Strong name block |
+
+Default order: name / title → contacts → summary (optional) → experience → education → skills → extras.
+
+## Type & hierarchy
+
 | Role | Feel |
 |------|------|
-| Name | Largest; one accent color allowed |
-| Section title | Consistent size/weight; optional hairline |
+| Name | Largest; one accent allowed |
+| Section title | Consistent; optional hairline |
 | Body | Comfortable measure |
-| Meta | Dates, locations — smaller / muted |
+| Meta | Dates / locations — smaller, muted |
 
-## Canvas craft
-- Section titles: consistent; optional hairline — not heavy chrome.
-- Spacing: base 8; section gaps > item gaps.
-- Photo (only if user wants): small; never dominate.
-- Experience items: role + employer + dates + 2–4 bullets max unless user provided more.
+Experience: role + employer + dates + short bullets (2–4 unless user gave more).
 
-## Missing content protocol
-| Situation | Action |
-|-----------|--------|
-| Critical contact/experience missing | Ask once; leave labeled gap if user skips |
-| Optional summary missing | Omit section — do not invent |
-| Photo not requested | Do not add stock headshot |
+## Vector vs image
 
-## Do not
-- Festive illustration heroes or shape decoration piles
-- Emoji section icons / clip-art
-- 5+ type sizes or competing accents
-- Invent content to “look complete”
-- Turn CV into a marketing landing or poster
+Hairline rules, column guides, subtle section marks → vector. Photo only when requested — small, never dominant; soft-avoid stock headshots and clip-art piles.
+
+## Honesty
+
+Unless the user provides them, avoid inventing board facts such as employers, dates, GPAs, phone numbers, titles, etc. Omit optional sections rather than fabricating them. Ask once for critical gaps.
+
+## Place on board
+
+Typeset the document grid first. `image_gen` only if a real photo plate is needed. `shadcn_ui` only if the brief is a resume **builder UI**.
 
 ## Related
-`shadcn_ui` only if the brief is a resume **builder UI**, not the CV document itself.
+
+`shadcn_ui` (builder UI only), `image_gen` (photo when asked)
 
 ## Done when
-Recruiter can scan name, latest role, and skills in seconds; margins even; no overflow; language matches user.
+
+Scan path works; margins even; no overflow; language matches the user.

--- a/apps/api/seeds/design_skills/resume_layout/_meta.json
+++ b/apps/api/seeds/design_skills/resume_layout/_meta.json
@@ -35,7 +35,7 @@
     }
   ],
   "mutex_group": "",
-  "prompt_negative": "Do not turn a resume into a festive poster; do not invent employers/dates/metrics; do not use emoji as section icons; do not clip body text.",
+  "prompt_negative": "Prefer a professional document over a festive poster. Unless the user provides them, avoid inventing board facts such as employers, dates, metrics, phone numbers, etc. Prefer plain section titles over emoji icons. Prefer readable body with margin.",
   "locales": {
     "zh-CN": {
       "displayName": "简历 / CV",

--- a/apps/api/seeds/design_skills/type_specimen/SKILL.md
+++ b/apps/api/seeds/design_skills/type_specimen/SKILL.md
@@ -1,29 +1,50 @@
 # Typography / font specimen
 
-Playbook for **字体展示 / type specimen / font pairing** — catalog faces only.
+Craft for **字体展示 / type specimen / font pairing** — catalog faces only; type is the hero. Simple rules stay vector; complex lettering art uses image only when asked.
 
-## Principles
-1. **Available fonts only** — never invent font names; pick from the runtime catalog.
-2. **Hierarchy is the craft** — size, weight, tracking, and measure beat decoration.
-3. **Sparse plate** — calm background; type is the hero, not photo collage.
-4. **Honest pairing** — one display + one text face; name both on the board.
+## Design thinking
 
-## Workflow
-1. Lock board (common: 1080×1350, 1920×1080, A4-like 1240×1754).
-2. Pick 1–2 catalog faces that fit the brief mood; state pairing in a small caption.
-3. Specimen block: large display sample + alphabet or 汉字示意 if relevant.
-4. Text block: 2–4 lines at body size showing measure and leading.
-5. Meta row: face name, weight, suggested use — small muted type.
-6. Optional thin rules for Swiss/editorial structure — no emoji.
+| Ask | Aim |
+|-----|-----|
+| **Job** | Single face / pairing / weight ladder |
+| **Tone** | Calm plate — Swiss / editorial / quiet study |
+| **Faces** | 1–2 from Available fonts; caption names on board |
+| **Bitmap vs vector** | Type + thin rules → vector/text. Illustrated lettering / complex glyph art → bitmap only if the user asks (`image_gen`) |
+| **Size** | e.g. 1080×1350 / 1920×1080 / A4-ish or user WxH |
 
-## Layout recipes
+Quality bar: **intentional design** — hierarchy and measure do the work. Soft-avoid invented font names and festive poster chrome.
+
+## Composition recipes
+
 | Ask | Structure |
 |-----|-----------|
-| Single face specimen | Giant sample → metrics → short paragraph |
-| Pairing board | Left display / right text; shared baseline grid |
-| Weight ladder | Same face, 3–5 weights stacked with labels |
+| Single face | Giant sample → metrics → short paragraph |
+| Pairing | Display \| text; shared baseline |
+| Weight ladder | Same face, several weights labeled |
 
-## Avoid
-- Invented font names
-- Lettering bitmaps unless user explicitly wants illustrated lettering art
-- Turning the board into a festive poster with heroes and CTAs
+## Type
+
+- Large display sample + optional alphabet / CJK demo.
+- Body block (2–4 lines) for measure and leading.
+- Meta row: name, weight, suggested use — small muted type.
+- Prefer **add text** over lettering bitmaps unless the user asks for illustrated lettering.
+
+## Vector vs image
+
+Optional thin rules and baseline guides → vector. Soft-avoid decorative shape piles and photo collage that steals the specimen job.
+
+## Honesty
+
+Prefer catalog font names only. Soft-avoid inventing face names.
+
+## Place on board
+
+Lock board → place display → body → meta → optional rules.
+
+## Related
+
+`image_gen` (illustrated lettering only when asked), `garden_style`
+
+## Done when
+
+Faces named correctly; hierarchy clear; plate stays calm; language matches the user.

--- a/apps/api/seeds/design_skills/type_specimen/_meta.json
+++ b/apps/api/seeds/design_skills/type_specimen/_meta.json
@@ -30,7 +30,7 @@
     }
   ],
   "mutex_group": "",
-  "prompt_negative": "Never invent fontFamily names; do not fake specimen with lettering images unless user asks for display lettering art; do not turn specimen into a busy poster collage.",
+  "prompt_negative": "Prefer catalog fontFamily names only. Prefer editable text specimens over lettering images unless the user asks for display lettering art. Prefer a calm specimen plate over a busy poster collage.",
   "locales": {
     "zh-CN": {
       "displayName": "字体 / 字样展示",


### PR DESCRIPTION
## Summary
- Rewrite deliverable design skills around design-thinking, intentional craft, and simple-vector / complex-image medium choice
- Soften absolute invent bans to example-based honesty; map preferred tools to natural canvas actions in SKILL_DETAILS
- Nudge paint stage to use create_image when vectors would look crude

## Test plan
- [x] Local poster E2E: prompt with poster keyword loads poster_craft + image_gen
- [x] Paint emits create_image atmosphere + text/shape info band (not ellipse-only hero)
- [ ] Spot-check skill seed hot-reload / ensure_design_skills picks up new SKILL.md bodies