### PR TITLE
feat: Canvas plugins Phase B (toolbar registry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ for tagged releases (`vMAJOR.MINOR.PATCH`).
 - Async **chat image** jobs (`POST/GET /api/v1/chat/image/jobs`) so editor generate does not hold API workers
 - Design Agent hydrate **progress** on the existing SSE (`activity` + `task_id`)
 - Skill **extensions** Phase A: two roots (`seeds/design_skills` + `plugins/skills`), canonical pack layout (`schema.json` / `assets/` / reserved `handler.py`), meta aliases, sample `festival_poster` (ADR 0013)
+- Canvas **plugins** Phase B: `plugins/canvas` host + toolbar registry + sample `watermark` (ADR 0014)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ User-facing help **source** is private; CI publishes only the built static site 
 | User docs | [recombyn.github.io/recombyn](https://recombyn.github.io/recombyn/) |
 | Self-host / architecture | [docs/self-hosting.md](docs/self-hosting.md) |
 | Skill extensions | [docs/skill-extensions.md](docs/skill-extensions.md) |
+| Canvas plugins | [docs/canvas-plugins.md](docs/canvas-plugins.md) |
 | AgentProfile / sub-agents | [docs/agent-profile.md](docs/agent-profile.md) |
 | Canvas (RCB / SVG / Path2D / LOD) | [docs/canvas-architecture.md](docs/canvas-architecture.md) |
 | Web data layer (Query / oRPC / nuqs) | [docs/web-frontend.md](docs/web-frontend.md) |

--- a/apps/web/src/components/editor/chrome/EditorToolStrip.tsx
+++ b/apps/web/src/components/editor/chrome/EditorToolStrip.tsx
@@ -43,6 +43,12 @@ import {
   failImageProcess,
 } from '@/store/modules/editor';
 import {
+  ensureCanvasPlugins,
+  listCanvasToolbarButtons,
+  buildCanvasPluginRuntime,
+  type CanvasToolbarButton,
+} from '@/plugins/canvas/host';
+import {
   fitImageSize,
   measureImageNaturalSize,
   prepareVideoUploadPreview
@@ -319,7 +325,21 @@ function EditorToolStrip({
   const imageInputRef = useRef<HTMLInputElement>(null);
   const videoInputRef = useRef<HTMLInputElement>(null);
   const [openMenu, setOpenMenu] = useState<string | null>(null);
+  const [pluginButtons, setPluginButtons] = useState<CanvasToolbarButton[]>([]);
   const toolsLocked = Boolean(selectOnly);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadPlugins() {
+      await ensureCanvasPlugins();
+      if (cancelled) return;
+      setPluginButtons(listCanvasToolbarButtons());
+    }
+    void loadPlugins();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!toolsLocked) return;
@@ -837,6 +857,31 @@ function EditorToolStrip({
           <LuImagePlus className={TOOL_ICON_CLASS} strokeWidth={STROKE} />
         </ToolIcon>
       </ToolBtn>
+
+      {pluginButtons.map((btn) => (
+        <ToolBtn
+          key={btn.id}
+          tip={btn.tip}
+          disabled={toolsLocked}
+          onClick={() => {
+            const runtime = buildCanvasPluginRuntime(dispatch as any, () => store.getState(), {
+              camera,
+              stageEl,
+            });
+            btn.onClick(runtime);
+          }}
+        >
+          <ToolIcon>
+            {btn.icon ? (
+              btn.icon
+            ) : btn.iconSrc ? (
+              <img src={btn.iconSrc} alt="" className={TOOL_ICON_CLASS} />
+            ) : (
+              <LuHexagon className={TOOL_ICON_CLASS} strokeWidth={STROKE} />
+            )}
+          </ToolIcon>
+        </ToolBtn>
+      ))}
 
       <input
         ref={imageInputRef}

--- a/apps/web/src/plugins/canvas/host.test.ts
+++ b/apps/web/src/plugins/canvas/host.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  __resetCanvasPluginsForTests,
+  installCanvasPlugin,
+  listCanvasToolbarButtons,
+  type CanvasPluginModule,
+} from '@/plugins/canvas/host';
+
+describe('canvas plugin host', () => {
+  beforeEach(() => {
+    __resetCanvasPluginsForTests();
+  });
+
+  it('registers toolbar buttons from a pack', () => {
+    const pack: CanvasPluginModule = {
+      manifest: { id: 'demo', name: 'Demo', enabled: true },
+      register(api) {
+        api.registerToolbarButton({
+          id: 'demo.btn',
+          tip: 'Demo tip',
+          order: 10,
+          onClick() {},
+        });
+      },
+    };
+    installCanvasPlugin(pack);
+    const buttons = listCanvasToolbarButtons();
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]?.id).toBe('demo.btn');
+    expect(buttons[0]?.pluginId).toBe('demo');
+    expect(buttons[0]?.tip).toBe('Demo tip');
+  });
+
+  it('skips disabled packs and duplicate installs', () => {
+    const pack: CanvasPluginModule = {
+      manifest: { id: 'off', name: 'Off', enabled: false },
+      register(api) {
+        api.registerToolbarButton({ id: 'off.btn', tip: 'x', onClick() {} });
+      },
+    };
+    installCanvasPlugin(pack);
+    expect(listCanvasToolbarButtons()).toHaveLength(0);
+
+    const on: CanvasPluginModule = {
+      manifest: { id: 'once', name: 'Once' },
+      register(api) {
+        api.registerToolbarButton({ id: 'once.btn', tip: 'y', onClick() {} });
+      },
+    };
+    installCanvasPlugin(on);
+    installCanvasPlugin(on);
+    expect(listCanvasToolbarButtons()).toHaveLength(1);
+  });
+});

--- a/apps/web/src/plugins/canvas/host.ts
+++ b/apps/web/src/plugins/canvas/host.ts
@@ -1,0 +1,182 @@
+/**
+ * Canvas plugin host (Phase B) — in-process toolbar / future export hooks.
+ *
+ * Packs live under ``plugins/canvas/<id>/`` and register at boot via
+ * ``ensureCanvasPlugins()``. No browser sandbox yet — plugins share the editor
+ * bundle (same trust as first-party UI code).
+ */
+import type { ReactNode } from 'react';
+import type { AppDispatch, RootState } from '@/store';
+import { spawnCreatedNode } from '@/store/modules/editor';
+import { createTextNode } from '@/components/rcb/scene/document/nodeFactories';
+import {
+  rcbScreenToScene,
+  type RcbCamera,
+} from '@/components/rcb';
+import type { SceneDocument } from '@/components/rcb/sceneNode';
+import { sceneToDocumentCoords } from '@/components/rcb/scene/paint/svgToScene';
+
+export type CanvasPluginManifest = {
+  id: string;
+  name: string;
+  version?: string;
+  author?: string;
+  enabled?: boolean;
+  mounts?: string[];
+  permissions?: string[];
+};
+
+export type CanvasPluginRuntime = {
+  dispatch: AppDispatch;
+  getState: () => RootState;
+  /** Place a text node near the stage center (document coords). */
+  placeText: (opts: {
+    text: string;
+    x?: number;
+    y?: number;
+    fontSize?: number;
+    opacity?: number;
+  }) => void;
+  /** Document-space point under the viewport center (fallback mid-board). */
+  viewportCenterDoc: () => { x: number; y: number };
+};
+
+export type CanvasToolbarButton = {
+  id: string;
+  pluginId: string;
+  tip: string;
+  order: number;
+  iconSrc?: string;
+  icon?: ReactNode;
+  onClick: (runtime: CanvasPluginRuntime) => void;
+};
+
+export type CanvasPluginApi = {
+  registerToolbarButton: (
+    btn: Omit<CanvasToolbarButton, 'pluginId'> & { pluginId?: string }
+  ) => void;
+};
+
+export type CanvasPluginModule = {
+  manifest: CanvasPluginManifest;
+  register: (api: CanvasPluginApi) => void;
+};
+
+const toolbarButtons = new Map<string, CanvasToolbarButton>();
+const installed = new Set<string>();
+let bootstrapped = false;
+
+/** Test helper — clear registry between unit cases. */
+export function __resetCanvasPluginsForTests(): void {
+  toolbarButtons.clear();
+  installed.clear();
+  bootstrapped = false;
+}
+
+export function listCanvasToolbarButtons(): CanvasToolbarButton[] {
+  return [...toolbarButtons.values()].sort(
+    (a, b) => a.order - b.order || a.id.localeCompare(b.id)
+  );
+}
+
+export function installCanvasPlugin(mod: CanvasPluginModule): void {
+  const manifest = mod?.manifest;
+  const id = String(manifest?.id || '').trim();
+  if (!id || !mod?.register) return;
+  if (manifest?.enabled === false) return;
+  if (installed.has(id)) return;
+  installed.add(id);
+  const api: CanvasPluginApi = {
+    registerToolbarButton(btn) {
+      const bid = String(btn.id || '').trim();
+      if (!bid) return;
+      toolbarButtons.set(bid, {
+        id: bid,
+        pluginId: String(btn.pluginId || id),
+        tip: String(btn.tip || manifest?.name || bid),
+        order: Number.isFinite(btn.order) ? Number(btn.order) : 100,
+        iconSrc: btn.iconSrc,
+        icon: btn.icon,
+        onClick: btn.onClick,
+      });
+    },
+  };
+  try {
+    mod.register(api);
+  } catch (err) {
+    console.warn(`[canvas-plugin] ${id} register failed`, err);
+  }
+}
+
+function readViewportCenterDoc(
+  state: RootState,
+  camera?: RcbCamera | null,
+  stageEl?: HTMLElement | null
+): { x: number; y: number } {
+  const doc = state.editor?.document as SceneDocument | null | undefined;
+  if (!doc) return { x: 40, y: 40 };
+  if (camera && stageEl) {
+    const view = stageEl.getBoundingClientRect();
+    if (view.width > 0 && view.height > 0) {
+      const scene = rcbScreenToScene(
+        camera,
+        stageEl,
+        view.left + view.width / 2,
+        view.top + view.height / 2
+      );
+      return sceneToDocumentCoords(doc, scene.x, scene.y);
+    }
+  }
+  const w = Number(doc.width) || 800;
+  const h = Number(doc.height) || 600;
+  return { x: Math.max(40, w * 0.5 - 80), y: Math.max(40, h * 0.5 - 20) };
+}
+
+export function buildCanvasPluginRuntime(
+  dispatch: AppDispatch,
+  getState: () => RootState,
+  opts?: { camera?: RcbCamera | null; stageEl?: HTMLElement | null }
+): CanvasPluginRuntime {
+  const camera = opts?.camera;
+  const stageEl = opts?.stageEl;
+  return {
+    dispatch,
+    getState,
+    viewportCenterDoc: () => readViewportCenterDoc(getState(), camera, stageEl),
+    placeText(textOpts) {
+      const text = String(textOpts.text || '').trim();
+      if (!text) return;
+      const center = readViewportCenterDoc(getState(), camera, stageEl);
+      const x = textOpts.x ?? center.x;
+      const y = textOpts.y ?? center.y;
+      const { id, node } = createTextNode({
+        x,
+        y,
+        text,
+        fontSize: textOpts.fontSize ?? 28,
+        autoSize: true,
+      });
+      const opacity = textOpts.opacity;
+      if (opacity != null && Number.isFinite(opacity)) {
+        (node.attrs as Record<string, unknown>).opacity = String(
+          Math.min(1, Math.max(0.05, Number(opacity)))
+        );
+      }
+      dispatch(spawnCreatedNode({ id, node }));
+    },
+  };
+}
+
+/** Idempotent — import built-in packs once. */
+export async function ensureCanvasPlugins(): Promise<void> {
+  if (bootstrapped) return;
+  bootstrapped = true;
+  try {
+    const mod = await import('@canvas-plugins/watermark');
+    const pack =
+      (mod as { default?: CanvasPluginModule }).default || (mod as CanvasPluginModule);
+    if (pack?.manifest) installCanvasPlugin(pack);
+  } catch (err) {
+    console.warn('[canvas-plugin] builtin watermark failed to load', err);
+  }
+}

--- a/apps/web/src/plugins/canvas/host.ts
+++ b/apps/web/src/plugins/canvas/host.ts
@@ -45,7 +45,7 @@ export type CanvasToolbarButton = {
   id: string;
   pluginId: string;
   tip: string;
-  order: number;
+  order?: number;
   iconSrc?: string;
   icon?: ReactNode;
   onClick: (runtime: CanvasPluginRuntime) => void;
@@ -75,7 +75,7 @@ export function __resetCanvasPluginsForTests(): void {
 
 export function listCanvasToolbarButtons(): CanvasToolbarButton[] {
   return [...toolbarButtons.values()].sort(
-    (a, b) => a.order - b.order || a.id.localeCompare(b.id)
+    (a, b) => (a.order ?? 100) - (b.order ?? 100) || a.id.localeCompare(b.id)
   );
 }
 
@@ -173,8 +173,9 @@ export async function ensureCanvasPlugins(): Promise<void> {
   bootstrapped = true;
   try {
     const mod = await import('@canvas-plugins/watermark');
-    const pack =
-      (mod as { default?: CanvasPluginModule }).default || (mod as CanvasPluginModule);
+    const pack = (mod as { default?: unknown }).default as
+      | CanvasPluginModule
+      | undefined;
     if (pack?.manifest) installCanvasPlugin(pack);
   } catch (err) {
     console.warn('[canvas-plugin] builtin watermark failed to load', err);

--- a/apps/web/src/store/modules/editor.ts
+++ b/apps/web/src/store/modules/editor.ts
@@ -1394,6 +1394,25 @@ const editorSlice = createSlice({
       state.activeTool = 'select';
     },
     /**
+     * Insert a pre-built scene node (canvas plugins / host helpers).
+     * Payload must already include a stable ``id`` matching ``node.id``.
+     */
+    spawnCreatedNode(state, action) {
+      if (!state.document) return;
+      const id = String(action.payload?.id || '').trim();
+      const node = action.payload?.node;
+      if (!id || !node || typeof node !== 'object') return;
+      pushHistory(state);
+      const next = { ...node, id };
+      state.document = addNodeToDocument(state.document, id, next);
+      state.dirty = true;
+      state.sceneReloadToken += 1;
+      state.selectedNodeId = id;
+      state.selectedNodeIds = [id];
+      state.pendingImageSrc = null;
+      state.activeTool = 'select';
+    },
+    /**
      * Place a library / AI asset onto the canvas (image | video | audio | lottie).
      * Used by the Assets dock — source URL already hosted.
      */
@@ -1999,6 +2018,7 @@ export const {
   spawnAudioGenerator,
   spawnLottie,
   spawnAudio,
+  spawnCreatedNode,
   placeMediaAsset,
   finishImageGenerator,
   finishVideoGenerator,

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,8 +2,9 @@
   "extends": "@repo/tsconfig/react-web.json",
   "compilerOptions": {
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@canvas-plugins/*": ["../../plugins/canvas/*"]
     }
   },
-  "include": ["src", "vite.config.ts", "vitest.config.ts"]
+  "include": ["src", "../../plugins/canvas", "vite.config.ts", "vitest.config.ts"]
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -83,6 +83,7 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         '@': path.resolve(__dirname, 'src'),
+        '@canvas-plugins': path.resolve(__dirname, '../../plugins/canvas'),
       },
       // Prefer TS sources — leftover/cached `.js` URLs must not 404 after sibling emits were removed.
       extensions: ['.mjs', '.mts', '.ts', '.tsx', '.jsx', '.js', '.json'],

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -26,9 +26,13 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
+      '@canvas-plugins': path.resolve(__dirname, '../../plugins/canvas'),
     },
   },
   define: {
     __GOOGLE_CLIENT_ID__: JSON.stringify(''),
+    __DOCS_URL__: JSON.stringify(''),
+    __DESKTOP_MODE__: JSON.stringify(''),
+    __API_BASE_URL__: JSON.stringify(''),
   },
 });

--- a/docs/adr/0014-canvas-plugins.md
+++ b/docs/adr/0014-canvas-plugins.md
@@ -1,0 +1,41 @@
+# Extensibility — Canvas plugins (Phase B)
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+After Skill playbooks (ADR 0013), the second extension surface is **canvas-native UI**: toolbar buttons, later export formats / selection chrome. Authors described packs as `manifest.json` + TypeScript entry (e.g. watermark).
+
+## Decision
+
+1. **Phase B = in-process canvas plugins.** Packs under `plugins/canvas/<id>/` register with a small host API (`registerToolbarButton`, …). They run in the editor bundle — **not** a browser sandbox yet.
+2. **Host** lives in `apps/web/src/plugins/canvas/host.ts`; the bottom tool strip renders registered buttons after `ensureCanvasPlugins()`.
+3. **Scene writes** go through existing Redux helpers (`spawnCreatedNode`, `placeText` on the runtime) — plugins must not invent a second document writer.
+4. **Sample:** `plugins/canvas/watermark` — toolbar inserts translucent text.
+5. **Out of scope here:** sandboxed iframes, remote CDN plugins, Python `handler.py` runners (Skill Phase next), `.recombyn-plugin` zip install.
+
+## Consequences
+
+### Positive
+
+- Same mount story as Skills (`plugins/…` at repo root).
+- Toolbar extensions without editing `EditorToolStrip` for every private button.
+- Clear split: Skills = Agent craft; Canvas plugins = editor UI/tools.
+
+### Negative / trade-offs
+
+- Trust model = first-party code until a sandbox lands.
+- New packs must be wired into `ensureCanvasPlugins()` (static import) until a zip installer exists.
+
+## Alternatives considered
+
+1. **Only Skill `handler.py` next** — deferred; canvas UI was the second half of the author’s two-system design.
+2. **iframe sandbox first** — too heavy for the first mount point.
+
+## References
+
+- [docs/canvas-plugins.md](../canvas-plugins.md)
+- `plugins/canvas/README.md`
+- `apps/web/src/plugins/canvas/host.ts`
+- [ADR 0013](./0013-skill-extensions.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,3 +33,4 @@ Cross-cutting or irreversible technical choices live here. Product feature notes
 | [0011](./0011-opentelemetry-optional.md) | Optional OpenTelemetry SDK | Accepted |
 | [0012](./0012-k8s-starter-manifests.md) | Optional Kubernetes starter manifests | Accepted |
 | [0013](./0013-skill-extensions.md) | Skill extension packs (Phase A plugins) | Accepted |
+| [0014](./0014-canvas-plugins.md) | Canvas toolbar plugins (Phase B) | Accepted |

--- a/docs/canvas-plugins.md
+++ b/docs/canvas-plugins.md
@@ -1,0 +1,57 @@
+# Canvas plugins (authoring)
+
+Canvas plugins extend the **editor UI** (toolbar today). They are separate from AI Skill packs (`plugins/skills/`).
+
+## Layout
+
+```
+plugins/canvas/my_tool/
+├── manifest.json
+├── icon.svg
+└── index.ts          # default export: { manifest, register(api) }
+```
+
+## `manifest.json`
+
+| Field | Required | Notes |
+|-------|----------|--------|
+| `id` | yes | Stable pack id |
+| `name` | yes | Display / fallback tip |
+| `version` | optional | Semver string |
+| `enabled` | optional | `false` skips install |
+| `mounts` | optional | e.g. `["toolbar"]` (docs; host uses what you register) |
+| `permissions` | optional | Docs / future ACL (`insert_nodes`, …) |
+
+## `register(api)`
+
+```ts
+api.registerToolbarButton({
+  id: 'my_tool.action',
+  tip: 'Do the thing',
+  order: 200,
+  iconSrc: iconUrl,
+  onClick(runtime) {
+    runtime.placeText({ text: 'Hello', opacity: 0.4 });
+  },
+});
+```
+
+Runtime helpers: `placeText`, `viewportCenterDoc`, `dispatch`, `getState`.
+
+## Load path
+
+1. Add the folder under `plugins/canvas/`.
+2. Import it from `ensureCanvasPlugins()` in `apps/web/src/plugins/canvas/host.ts` (static list for now).
+3. Restart / refresh the web app.
+
+Vite alias: `@canvas-plugins/*` → `plugins/canvas/*`.
+
+## Sample
+
+[`plugins/canvas/watermark`](../plugins/canvas/watermark/) — bottom strip button → translucent `© Watermark`.
+
+## Later
+
+Export format registry, selection chrome hooks, sandboxed loaders, zip install.
+
+→ [ADR 0014](./adr/0014-canvas-plugins.md) · Skills: [skill-extensions.md](./skill-extensions.md)

--- a/docs/roadmap/platform.md
+++ b/docs/roadmap/platform.md
@@ -40,6 +40,7 @@ One FastAPI app with domain modules, plus the collab WebSocket process:
 | 异步任务 | Celery worker sharing the API codebase (hydrate / export / image) |
 | 协同 | `apps/collab` WebSocket process |
 | 扩展（Skill） | File packs: `seeds/design_skills` + `plugins/skills` ([ADR 0013](../adr/0013-skill-extensions.md)) |
+| 扩展（Canvas） | Toolbar plugins: `plugins/canvas` ([ADR 0014](../adr/0014-canvas-plugins.md)) |
 
 → See [ADR 0004](../adr/0004-modular-monolith-first.md).
 
@@ -170,6 +171,6 @@ One FastAPI app with domain modules, plus the collab WebSocket process:
 ### Phase 7 — Extensibility (plugins)
 
 - [x] Skill playbook packs + private mount (`plugins/skills`) — ADR 0013
-- [ ] Canvas toolbar / exporter registry (TS SDK, in-process)
+- [x] Canvas toolbar registry (TS, in-process) + sample watermark — ADR 0014
 - [ ] Optional skill ops runner (return `tool_ops` only)
 - [ ] Packaged install (`.recombyn-plugin` zip) + permissions / signatures

--- a/docs/skill-extensions.md
+++ b/docs/skill-extensions.md
@@ -82,7 +82,7 @@ Duplicate `skill_key`: **later root wins** (plugins override seeds).
 
 ## Out of scope here
 
-- Frontend toolbar plugins (`manifest.json` + TypeScript) — separate Phase C  
-- Executing `handler.py` / sandboxes / `.recombyn-plugin` zip install — Phase B/D  
+- Frontend toolbar plugins (`manifest.json` + TypeScript) — [canvas-plugins.md](./canvas-plugins.md) (Phase B)
+- Executing `handler.py` / sandboxes / `.recombyn-plugin` zip install — Phase C/D
 
 → [ADR 0013](./adr/0013-skill-extensions.md)

--- a/plugins/canvas/README.md
+++ b/plugins/canvas/README.md
@@ -1,0 +1,28 @@
+# Canvas plugins (`plugins/canvas`)
+
+Frontend **canvas runtime** packs (Phase B). Distinct from AI Skill packs under `plugins/skills/`.
+
+## Layout
+
+```
+my_toolbar_plugin/
+├── manifest.json   # id / name / mounts / permissions
+├── icon.svg        # toolbar thumb
+└── index.ts        # register(api) — toolbar / future export hooks
+```
+
+## What works today
+
+| Mount | Status |
+|-------|--------|
+| `toolbar` | Bottom tool strip extra buttons |
+| Export formats / selection chrome | Later |
+| Browser sandbox | Later (plugins run in-process today) |
+
+## Sample
+
+`watermark/` — toolbar button inserts translucent `© Watermark` text.
+
+Shipped packs are imported by `apps/web/src/plugins/canvas/host.ts` at editor boot. Self-host: add a pack folder and register it in `ensureCanvasPlugins()`.
+
+See [docs/canvas-plugins.md](../../docs/canvas-plugins.md).

--- a/plugins/canvas/watermark/icon.svg
+++ b/plugins/canvas/watermark/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <path d="M24 0H40C58 0 64 6 64 24V40C64 58 58 64 40 64H24C6 64 0 58 0 40V24C0 6 6 0 24 0Z" fill="#1F2937"/>
+  <path d="M20 40l8-22h8l8 22" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M24 32h16" stroke="#93C5FD" stroke-width="2.2" stroke-linecap="round"/>
+  <circle cx="44" cy="18" r="6" fill="none" stroke="#93C5FD" stroke-width="2"/>
+  <path d="M44 15.5v5M41.5 18h5" stroke="#93C5FD" stroke-width="1.6" stroke-linecap="round"/>
+</svg>

--- a/plugins/canvas/watermark/index.ts
+++ b/plugins/canvas/watermark/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Sample canvas plugin — inserts a translucent text watermark at viewport center.
+ */
+import type { CanvasPluginModule } from '@/plugins/canvas/host';
+import manifestJson from './manifest.json';
+import iconUrl from './icon.svg';
+
+const manifest = manifestJson as CanvasPluginModule['manifest'];
+
+function tipForLocale(): string {
+  const lang =
+    typeof navigator !== 'undefined' ? String(navigator.language || '').toLowerCase() : 'en';
+  const locales = (manifestJson as { locales?: Record<string, { tip?: string }> }).locales || {};
+  if (lang.startsWith('zh')) return locales['zh-CN']?.tip || '插入半透明水印文字';
+  return locales.en?.tip || 'Insert a translucent watermark';
+}
+
+const watermarkPlugin: CanvasPluginModule = {
+  manifest,
+  register(api) {
+    api.registerToolbarButton({
+      id: 'canvas-watermark.insert',
+      tip: tipForLocale(),
+      order: 220,
+      iconSrc: iconUrl,
+      onClick(runtime) {
+        const state = runtime.getState();
+        if (!state.editor?.document) return;
+        runtime.placeText({
+          text: '© Watermark',
+          fontSize: 36,
+          opacity: 0.35,
+        });
+      },
+    });
+  },
+};
+
+export default watermarkPlugin;

--- a/plugins/canvas/watermark/manifest.json
+++ b/plugins/canvas/watermark/manifest.json
@@ -1,0 +1,13 @@
+{
+  "id": "canvas-watermark",
+  "name": "Watermark",
+  "version": "1.0.0",
+  "author": "recombyn",
+  "enabled": true,
+  "mounts": ["toolbar"],
+  "permissions": ["insert_nodes"],
+  "locales": {
+    "zh-CN": { "name": "水印", "tip": "插入半透明水印文字" },
+    "en": { "name": "Watermark", "tip": "Insert a translucent watermark" }
+  }
+}


### PR DESCRIPTION
## Summary
- In-process canvas plugin host (`registerToolbarButton`) under `plugins/canvas`
- Sample `watermark` pack wired into the bottom tool strip
- ADR 0014 + authoring docs; `spawnCreatedNode` for plugin inserts

## Test plan
- [x] `npx vitest run src/plugins/canvas/host.test.ts`
- [ ] Editor: open a board, click watermark tool → translucent © Watermark text appears
