### PR TITLE
feat: Skill ops runner Phase C (handler.py → tool_ops)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ for tagged releases (`vMAJOR.MINOR.PATCH`).
 - Design Agent hydrate **progress** on the existing SSE (`activity` + `task_id`)
 - Skill **extensions** Phase A: two roots (`seeds/design_skills` + `plugins/skills`), canonical pack layout (`schema.json` / `assets/` / reserved `handler.py`), meta aliases, sample `festival_poster` (ADR 0013)
 - Canvas **plugins** Phase B: `plugins/canvas` host + toolbar registry + sample `watermark` (ADR 0014)
+- Skill **ops runner** Phase C: opt-in `handler.py` → `tool_ops` before LLM paint (subprocess + validate), sample `festival_poster` (ADR 0015)
 
 ### Changed
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -52,6 +52,9 @@ S3_ENABLED=false
 # DESIGN_SKILLS_HOT_RELOAD_INTERVAL_SEC=2
 # Extra skill pack dirs (comma-separated). Default also scans <repo>/plugins/skills.
 # DESIGN_SKILLS_PLUGIN_DIRS=
+# Opt-in: run pack handler.py → tool_ops before LLM paint (subprocess).
+# DESIGN_SKILL_OPS_RUNNER=false
+# DESIGN_SKILL_OPS_RUNNER_TIMEOUT_SEC=8
 # Design Agent Profile + graph / quality gate (see docs/agent-profile.md)
 # AGENT_PROFILE_ID=design.canvas
 # DESIGN_CRITIQUE_ENABLED=true

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -204,6 +204,9 @@ class Settings(BaseSettings):
     # Extra skill pack roots (comma-separated). Always also scans <repo>/plugins/skills when present.
     # Self-host: mount host ./plugins/skills → container /app/plugins/skills.
     design_skills_plugin_dirs: str = ""
+    # Opt-in: run pack handler.py → tool_ops before LLM paint (subprocess, validated).
+    design_skill_ops_runner: bool = False
+    design_skill_ops_runner_timeout_sec: float = 8.0
 
     # Active AgentProfile id (seeds/agents/profiles/{id}.yaml). Empty → bindings.default.
     agent_profile_id: str = "design.canvas"

--- a/apps/api/app/services/design/prompts/skill_store/ops_runner.py
+++ b/apps/api/app/services/design/prompts/skill_store/ops_runner.py
@@ -1,0 +1,220 @@
+"""Optional skill ``handler.py`` runner — returns tool_ops only (Phase C).
+
+Opt-in via ``DESIGN_SKILL_OPS_RUNNER=true``. Handlers must export::
+
+    def run(ctx: dict, payload: dict) -> list[dict]:
+        ...
+
+Execution is a short-lived subprocess (JSON in/out) so a bad handler cannot
+take down the API process. Results always pass through the normal paint
+``validate_ops`` gate (preferred_tools / contract).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_BOOTSTRAP = r'''
+import importlib.util
+import json
+import sys
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        msg = json.loads(raw or "{}")
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": f"bad_input:{exc}"}))
+        return 2
+    path = str(msg.get("handler") or "").strip()
+    ctx = msg.get("ctx") if isinstance(msg.get("ctx"), dict) else {}
+    payload = msg.get("payload") if isinstance(msg.get("payload"), dict) else {}
+    if not path:
+        print(json.dumps({"ok": False, "error": "handler_missing"}))
+        return 2
+    try:
+        spec = importlib.util.spec_from_file_location("skill_ops_handler", path)
+        if spec is None or spec.loader is None:
+            print(json.dumps({"ok": False, "error": "handler_spec"}))
+            return 2
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        run = getattr(mod, "run", None)
+        if not callable(run):
+            print(json.dumps({"ok": False, "error": "run_missing"}))
+            return 2
+        out = run(ctx, payload)
+        if not isinstance(out, list):
+            print(json.dumps({"ok": False, "error": "ops_not_list"}))
+            return 2
+        ops = [x for x in out if isinstance(x, dict)]
+        print(json.dumps({"ok": True, "ops": ops}, ensure_ascii=False))
+        return 0
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": f"handler_exc:{type(exc).__name__}:{exc}"}))
+        return 1
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+def _runner_enabled() -> bool:
+    from app.core.config import settings
+
+    return bool(getattr(settings, "design_skill_ops_runner", False))
+
+
+def _runner_timeout_sec() -> float:
+    from app.core.config import settings
+
+    raw = getattr(settings, "design_skill_ops_runner_timeout_sec", 8.0)
+    try:
+        return max(1.0, float(raw or 8.0))
+    except (TypeError, ValueError):
+        return 8.0
+
+
+def resolve_skill_handler_path(skill_key: str) -> Path | None:
+    """Locate ``handler.py`` for a loaded skill under known pack roots."""
+    from .pack_io import _file_skills_dirs
+
+    key = str(skill_key or "").strip().lower()
+    if not key:
+        return None
+    # Bare key or last segment of namespace.qualified
+    local = key.split(".")[-1] if "." in key else key
+    for root in _file_skills_dirs():
+        for folder in (local, key):
+            pack = root / folder
+            handler = pack / "handler.py"
+            if handler.is_file():
+                try:
+                    # Stay inside the pack root.
+                    handler.resolve().relative_to(pack.resolve())
+                except Exception:
+                    continue
+                return handler
+    return None
+
+
+def find_handler_for_skills(skill_keys: list[str] | tuple[str, ...] | None) -> tuple[str, Path] | None:
+    """Return ``(skill_key, handler_path)`` for the first loaded skill with a handler."""
+    for raw in skill_keys or []:
+        key = str(raw or "").strip()
+        if not key:
+            continue
+        path = resolve_skill_handler_path(key)
+        if path is not None:
+            return key, path
+    return None
+
+
+def run_skill_handler_ops(
+    *,
+    handler_path: Path,
+    skill_key: str,
+    ctx: dict[str, Any],
+    payload: dict[str, Any],
+    timeout_sec: float | None = None,
+) -> tuple[list[dict[str, Any]] | None, str | None]:
+    """Subprocess-run ``handler.run`` → ``(ops, error)``.
+
+    On success ``error`` is None. Empty ops list is a valid success (caller may
+    fall through to LLM paint).
+    """
+    if not _runner_enabled():
+        return None, "runner_disabled"
+    path = Path(handler_path)
+    if not path.is_file():
+        return None, "handler_missing"
+    timeout = _runner_timeout_sec() if timeout_sec is None else max(1.0, float(timeout_sec))
+    msg = {
+        "handler": str(path.resolve()),
+        "ctx": {
+            "skill_key": skill_key,
+            **(ctx if isinstance(ctx, dict) else {}),
+        },
+        "payload": payload if isinstance(payload, dict) else {},
+    }
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", _BOOTSTRAP],
+            input=json.dumps(msg, ensure_ascii=False).encode("utf-8"),
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("skill ops runner timeout skill=%s path=%s", skill_key, path)
+        return None, "timeout"
+    except Exception as exc:
+        logger.warning("skill ops runner spawn failed skill=%s: %s", skill_key, exc)
+        return None, f"spawn:{type(exc).__name__}"
+
+    raw_out = (proc.stdout or b"").decode("utf-8", errors="replace").strip()
+    if not raw_out:
+        err = (proc.stderr or b"").decode("utf-8", errors="replace").strip()[:200]
+        return None, f"empty_stdout:{err or proc.returncode}"
+    try:
+        data = json.loads(raw_out.splitlines()[-1])
+    except Exception:
+        return None, "bad_stdout_json"
+    if not isinstance(data, dict) or not data.get("ok"):
+        return None, str((data or {}).get("error") or "handler_failed")
+    ops = data.get("ops")
+    if not isinstance(ops, list):
+        return None, "ops_not_list"
+    return [x for x in ops if isinstance(x, dict)], None
+
+
+def try_skill_ops_for_paint(
+    *,
+    skill_keys: list[str] | None,
+    prompt: str,
+    scene_key: str,
+    scene_nodes: list[Any] | None = None,
+    scene_frames: list[Any] | None = None,
+    design_brief: dict[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]] | None, str | None, str | None]:
+    """Paint short-circuit helper.
+
+    Returns ``(ops, skill_key, error)``.
+    - ``ops is not None`` → runner produced a list (may be empty)
+    - ``ops is None`` and ``error`` → skip / fail; caller falls through to LLM
+    - ``ops is None`` and ``error is None`` → runner off or no handler
+    """
+    if not _runner_enabled():
+        return None, None, None
+    hit = find_handler_for_skills(skill_keys)
+    if not hit:
+        return None, None, None
+    skill_key, handler = hit
+    ctx = {
+        "skill_key": skill_key,
+        "prompt": str(prompt or "")[:4000],
+        "scene": str(scene_key or "website"),
+        "scene_nodes": list(scene_nodes or [])[:80],
+        "scene_frames": list(scene_frames or [])[:40],
+        "design_brief": design_brief if isinstance(design_brief, dict) else {},
+    }
+    payload = {
+        "prompt": str(prompt or "")[:4000],
+        "scene": str(scene_key or "website"),
+    }
+    ops, err = run_skill_handler_ops(
+        handler_path=handler,
+        skill_key=skill_key,
+        ctx=ctx,
+        payload=payload,
+    )
+    if err:
+        logger.info("skill ops runner skip skill=%s err=%s", skill_key, err)
+        return None, skill_key, err
+    return ops or [], skill_key, None

--- a/apps/api/app/services/design/prompts/skill_store/pack_io.py
+++ b/apps/api/app/services/design/prompts/skill_store/pack_io.py
@@ -495,13 +495,21 @@ def _load_schema_json(pack_dir: Path) -> tuple[Any, Any]:
     return inp, out
 
 
-def _note_deferred_handler(pack_dir: Path) -> None:
-    """``handler.py`` is reserved for Phase B ops runners — do not execute yet."""
-    if (pack_dir / "handler.py").is_file():
-        logger.info(
-            "skill pack %s has handler.py (ignored until skill runner Phase B)",
-            pack_dir.name,
-        )
+def _handler_py_path(pack_dir: Path) -> Path | None:
+    p = pack_dir / "handler.py"
+    return p if p.is_file() else None
+
+
+def _note_handler(pack_dir: Path) -> str | None:
+    """Record optional ``handler.py`` path (executed only when ops runner is on)."""
+    path = _handler_py_path(pack_dir)
+    if not path:
+        return None
+    logger.info(
+        "skill pack %s has handler.py (ops runner; enable DESIGN_SKILL_OPS_RUNNER)",
+        pack_dir.name,
+    )
+    return str(path)
 
 
 def _load_pack_dir(pack_dir: Path) -> dict[str, Any] | None:
@@ -543,13 +551,18 @@ def _load_pack_dir(pack_dir: Path) -> dict[str, Any] | None:
     ):
         meta["output_schema"] = schema_out
 
-    _note_deferred_handler(pack_dir)
-    return _skill_item_from_parts(
+    item = _skill_item_from_parts(
         pack_dir=pack_dir,
         meta=meta,
         body=body,
         skill_md_path=skill_md,
     )
+    if not item:
+        return None
+    handler = _note_handler(pack_dir)
+    if handler:
+        item["_handler"] = handler
+    return item
 
 
 def _load_file_skills() -> list[dict[str, Any]]:

--- a/apps/api/app/services/design/runtime/graph/nodes/paint.py
+++ b/apps/api/app/services/design/runtime/graph/nodes/paint.py
@@ -118,6 +118,71 @@ async def _node_paint_ops(state: GraphState) -> Command:
         list(st.tools_loaded or [])[:8],
     )
 
+    # Opt-in skill handler.py → tool_ops (before LLM). Falls through on miss/error.
+    try:
+        from app.services.design.prompts.skill_store.ops_runner import (
+            try_skill_ops_for_paint,
+        )
+
+        runner_ops, runner_skill, runner_err = try_skill_ops_for_paint(
+            skill_keys=list(st.skills_loaded or []),
+            prompt=str(rt.prompt or ""),
+            scene_key=str(rt.scene_key or "website"),
+            scene_nodes=list(rt.scene_nodes or []),
+            scene_frames=list(rt.scene_frames or []),
+            design_brief=rt.flags.get("design_brief")
+            if isinstance(rt.flags.get("design_brief"), dict)
+            else None,
+        )
+    except Exception as exc:
+        _log.warning("skill ops runner failed: %s", exc)
+        runner_ops, runner_skill, runner_err = None, None, str(exc)
+
+    if runner_ops is not None:
+        step_ops, op_errors = resolve_tool_host().validate_ops(
+            runner_ops,
+            scene_nodes=rt.scene_nodes,
+            scene_frames=rt.scene_frames,
+            rules=rt.rules,
+            skill_keys=list(st.skills_loaded or []),
+            scene=rt.scene_key or "website",
+            runtime=rt,
+        )
+        rt.step_ops = step_ops
+        rt.op_errors = list(op_errors or [])
+        st.push_log(
+            phase="paint_ops",
+            intent=want,
+            summary=(
+                f"skill_ops_runner skill={runner_skill or '?'} "
+                f"ops={len(step_ops)} err={runner_err or ''}"
+            ),
+            model="skill_ops_runner",
+            ops_count=len(step_ops),
+            attempt=0,
+            **({"errors": _op_errors_for_log(op_errors)} if op_errors else {}),
+        )
+        if step_ops:
+            ask_mode = str(rt.flags.get("mode") or "") == "ask"
+            _emit_canvas_size_from_ops(rt, step_ops)
+            st.reply = _paint_user_reply("")
+            st.intent = want
+            rt.turn = {
+                "intent": want,
+                "reply": st.reply,
+                "tool_ops_raw": runner_ops,
+                "skill_ops_runner": runner_skill,
+            }
+            if ask_mode:
+                st.reply = ""
+                return Command(update=_bump(rt), goto="propose")
+            return Command(update=_bump(rt), goto="action")
+        _log.info(
+            "skill ops runner produced no valid ops skill=%s errors=%s — LLM paint",
+            runner_skill,
+            (op_errors or [])[:3],
+        )
+
     for attempt in range(max_attempts):
         round_i = st.round
         _emit(

--- a/apps/api/tests/unit_tests/test_skill_ops_runner.py
+++ b/apps/api/tests/unit_tests/test_skill_ops_runner.py
@@ -1,0 +1,80 @@
+"""Optional skill handler.py → tool_ops runner."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.services.design.prompts.skill_store import ops_runner
+
+
+def test_runner_disabled_by_default(monkeypatch):
+    monkeypatch.setattr(ops_runner, "_runner_enabled", lambda: False)
+    ops, key, err = ops_runner.try_skill_ops_for_paint(
+        skill_keys=["festival_poster"],
+        prompt="中秋红色海报",
+        scene_key="website",
+    )
+    assert ops is None
+    assert key is None
+    assert err is None
+
+
+def test_festival_handler_resolves_and_runs(monkeypatch, tmp_path):
+    monkeypatch.setattr(ops_runner, "_runner_enabled", lambda: True)
+    monkeypatch.setattr(ops_runner, "_runner_timeout_sec", lambda: 10.0)
+
+    repo = Path(__file__).resolve().parents[4]
+    sample = repo / "plugins" / "skills" / "festival_poster" / "handler.py"
+    assert sample.is_file(), f"missing sample handler: {sample}"
+
+    root = tmp_path / "skills"
+    pack = root / "festival_poster"
+    pack.mkdir(parents=True)
+    (pack / "handler.py").write_text(sample.read_text(encoding="utf-8"), encoding="utf-8")
+    monkeypatch.setattr(
+        "app.services.design.prompts.skill_store.pack_io._file_skills_dirs",
+        lambda: [root],
+    )
+
+    hit = ops_runner.find_handler_for_skills(["festival_poster"])
+    assert hit is not None
+    assert hit[0] == "festival_poster"
+
+    ops, key, err = ops_runner.try_skill_ops_for_paint(
+        skill_keys=["festival_poster"],
+        prompt="帮我生成一张中秋红色海报",
+        scene_key="website",
+    )
+    assert err is None
+    assert key == "festival_poster"
+    assert ops is not None
+    names = [str(o.get("name")) for o in ops]
+    assert "create_frame" in names
+    assert "create_text" in names
+
+
+def test_handler_missing_run_returns_error(monkeypatch, tmp_path):
+    monkeypatch.setattr(ops_runner, "_runner_enabled", lambda: True)
+    pack = tmp_path / "broken"
+    pack.mkdir()
+    (pack / "handler.py").write_text("x = 1\n", encoding="utf-8")
+    ops, err = ops_runner.run_skill_handler_ops(
+        handler_path=pack / "handler.py",
+        skill_key="broken",
+        ctx={},
+        payload={},
+        timeout_sec=5.0,
+    )
+    assert ops is None
+    assert err and "run_missing" in err
+
+
+def test_pack_load_records_handler_path():
+    from app.services.design.prompts.skill_store.pack_io import _load_file_skills
+
+    items = {str(x.get("skill_key")): x for x in _load_file_skills()}
+    fp = items.get("festival_poster")
+    assert fp is not None
+    handler = str(fp.get("_handler") or "")
+    assert handler.endswith("handler.py")

--- a/docs/adr/0015-skill-ops-runner.md
+++ b/docs/adr/0015-skill-ops-runner.md
@@ -1,0 +1,40 @@
+# Extensibility — Skill ops runner (Phase C)
+
+- **Status:** Accepted
+- **Date:** 2026-08-12
+
+## Context
+
+Skill packs (ADR 0013) are playbooks: the LLM Paint stage emits `tool_ops`. Authors also want an optional deterministic `handler.py` that returns the same ops shape without inventing a second canvas writer.
+
+## Decision
+
+1. **Opt-in runner** (`DESIGN_SKILL_OPS_RUNNER`, default off). When on, Paint tries a pack `handler.py` **before** the LLM structured call.
+2. **Contract:** `def run(ctx: dict, payload: dict) -> list[dict]` only. Return value must be a list of op dicts.
+3. **Isolation:** subprocess + JSON stdin/stdout + timeout (`DESIGN_SKILL_OPS_RUNNER_TIMEOUT_SEC`). Bad handlers do not crash the API worker.
+4. **Trust boundary:** only `handler.py` under known pack roots (`seeds/design_skills`, `plugins/skills`, `DESIGN_SKILLS_PLUGIN_DIRS`). No Admin-zip / remote code in this phase.
+5. **Always re-validate** via existing `validate_ops` (preferred_tools / output_schema / canvas contract). Empty or invalid ops → fall through to LLM paint.
+6. **Sample:** `plugins/skills/festival_poster/handler.py`.
+
+## Consequences
+
+### Positive
+
+- Deterministic layouts for self-host packs without waiting on the LLM.
+- Same apply/SSE path as Paint (`action` node).
+
+### Negative / trade-offs
+
+- Still not a full sandbox (subprocess shares host Python env).
+- Authors must keep handlers aligned with `preferred_tools`.
+
+## Alternatives considered
+
+1. **In-process importlib only** — simpler, weaker isolation.
+2. **Replace LLM paint entirely when handler exists** — too brittle when handler returns empty; fallthrough is safer.
+
+## References
+
+- [docs/skill-extensions.md](../skill-extensions.md)
+- `app/services/design/prompts/skill_store/ops_runner.py`
+- [ADR 0013](./0013-skill-extensions.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,3 +34,4 @@ Cross-cutting or irreversible technical choices live here. Product feature notes
 | [0012](./0012-k8s-starter-manifests.md) | Optional Kubernetes starter manifests | Accepted |
 | [0013](./0013-skill-extensions.md) | Skill extension packs (Phase A plugins) | Accepted |
 | [0014](./0014-canvas-plugins.md) | Canvas toolbar plugins (Phase B) | Accepted |
+| [0015](./0015-skill-ops-runner.md) | Skill `handler.py` ops runner (Phase C) | Accepted |

--- a/docs/roadmap/platform.md
+++ b/docs/roadmap/platform.md
@@ -172,5 +172,5 @@ One FastAPI app with domain modules, plus the collab WebSocket process:
 
 - [x] Skill playbook packs + private mount (`plugins/skills`) — ADR 0013
 - [x] Canvas toolbar registry (TS, in-process) + sample watermark — ADR 0014
-- [ ] Optional skill ops runner (return `tool_ops` only)
+- [x] Optional skill ops runner (`handler.py` → `tool_ops`) — ADR 0015
 - [ ] Packaged install (`.recombyn-plugin` zip) + permissions / signatures

--- a/docs/skill-extensions.md
+++ b/docs/skill-extensions.md
@@ -52,11 +52,23 @@ Expands to a `create`/`edit` trigger with `prompt_includes_any` when `triggers` 
 
 Aliases: `input_schema` / `output_schema`. Values merge into the skill row (meta fields win if both set). Used for validation hints / future runners — Phase A still relies on `preferred_tools` for live op gating.
 
-## `handler.py` (optional, not run yet)
+## `handler.py` (optional ops runner)
 
-If present, the loader logs that it was found and continues. Phase B will allow a runner that **returns `tool_ops` only**. Until then, put craft in `SKILL.md`.
+When **`DESIGN_SKILL_OPS_RUNNER=true`**, Paint will try the first loaded skill that has `handler.py` **before** the LLM:
 
-See `plugins/skills/festival_poster/handler.py.example`.
+```python
+def run(ctx: dict, payload: dict) -> list[dict]:
+    """Return tool_ops only — never mutate Redis/DB/canvas directly."""
+    return [{"name": "create_frame", "args": {...}}, ...]
+```
+
+- Subprocess + timeout (`DESIGN_SKILL_OPS_RUNNER_TIMEOUT_SEC`, default 8s)
+- Output always passes `validate_ops` (`preferred_tools` / contract)
+- Empty or invalid → fall through to normal LLM paint
+
+Sample: [`plugins/skills/festival_poster/handler.py`](../plugins/skills/festival_poster/handler.py) · [ADR 0015](./adr/0015-skill-ops-runner.md)
+
+Default is **off** — craft in `SKILL.md` still works without a handler.
 
 ## `assets/` / `examples/`
 
@@ -82,7 +94,7 @@ Duplicate `skill_key`: **later root wins** (plugins override seeds).
 
 ## Out of scope here
 
-- Frontend toolbar plugins (`manifest.json` + TypeScript) — [canvas-plugins.md](./canvas-plugins.md) (Phase B)
-- Executing `handler.py` / sandboxes / `.recombyn-plugin` zip install — Phase C/D
+- Frontend toolbar plugins — [canvas-plugins.md](./canvas-plugins.md) / ADR 0014  
+- Full process sandbox / `.recombyn-plugin` zip install — later  
 
-→ [ADR 0013](./adr/0013-skill-extensions.md)
+→ [ADR 0013](./adr/0013-skill-extensions.md) · [ADR 0015](./adr/0015-skill-ops-runner.md)

--- a/plugins/skills/README.md
+++ b/plugins/skills/README.md
@@ -9,12 +9,12 @@ my_poster_plugin/
 ├── _meta.json        # required — triggers, preferred_tools, id/version
 ├── SKILL.md          # required — Agent craft rules
 ├── schema.json       # optional — input / output JSON schema
-├── handler.py        # optional — ignored until Phase B (ops runner)
+├── handler.py        # optional — DESIGN_SKILL_OPS_RUNNER → tool_ops
 ├── assets/           # optional — icon.svg / logo (list + picker thumb)
 └── examples/         # optional — reference images (docs only today)
 ```
 
-Skills are **playbooks**: the Design Agent still emits `tool_ops`. There is no separate canvas Python SDK in Phase A.
+Skills are **playbooks** by default (LLM paint). With the ops runner enabled, `handler.py` may return `tool_ops` first.
 
 ## Two product roots only
 

--- a/plugins/skills/festival_poster/handler.py
+++ b/plugins/skills/festival_poster/handler.py
@@ -1,0 +1,79 @@
+"""Festival poster skill ops runner — returns tool_ops only.
+
+Enable with ``DESIGN_SKILL_OPS_RUNNER=true``. Never mutates Redis/DB/canvas
+directly; the Design Agent paint gate still validates preferred_tools.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def _pick_festival(prompt: str, payload: dict[str, Any]) -> str:
+    raw = str(payload.get("festival") or "").strip()
+    if raw:
+        return raw
+    p = str(prompt or "")
+    for word in ("中秋", "春节", "国庆", "圣诞", "新年", "Mid-Autumn", "Christmas"):
+        if word.lower() in p.lower() or word in p:
+            return word
+    return "节日"
+
+
+def _pick_color(prompt: str, payload: dict[str, Any]) -> str:
+    raw = str(payload.get("color_theme") or payload.get("color") or "").strip()
+    if raw:
+        return raw
+    p = str(prompt or "")
+    for word, hex_color in (
+        ("红", "#C23A2B"),
+        ("red", "#C23A2B"),
+        ("金", "#D4A017"),
+        ("gold", "#D4A017"),
+        ("蓝", "#1F4E79"),
+        ("blue", "#1F4E79"),
+    ):
+        if word in p.lower() or word in p:
+            return hex_color
+    return "#C23A2B"
+
+
+def run(ctx: dict[str, Any], payload: dict[str, Any]) -> list[dict[str, Any]]:
+    prompt = str((payload or {}).get("prompt") or (ctx or {}).get("prompt") or "")
+    festival = _pick_festival(prompt, payload or {})
+    color = _pick_color(prompt, payload or {})
+    width = float((payload or {}).get("width") or 1080)
+    height = float((payload or {}).get("height") or 1440)
+    title = f"{festival}快乐"
+    return [
+        {
+            "name": "create_frame",
+            "args": {
+                "x": 40,
+                "y": 40,
+                "width": width,
+                "height": height,
+                "name": f"{festival} poster",
+                "fill": color,
+            },
+        },
+        {
+            "name": "create_text",
+            "args": {
+                "x": 40 + width * 0.12,
+                "y": 40 + height * 0.38,
+                "text": title,
+                "fontSize": max(48, int(width * 0.08)),
+                "fill": "#FFFFFF",
+            },
+        },
+        {
+            "name": "create_text",
+            "args": {
+                "x": 40 + width * 0.12,
+                "y": 40 + height * 0.52,
+                "text": "Holiday KV",
+                "fontSize": max(22, int(width * 0.028)),
+                "fill": "#F5E6C8",
+            },
+        },
+    ]

--- a/plugins/skills/festival_poster/handler.py.example
+++ b/plugins/skills/festival_poster/handler.py.example
@@ -1,11 +1,7 @@
-# Reserved — Skill ops runner (Phase B)
+# Skill ops runner sample — see handler.py
 
-# This file is NOT executed yet. Packs may include `handler.py` for forward
-# compatibility; the loader only logs that it was found.
+# Enable: DESIGN_SKILL_OPS_RUNNER=true
 #
-# Future contract (tentative):
+# Contract:
 #   def run(ctx, payload: dict) -> list[dict]:
 #       """Return tool_ops only — never mutate Redis/DB/canvas directly."""
-#       ...
-#
-# Until Phase B ships, craft lives entirely in SKILL.md + preferred_tools.


### PR DESCRIPTION
## Summary
- Opt-in `DESIGN_SKILL_OPS_RUNNER` runs pack `handler.py` before LLM paint
- Subprocess + timeout; always re-validates via existing ops gate
- Sample `festival_poster/handler.py` + ADR 0015

## Test plan
- [x] `pytest tests/unit_tests/test_skill_ops_runner.py -q`
- [ ] With `DESIGN_SKILL_OPS_RUNNER=true`, chat 「中秋红色海报」 with festival_poster loaded → deterministic frame/text ops
