### PR TITLE
feat: Skill extensions Phase A (plugins/skills)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ for tagged releases (`vMAJOR.MINOR.PATCH`).
 - Admin **export DLQ** replay (`/api/v1/admin/ops/export-dlq`) + `recombyn_export_dlq_depth`
 - Async **chat image** jobs (`POST/GET /api/v1/chat/image/jobs`) so editor generate does not hold API workers
 - Design Agent hydrate **progress** on the existing SSE (`activity` + `task_id`)
-- Skill **extensions** Phase A: `plugins/skills` mount, `_meta` aliases (`id` / `trigger_keywords` / `enabled`), sample `festival_poster` (ADR 0013)
+- Skill **extensions** Phase A: two roots (`seeds/design_skills` + `plugins/skills`), canonical pack layout (`schema.json` / `assets/` / reserved `handler.py`), meta aliases, sample `festival_poster` (ADR 0013)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ for tagged releases (`vMAJOR.MINOR.PATCH`).
 - Admin **export DLQ** replay (`/api/v1/admin/ops/export-dlq`) + `recombyn_export_dlq_depth`
 - Async **chat image** jobs (`POST/GET /api/v1/chat/image/jobs`) so editor generate does not hold API workers
 - Design Agent hydrate **progress** on the existing SSE (`activity` + `task_id`)
+- Skill **extensions** Phase A: `plugins/skills` mount, `_meta` aliases (`id` / `trigger_keywords` / `enabled`), sample `festival_poster` (ADR 0013)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Typical turn: `intent` → (chat settle / lean `paint` / design `decide`) → `p
 
 ### What Skills are
 
-One folder per skill: `apps/api/seeds/design_skills/<key>/` (`_meta.json` + `SKILL.md`).
+One folder per skill: `apps/api/seeds/design_skills/<key>/` (canonical: `_meta.json` + `SKILL.md`; optional `schema.json`, `assets/`, …).
 
 - **`_meta.json`** — `when_to_use`, triggers, `preferred_tools`, mutex — Decide picks skills from this
 - **`SKILL.md`** — how to craft that deliverable (landing, poster, resume, dashboard, motion, …)

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ User-facing help **source** is private; CI publishes only the built static site 
 |--|--|
 | User docs | [recombyn.github.io/recombyn](https://recombyn.github.io/recombyn/) |
 | Self-host / architecture | [docs/self-hosting.md](docs/self-hosting.md) |
+| Skill extensions | [docs/skill-extensions.md](docs/skill-extensions.md) |
 | AgentProfile / sub-agents | [docs/agent-profile.md](docs/agent-profile.md) |
 | Canvas (RCB / SVG / Path2D / LOD) | [docs/canvas-architecture.md](docs/canvas-architecture.md) |
 | Web data layer (Query / oRPC / nuqs) | [docs/web-frontend.md](docs/web-frontend.md) |

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Atomic canvas ops live in [`apps/api/seeds/canvas_actions_seed.json`](apps/api/s
 2. Fill triggers + `preferred_tools`  
 3. Restart / re-ensure seeds — Decide can attach it
 
+Private packs can also live under [`plugins/skills/`](plugins/skills/) (Compose-mounted). Authoring: [docs/skill-extensions.md](docs/skill-extensions.md).
+
 Env knobs (Review on/off, timeouts): [docs/agent-profile.md § Env knobs](docs/agent-profile.md#env-knobs). Seeds overview: [`apps/api/seeds/README.md`](apps/api/seeds/README.md). Models / OpenRouter: [docs/self-hosting.md](docs/self-hosting.md).
 
 ## Quick start (self-host)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -70,7 +70,7 @@
 
 ### Skills 是什么
 
-每个技能一个目录：`apps/api/seeds/design_skills/<key>/`（`_meta.json` + `SKILL.md`）。
+每个技能一个目录：`apps/api/seeds/design_skills/<key>/`（规范：`_meta.json` + `SKILL.md`；可选 `schema.json`、`assets/` 等）。
 
 - **`_meta.json`**：`when_to_use`、触发词、`preferred_tools`、互斥组等 —— Decide 用它选技能
 - **`SKILL.md`**：该品类怎么做（落地页 / 海报 / 简历 / 仪表盘 / 动效……）

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -104,6 +104,8 @@
 2. 填触发条件与 `preferred_tools`  
 3. 重启 / 重新 ensure seeds 后，Decide 即可按触发挂上
 
+私有扩展也可放在 [`plugins/skills/`](plugins/skills/)（Compose 已挂载）。写法见 [docs/skill-extensions.md](docs/skill-extensions.md)。
+
 环境开关（Review 开关、超时等）见 [docs/agent-profile.md § Env knobs](docs/agent-profile.md#env-knobs)；种子总览 [`apps/api/seeds/README.md`](apps/api/seeds/README.md)。模型密钥 / OpenRouter： [docs/self-hosting.md](docs/self-hosting.md)。
 
 ## 快速开始（自托管）

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -50,6 +50,8 @@ S3_ENABLED=false
 # Design skills hot reload (poll seed JSON + seeds/design_skills packs)
 # DESIGN_SKILLS_HOT_RELOAD=true
 # DESIGN_SKILLS_HOT_RELOAD_INTERVAL_SEC=2
+# Extra skill pack dirs (comma-separated). Default also scans <repo>/plugins/skills.
+# DESIGN_SKILLS_PLUGIN_DIRS=
 # Design Agent Profile + graph / quality gate (see docs/agent-profile.md)
 # AGENT_PROFILE_ID=design.canvas
 # DESIGN_CRITIQUE_ENABLED=true

--- a/apps/api/app/api/routes/design.py
+++ b/apps/api/app/api/routes/design.py
@@ -299,7 +299,7 @@ class UserSkillIn(BaseModel):
     promptPositive: str = Field(..., min_length=1, max_length=120_000)
     promptNegative: str | None = Field(default=None, max_length=40_000)
     skillKey: str | None = Field(default=None, max_length=64)
-    logo: str | None = Field(default=None, max_length=512)
+    logo: str | None = Field(default=None, max_length=80_000)
     category: str | None = Field(default=None, max_length=64)
     enabled: bool = True
 

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -201,6 +201,9 @@ class Settings(BaseSettings):
     # Design skills: poll seed JSON + .agents/skills + seeds/design_skills for hot reload.
     design_skills_hot_reload: bool = True
     design_skills_hot_reload_interval_sec: float = 2.0
+    # Extra skill pack roots (comma-separated). Always also scans <repo>/plugins/skills when present.
+    # Self-host: mount host ./plugins/skills → container /app/plugins/skills.
+    design_skills_plugin_dirs: str = ""
 
     # Active AgentProfile id (seeds/agents/profiles/{id}.yaml). Empty → bindings.default.
     agent_profile_id: str = "design.canvas"

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -198,7 +198,7 @@ class Settings(BaseSettings):
     langfuse_tracing: bool = False
     langfuse_project_id: str = ""
 
-    # Design skills: poll seed JSON + .agents/skills + seeds/design_skills for hot reload.
+    # Design skills: poll seeds/design_skills + plugins/skills (hot reload).
     design_skills_hot_reload: bool = True
     design_skills_hot_reload_interval_sec: float = 2.0
     # Extra skill pack roots (comma-separated). Always also scans <repo>/plugins/skills when present.

--- a/apps/api/app/services/design/prompts/skill_store/__init__.py
+++ b/apps/api/app/services/design/prompts/skill_store/__init__.py
@@ -2,7 +2,7 @@
 
 Namespaces (conflict isolation):
   - core  — legacy SOURCE_SEED only (no longer shipped); bare keys stay BC aliases
-  - ext   — file packs under ``.agents/skills`` + seeds/design_skills (source=file)
+  - ext   — file packs under ``seeds/design_skills`` + ``plugins/skills`` (source=file)
   - user  — admin / user-extension skills (source=admin); keys use ``user.<local>``
 
 Also:

--- a/apps/api/app/services/design/prompts/skill_store/pack_io.py
+++ b/apps/api/app/services/design/prompts/skill_store/pack_io.py
@@ -140,7 +140,7 @@ def _repo_root() -> Path:
     return _API_ROOT.parent.parent
 
 def _agents_skills_dir() -> Path:
-    """Repo-root official ext packs: ``<repo>/.agents/skills``."""
+    """Cursor/IDE skills tree — not scanned by the Design Agent."""
     return _repo_root() / ".agents" / "skills"
 
 
@@ -188,7 +188,10 @@ def _file_skills_dir() -> Path:
     return resolve_seed_dir("design_skills")
 
 def _file_skills_dirs() -> list[Path]:
-    """``.agents/skills`` + ``seeds/design_skills`` + ``plugins/skills`` (+ env dirs).
+    """``seeds/design_skills`` + ``plugins/skills`` (+ env dirs).
+
+    Product skills live only under seeds (shipped) and plugins (private mount).
+    ``.agents/skills`` is IDE/Cursor tooling — not scanned by the Design Agent.
 
     Later roots win on duplicate ``skill_key`` (private plugins override shipped packs).
     """
@@ -197,7 +200,6 @@ def _file_skills_dirs() -> list[Path]:
     dirs: list[Path] = []
     seen: set[str] = set()
     for root in (
-        _agents_skills_dir(),
         api_seeds_dir() / "design_skills",
         *_plugin_skills_dirs(),
     ):
@@ -313,6 +315,11 @@ def _resolve_pack_logo(pack_dir: Path, meta: dict[str, Any]) -> str:
     key = pack_dir.name
     candidates.extend(
         [
+            pack_dir / "assets" / "logo.png",
+            pack_dir / "assets" / "logo.svg",
+            pack_dir / "assets" / "logo.webp",
+            pack_dir / "assets" / "icon.svg",
+            pack_dir / "assets" / "icon.png",
             pack_dir / f"{key}-logo.png",
             pack_dir / f"{key}-logo.svg",
             pack_dir / f"{key}-logo.webp",
@@ -437,8 +444,33 @@ def _skill_item_from_parts(
         ),
     }
 
+def _load_schema_json(pack_dir: Path) -> tuple[Any, Any]:
+    """Optional ``schema.json`` → (input_schema, output_schema)."""
+    path = pack_dir / "schema.json"
+    if not path.is_file():
+        return None, None
+    data = _read_json_file(path)
+    if not data:
+        return None, None
+    inp = data.get("input_schema") or data.get("input") or data.get("inputSchema")
+    out = data.get("output_schema") or data.get("output") or data.get("outputSchema")
+    # Whole file is a single object schema → treat as input.
+    if inp is None and out is None and ("type" in data or "properties" in data):
+        inp = data
+    return inp, out
+
+
+def _note_deferred_handler(pack_dir: Path) -> None:
+    """``handler.py`` is reserved for Phase B ops runners — do not execute yet."""
+    if (pack_dir / "handler.py").is_file():
+        logger.info(
+            "skill pack %s has handler.py (ignored until skill runner Phase B)",
+            pack_dir.name,
+        )
+
+
 def _load_pack_dir(pack_dir: Path) -> dict[str, Any] | None:
-    """Load one skill pack: ``_meta.json`` + ``SKILL.md``, or frontmatter-only ``SKILL.md``."""
+    """Load one skill pack: ``_meta.json`` + ``SKILL.md``, optional ``schema.json``."""
     if not pack_dir.is_dir():
         return None
     skill_md = _skill_md_path(pack_dir)
@@ -465,6 +497,18 @@ def _load_pack_dir(pack_dir: Path) -> dict[str, Any] | None:
     meta = _normalize_pack_meta(meta, folder=pack_dir.name)
     if not meta:
         return None
+
+    schema_in, schema_out = _load_schema_json(pack_dir)
+    if schema_in is not None and not (
+        meta.get("input_schema") or meta.get("inputSchema")
+    ):
+        meta["input_schema"] = schema_in
+    if schema_out is not None and not (
+        meta.get("output_schema") or meta.get("outputSchema")
+    ):
+        meta["output_schema"] = schema_out
+
+    _note_deferred_handler(pack_dir)
     return _skill_item_from_parts(
         pack_dir=pack_dir,
         meta=meta,
@@ -472,27 +516,12 @@ def _load_pack_dir(pack_dir: Path) -> dict[str, Any] | None:
         skill_md_path=skill_md,
     )
 
-def _load_file_skills() -> list[dict[str, Any]]:
-    """Scan ``.agents/skills`` + design_skills + plugins/skills → skill dicts (later roots win).
 
-    Under ``.agents/skills``, only packs with product ``_meta.json`` are ingested
-    (skips IDE-only docs such as ``langfuse``).
-    """
+def _load_file_skills() -> list[dict[str, Any]]:
+    """Scan design_skills + plugins/skills → skill dicts (later roots win)."""
     by_key: dict[str, dict[str, Any]] = {}
-    agents_root = _agents_skills_dir()
-    try:
-        agents_resolved = agents_root.resolve()
-    except Exception:
-        agents_resolved = agents_root
     for root in _file_skills_dirs():
-        try:
-            root_resolved = root.resolve()
-        except Exception:
-            root_resolved = root
-        require_product_meta = root_resolved == agents_resolved
         for pack_dir in sorted(p for p in root.iterdir() if p.is_dir()):
-            if require_product_meta and not _pack_has_product_meta(pack_dir):
-                continue
             item = _load_pack_dir(pack_dir)
             if not item:
                 continue

--- a/apps/api/app/services/design/prompts/skill_store/pack_io.py
+++ b/apps/api/app/services/design/prompts/skill_store/pack_io.py
@@ -143,6 +143,44 @@ def _agents_skills_dir() -> Path:
     """Repo-root official ext packs: ``<repo>/.agents/skills``."""
     return _repo_root() / ".agents" / "skills"
 
+
+def _default_plugin_skills_dir() -> Path:
+    """Private / self-host mount point: ``<repo>/plugins/skills``."""
+    return _repo_root() / "plugins" / "skills"
+
+
+def _plugin_skills_dirs() -> list[Path]:
+    """Configured + default plugin skill roots (exist on disk only)."""
+    from app.core.config import settings
+
+    out: list[Path] = []
+    seen: set[str] = set()
+
+    def _add(root: Path) -> None:
+        try:
+            if not root.is_dir():
+                return
+            key = str(root.resolve()).lower()
+        except Exception:
+            return
+        if key in seen:
+            return
+        seen.add(key)
+        out.append(root)
+
+    _add(_default_plugin_skills_dir())
+    raw = str(getattr(settings, "design_skills_plugin_dirs", "") or "").strip()
+    for part in raw.split(","):
+        p = part.strip()
+        if not p:
+            continue
+        path = Path(p)
+        if not path.is_absolute():
+            path = _repo_root() / path
+        _add(path)
+    return out
+
+
 def _file_skills_dir() -> Path:
     """Primary design_skills dir under apps/api/seeds/."""
     from app.core.config import resolve_seed_dir
@@ -150,7 +188,10 @@ def _file_skills_dir() -> Path:
     return resolve_seed_dir("design_skills")
 
 def _file_skills_dirs() -> list[Path]:
-    """``.agents/skills`` + ``apps/api/seeds/design_skills``."""
+    """``.agents/skills`` + ``seeds/design_skills`` + ``plugins/skills`` (+ env dirs).
+
+    Later roots win on duplicate ``skill_key`` (private plugins override shipped packs).
+    """
     from app.core.config import api_seeds_dir
 
     dirs: list[Path] = []
@@ -158,6 +199,7 @@ def _file_skills_dirs() -> list[Path]:
     for root in (
         _agents_skills_dir(),
         api_seeds_dir() / "design_skills",
+        *_plugin_skills_dirs(),
     ):
         try:
             resolved = root.resolve()
@@ -172,6 +214,49 @@ def _file_skills_dirs() -> list[Path]:
 
 def _pack_has_product_meta(pack_dir: Path) -> bool:
     return any((pack_dir / name).is_file() for name in _META_NAMES)
+
+
+def _normalize_pack_meta(meta: dict[str, Any], *, folder: str) -> dict[str, Any] | None:
+    """Normalize extension-friendly aliases onto the product skill meta shape.
+
+    Accepts optional plugin-style fields (``id``, ``trigger_keywords``, ``enabled``,
+    ``author``, ``permissions``) without requiring a separate plugin runtime.
+    Returns ``None`` when the pack is disabled.
+    """
+    out = dict(meta)
+    if "enabled" in out and out.get("enabled") in (False, "false", "0", 0, "no", "off"):
+        return None
+
+    if not str(out.get("skill_key") or out.get("skillKey") or "").strip():
+        alt = str(out.get("id") or out.get("name") or folder or "").strip()
+        if alt:
+            out["skill_key"] = alt
+
+    # Shortcut keywords → create-intent trigger (only when triggers absent).
+    triggers = out.get("triggers")
+    keywords = out.get("trigger_keywords") or out.get("triggerKeywords")
+    if (not triggers) and isinstance(keywords, list):
+        words = [str(x).strip() for x in keywords if str(x).strip()]
+        if words:
+            out["triggers"] = [
+                {
+                    "intent_in": ["create", "edit"],
+                    "prompt_includes_any": words,
+                }
+            ]
+
+    # permissions is documentation / future ACL; preferred_tools remains the live gate.
+    # Map a few Chinese/English labels onto allowed_resources when unset.
+    if out.get("allowed_resources") is None and out.get("allowedResources") is None:
+        perms = out.get("permissions")
+        if isinstance(perms, list) and perms:
+            out["allowed_resources"] = ["tools"]
+
+    author = str(out.get("author") or "").strip()
+    if author:
+        out["_author"] = author
+    return out
+
 
 # Legacy SOURCE_SEED / core-reserved path removed — skills ship as file packs only.
 _SEED: list[dict[str, Any]] = []
@@ -345,6 +430,11 @@ def _skill_item_from_parts(
         "namespace": NS_EXT,
         "_path": str(skill_md_path),
         "_pack": str(pack_dir),
+        **(
+            {"author": str(meta.get("_author") or meta.get("author") or "").strip()}
+            if str(meta.get("_author") or meta.get("author") or "").strip()
+            else {}
+        ),
     }
 
 def _load_pack_dir(pack_dir: Path) -> dict[str, Any] | None:
@@ -372,6 +462,9 @@ def _load_pack_dir(pack_dir: Path) -> dict[str, Any] | None:
         meta = _meta_from_agent_skill_frontmatter(fm, folder=pack_dir.name)
     if not meta:
         return None
+    meta = _normalize_pack_meta(meta, folder=pack_dir.name)
+    if not meta:
+        return None
     return _skill_item_from_parts(
         pack_dir=pack_dir,
         meta=meta,
@@ -380,7 +473,7 @@ def _load_pack_dir(pack_dir: Path) -> dict[str, Any] | None:
     )
 
 def _load_file_skills() -> list[dict[str, Any]]:
-    """Scan ``.agents/skills`` + design_skills dirs → skill dicts (later roots win).
+    """Scan ``.agents/skills`` + design_skills + plugins/skills → skill dicts (later roots win).
 
     Under ``.agents/skills``, only packs with product ``_meta.json`` are ingested
     (skips IDE-only docs such as ``langfuse``).

--- a/apps/api/app/services/design/prompts/skill_store/pack_io.py
+++ b/apps/api/app/services/design/prompts/skill_store/pack_io.py
@@ -299,8 +299,41 @@ def _locale_pick(
             return block
     return {}
 
+_LOGO_DATA_URL_MAX_BYTES = 48_000
+
+
+def _file_to_logo_data_url(path: Path) -> str | None:
+    """Inline small pack logos so FE/admin can use them as ``<img src>``."""
+    import base64
+    import urllib.parse
+
+    try:
+        raw = path.read_bytes()
+    except Exception:
+        return None
+    if not raw or len(raw) > _LOGO_DATA_URL_MAX_BYTES:
+        return None
+    suffix = path.suffix.lower()
+    if suffix == ".svg":
+        text = raw.decode("utf-8", errors="replace").strip()
+        if not text:
+            return None
+        # Prefer compact URL-encoding for SVG (readable in Admin preview).
+        return "data:image/svg+xml," + urllib.parse.quote(text, safe="")
+    mime = {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".webp": "image/webp",
+        ".gif": "image/gif",
+    }.get(suffix)
+    if not mime:
+        return None
+    return f"data:{mime};base64," + base64.b64encode(raw).decode("ascii")
+
+
 def _resolve_pack_logo(pack_dir: Path, meta: dict[str, Any]) -> str:
-    """Return path relative to design_skills root, or absolute URL, or ''."""
+    """Return usable logo URL (http/data) or '' — prefer inlined pack ``assets/icon``."""
     raw = str(meta.get("logo") or "").strip()
     if raw.startswith(("http://", "https://", "data:")):
         return raw
@@ -315,11 +348,11 @@ def _resolve_pack_logo(pack_dir: Path, meta: dict[str, Any]) -> str:
     key = pack_dir.name
     candidates.extend(
         [
-            pack_dir / "assets" / "logo.png",
-            pack_dir / "assets" / "logo.svg",
-            pack_dir / "assets" / "logo.webp",
             pack_dir / "assets" / "icon.svg",
             pack_dir / "assets" / "icon.png",
+            pack_dir / "assets" / "logo.svg",
+            pack_dir / "assets" / "logo.png",
+            pack_dir / "assets" / "logo.webp",
             pack_dir / f"{key}-logo.png",
             pack_dir / f"{key}-logo.svg",
             pack_dir / f"{key}-logo.webp",
@@ -330,18 +363,20 @@ def _resolve_pack_logo(pack_dir: Path, meta: dict[str, Any]) -> str:
             pack_dir / "logo.jpg",
         ]
     )
-    root = pack_dir.parent.resolve()
+    root = pack_dir.resolve()
     for cand in candidates:
         try:
             if not cand.is_file():
                 continue
             resolved = cand.resolve()
             try:
-                rel = resolved.relative_to(root)
-                return rel.as_posix()
+                resolved.relative_to(root)
             except ValueError:
-                # Outside this pack's design_skills root — deny.
+                # Outside this pack dir — deny.
                 continue
+            data_url = _file_to_logo_data_url(resolved)
+            if data_url:
+                return data_url
         except Exception:
             continue
     return ""

--- a/apps/api/seeds/README.md
+++ b/apps/api/seeds/README.md
@@ -13,6 +13,7 @@ Owner docs: [self-hosting.md](../../../docs/self-hosting.md) · AgentProfile: [a
 | `agents/profiles/*.yaml`                                                 | AgentProfile YAML (`design.canvas`)               |
 | `design_prompt_packs/`                                                   | `_index.json` + `stages/*.md` + `snippets.md` (pack sections) |
 | `design_skills/<key>/`                                                   | All design skill packs (`_meta.json` + `SKILL.md`) — vision, edit, image, brush, motion, poster, resume, ecommerce, landing, UI, … |
+| Private extensions                                                       | Also `<repo>/plugins/skills/<key>/` — see [docs/skill-extensions.md](../../docs/skill-extensions.md) |
 | `canvas_actions_seed.json`                                               | Canvas tool registry                              |
 | `design_agent_stress_suite.json`                                         | Agent SSE / browser stress cases (not loaded at runtime) |
 | `fonts_seed.json` · `design_tokens_seed.json` · `design_dicts_seed.json` | Fonts / tokens / dicts                            |

--- a/apps/api/seeds/README.md
+++ b/apps/api/seeds/README.md
@@ -12,8 +12,8 @@ Owner docs: [self-hosting.md](../../../docs/self-hosting.md) · AgentProfile: [a
 | `agents/bindings.yaml`                                                   | product/surface → Profile id                      |
 | `agents/profiles/*.yaml`                                                 | AgentProfile YAML (`design.canvas`)               |
 | `design_prompt_packs/`                                                   | `_index.json` + `stages/*.md` + `snippets.md` (pack sections) |
-| `design_skills/<key>/`                                                   | All design skill packs (`_meta.json` + `SKILL.md`) — vision, edit, image, brush, motion, poster, resume, ecommerce, landing, UI, … |
-| Private extensions                                                       | Also `<repo>/plugins/skills/<key>/` — see [docs/skill-extensions.md](../../docs/skill-extensions.md) |
+| `design_skills/<key>/`                                                   | Shipped skill packs — same layout as plugins (`_meta.json` + `SKILL.md`; optional `schema.json` / `assets/` / `handler.py`) |
+| Private extensions                                                       | `<repo>/plugins/skills/<key>/` — [docs/skill-extensions.md](../../docs/skill-extensions.md) |
 | `canvas_actions_seed.json`                                               | Canvas tool registry                              |
 | `design_agent_stress_suite.json`                                         | Agent SSE / browser stress cases (not loaded at runtime) |
 | `fonts_seed.json` · `design_tokens_seed.json` · `design_dicts_seed.json` | Fonts / tokens / dicts                            |

--- a/apps/api/seeds/design_skills/awesome_design_md/LICENSE
+++ b/apps/api/seeds/design_skills/awesome_design_md/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Inspired by bergside/awesome-design-skills (MIT).
+Product adaptation for Design Agent — Recombyn OSS packs.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/api/seeds/design_skills/awesome_design_md/SKILL.md
+++ b/apps/api/seeds/design_skills/awesome_design_md/SKILL.md
@@ -1,0 +1,50 @@
+# Brand visual parameters
+
+Turn a visual system into a **parameter sheet**, then execute every paint against that sheet — do not invent a new style each turn.
+
+## Principles
+1. **Sheet is law for this run** — local edits must not break semantic colors or type scale.
+2. **Roles > scattered hex** — primary / secondary / accent / muted / danger mean something.
+3. **Ask short, never invent** — missing logo/slogan/hex → ask; do not fabricate brand assets.
+4. **Declare switch mode** — cover / merge / accent-only when changing systems.
+5. **Prefer refine over wipe** — recolor / resize / spacing on existing nodes first.
+
+## Workflow
+1. Style name or reference given → extract the sheet (ask only for missing slots).
+2. Custom brand → ask the shortest questions to fill the sheet.
+3. Lock sheet as hard constraints; paint against it.
+4. Switching style → declare **cover / merge / accent-only**, then recolor systematically.
+5. Self-check: one palette mood, one type mood across the board.
+
+## Parameter sheet (fill before paint)
+| Slot | Capture |
+|------|---------|
+| Tone | One sentence (calm engineering / warm editorial / …) |
+| Colors | Primary / secondary / accent as **roles** + sample hex |
+| Type | Display + body; weight ladder |
+| Radius / stroke | Shared scale |
+| Spacing | Base step (4 or 8) |
+| Surfaces | Border? Shadow? Flat vs elevated |
+| Forbidden | Explicit anti-patterns for this brand |
+
+## Apply on canvas
+| Sheet slot | How |
+|------------|-----|
+| Color roles | Map to fills/strokes; keep text on readable surfaces |
+| Type scale | Jump sizes per sheet; no second display face mid-run |
+| Radius/stroke | Shared on cards/buttons/inputs |
+| Spacing | Gaps and padding from base step |
+| Cover switch | Replace palette/type systematically |
+| Merge switch | Keep structure, swap roles |
+| Accent-only | Touch primary/CTA only; leave neutrals |
+
+## Do not
+- Invent logos, slogans, or trademark marks
+- Introduce a competing second palette mid-run without declaring switch mode
+- Wipe the board when a recolor pass would suffice
+
+## Related
+`garden_style` (taste), `shadcn_ui` (control grammar).
+
+## Done when
+One coherent sheet visible across the artboard; no competing second palette or type mood.

--- a/apps/api/seeds/design_skills/awesome_design_md/_meta.json
+++ b/apps/api/seeds/design_skills/awesome_design_md/_meta.json
@@ -1,0 +1,34 @@
+{
+  "skill_key": "awesome_design_md",
+  "name": "awesome_design_md",
+  "displayName": "Awesome DesignMD",
+  "description": "品牌视觉参数注入：把风格系统变成可执行的设计约束",
+  "when_to_use": "Inject or switch a brand visual system: palette, type, radius, spacing, surface rules. Use when the user gives a style name, brand kit, or asks for a coherent look across the board.",
+  "category": "brand",
+  "scenes": "all",
+  "sort_weight": 36,
+  "version": "1.1.0",
+  "preferred_tools": [
+    "create_frame",
+    "create_shape",
+    "create_text",
+    "create_image",
+    "update_node"
+  ],
+  "allowed_resources": [
+    "tools"
+  ],
+  "triggers": [],
+  "mutex_group": "",
+  "prompt_negative": "不要同时混用两套互斥风格；不要在未确认品牌参数前随意发明第二套色板。",
+  "locales": {
+    "zh-CN": {
+      "displayName": "Awesome DesignMD",
+      "description": "品牌视觉参数注入：把风格系统变成可执行的设计约束"
+    },
+    "en": {
+      "displayName": "Awesome DesignMD",
+      "description": "Brand visual parameter injector — turn a style system into enforceable design constraints"
+    }
+  }
+}

--- a/apps/api/seeds/design_skills/awesome_design_md/assets/icon.svg
+++ b/apps/api/seeds/design_skills/awesome_design_md/assets/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#1A365D"/>
+  <path d="M16 14h20c6 0 10 3 10 8v28c-4-3-8-4-14-4H16z" fill="none" stroke="#fff" stroke-width="2.2" stroke-linejoin="round"/>
+    <path d="M16 14v32c6 0 10 1 14 4V18c-4-3-8-4-14-4z" fill="#fff" opacity="0.15"/>
+    <path d="M22 24h10M22 30h8" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/apps/api/seeds/design_skills/banner_ad/assets/icon.svg
+++ b/apps/api/seeds/design_skills/banner_ad/assets/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#0F4C5C"/>
+  <rect x="10" y="22" width="44" height="20" rx="3" fill="none" stroke="#fff" stroke-width="2.2"/>
+    <rect x="14" y="26" width="14" height="12" rx="1.5" fill="#fff" opacity="0.85"/>
+    <path d="M32 30h16M32 36h12" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/apps/api/seeds/design_skills/brush_ops/assets/icon.svg
+++ b/apps/api/seeds/design_skills/brush_ops/assets/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#5C3D2E"/>
+  <path d="M18 42c8-2 14-10 18-18 2-4 8-8 12-8-2 6-4 12-10 16-6 4-14 8-20 10z" fill="#fff" opacity="0.95"/>
+    <path d="M18 42c-2 4 2 8 6 6 2-6 4-8 0-12" fill="#D4A574"/>
+</svg>

--- a/apps/api/seeds/design_skills/dashboard_ui/assets/icon.svg
+++ b/apps/api/seeds/design_skills/dashboard_ui/assets/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#243B53"/>
+  <rect x="12" y="14" width="40" height="36" rx="3" fill="none" stroke="#fff" stroke-width="2.2"/>
+    <rect x="16" y="34" width="6" height="10" rx="1" fill="#fff"/>
+    <rect x="26" y="28" width="6" height="16" rx="1" fill="#fff" opacity="0.75"/>
+    <rect x="36" y="22" width="6" height="22" rx="1" fill="#fff"/>
+    <path d="M16 20h20" stroke="#fff" stroke-width="2" stroke-linecap="round" opacity="0.7"/>
+</svg>

--- a/apps/api/seeds/design_skills/ecommerce_surface/assets/icon.svg
+++ b/apps/api/seeds/design_skills/ecommerce_surface/assets/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#4A3728"/>
+  <path d="M20 24h24l-2 22H22z" fill="none" stroke="#fff" stroke-width="2.2" stroke-linejoin="round"/>
+    <path d="M24 24c0-5 3.5-9 8-9s8 4 8 9" fill="none" stroke="#fff" stroke-width="2.2"/>
+    <circle cx="40" cy="18" r="6" fill="#E9C46A"/>
+    <path d="M40 15v6M37 18h6" stroke="#4A3728" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/apps/api/seeds/design_skills/garden_style/LICENSE
+++ b/apps/api/seeds/design_skills/garden_style/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Upstream: ConardLi/garden-skills (web-design-engineer)
+Copyright (c) 2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/api/seeds/design_skills/garden_style/SKILL.md
+++ b/apps/api/seeds/design_skills/garden_style/SKILL.md
@@ -1,0 +1,59 @@
+# Garden style
+
+Deliver canvas work that looks **intentional and memorable** — not a safe AI draft.
+
+## Design thinking
+
+| Ask | Aim |
+|-----|-----|
+| **Purpose** | Who sees this and what job it does |
+| **Tone** | One direction from the catalog — do not mix casually |
+| **Memory point** | Hero image **or** hero title — not both fighting |
+| **Bitmap vs vector** | Simple geometry / flat language that stays crisp → vector. Complex atmosphere, materials, faces, busy illustration → bitmap. If vectors look crude, use image |
+
+Quality bar: **intentional design** — alignments, contrast, and type mood fit this brief. Soft-avoid generic AI postcard defaults. Not a “handmade texture” mandate.
+
+## Direction catalog (pick one)
+
+| Direction | Cues |
+|-----------|------|
+| Minimal | Few elements, precise gaps, quiet palette, one accent |
+| Editorial | Strong display type, asymmetric crop, magazine margins |
+| Industrial | Utility type, hard edges, restrained metal/ink palette |
+| Organic | Soft forms, natural textures, muted earth/plant tones |
+| Luxury | High contrast, generous empty, refined metals/ink |
+| Festive hand | Expressive lettering + illustrated or rich atmosphere when complexity needs it; simple flat festive language may stay vector |
+| Playful geometric | Bold primitives, flat color blocks, friendly type — vector-friendly |
+| Retro-futurist | Period cues + modern restraint; soft-avoid costume-party clutter |
+
+## Anti-defaults (unless brief demands)
+
+Purple→indigo gradients on white; Inter/Roboto/Arial as “design”; warm cream `#F4F1EA` + terracotta serif cliché; dense broadsheet hairlines; glow stacks; rounded-full pill spam; emoji-as-icon; Space Grotesk convergence.
+
+## Build rules
+
+- Atmosphere that needs depth/light/material → real bitmap; soft-avoid crude shape spam as a fake scene.
+- Simple intentional geometry is fine when that is the language (e.g. playful geometric).
+- Type: distinctive display + restrained body; soft-avoid forcing generic UI sans onto illustration posters.
+- Color: one dominant + sharp accent; copy clears the background.
+- Space: generous whitespace **or** controlled density — soft-avoid “everything centered, nothing focal.”
+- Decoration only when they serve the theme.
+- Motion (if allowed): 1–2 high-impact beats via `motion_lottie`.
+
+## Far / near check
+
+- Far (~1s): theme + main title readable; medium matches complexity.
+- Near: soft-avoid clipped glyphs, low contrast, emoji tofu, unrelated icons.
+- Tone: type mood matches the picture.
+
+## Honesty
+
+Unless the user provides them, avoid inventing board facts such as logos, slogans, trademark marks, etc.
+
+## Related
+
+`poster_craft` / `landing_page` / `image_gen` for surface playbooks; `awesome_design_md` when a brand parameter sheet exists.
+
+## Done when
+
+Direction is nameable in one phrase; one memory point; anti-defaults cleared; far/near pass.

--- a/apps/api/seeds/design_skills/garden_style/_meta.json
+++ b/apps/api/seeds/design_skills/garden_style/_meta.json
@@ -1,0 +1,54 @@
+{
+  "skill_key": "garden_style",
+  "name": "garden_style",
+  "displayName": "Garden Style",
+  "description": "风格配方引擎：大胆审美方向 + 字体气质匹配 + 海报质检",
+  "when_to_use": "Need a bold visual direction, type-mood fit, or poster quality bar — festive/illustration/atmosphere work that must look intentional, not drafty.",
+  "category": "style",
+  "scenes": "all",
+  "sort_weight": 82,
+  "version": "1.4.0",
+  "preferred_tools": [
+    "create_frame",
+    "create_shape",
+    "create_text",
+    "create_image",
+    "create_svg",
+    "update_node"
+  ],
+  "allowed_resources": [
+    "tools"
+  ],
+  "triggers": [
+    {
+      "intent_in": ["create", "edit"],
+      "prompt_includes_any": [
+        "调性",
+        "氛围感",
+        "视觉方向",
+        "审美方向",
+        "海报风",
+        "节日氛围",
+        "插画风",
+        "garden style",
+        "aesthetic direction",
+        "style direction",
+        "visual direction",
+        "festive",
+        "editorial look"
+      ]
+    }
+  ],
+  "mutex_group": "",
+  "prompt_negative": "禁止套用紫渐变白底、Inter/Roboto 默认栈、无意义发光与满屏圆角胶囊；勿复制参考图 Logo/二维码/价格；禁止用 emoji/ pictograph 文字冒充图标；禁止 UI 产品界面默认套用节日海报装饰；禁止标题裁切与低对比文案。",
+  "locales": {
+    "zh-CN": {
+      "displayName": "Garden 风格配方",
+      "description": "风格配方引擎：大胆审美方向 + 字体气质匹配 + 海报质检"
+    },
+    "en": {
+      "displayName": "Garden Style",
+      "description": "Style recipe engine: bold direction, type-mood fit, poster craft checks"
+    }
+  }
+}

--- a/apps/api/seeds/design_skills/garden_style/assets/icon.svg
+++ b/apps/api/seeds/design_skills/garden_style/assets/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#2D6A4F"/>
+  <path d="M32 46c0-14 10-22 18-24-4 12-10 20-18 24z" fill="#fff"/>
+    <path d="M32 46c0-14-10-22-18-24 4 12 10 20 18 24z" fill="#B7E4C7"/>
+    <path d="M32 46V20" stroke="#fff" stroke-width="2.2" stroke-linecap="round"/>
+</svg>

--- a/apps/api/seeds/design_skills/icon_set/assets/icon.svg
+++ b/apps/api/seeds/design_skills/icon_set/assets/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#3A3F58"/>
+  <rect x="14" y="14" width="14" height="14" rx="3" fill="#fff"/>
+    <rect x="36" y="14" width="14" height="14" rx="3" fill="#fff" opacity="0.55"/>
+    <rect x="14" y="36" width="14" height="14" rx="3" fill="#fff" opacity="0.55"/>
+    <rect x="36" y="36" width="14" height="14" rx="3" fill="#fff"/>
+</svg>

--- a/apps/api/seeds/design_skills/image_gen/assets/icon.svg
+++ b/apps/api/seeds/design_skills/image_gen/assets/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#2C4A3E"/>
+  <rect x="14" y="16" width="36" height="32" rx="4" fill="none" stroke="#fff" stroke-width="2.2"/>
+    <circle cx="24" cy="26" r="3.5" fill="#fff"/>
+    <path d="M14 40l10-8 8 6 8-10 10 12" fill="none" stroke="#fff" stroke-width="2.2" stroke-linejoin="round"/>
+    <path d="M44 14l2.5 5.5L52 22l-5.5 2.5L44 30l-2.5-5.5L36 22l5.5-2.5z" fill="#B8E0D2"/>
+</svg>

--- a/apps/api/seeds/design_skills/landing_page/assets/icon.svg
+++ b/apps/api/seeds/design_skills/landing_page/assets/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#1B4332"/>
+  <rect x="12" y="14" width="40" height="36" rx="3" fill="none" stroke="#fff" stroke-width="2.2"/>
+    <path d="M12 22h40" stroke="#fff" stroke-width="2"/>
+    <circle cx="17" cy="18" r="1.6" fill="#fff"/><circle cx="22" cy="18" r="1.6" fill="#fff"/><circle cx="27" cy="18" r="1.6" fill="#fff"/>
+    <rect x="18" y="28" width="16" height="10" rx="1.5" fill="#fff" opacity="0.9"/>
+    <path d="M38 30h10M38 36h8" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/apps/api/seeds/design_skills/long_scroll/assets/icon.svg
+++ b/apps/api/seeds/design_skills/long_scroll/assets/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#314E52"/>
+  <rect x="22" y="10" width="20" height="44" rx="3" fill="none" stroke="#fff" stroke-width="2.2"/>
+    <path d="M27 20h10M27 27h10M27 34h8M27 41h6" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+    <path d="M46 18v28" stroke="#A8DADC" stroke-width="2.2" stroke-linecap="round"/>
+    <path d="M43 42l3 4 3-4" fill="none" stroke="#A8DADC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/api/seeds/design_skills/mobile_app_ui/assets/icon.svg
+++ b/apps/api/seeds/design_skills/mobile_app_ui/assets/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#2D3142"/>
+  <rect x="22" y="10" width="20" height="44" rx="4" fill="none" stroke="#fff" stroke-width="2.2"/>
+    <rect x="26" y="18" width="12" height="22" rx="1.5" fill="#fff" opacity="0.85"/>
+    <circle cx="32" cy="46" r="2.2" fill="#fff"/>
+</svg>

--- a/apps/api/seeds/design_skills/motion_lottie/assets/icon.svg
+++ b/apps/api/seeds/design_skills/motion_lottie/assets/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#3D2C5E"/>
+  <circle cx="32" cy="32" r="16" fill="none" stroke="#fff" stroke-width="2.2"/>
+    <path d="M27 24l16 8-16 8z" fill="#fff"/>
+    <path d="M48 18c4 4 6 10 4 16" fill="none" stroke="#CDB4DB" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/apps/api/seeds/design_skills/poster_craft/assets/icon.svg
+++ b/apps/api/seeds/design_skills/poster_craft/assets/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#1F3A5F"/>
+  <rect x="22" y="12" width="20" height="40" rx="2.5" fill="none" stroke="#fff" stroke-width="2.2"/>
+    <rect x="26" y="16" width="12" height="16" rx="1.5" fill="#fff" opacity="0.9"/>
+    <path d="M26 38h12M26 43h8" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/apps/api/seeds/design_skills/resume_layout/assets/icon.svg
+++ b/apps/api/seeds/design_skills/resume_layout/assets/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#2E4057"/>
+  <rect x="18" y="12" width="28" height="40" rx="3" fill="none" stroke="#fff" stroke-width="2.2"/>
+    <circle cx="26" cy="24" r="4" fill="#fff"/>
+    <path d="M34 22h8M34 27h6" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+    <path d="M22 36h20M22 42h14" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/apps/api/seeds/design_skills/shadcn_ui/LICENSE
+++ b/apps/api/seeds/design_skills/shadcn_ui/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Upstream: shadcn-ui/ui (skills/shadcn)
+Copyright (c) 2023 shadcn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/api/seeds/design_skills/shadcn_ui/SKILL.md
+++ b/apps/api/seeds/design_skills/shadcn_ui/SKILL.md
@@ -1,0 +1,54 @@
+# shadcn/ui composition
+
+Map product UI onto the canvas with shadcn-like grammar — roles, tokens, and patterns (not React trees).
+
+## Principles
+1. **Roles, not one-off skins** — primary / secondary / ghost / destructive mean the same everywhere.
+2. **Semantic color** — background / foreground / primary / muted / danger — not random hex.
+3. **One radius + spacing rhythm** across the board.
+4. **Labeled states** — never color alone for active/error/disabled.
+5. **Compose from patterns** — invent chrome only if nothing fits.
+
+## Workflow
+1. Name the screen job (settings, dashboard, form, dialog, marketing section …).
+2. Pull tokens from `awesome_design_md` if available.
+3. Compose from the pattern table; keep heights aligned within a control family.
+4. Verify labels, errors, and primary action.
+
+## Patterns
+| Need | Compose |
+|------|---------|
+| Button primary | Filled primary + centered label; loading = visible state |
+| Button secondary/ghost | Stroke or muted fill + label; same height as primary |
+| Destructive | Danger fill/stroke + clear label |
+| Input | Label above; field; optional placeholder; error adjacent |
+| Form group | Related fields stacked with shared left edge |
+| Card | Surface + title + body + optional action row |
+| Table | Header row + aligned columns; no clipped cells |
+| Nav | Top or side; active = weight **and** color |
+| Tabs | Label row; active underline; panel below |
+| Dialog / drawer | Panel with **title** + body + actions |
+| Toast / alert | Compact surface + short message |
+| Badge / avatar | Small pill or circle + short text/initials |
+| Skeleton | Muted bars matching content layout |
+| Switch / checkbox | Affordances labeled by adjacent text |
+
+## Density notes
+| Context | Lean |
+|---------|------|
+| Settings | Comfortable field spacing; clear section titles |
+| Dashboard | Tighter tables OK; keep header distinct |
+| Marketing embed | Fewer controls; one primary CTA |
+
+## Do not
+- Stack fields with only spacing and no labels
+- Open dialog/drawer without a title
+- Rely on color alone for state
+- Mix Material festive icons into product UI chrome
+- Emit React/JSX
+
+## Related
+`dashboard_ui` / `mobile_app_ui` / `landing_page`; `awesome_design_md` for brand tokens.
+
+## Done when
+Hierarchy reads in one glance; interactive states are labeled; spacing rhythm is consistent; primary action is obvious.

--- a/apps/api/seeds/design_skills/shadcn_ui/_meta.json
+++ b/apps/api/seeds/design_skills/shadcn_ui/_meta.json
@@ -1,0 +1,34 @@
+{
+  "skill_key": "shadcn_ui",
+  "name": "shadcn_ui",
+  "displayName": "shadcn/ui",
+  "description": "组件组合说明书：语义色、表单结构、叠层与变体优先",
+  "when_to_use": "Compose product UI on canvas (settings, forms, dialogs, nav, feedback) using semantic roles and shadcn-like composition — not ad-hoc chrome.",
+  "category": "ui",
+  "scenes": "all",
+  "sort_weight": 34,
+  "version": "1.1.0",
+  "preferred_tools": [
+    "create_frame",
+    "create_shape",
+    "create_text",
+    "create_image",
+    "update_node"
+  ],
+  "allowed_resources": [
+    "tools"
+  ],
+  "triggers": [],
+  "mutex_group": "",
+  "prompt_negative": "不要用随意蓝/绿 hex 充当状态色；不要把所有内容塞进一个无结构容器；不要省略对话框标题级信息。",
+  "locales": {
+    "zh-CN": {
+      "displayName": "shadcn/ui 说明书",
+      "description": "组件组合说明书：语义色、表单结构、叠层与变体优先"
+    },
+    "en": {
+      "displayName": "shadcn/ui handbook",
+      "description": "Compose UI with semantic colors, form structure, overlays, and variants first"
+    }
+  }
+}

--- a/apps/api/seeds/design_skills/shadcn_ui/assets/icon.svg
+++ b/apps/api/seeds/design_skills/shadcn_ui/assets/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#111827"/>
+  <rect x="14" y="16" width="36" height="32" rx="5" fill="none" stroke="#fff" stroke-width="2.2"/>
+    <rect x="20" y="24" width="14" height="8" rx="2" fill="#fff"/>
+    <path d="M20 40h24" stroke="#fff" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+    <circle cx="42" cy="28" r="4" fill="#9AE6B4"/>
+</svg>

--- a/apps/api/seeds/design_skills/type_specimen/assets/icon.svg
+++ b/apps/api/seeds/design_skills/type_specimen/assets/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#1C2B3A"/>
+  <path d="M20 46L32 14l12 32" fill="none" stroke="#fff" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M24.5 36h15" stroke="#fff" stroke-width="2.4" stroke-linecap="round"/>
+</svg>

--- a/apps/api/tests/unit_tests/test_skill_store.py
+++ b/apps/api/tests/unit_tests/test_skill_store.py
@@ -493,6 +493,42 @@ def test_schema_json_merges_into_pack(tmp_path):
     assert "create_frame" in item["output_schema"]["allowed_ops"]
 
 
+def test_pack_icon_svg_inlines_as_data_url(tmp_path):
+    from app.services.design.prompts.skill_store.pack_io import _load_pack_dir
+
+    pack = tmp_path / "icon_pack"
+    (pack / "assets").mkdir(parents=True)
+    (pack / "_meta.json").write_text(
+        '{"skill_key":"icon_pack","name":"icon_pack",'
+        '"preferred_tools":["create_frame"],"version":"1.0.0"}',
+        encoding="utf-8",
+    )
+    (pack / "SKILL.md").write_text("# Icon pack\n\nBody.\n", encoding="utf-8")
+    (pack / "assets" / "icon.svg").write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">'
+        '<rect width="64" height="64" fill="#123"/></svg>',
+        encoding="utf-8",
+    )
+    item = _load_pack_dir(pack)
+    assert item is not None
+    logo = str(item.get("logo") or "")
+    assert logo.startswith("data:image/svg+xml,")
+    assert "64" in logo
+
+
+def test_built_in_skills_have_icons():
+    items = {str(x.get("skill_key")): x for x in _load_file_skills()}
+    for key in (
+        "poster_craft",
+        "banner_ad",
+        "image_gen",
+        "garden_style",
+        "festival_poster",
+    ):
+        logo = str((items.get(key) or {}).get("logo") or "")
+        assert logo.startswith("data:image/"), f"{key} missing icon logo"
+
+
 def test_festival_poster_pack_has_schema():
     items = {str(x.get("skill_key")): x for x in _load_file_skills()}
     fp = items.get("festival_poster")

--- a/apps/api/tests/unit_tests/test_skill_store.py
+++ b/apps/api/tests/unit_tests/test_skill_store.py
@@ -407,6 +407,7 @@ def test_oss_ext_packs_present():
         "icon_set",
         "type_specimen",
         "long_scroll",
+        "festival_poster",
     ):
         assert key in keys
     assert "ui_ux_pro_max" not in keys
@@ -414,3 +415,66 @@ def test_oss_ext_packs_present():
     assert "canvas_edit" not in keys
     assert "frontend_ui" not in keys
     assert "example_ext" not in keys
+
+
+def test_normalize_pack_meta_aliases():
+    from app.services.design.prompts.skill_store.pack_io import _normalize_pack_meta
+
+    meta = _normalize_pack_meta(
+        {
+            "id": "my_plugin",
+            "trigger_keywords": ["中秋海报", "holiday poster"],
+            "author": "ops",
+            "permissions": ["新建画布帧"],
+            "enabled": True,
+        },
+        folder="my_plugin",
+    )
+    assert meta is not None
+    assert meta["skill_key"] == "my_plugin"
+    assert meta["triggers"][0]["prompt_includes_any"] == ["中秋海报", "holiday poster"]
+    assert meta["allowed_resources"] == ["tools"]
+    assert meta["_author"] == "ops"
+
+
+def test_normalize_pack_meta_disabled():
+    from app.services.design.prompts.skill_store.pack_io import _normalize_pack_meta
+
+    assert (
+        _normalize_pack_meta(
+            {"id": "x", "enabled": False, "triggers": []},
+            folder="x",
+        )
+        is None
+    )
+
+
+def test_plugin_style_pack_loads(tmp_path, monkeypatch):
+    from app.services.design.prompts.skill_store import pack_io
+
+    root = tmp_path / "plugins_skills"
+    pack = root / "kw_poster"
+    pack.mkdir(parents=True)
+    (pack / "_meta.json").write_text(
+        '{"id":"kw_poster","name":"kw_poster","trigger_keywords":["春节海报"],'
+        '"preferred_tools":["create_frame","create_text"],"version":"1.0.0"}',
+        encoding="utf-8",
+    )
+    (pack / "SKILL.md").write_text("# KW poster\n\nCreate a festive board.\n", encoding="utf-8")
+
+    monkeypatch.setattr(pack_io, "_file_skills_dirs", lambda: [root])
+    items = pack_io._load_file_skills()
+    by_key = {str(x.get("skill_key")): x for x in items}
+    assert "kw_poster" in by_key
+    triggers = by_key["kw_poster"].get("triggers") or []
+    assert triggers and "春节海报" in triggers[0].get("prompt_includes_any", [])
+
+
+def test_resolve_triggered_festival_keyword():
+    keys = resolve_triggered_skill_keys(
+        prompt="帮我生成一张中秋红色海报",
+        intent="create",
+        empty_canvas=True,
+        has_images=False,
+    )
+    assert "festival_poster" in keys

--- a/apps/api/tests/unit_tests/test_skill_store.py
+++ b/apps/api/tests/unit_tests/test_skill_store.py
@@ -470,6 +470,37 @@ def test_plugin_style_pack_loads(tmp_path, monkeypatch):
     assert triggers and "春节海报" in triggers[0].get("prompt_includes_any", [])
 
 
+def test_schema_json_merges_into_pack(tmp_path):
+    from app.services.design.prompts.skill_store.pack_io import _load_pack_dir
+
+    pack = tmp_path / "schema_pack"
+    pack.mkdir()
+    (pack / "_meta.json").write_text(
+        '{"skill_key":"schema_pack","name":"schema_pack",'
+        '"preferred_tools":["create_frame"],"version":"1.0.0"}',
+        encoding="utf-8",
+    )
+    (pack / "SKILL.md").write_text("# Schema pack\n\nBody.\n", encoding="utf-8")
+    (pack / "schema.json").write_text(
+        '{"input":{"type":"object","properties":{"festival":{"type":"string"}},'
+        '"required":["festival"]},'
+        '"output":{"type":"object","allowed_ops":["create_frame","create_text"]}}',
+        encoding="utf-8",
+    )
+    item = _load_pack_dir(pack)
+    assert item is not None
+    assert item["input_schema"]["required"] == ["festival"]
+    assert "create_frame" in item["output_schema"]["allowed_ops"]
+
+
+def test_festival_poster_pack_has_schema():
+    items = {str(x.get("skill_key")): x for x in _load_file_skills()}
+    fp = items.get("festival_poster")
+    assert fp is not None
+    assert isinstance(fp.get("input_schema"), dict)
+    assert "festival" in (fp["input_schema"].get("properties") or {})
+
+
 def test_resolve_triggered_festival_keyword():
     keys = resolve_triggered_skill_keys(
         prompt="帮我生成一张中秋红色海报",

--- a/apps/web/src/components/home/SkillsLibraryPanel.tsx
+++ b/apps/web/src/components/home/SkillsLibraryPanel.tsx
@@ -148,15 +148,31 @@ function SkillCard({
       )}
     >
       <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-[14px] font-medium leading-[21px] text-[var(--ink)]">
-            {row.name}
-          </div>
-          {row.whenToUse ? (
-            <div className="mt-1 line-clamp-2 text-[12px] leading-[18px] text-[var(--muted)]">
-              {row.whenToUse}
+        <div className="flex min-w-0 flex-1 items-start gap-2.5">
+          {row.logo ? (
+            <img
+              src={row.logo}
+              alt=""
+              className="mt-0.5 h-9 w-9 shrink-0 rounded-[10px] object-cover"
+            />
+          ) : (
+            <div
+              aria-hidden
+              className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[var(--canvas)] text-[13px] font-semibold text-[var(--muted)]"
+            >
+              {(row.name || '?').slice(0, 1).toUpperCase()}
             </div>
-          ) : null}
+          )}
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-[14px] font-medium leading-[21px] text-[var(--ink)]">
+              {row.name}
+            </div>
+            {row.whenToUse ? (
+              <div className="mt-1 line-clamp-2 text-[12px] leading-[18px] text-[var(--muted)]">
+                {row.whenToUse}
+              </div>
+            ) : null}
+          </div>
         </div>
         <div
           className="flex shrink-0 items-center gap-2"
@@ -479,11 +495,20 @@ function SkillsLibraryPanel(): ReactNode {
       >
         {preview ? (
           <div className="space-y-3.5">
-            {preview.whenToUse || preview.description ? (
-              <p className="text-[13px] leading-relaxed text-[var(--muted)]">
-                {preview.whenToUse || preview.description}
-              </p>
-            ) : null}
+            <div className="flex items-start gap-3">
+              {preview.logo ? (
+                <img
+                  src={preview.logo}
+                  alt=""
+                  className="h-11 w-11 shrink-0 rounded-[12px] object-cover"
+                />
+              ) : null}
+              {preview.whenToUse || preview.description ? (
+                <p className="min-w-0 flex-1 text-[13px] leading-relaxed text-[var(--muted)]">
+                  {preview.whenToUse || preview.description}
+                </p>
+              ) : null}
+            </div>
             <div className="max-h-[min(52vh,420px)] overflow-y-auto rounded-lg border border-[var(--line)] bg-[var(--canvas)] px-3.5 py-3">
               <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--muted)]">
                 {t('agent.skillsPreviewBody')}

--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY packages/scene-builder-py ./packages/scene-builder-py
 COPY apps/api ./apps/api
-COPY .agents/skills ./.agents/skills
+# Product skills ship under apps/api/seeds/design_skills; private packs mount at /app/plugins/skills.
 
 ARG INSTALL_OCR=false
 ARG INSTALL_AV=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,8 @@ services:
     volumes:
       - ./apps/api/storage/uploads:/app/apps/api/storage/uploads
       - ./apps/api/storage/results:/app/apps/api/storage/results
+      # Private skill packs (Phase A) — drop folders without rebuilding the image
+      - ./plugins/skills:/app/plugins/skills
     environment:
       - LIBREOFFICE_PATH=/usr/bin/soffice
       - REDIS_URL=redis://redis:6379/0

--- a/docs/adr/0013-skill-extensions.md
+++ b/docs/adr/0013-skill-extensions.md
@@ -5,22 +5,32 @@
 
 ## Context
 
-We want third-party / private-deploy **extensions** without a full plugin platform (canvas SDK, Python handlers, sandboxes). The Design Agent already loads file skill packs (`_meta.json` + `SKILL.md`) and gates ops via `preferred_tools`.
+We want third-party / private-deploy **extensions** without a full plugin platform (canvas SDK, Python handlers, sandboxes). The Design Agent already loads file skill packs and gates ops via `preferred_tools`.
 
 ## Decision
 
-1. **Phase A = Skill playbooks only.** A “skill plugin” is a folder the agent can load; it does **not** execute arbitrary Python (`handler.py` deferred).
-2. **Mount roots** (later wins on duplicate `skill_key`):
-   - `<repo>/.agents/skills` (product `_meta.json` required)
-   - `apps/api/seeds/design_skills`
-   - `<repo>/plugins/skills` (default private mount)
+1. **Phase A = Skill playbooks only.** A pack teaches the agent; it does **not** execute `handler.py` yet.
+2. **Two product roots only** (later wins on duplicate `skill_key`):
+   - `apps/api/seeds/design_skills` — shipped / first-party
+   - `<repo>/plugins/skills` — private / self-host mount
    - Extra dirs from `DESIGN_SKILLS_PLUGIN_DIRS` (comma-separated)
-3. **Meta aliases** (optional, normalized at load):
+3. **`.agents/skills` is out of product scan** — Cursor/IDE agents only; do not place Design Agent packs there.
+4. **Canonical pack layout:**
+   ```
+   my_poster_plugin/
+   ├── _meta.json        # required
+   ├── SKILL.md          # required
+   ├── schema.json       # optional — input / output JSON Schema
+   ├── handler.py        # optional — reserved Phase B (logged, not executed)
+   ├── assets/           # optional — logo / icon / previews
+   └── examples/         # optional — reference art (docs only)
+   ```
+5. **Meta aliases** (optional, normalized at load):
    - `id` → `skill_key`
    - `trigger_keywords` → `triggers[].prompt_includes_any` (when `triggers` absent)
    - `enabled: false` → skip pack
    - `author` / `permissions` → recorded / documented; live ACL remains `preferred_tools` + `allowed_resources`
-4. **Later phases** (not this ADR): canvas toolbar plugins (TS registry), optional skill `ops` runners, zip/signature installers.
+6. **Later phases** (not this ADR): canvas toolbar plugins (TS), optional skill ops runners (`handler.py`), zip/signature installers.
 
 ## Consequences
 
@@ -28,17 +38,20 @@ We want third-party / private-deploy **extensions** without a full plugin platfo
 
 - Private deploys add craft by dropping folders + restart/hot-reload.
 - Same Decide / Paint / tool_ops path as shipped skills — no second canvas writer.
+- One layout for seeds and plugins; `schema.json` / `assets/` ready without a second format.
 - Compose can volume-mount `./plugins/skills` without rebuilding the image.
 
 ### Negative / trade-offs
 
 - Deterministic layout still depends on the LLM following `SKILL.md`.
 - No process sandbox for skill bodies (they are prompts, not code).
+- `handler.py` presence may confuse authors until Phase B docs are prominent.
 
 ## Alternatives considered
 
 1. **Runnable `handler.py` + CanvasContext** — deferred; conflicts with tool_ops ownership and needs a runner ADR.
-2. **Only Admin zip uploads** — kept, but filesystem mount is better for self-host ops.
+2. **Three roots including `.agents/skills`** — rejected; split IDE vs product catalogs.
+3. **Only Admin zip uploads** — kept, but filesystem mount is better for self-host ops.
 
 ## References
 

--- a/docs/adr/0013-skill-extensions.md
+++ b/docs/adr/0013-skill-extensions.md
@@ -1,0 +1,48 @@
+# Extensibility — Skill packs (Phase A)
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+We want third-party / private-deploy **extensions** without a full plugin platform (canvas SDK, Python handlers, sandboxes). The Design Agent already loads file skill packs (`_meta.json` + `SKILL.md`) and gates ops via `preferred_tools`.
+
+## Decision
+
+1. **Phase A = Skill playbooks only.** A “skill plugin” is a folder the agent can load; it does **not** execute arbitrary Python (`handler.py` deferred).
+2. **Mount roots** (later wins on duplicate `skill_key`):
+   - `<repo>/.agents/skills` (product `_meta.json` required)
+   - `apps/api/seeds/design_skills`
+   - `<repo>/plugins/skills` (default private mount)
+   - Extra dirs from `DESIGN_SKILLS_PLUGIN_DIRS` (comma-separated)
+3. **Meta aliases** (optional, normalized at load):
+   - `id` → `skill_key`
+   - `trigger_keywords` → `triggers[].prompt_includes_any` (when `triggers` absent)
+   - `enabled: false` → skip pack
+   - `author` / `permissions` → recorded / documented; live ACL remains `preferred_tools` + `allowed_resources`
+4. **Later phases** (not this ADR): canvas toolbar plugins (TS registry), optional skill `ops` runners, zip/signature installers.
+
+## Consequences
+
+### Positive
+
+- Private deploys add craft by dropping folders + restart/hot-reload.
+- Same Decide / Paint / tool_ops path as shipped skills — no second canvas writer.
+- Compose can volume-mount `./plugins/skills` without rebuilding the image.
+
+### Negative / trade-offs
+
+- Deterministic layout still depends on the LLM following `SKILL.md`.
+- No process sandbox for skill bodies (they are prompts, not code).
+
+## Alternatives considered
+
+1. **Runnable `handler.py` + CanvasContext** — deferred; conflicts with tool_ops ownership and needs a runner ADR.
+2. **Only Admin zip uploads** — kept, but filesystem mount is better for self-host ops.
+
+## References
+
+- [docs/skill-extensions.md](../skill-extensions.md)
+- `plugins/skills/README.md`
+- `app/services/design/prompts/skill_store/pack_io.py`
+- Roadmap Phase A in [platform.md](../roadmap/platform.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,3 +32,4 @@ Cross-cutting or irreversible technical choices live here. Product feature notes
 | [0010](./0010-desktop-signing.md) | Desktop (Tauri) release signing | Accepted |
 | [0011](./0011-opentelemetry-optional.md) | Optional OpenTelemetry SDK | Accepted |
 | [0012](./0012-k8s-starter-manifests.md) | Optional Kubernetes starter manifests | Accepted |
+| [0013](./0013-skill-extensions.md) | Skill extension packs (Phase A plugins) | Accepted |

--- a/docs/roadmap/platform.md
+++ b/docs/roadmap/platform.md
@@ -39,7 +39,7 @@ One FastAPI app with domain modules, plus the collab WebSocket process:
 | AI 模型入口 | In-process façade (`get_llm_endpoint` / `build_chat_model`) |
 | 异步任务 | Celery worker sharing the API codebase (hydrate / export / image) |
 | 协同 | `apps/collab` WebSocket process |
-| 扩展（Skill） | File packs: seeds + `.agents/skills` + `plugins/skills` ([ADR 0013](../adr/0013-skill-extensions.md)) |
+| 扩展（Skill） | File packs: `seeds/design_skills` + `plugins/skills` ([ADR 0013](../adr/0013-skill-extensions.md)) |
 
 → See [ADR 0004](../adr/0004-modular-monolith-first.md).
 

--- a/docs/roadmap/platform.md
+++ b/docs/roadmap/platform.md
@@ -39,6 +39,7 @@ One FastAPI app with domain modules, plus the collab WebSocket process:
 | AI 模型入口 | In-process façade (`get_llm_endpoint` / `build_chat_model`) |
 | 异步任务 | Celery worker sharing the API codebase (hydrate / export / image) |
 | 协同 | `apps/collab` WebSocket process |
+| 扩展（Skill） | File packs: seeds + `.agents/skills` + `plugins/skills` ([ADR 0013](../adr/0013-skill-extensions.md)) |
 
 → See [ADR 0004](../adr/0004-modular-monolith-first.md).
 
@@ -164,3 +165,11 @@ One FastAPI app with domain modules, plus the collab WebSocket process:
 - [x] Export DLQ admin replay (`GET/POST/DELETE /admin/ops/export-dlq`) + depth gauge / Insights tab
 - [x] Chat image gen jobs (`POST/GET /chat/image/jobs`) — editor polls; sync `POST /chat/image` kept for scripts
 - [x] Hydrate job progress on Design Agent SSE (`activity` + `task_id`)
+- [x] Skill extensions Phase A — `plugins/skills` mount, meta aliases, sample `festival_poster` ([ADR 0013](../adr/0013-skill-extensions.md))
+
+### Phase 7 — Extensibility (plugins)
+
+- [x] Skill playbook packs + private mount (`plugins/skills`) — ADR 0013
+- [ ] Canvas toolbar / exporter registry (TS SDK, in-process)
+- [ ] Optional skill ops runner (return `tool_ops` only)
+- [ ] Packaged install (`.recombyn-plugin` zip) + permissions / signatures

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -225,12 +225,12 @@ User turn
 | Namespace | Source | Notes |
 |-----------|--------|--------|
 | `core` | Legacy `source=seed` only (not shipped) | Prefer file packs; bare keys stay BC aliases |
-| `ext` | `seeds/design_skills/<key>/` (`_meta.json` + `SKILL.md`) | Deliverable/tool playbooks; also `.agents/skills/` and **`plugins/skills/`** (private mount) |
+| `ext` | `seeds/design_skills/<key>/` + **`plugins/skills/`** | Same canonical layout; `.agents/skills` is IDE-only |
 | `user` | Admin API | Always `user.<local>`; cannot claim core keys |
 
 Env: `DESIGN_SKILLS_HOT_RELOAD` (default true), `DESIGN_SKILLS_HOT_RELOAD_INTERVAL_SEC`, `DESIGN_SKILLS_PLUGIN_DIRS` (extra roots). Manual: Admin `POST /api/v1/admin/design/skills/resync`.
 
-Pack layout: `_meta.json` + `SKILL.md`. Authoring + aliases: [skill-extensions.md](./skill-extensions.md) · sample [`plugins/skills/festival_poster/`](../plugins/skills/festival_poster/).
+Canonical layout: `_meta.json` + `SKILL.md` (+ optional `schema.json`, `handler.py`, `assets/`, `examples/`). Authoring: [skill-extensions.md](./skill-extensions.md) · sample [`plugins/skills/festival_poster/`](../plugins/skills/festival_poster/).
 
 Compose mounts `./plugins/skills` into the API container so private packs survive image upgrades.
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -225,12 +225,14 @@ User turn
 | Namespace | Source | Notes |
 |-----------|--------|--------|
 | `core` | Legacy `source=seed` only (not shipped) | Prefer file packs; bare keys stay BC aliases |
-| `ext` | `seeds/design_skills/<key>/` (`_meta.json` + `SKILL.md`) | Deliverable/tool playbooks: `image_gen`, `poster_craft`, …; also `.agents/skills/` |
+| `ext` | `seeds/design_skills/<key>/` (`_meta.json` + `SKILL.md`) | Deliverable/tool playbooks; also `.agents/skills/` and **`plugins/skills/`** (private mount) |
 | `user` | Admin API | Always `user.<local>`; cannot claim core keys |
 
-Env: `DESIGN_SKILLS_HOT_RELOAD` (default true), `DESIGN_SKILLS_HOT_RELOAD_INTERVAL_SEC`. Manual: Admin `POST /api/v1/admin/design/skills/resync`.
+Env: `DESIGN_SKILLS_HOT_RELOAD` (default true), `DESIGN_SKILLS_HOT_RELOAD_INTERVAL_SEC`, `DESIGN_SKILLS_PLUGIN_DIRS` (extra roots). Manual: Admin `POST /api/v1/admin/design/skills/resync`.
 
-Pack layout: `seeds/design_skills/<key>/_meta.json` + `SKILL.md` (copy any existing pack folder to add one).
+Pack layout: `_meta.json` + `SKILL.md`. Authoring + aliases: [skill-extensions.md](./skill-extensions.md) · sample [`plugins/skills/festival_poster/`](../plugins/skills/festival_poster/).
+
+Compose mounts `./plugins/skills` into the API container so private packs survive image upgrades.
 
 ### Prompt packs
 

--- a/docs/skill-extensions.md
+++ b/docs/skill-extensions.md
@@ -1,72 +1,86 @@
 # Skill extensions (authoring)
 
-Skill packs teach the Design Agent **how** to do a class of work. They are **not** executable plugins.
+Skill packs teach the Design Agent **how** to do a class of work.
 
-## Pack layout
+## Two roots only
+
+| Path | Role |
+|------|------|
+| `apps/api/seeds/design_skills/<key>/` | Shipped product skills |
+| `plugins/skills/<key>/` | Private / self-host extensions (Compose-mounted) |
+
+Do **not** put product skills in `.agents/skills/` — that tree is for Cursor/IDE coding agents only.
+
+## Canonical layout
 
 ```
-plugins/skills/my_pack/          # or apps/api/seeds/design_skills/my_pack/
-  _meta.json                     # required for plugins/ + .agents/
-  SKILL.md                       # craft rules (required body)
+my_poster_plugin/
+├── _meta.json        # required
+├── SKILL.md          # required
+├── schema.json       # optional — input / output JSON Schema
+├── handler.py        # optional — reserved (Phase B runner; not executed yet)
+├── assets/           # optional — logo / icon / previews
+└── examples/         # optional — reference art (not loaded by runtime)
 ```
 
-Optional later (not Phase A): `assets/`, examples — ignored by the loader today except logos referenced from `_meta`.
+Required today: `_meta.json` + `SKILL.md`.  
+Everything else is optional; missing files are fine.
 
-## `_meta.json` (product fields)
+## `_meta.json`
 
 | Field | Required | Notes |
 |-------|----------|--------|
-| `skill_key` / `id` / `name` | yes | Technical id; folder name used as fallback |
-| `when_to_use` | recommended | Catalog + routing hint |
-| `preferred_tools` | recommended | Live op allowlist for this skill |
-| `triggers` **or** `trigger_keywords` | recommended | When Decide auto-attaches the skill |
-| `version` | optional | e.g. `1.0.0` |
-| `enabled` | optional | `false` skips the pack |
-| `author` | optional | Metadata only |
-| `permissions` | optional | Docs / future ACL; does **not** replace `preferred_tools` |
-| `locales` | optional | `displayName` / `description` |
+| `skill_key` / `id` / `name` | yes | Technical id |
+| `when_to_use` | recommended | Catalog + routing |
+| `preferred_tools` | recommended | Live op allowlist |
+| `triggers` **or** `trigger_keywords` | recommended | Auto-attach |
+| `version` / `enabled` / `author` | optional | `enabled: false` skips pack |
+| `permissions` | optional | Docs only for now |
 
 ### `trigger_keywords` shortcut
 
-```json
-"trigger_keywords": ["中秋海报", "festival poster"]
-```
+Expands to a `create`/`edit` trigger with `prompt_includes_any` when `triggers` is absent.
 
-expands to:
+## `schema.json` (optional)
 
 ```json
-"triggers": [
-  {
-    "intent_in": ["create", "edit"],
-    "prompt_includes_any": ["中秋海报", "festival poster"]
-  }
-]
+{
+  "input": { "type": "object", "properties": { "...": {} }, "required": [] },
+  "output": { "type": "object", "allowed_ops": ["create_frame", "create_text"] }
+}
 ```
 
-Prefer full `triggers` when you need `empty_canvas`, `min_prompt_chars`, etc. (see existing seed packs).
+Aliases: `input_schema` / `output_schema`. Values merge into the skill row (meta fields win if both set). Used for validation hints / future runners — Phase A still relies on `preferred_tools` for live op gating.
 
-## `SKILL.md`
+## `handler.py` (optional, not run yet)
 
-Natural-language craft: when to use images vs vectors, hierarchy, honesty rules, related skills. Keep it actionable — the model reads this in `SKILL_DETAILS`.
+If present, the loader logs that it was found and continues. Phase B will allow a runner that **returns `tool_ops` only**. Until then, put craft in `SKILL.md`.
+
+See `plugins/skills/festival_poster/handler.py.example`.
+
+## `assets/` / `examples/`
+
+- `assets/logo.png` (or `icon.svg`) — picked up as pack logo when present  
+- `examples/` — human reference only
 
 ## Load / reload
 
 | Mode | Behavior |
 |------|----------|
-| Local API | Scans dirs on ensure; hot reload polls disk (default every 2s) |
-| Docker | Mount `./plugins/skills:/app/plugins/skills`; set `DESIGN_SKILLS_PLUGIN_DIRS` for extra paths |
-| Admin | Zip import still available (`POST /api/v1/design/skills/import`) |
+| Local API | Hot reload polls disk (default 2s) |
+| Docker | `./plugins/skills:/app/plugins/skills` |
+| Extra dirs | `DESIGN_SKILLS_PLUGIN_DIRS` |
+| Admin zip | Still available |
 
 Duplicate `skill_key`: **later root wins** (plugins override seeds).
 
 ## Sample
 
-See [`plugins/skills/festival_poster/`](../plugins/skills/festival_poster/) — chat: 「生成中秋红色海报」.
+[`plugins/skills/festival_poster/`](../plugins/skills/festival_poster/) — 「生成中秋红色海报」.
 
-## Out of scope (later)
+## Out of scope here
 
-- `handler.py` / Python canvas SDK  
-- Frontend toolbar plugins  
-- `.recombyn-plugin` installer / signature  
+- Frontend toolbar plugins (`manifest.json` + TypeScript) — separate Phase C  
+- Executing `handler.py` / sandboxes / `.recombyn-plugin` zip install — Phase B/D  
 
 → [ADR 0013](./adr/0013-skill-extensions.md)

--- a/docs/skill-extensions.md
+++ b/docs/skill-extensions.md
@@ -60,8 +60,10 @@ See `plugins/skills/festival_poster/handler.py.example`.
 
 ## `assets/` / `examples/`
 
-- `assets/logo.png` (or `icon.svg`) — picked up as pack logo when present  
+- **`assets/icon.svg`** (or `logo.png`) — picked up as pack logo and inlined as a `data:` URL for the Skills list / `/` picker  
 - `examples/` — human reference only
+
+Shipped seeds already include `assets/icon.svg`.
 
 ## Load / reload
 

--- a/docs/skill-extensions.md
+++ b/docs/skill-extensions.md
@@ -1,0 +1,72 @@
+# Skill extensions (authoring)
+
+Skill packs teach the Design Agent **how** to do a class of work. They are **not** executable plugins.
+
+## Pack layout
+
+```
+plugins/skills/my_pack/          # or apps/api/seeds/design_skills/my_pack/
+  _meta.json                     # required for plugins/ + .agents/
+  SKILL.md                       # craft rules (required body)
+```
+
+Optional later (not Phase A): `assets/`, examples — ignored by the loader today except logos referenced from `_meta`.
+
+## `_meta.json` (product fields)
+
+| Field | Required | Notes |
+|-------|----------|--------|
+| `skill_key` / `id` / `name` | yes | Technical id; folder name used as fallback |
+| `when_to_use` | recommended | Catalog + routing hint |
+| `preferred_tools` | recommended | Live op allowlist for this skill |
+| `triggers` **or** `trigger_keywords` | recommended | When Decide auto-attaches the skill |
+| `version` | optional | e.g. `1.0.0` |
+| `enabled` | optional | `false` skips the pack |
+| `author` | optional | Metadata only |
+| `permissions` | optional | Docs / future ACL; does **not** replace `preferred_tools` |
+| `locales` | optional | `displayName` / `description` |
+
+### `trigger_keywords` shortcut
+
+```json
+"trigger_keywords": ["中秋海报", "festival poster"]
+```
+
+expands to:
+
+```json
+"triggers": [
+  {
+    "intent_in": ["create", "edit"],
+    "prompt_includes_any": ["中秋海报", "festival poster"]
+  }
+]
+```
+
+Prefer full `triggers` when you need `empty_canvas`, `min_prompt_chars`, etc. (see existing seed packs).
+
+## `SKILL.md`
+
+Natural-language craft: when to use images vs vectors, hierarchy, honesty rules, related skills. Keep it actionable — the model reads this in `SKILL_DETAILS`.
+
+## Load / reload
+
+| Mode | Behavior |
+|------|----------|
+| Local API | Scans dirs on ensure; hot reload polls disk (default every 2s) |
+| Docker | Mount `./plugins/skills:/app/plugins/skills`; set `DESIGN_SKILLS_PLUGIN_DIRS` for extra paths |
+| Admin | Zip import still available (`POST /api/v1/design/skills/import`) |
+
+Duplicate `skill_key`: **later root wins** (plugins override seeds).
+
+## Sample
+
+See [`plugins/skills/festival_poster/`](../plugins/skills/festival_poster/) — chat: 「生成中秋红色海报」.
+
+## Out of scope (later)
+
+- `handler.py` / Python canvas SDK  
+- Frontend toolbar plugins  
+- `.recombyn-plugin` installer / signature  
+
+→ [ADR 0013](./adr/0013-skill-extensions.md)

--- a/plugins/skills/README.md
+++ b/plugins/skills/README.md
@@ -1,0 +1,27 @@
+# Skill plugins (`plugins/skills`)
+
+Private / self-host **Skill extension** packs (Phase A). Same format as `apps/api/seeds/design_skills/`: `_meta.json` + `SKILL.md`.
+
+Skills are **playbooks for the Design Agent** (triggers + preferred tools + craft text). They do **not** run `handler.py`. The agent still emits `tool_ops` through the existing canvas tool host.
+
+## Add a pack
+
+1. Create `plugins/skills/<key>/_meta.json` and `SKILL.md` (see [docs/skill-extensions.md](../docs/skill-extensions.md)).
+2. Restart API, or wait for hot reload (`DESIGN_SKILLS_HOT_RELOAD`, default on).
+3. Chat in the editor with a trigger phrase (e.g. sample pack: 「生成中秋红色海报」).
+
+## Docker
+
+Compose mounts this folder into the API container:
+
+```yaml
+# docker-compose.yml (api service)
+volumes:
+  - ./plugins/skills:/app/plugins/skills
+```
+
+Extra roots: `DESIGN_SKILLS_PLUGIN_DIRS=/other/path,/another` (comma-separated).
+
+## Sample
+
+`festival_poster/` — holiday poster playbook (plugin-style `_meta` aliases: `id`, `trigger_keywords`, `permissions`, `author`).

--- a/plugins/skills/README.md
+++ b/plugins/skills/README.md
@@ -1,27 +1,43 @@
 # Skill plugins (`plugins/skills`)
 
-Private / self-host **Skill extension** packs (Phase A). Same format as `apps/api/seeds/design_skills/`: `_meta.json` + `SKILL.md`.
+Private / self-host **Skill packs**. Same layout as shipped `apps/api/seeds/design_skills/`.
 
-Skills are **playbooks for the Design Agent** (triggers + preferred tools + craft text). They do **not** run `handler.py`. The agent still emits `tool_ops` through the existing canvas tool host.
+## Canonical pack layout
+
+```
+my_poster_plugin/
+├── _meta.json        # required — triggers, preferred_tools, id/version
+├── SKILL.md          # required — Agent craft rules
+├── schema.json       # optional — input / output JSON schema
+├── handler.py        # optional — ignored until Phase B (ops runner)
+├── assets/           # optional — logo/icon/preview (logo.png, icon.svg, …)
+└── examples/         # optional — reference images (docs only today)
+```
+
+Skills are **playbooks**: the Design Agent still emits `tool_ops`. There is no separate canvas Python SDK in Phase A.
+
+## Two product roots only
+
+| Root | Who |
+|------|-----|
+| `apps/api/seeds/design_skills/` | Shipped / first-party |
+| `plugins/skills/` | Private deploy mount |
+
+`.agents/skills/` is for Cursor/IDE agents only — **not** loaded by the Design Agent.
 
 ## Add a pack
 
-1. Create `plugins/skills/<key>/_meta.json` and `SKILL.md` (see [docs/skill-extensions.md](../docs/skill-extensions.md)).
-2. Restart API, or wait for hot reload (`DESIGN_SKILLS_HOT_RELOAD`, default on).
-3. Chat in the editor with a trigger phrase (e.g. sample pack: 「生成中秋红色海报」).
+1. Create the folder under `plugins/skills/<key>/` with at least `_meta.json` + `SKILL.md`.
+2. Restart API, or wait for hot reload.
+3. Chat with a trigger (sample: 「生成中秋红色海报」 → `festival_poster`).
 
 ## Docker
 
-Compose mounts this folder into the API container:
-
 ```yaml
-# docker-compose.yml (api service)
 volumes:
   - ./plugins/skills:/app/plugins/skills
 ```
 
-Extra roots: `DESIGN_SKILLS_PLUGIN_DIRS=/other/path,/another` (comma-separated).
+Extra roots: `DESIGN_SKILLS_PLUGIN_DIRS=...`
 
-## Sample
-
-`festival_poster/` — holiday poster playbook (plugin-style `_meta` aliases: `id`, `trigger_keywords`, `permissions`, `author`).
+See [docs/skill-extensions.md](../docs/skill-extensions.md).

--- a/plugins/skills/README.md
+++ b/plugins/skills/README.md
@@ -10,7 +10,7 @@ my_poster_plugin/
 ├── SKILL.md          # required — Agent craft rules
 ├── schema.json       # optional — input / output JSON schema
 ├── handler.py        # optional — ignored until Phase B (ops runner)
-├── assets/           # optional — logo/icon/preview (logo.png, icon.svg, …)
+├── assets/           # optional — icon.svg / logo (list + picker thumb)
 └── examples/         # optional — reference images (docs only today)
 ```
 

--- a/plugins/skills/festival_poster/SKILL.md
+++ b/plugins/skills/festival_poster/SKILL.md
@@ -1,0 +1,34 @@
+# Festival / holiday poster
+
+Craft for **节日海报** — Mid-Autumn, Spring Festival / New Year, National Day, Christmas, and branded celebration KV. Atmosphere + one memorable title; keep the board honest.
+
+## Design thinking
+
+| Ask | Aim |
+|-----|-----|
+| **Festival** | Which holiday / celebration? (user-named) |
+| **Tone** | Warm lantern night, crisp winter, festive red/gold, quiet moonlit, etc. — pick **one** |
+| **Memory point** | Hero mood **or** dominant festival title — not both fighting |
+| **Size** | Default portrait ~900×1200 unless the user specifies; roll-up uses tall hierarchy |
+| **Copy** | Festival name / greeting + ≤2 support lines |
+
+## Layout
+
+1. Create one artboard frame first (portrait unless asked otherwise).
+2. Background: theme color field and/or `create_image` hero via **`image_gen`** when the mood needs atmosphere (moon, lanterns, snowfall, fireworks) — not a pile of random shapes.
+3. Title cluster centered or on a quiet band; support text smaller, generous margins.
+4. Optional sparse vector accents (discs, bars) only if they reinforce the festival language.
+
+## Tools
+
+Prefer: `create_frame` → (`create_image` / `create_shape`) → `create_text` → `update_node` for alignment.
+
+Load **`image_gen`** when placing bitmaps. For generic (non-holiday) posters, prefer **`poster_craft`**.
+
+## Honesty
+
+Do not invent prices, phone numbers, QR codes, or third-party logos unless the user provides them.
+
+## Done when
+
+Far: festival tone + title readable in ~1s. Near: language matches the user; margins clean; no fake brand marks.

--- a/plugins/skills/festival_poster/_meta.json
+++ b/plugins/skills/festival_poster/_meta.json
@@ -1,0 +1,48 @@
+{
+  "id": "festival_poster",
+  "skill_key": "festival_poster",
+  "name": "festival_poster",
+  "displayName": "Festival poster",
+  "description": "Holiday / festival poster playbook: theme color, hero mood, title hierarchy",
+  "when_to_use": "Festival or holiday posters — Mid-Autumn, New Year, Spring Festival, Christmas, National Day, branded celebration KV",
+  "author": "recombyn",
+  "category": "deliverable",
+  "version": "1.0.0",
+  "enabled": true,
+  "scenes": "all",
+  "sort_weight": 76,
+  "preferred_tools": [
+    "create_frame",
+    "create_image",
+    "create_text",
+    "create_shape",
+    "update_node"
+  ],
+  "allowed_resources": ["tools"],
+  "permissions": ["读取画布图层", "新建画布帧", "调用LLM生成图文"],
+  "trigger_keywords": [
+    "中秋海报",
+    "中秋",
+    "新年海报",
+    "春节海报",
+    "国庆海报",
+    "圣诞海报",
+    "节日海报",
+    "festival poster",
+    "holiday poster",
+    "new year poster",
+    "mid-autumn"
+  ],
+  "mutex_group": "",
+  "prompt_negative": "Unless the user provides them, avoid inventing board facts such as prices, phones, QR codes, or real brand logos. Prefer overlay text over baking titles into the background. Prefer poster_craft for generic non-holiday posters.",
+  "locales": {
+    "zh-CN": {
+      "displayName": "节日海报",
+      "description": "节日主题海报：主题色、氛围图、标题层级"
+    },
+    "en": {
+      "displayName": "Festival poster",
+      "description": "Holiday posters: theme color, mood, title hierarchy"
+    }
+  }
+}

--- a/plugins/skills/festival_poster/assets/icon.svg
+++ b/plugins/skills/festival_poster/assets/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#7A1F2B"/>
+  <circle cx="38" cy="22" r="9" fill="#F5D76E"/>
+    <circle cx="34" cy="22" r="9" fill="#7A1F2B"/>
+    <path d="M18 44c6-10 22-10 28 0" fill="none" stroke="#fff" stroke-width="2.2" stroke-linecap="round"/>
+    <path d="M32 34v12" stroke="#F5D76E" stroke-width="2.2" stroke-linecap="round"/>
+</svg>

--- a/plugins/skills/festival_poster/handler.py.example
+++ b/plugins/skills/festival_poster/handler.py.example
@@ -1,0 +1,11 @@
+# Reserved — Skill ops runner (Phase B)
+
+# This file is NOT executed yet. Packs may include `handler.py` for forward
+# compatibility; the loader only logs that it was found.
+#
+# Future contract (tentative):
+#   def run(ctx, payload: dict) -> list[dict]:
+#       """Return tool_ops only — never mutate Redis/DB/canvas directly."""
+#       ...
+#
+# Until Phase B ships, craft lives entirely in SKILL.md + preferred_tools.

--- a/plugins/skills/festival_poster/schema.json
+++ b/plugins/skills/festival_poster/schema.json
@@ -1,0 +1,22 @@
+{
+  "input": {
+    "type": "object",
+    "properties": {
+      "festival": { "type": "string", "description": "Holiday name, e.g. Mid-Autumn" },
+      "color_theme": { "type": "string", "description": "Primary mood color or palette hint" },
+      "width": { "type": "number" },
+      "height": { "type": "number" }
+    },
+    "required": ["festival"]
+  },
+  "output": {
+    "type": "object",
+    "allowed_ops": [
+      "create_frame",
+      "create_image",
+      "create_text",
+      "create_shape",
+      "update_node"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Mountable Skill packs under `plugins/skills` (+ `DESIGN_SKILLS_PLUGIN_DIRS`)
- Meta aliases: `id`, `trigger_keywords`, `enabled`, `author` / `permissions`
- Sample `festival_poster` + ADR 0013 / authoring docs

## Test plan
- [x] `node scripts/run-api-tests.mjs tests/unit_tests/test_skill_store.py -q`
- [ ] Chat in editor: 「生成中秋红色海报」 attaches `festival_poster` (API + optional worker/hot reload)
