### PR TITLE
fix: stabilize media E2E and gate Send on model availability

### DIFF
--- a/apps/web/src/components/editor/panels/AgentDock.tsx
+++ b/apps/web/src/components/editor/panels/AgentDock.tsx
@@ -3279,7 +3279,7 @@ function AgentDock({
         placeholder={composerPlaceholder}
         flyLandId="agent"
         canSend={
-          !sending && !!editDraft.trim() && !attachmentsUploading
+          !sending && !!editDraft.trim() && !attachmentsUploading && available !== false
         }
         sendVariant="circle"
         sendTone="ink"
@@ -3380,7 +3380,8 @@ function AgentDock({
               canSend={
                 !sending &&
                 (!!input.trim() || contextChips.length > 0) &&
-                !attachmentsUploading
+                !attachmentsUploading &&
+                available !== false
               }
               sendDisabledReason={composerSendDisabledReason({
                 t,

--- a/e2e/tests/agent.paint-mode.spec.ts
+++ b/e2e/tests/agent.paint-mode.spec.ts
@@ -8,7 +8,7 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import { test, expect, type Page, type Request } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { E2E_TOKEN_SKIP_REASON, resolveE2EToken } from './e2eAuth';
 
 const ROOT = path.resolve(__dirname, '../..');
@@ -52,37 +52,42 @@ async function dismissTour(page: Page) {
   }
 }
 
+async function seedAuthSession(page: Page) {
+  const api = (process.env.E2E_API || 'http://127.0.0.1:8000').replace(/\/$/, '');
+  const me = await page.request.get(`${api}/api/v1/auth/me`, {
+    headers: { Authorization: `Bearer ${TOKEN}` },
+    timeout: 45_000,
+  });
+  if (!me.ok()) throw new Error(`auth/me ${me.status()}`);
+  const body = await me.json();
+  const user = body?.user;
+  if (!user?.id) throw new Error('auth/me missing user');
+  await page.goto('/home', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page.evaluate(
+    ({ tok, user: u }) => {
+      localStorage.setItem('recombine-auth-token-v1', tok);
+      localStorage.setItem('resume-scene-auth-v1', JSON.stringify({ user: u }));
+      localStorage.setItem('recombyn-editor-tour-v3', '1');
+      localStorage.setItem('recombyn-editor-tour-v3:user_super_admin', '1');
+    },
+    { tok: TOKEN, user }
+  );
+}
+
 async function openEditor(page: Page) {
   const known = process.env.E2E_EDITOR_PATH || '/editor/aZ0FRsXFkjbQtnPFmohSZ';
-  await page.goto(known);
-  await page.waitForURL(/\/editor\//, { timeout: 60_000 });
-  await page.waitForLoadState('domcontentloaded');
+  await seedAuthSession(page);
+  await page.goto(known, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+  await expect(page).toHaveURL(/\/editor\//, { timeout: 45_000 });
   await dismissTour(page);
   await sleep(500);
 }
 
-/** Open Settings → Agent (account AgentModelsPanel). */
+/** Open Account → Agent (full AgentRoutePrefsEditor with board paint control). */
 async function openAgentSettings(page: Page) {
-  const accountBtn = page
-    .getByRole('button', { name: /Super Admin|Account|账户|账号|Settings|设置/i })
-    .first();
-  await expect(accountBtn).toBeVisible({ timeout: 20_000 });
-  await accountBtn.click({ force: true });
-  await sleep(400);
-
-  const dialog = page.locator('[role="dialog"]').first();
-  if (await dialog.isVisible({ timeout: 5_000 }).catch(() => false)) {
-    const tabInDialog = dialog.getByRole('tab', { name: /^Agent$/i });
-    if (await tabInDialog.isVisible({ timeout: 2_000 }).catch(() => false)) {
-      await tabInDialog.click({ force: true });
-    } else {
-      const btn = dialog.getByRole('button', { name: /^Agent$/i });
-      if (await btn.isVisible({ timeout: 1_000 }).catch(() => false)) {
-        await btn.click({ force: true });
-      }
-    }
-  }
-
+  await page.goto('/account?tab=agent', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await expect(page).toHaveURL(/\/account/, { timeout: 20_000 });
+  await dismissTour(page);
   const paint = page.getByRole('tablist', { name: /板式生成|Board paint/i });
   await expect(paint).toBeVisible({ timeout: 20_000 });
   return paint;
@@ -100,49 +105,80 @@ async function setPaintModeInSettings(page: Page, mode: 'ops' | 'img_layers') {
   await sleep(200);
   const stored = await page.evaluate(() => localStorage.getItem('resume.agentPaintMode.v1'));
   expect(stored).toBe(mode);
-  await page.keyboard.press('Escape');
-  await sleep(300);
 }
 
 async function ensureAgentDock(page: Page) {
   await dismissTour(page);
-  const byName = page.getByRole('textbox', {
-    name: /@Search for image, model, or project|Search|Ask|Design|描述/i,
+  await page.evaluate(() => {
+    for (const el of Array.from(document.querySelectorAll('[role="dialog"]'))) {
+      const t = el.textContent || '';
+      if (/Welcome to the editor|欢迎/i.test(t)) el.remove();
+    }
   });
-  if (await byName.isVisible({ timeout: 2_000 }).catch(() => false)) return byName;
-  const agentBtn = page.getByRole('button', { name: /^Agent$/i }).first();
-  if (await agentBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
-    await agentBtn.click({ force: true });
+
+  // Placeholder is a sibling overlay — textbox itself often has no accessible name.
+  let composer = page.locator('aside [role="textbox"], [data-agent-composer][role="textbox"]').last();
+  if (!(await composer.isVisible({ timeout: 2_000 }).catch(() => false))) {
+    const agentBtn = page.getByRole('button', { name: /^Agent$/i }).first();
+    if (await agentBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await agentBtn.click({ force: true });
+      await sleep(400);
+      await dismissTour(page);
+    }
+    composer = page.locator('aside [role="textbox"], [data-agent-composer][role="textbox"]').last();
   }
-  const fallback = page
-    .locator('aside [role="textbox"], [data-agent-composer] [role="textbox"]')
-    .last();
-  if (await fallback.isVisible({ timeout: 5_000 }).catch(() => false)) return fallback;
-  return byName;
+  await expect(composer).toBeVisible({ timeout: 20_000 });
+  return composer;
 }
 
-function isDesignRun(req: Request): boolean {
-  const u = req.url();
-  return req.method() === 'POST' && /\/design\/run\b/.test(u);
+async function ensureAgentInteractionMode(page: Page) {
+  const modeBtn = page.locator('aside button[aria-label]').filter({
+    has: page.locator('svg'),
+  });
+  // Mode picker is the first toolbar icon whose label is Agent/Ask/Image/Video.
+  const picker = page
+    .locator('aside')
+    .getByRole('button', { name: /^(Agent|Ask|Image|Video|智能体|提问|图片|视频)$/i })
+    .first();
+  if (!(await picker.isVisible({ timeout: 5_000 }).catch(() => false))) return;
+  const label = ((await picker.getAttribute('aria-label')) || '').trim();
+  if (/^Agent$|^智能体$/i.test(label)) return;
+  await picker.click({ force: true });
+  await sleep(200);
+  const agentItem = page
+    .getByRole('button', { name: /^Agent$|^智能体$/i })
+    .or(page.getByText(/^Agent$|^智能体$/i))
+    .last();
+  if (await agentItem.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await agentItem.click({ force: true });
+    await sleep(300);
+  }
+  void modeBtn;
 }
 
 async function sendShortPrompt(page: Page, prompt: string) {
   const composer = await ensureAgentDock(page);
-  await expect(composer).toBeVisible({ timeout: 20_000 });
+  await ensureAgentInteractionMode(page);
+  // Models catalog must resolve before send() will hit /design/run.
+  await page
+    .waitForResponse(
+      (r) => r.url().includes('/chat/models') && r.ok(),
+      { timeout: 60_000 }
+    )
+    .catch(() => undefined);
   await composer.click({ force: true });
   await sleep(200);
   await page.keyboard.press(process.platform === 'darwin' ? 'Meta+A' : 'Control+A');
-  await page.keyboard.type(prompt, { delay: 3 });
-  await sleep(300);
-  const send = page.getByRole('button', { name: /send|发送/i }).first();
-  for (let i = 0; i < 40; i += 1) {
-    if (!(await send.isDisabled().catch(() => true))) {
-      await send.click();
-      return;
-    }
-    await sleep(400);
-  }
-  await page.keyboard.press('Enter');
+  await page.keyboard.press('Backspace');
+  await composer.pressSequentially(prompt, { delay: 8 });
+  await expect
+    .poll(async () => ((await composer.textContent()) || '').trim().length, {
+      timeout: 10_000,
+    })
+    .toBeGreaterThan(5);
+  const send = page.locator('aside').getByRole('button', { name: /send|发送/i }).first();
+  await expect(send).toBeEnabled({ timeout: 30_000 });
+  await send.click({ force: true });
 }
 
 test.describe('agent paint_mode browser E2E', () => {
@@ -154,7 +190,7 @@ test.describe('agent paint_mode browser E2E', () => {
 
   test('A: Agent settings toggles paint_mode into localStorage', async ({ page }) => {
     await injectAuth(page);
-    await openEditor(page);
+    await seedAuthSession(page);
     await setPaintModeInSettings(page, 'img_layers');
     await setPaintModeInSettings(page, 'ops');
     await setPaintModeInSettings(page, 'img_layers');
@@ -164,18 +200,36 @@ test.describe('agent paint_mode browser E2E', () => {
   test('B: /design/run carries paint_mode=img_layers', async ({ page }) => {
     await injectAuth(page, 'img_layers');
     await openEditor(page);
+    await ensureAgentDock(page);
 
-    const bodyPromise = page.waitForRequest(isDesignRun, { timeout: 90_000 }).then(async (req) => {
-      try {
-        return req.postDataJSON() as Record<string, unknown>;
-      } catch {
-        const raw = req.postData() || '';
-        return JSON.parse(raw) as Record<string, unknown>;
-      }
+    const posts: string[] = [];
+    page.on('request', (req) => {
+      if (req.method() === 'POST') posts.push(req.url());
     });
 
+    const bodyPromise = page
+      .waitForRequest(
+        (req) => req.method() === 'POST' && /\/design\/run(?:\?|$)/.test(req.url()),
+        { timeout: 90_000 }
+      )
+      .then(async (req) => {
+        try {
+          return req.postDataJSON() as Record<string, unknown>;
+        } catch {
+          const raw = req.postData() || '';
+          return JSON.parse(raw) as Record<string, unknown>;
+        }
+      });
+
     await sendShortPrompt(page, '做一张极简海报：大标题 Hello，白底黑字，390x844');
-    const body = await bodyPromise;
+    let body: Record<string, unknown>;
+    try {
+      body = await bodyPromise;
+    } catch (err) {
+      throw new Error(
+        `design/run not seen. recent POSTs=${JSON.stringify(posts.slice(-12))}. cause=${err}`
+      );
+    }
     fs.writeFileSync(path.join(OUT, 'b-design-run-body.json'), JSON.stringify(body, null, 2));
     expect(body.paint_mode).toBe('img_layers');
     expect(String(body.prompt || '')).toMatch(/Hello|海报/);
@@ -189,7 +243,7 @@ test.describe('agent paint_mode browser E2E', () => {
 
   test('D: UI stress — settings paint mode 8×', async ({ page }) => {
     await injectAuth(page);
-    await openEditor(page);
+    await seedAuthSession(page);
     for (let i = 0; i < 8; i += 1) {
       const mode = i % 2 === 0 ? 'img_layers' : 'ops';
       await setPaintModeInSettings(page, mode);

--- a/e2e/tests/canvas.generators.spec.ts
+++ b/e2e/tests/canvas.generators.spec.ts
@@ -194,10 +194,13 @@ test.describe('canvas generators + element tools', () => {
     await expect(send).toBeEnabled({ timeout: 5_000 });
     await send.click({ force: true });
 
-    // Promote clears generator chrome; media node keeps the same id.
+    // Promote clears generator chrome; canvas paints via scene (preload <img> may be !hidden).
     await expect(page.locator('[data-image-generator]')).toHaveCount(0, { timeout: 20_000 });
     await expect(
       page.locator('img[src*="data:image/png"], image[href*="data:image/png"]').first()
+    ).toBeAttached({ timeout: 15_000 });
+    await expect(
+      page.getByRole('button', { name: /Quick edit|快速编辑|Upscale|高清放大/i }).first()
     ).toBeVisible({ timeout: 15_000 });
   });
 

--- a/scripts/smoke-media-plugin.mjs
+++ b/scripts/smoke-media-plugin.mjs
@@ -1,0 +1,81 @@
+/**
+ * Smoke: plugin install route + chat image/video/audio jobs enqueue.
+ * Usage: TOK=$(cat .tmp-token.txt) node scripts/smoke-media-plugin.mjs
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const api = (process.env.E2E_API || process.env.BASE_URL || 'http://127.0.0.1:8000').replace(
+  /\/$/,
+  ''
+);
+let tok = (process.env.TOK || process.env.E2E_TOKEN || '').trim();
+if (!tok) {
+  const p = path.join(root, '.tmp-token.txt');
+  if (existsSync(p)) tok = readFileSync(p, 'utf8').trim();
+}
+if (!tok) {
+  console.error('missing TOK / E2E_TOKEN / .tmp-token.txt');
+  process.exit(1);
+}
+
+const h = { Authorization: `Bearer ${tok}` };
+
+async function j(method, url, body) {
+  const r = await fetch(`${api}${url}`, {
+    method,
+    headers: { ...h, ...(body ? { 'Content-Type': 'application/json' } : {}) },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const t = await r.text();
+  let d;
+  try {
+    d = JSON.parse(t);
+  } catch {
+    d = t;
+  }
+  return { status: r.status, d };
+}
+
+const results = [];
+function ok(name, cond, detail) {
+  results.push({ name, ok: !!cond, detail });
+  console.log(`${cond ? '✓' : '✗'} ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+let r = await j('GET', '/api/v1/health');
+ok('health', r.status === 200, String(r.status));
+
+r = await j('GET', '/api/v1/design/skills');
+ok('design.skills', r.status === 200, `status=${r.status}`);
+
+r = await fetch(`${api}/api/v1/design/plugins/install`, { method: 'POST', headers: h });
+ok(
+  'plugins.install.route',
+  [400, 415, 422].includes(r.status),
+  `status=${r.status} (expect missing-file client error)`
+);
+
+for (const kind of ['image', 'video', 'audio']) {
+  const payload =
+    kind === 'audio'
+      ? { prompt: 'hello smoke' }
+      : { prompt: `smoke ${kind}` };
+  r = await j('POST', `/api/v1/chat/${kind}/jobs`, payload);
+  const acceptable = [200, 402, 503, 502];
+  ok(
+    `${kind}.jobs.create`,
+    acceptable.includes(r.status),
+    `status=${r.status} body=${JSON.stringify(r.d).slice(0, 140)}`
+  );
+  if (r.status === 200 && r.d?.job_id) {
+    const g = await j('GET', `/api/v1/chat/${kind}/jobs/${r.d.job_id}`);
+    ok(`${kind}.jobs.get`, g.status === 200, `status=${g.d?.status}`);
+  }
+}
+
+const failed = results.filter((x) => !x.ok);
+console.log(JSON.stringify({ pass: results.length - failed.length, fail: failed.length, failed }, null, 2));
+process.exit(failed.length ? 1 : 0);


### PR DESCRIPTION
## Summary
- Fix flaky image-gen E2E assert (promoted PNG lives in hidden preload `<img>`)
- Harden paint-mode E2E (account Agent tab, composer selection, wait for models)
- Gate Agent `canSend` on `available !== false` so Send cannot no-op when catalog is down
- Add `scripts/smoke-media-plugin.mjs` for plugin + image/video/audio jobs smoke

## Test plan
- [x] paint-mode A/B/D
- [x] canvas generators mock promote
- [x] `node scripts/smoke-media-plugin.mjs`
