### PR TITLE
fix: guest login modal, skills card UX, and deploy Docker builds

### DIFF
--- a/apps/web/src/components/base/AppLogo.tsx
+++ b/apps/web/src/components/base/AppLogo.tsx
@@ -10,26 +10,33 @@ type Props = {
   className?: string;
   bordered?: boolean;
   /**
-   * Kept for call-site compat. Mark asset is the dark-plate PNG (readable on light and dark rails).
-   * @deprecated Prefer omitting — both themes use `/logo-mark.png`.
+   * `dark` — white feather on dark plate (`/logo-mark.png`), for light rails.
+   * `light` — dark feather on light plate (`/logo-mark-light.png`), for dark rails (e.g. login art).
+   * `auto` / omit — same as `dark`.
    */
   scheme?: LogoScheme | 'auto';
 };
 
+function markSrc(scheme: LogoScheme | 'auto' | undefined): string {
+  if (scheme === 'light') return '/logo-mark-light.png';
+  return '/logo-mark.png';
+}
+
 /**
- * Brand mark — `/logo-mark.png` (white feather on dark plate).
+ * Brand mark — scheme picks the fixed plate (not CSS theme).
  * Used by: HomeBody, LoginDialog, EditorBootOverlay.
  */
 function AppLogo({
   size = 36,
   className,
   bordered = false,
+  scheme = 'dark',
 }: Props) {
   const { t } = useTranslation();
 
   return (
     <img
-      src="/logo-mark.png"
+      src={markSrc(scheme)}
       alt={t('app.name')}
       width={size}
       height={size}

--- a/apps/web/src/components/home/SkillsLibraryPanel.tsx
+++ b/apps/web/src/components/home/SkillsLibraryPanel.tsx
@@ -4,7 +4,6 @@ import {
   useRef,
   useState,
   type ChangeEvent,
-  type KeyboardEvent,
   type ReactNode,
 } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -22,19 +21,20 @@ import { cn } from '@/utils/classnames';
 
 /** Skills toolbox — same scale as Me / projects: 2 → 3 → 4 → 5 (2xl). */
 const DEFAULT_SKILL_GRID =
-  'grid w-full grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5';
+  'grid w-full grid-cols-2 gap-[10px] md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5';
 
-/** Loading placeholders only 鈥?not real totals (API count unknown until fetch). */
+/** Loading placeholders only — not real totals (API count unknown until fetch). */
 const SKILL_SKELETON_MINE = 1;
 /** ~one row on the 2xl 5-col grid. */
 const SKILL_SKELETON_OFFICIAL = 5;
 
+/** Skill card — icon + title/2-line subtitle + switch; 10px pad. */
 const SKILL_CARD_SHELL =
-  'w-full rounded-xl border border-[var(--line)] bg-[var(--surface)] px-3.5 py-3 text-left shadow-[0_2px_10px_rgba(15,23,42,0.06)]';
+  'flex h-full w-full flex-col rounded-xl border border-[var(--line)] bg-[var(--surface)] p-[10px] text-left shadow-[0_2px_8px_rgba(15,23,42,0.05)]';
 
-/** App-store style tile — fixed square; never let flex/preflight squeeze width. */
+/** Preview dialog mark — fixed square. */
 const SKILL_ICON_FRAME =
-  'inline-flex h-14 w-14 min-h-14 min-w-14 shrink-0 grow-0 overflow-hidden rounded-[14px] shadow-[0_1px_4px_rgba(15,23,42,0.08)]';
+  'inline-flex h-12 w-12 min-h-12 min-w-12 shrink-0 grow-0 overflow-hidden rounded-[12px] shadow-[0_1px_4px_rgba(15,23,42,0.08)]';
 const SKILL_ICON_IMG = 'h-full w-full max-w-none object-cover';
 
 /** Default picture icon when a pack has no logo — never use letter avatars. */
@@ -50,7 +50,7 @@ function SkillLogo({ src }: { src?: string | null }) {
 
 const SKILLS_PICKER_INPUT = { query: { manage: true as const } };
 
-/** Dashed upload tile 鈥?first cell in Mine grid (icon only, like New project). */
+/** Dashed upload tile — first cell in Mine grid. */
 function UploadSkillCard({
   label,
   disabled = false,
@@ -69,12 +69,12 @@ function UploadSkillCard({
       title={label}
       className={cn(
         SKILL_CARD_SHELL,
-        'flex min-h-[104px] flex-col items-center justify-center border-dashed shadow-none',
-        'transition hover:border-[var(--muted)] hover:bg-[var(--accent-soft)] hover:shadow-none',
+        'min-h-[76px] items-center justify-center border-dashed shadow-none',
+        'transition hover:border-[var(--muted)] hover:bg-[var(--accent-soft)]',
         'disabled:opacity-50'
       )}
     >
-      <HiOutlinePlus className="h-7 w-7 text-[var(--muted)]" strokeWidth={1.5} />
+      <HiOutlinePlus className="h-6 w-6 text-[var(--muted)]" strokeWidth={1.5} />
     </button>
   );
 }
@@ -86,13 +86,10 @@ function formatSkillUpdatedAt(ts: number | null | undefined, locale: string): st
   return date.toLocaleString(locale.startsWith('zh') ? 'zh-CN' : locale);
 }
 
-/** Same shell + title / line-clamp-2 desc metrics as the real skill card. */
+/** Same shell metrics as the real skill card. */
 function SkillCardSkeleton(): ReactNode {
   return (
-    <div
-      className={cn(SKILL_CARD_SHELL, 'rcb-skeleton-bone min-h-[104px] !rounded-xl shadow-none')}
-      aria-hidden
-    />
+    <div className={cn(SKILL_CARD_SHELL, 'rcb-skeleton-bone min-h-[76px] !rounded-xl shadow-none')} aria-hidden />
   );
 }
 
@@ -108,7 +105,7 @@ function SkillGroupSkeleton({
   gridClassName?: string;
 }): ReactNode {
   return (
-    <section className="space-y-2" aria-busy="true" aria-label={title}>
+    <section className="space-y-3" aria-busy="true" aria-label={title}>
       <h3 className="text-[12px] font-semibold uppercase tracking-wide text-[var(--muted)]">
         {title}
       </h3>
@@ -120,10 +117,6 @@ function SkillGroupSkeleton({
       </div>
     </section>
   );
-}
-
-function stopCardBubble(e: { stopPropagation: () => void }) {
-  e.stopPropagation();
 }
 
 function SkillCard({
@@ -139,29 +132,23 @@ function SkillCard({
 }): ReactNode {
   const on = row.enabled !== false;
 
-  const onKeyActivate = (e: KeyboardEvent) => {
-    if (e.key !== 'Enter' && e.key !== ' ') return;
-    e.preventDefault();
-    onPreview(row);
-  };
-
   return (
     <div
-      role="button"
-      tabIndex={0}
-      onClick={() => onPreview(row)}
-      onKeyDown={onKeyActivate}
       className={cn(
         SKILL_CARD_SHELL,
-        'cursor-pointer transition hover:shadow-[0_8px_22px_rgba(15,23,42,0.1)]',
+        'transition hover:border-[var(--muted)]',
         !on && 'opacity-55'
       )}
     >
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex min-w-0 flex-1 items-center gap-3">
+      <div className="flex items-start gap-3">
+        <button
+          type="button"
+          onClick={() => onPreview(row)}
+          className="flex min-w-0 flex-1 cursor-pointer items-start gap-3 border-0 bg-transparent p-0 text-left"
+        >
           <SkillLogo src={row.logo} />
           <div className="min-w-0 flex-1">
-            <div className="truncate text-[14px] font-medium leading-[21px] text-[var(--ink)]">
+            <div className="truncate text-[14px] font-semibold leading-5 text-[var(--ink)]">
               {row.name}
             </div>
             {row.whenToUse ? (
@@ -170,16 +157,10 @@ function SkillCard({
               </div>
             ) : null}
           </div>
-        </div>
-        <div
-          className="shrink-0 pt-0.5"
-          onClick={stopCardBubble}
-          onKeyDown={stopCardBubble}
-        >
-          <span title={enableLabel} className="inline-flex">
-            <Switch checked={on} onChange={(next) => onToggle(row.id, next)} />
-          </span>
-        </div>
+        </button>
+        <span title={enableLabel} className="inline-flex shrink-0 pt-0.5">
+          <Switch checked={on} onChange={(next) => onToggle(row.id, next)} />
+        </span>
       </div>
     </div>
   );
@@ -225,7 +206,7 @@ function SkillGroup({
   );
 
   return (
-    <section className="space-y-2">
+    <section className="space-y-3">
       <h3 className="text-[12px] font-semibold uppercase tracking-wide text-[var(--muted)]">
         {title}
       </h3>
@@ -395,7 +376,7 @@ function SkillsLibraryPanel(): ReactNode {
           tip={t('home.skillsHint')}
           placement="bottom"
           offset={8}
-          popupClassName="h-auto max-w-[280px] whitespace-normal py-2 leading-[1.4]"
+          popupClassName="!h-auto max-w-[340px] items-start whitespace-pre-line py-2.5 text-left leading-[1.45]"
         >
           <button
             type="button"

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -97,7 +97,7 @@ const en = {
     railSkills: 'Skills',
     skillsTitle: 'Skill toolbox',
     skillsHint:
-      'Upload a skill pack (.zip / .recombyn-plugin), or turn off official ones you do not need. In Chat, type / to pin one for the turn.',
+      'Upload a skill pack (.zip / .recombyn-plugin), or turn off official ones you do not need. In Chat, type / to pin one for the turn.\n\nRequired files:\n• _meta.json\n• SKILL.md\n\nOptional:\n• assets/icon.png — list icon\n• schema.json — input/output schema\n• handler.py — ops runner\n• examples/ — reference only\n\n_meta fields: skill_key (required); when_to_use, preferred_tools, triggers / trigger_keywords (recommended); version, enabled, author (optional).',
     viewAll: 'View all',
     inspiration: 'Inspiration',
     updatedAt: 'Updated {{time}}',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -95,7 +95,7 @@ const ja = {
     railSkills: 'スキル',
     skillsTitle: 'スキルツールボックス',
     skillsHint:
-      'スキルパック（.zip / .recombyn-plugin）をアップロードするか、不要な公式スキルをオフにできます。チャットで / を入力すると、このターンにスキルを固定できます。',
+      'スキルパック（.zip / .recombyn-plugin）をアップロードするか、不要な公式スキルをオフにできます。チャットで / を入力すると、このターンにスキルを固定できます。\n\n必須ファイル：\n• _meta.json\n• SKILL.md\n\n任意：\n• assets/icon.png — 一覧アイコン\n• schema.json — 入出力スキーマ\n• handler.py — ops ランナー\n• examples/ — 参考用\n\n_meta 項目：skill_key（必須）；when_to_use、preferred_tools、triggers / trigger_keywords（推奨）；version、enabled、author（任意）。',
     viewAll: 'すべて見る',
     inspiration: 'インスピレーション',
     updatedAt: '更新 {{time}}',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -84,7 +84,8 @@ const zhCN = {
     railAdd: '添加',
     railSkills: '技能',
     skillsTitle: '技能工具箱',
-    skillsHint: '上传技能包（.zip / .recombyn-plugin），或关闭不需要的官方技能；Chat 里输入 / 可为当前回合固定使用。',
+    skillsHint:
+      '上传技能包（.zip / .recombyn-plugin），或关闭不需要的官方技能；Chat 里输入 / 可为当前回合固定使用。\n\n必需文件：\n• _meta.json\n• SKILL.md\n\n可选：\n• assets/icon.png — 列表图标\n• schema.json — 输入/输出 schema\n• handler.py — ops 运行器\n• examples/ — 仅作参考\n\n_meta 字段：skill_key（必填）；when_to_use、preferred_tools、triggers / trigger_keywords（建议）；version、enabled、author（可选）。',
     viewAll: '查看全部',
     inspiration: '灵感发现',
     updatedAt: '更新于 {{time}}',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -94,7 +94,8 @@ const zhTW = {
     railAdd: '新增',
     railSkills: '技能',
     skillsTitle: '技能工具箱',
-    skillsHint: '上傳技能包（.zip / .recombyn-plugin），或關閉不需要的官方技能；Chat 裡輸入 / 可為當前回合固定使用。',
+    skillsHint:
+      '上傳技能包（.zip / .recombyn-plugin），或關閉不需要的官方技能；Chat 裡輸入 / 可為當前回合固定使用。\n\n必需檔案：\n• _meta.json\n• SKILL.md\n\n可選：\n• assets/icon.png — 列表圖示\n• schema.json — 輸入/輸出 schema\n• handler.py — ops 執行器\n• examples/ — 僅供參考\n\n_meta 欄位：skill_key（必填）；when_to_use、preferred_tools、triggers / trigger_keywords（建議）；version、enabled、author（可選）。',
     viewAll: '查看全部',
     inspiration: '靈感發現',
     updatedAt: '更新於 {{time}}',

--- a/apps/web/src/utils/goEditor.ts
+++ b/apps/web/src/utils/goEditor.ts
@@ -55,7 +55,7 @@ export function buildEditorIntentPath(opts?: GoEditorOpts): string {
   return '/editor';
 }
 
-/** Navigate to /editor/:projectId; guests go to login with ?from= intent. */
+/** Navigate to /editor/:projectId; guests open the login modal on this tab (ignore newWindow). */
 export function useGoEditor() {
   const user = useSelector((s: any) => s.auth.user);
   const navigate = useNavigate();
@@ -63,26 +63,30 @@ export function useGoEditor() {
   return useCallback(
     (opts?: GoEditorOpts) => {
       const path = buildEditorIntentPath(opts);
-      const dest = user ? path : buildLoginUrl(path);
+      // Guests: never window.open — that jumps to a new tab instead of the in-page login dialog.
+      if (!user) {
+        navigate(buildLoginUrl(path));
+        return;
+      }
       if (opts?.newWindow && canOpenEditorInNewWindow()) {
         if (opts.homeAgentBoot) {
-          const opened = openEditorWindowWithBoot(dest, opts.homeAgentBoot);
-          if (!opened) navigate(dest);
+          const opened = openEditorWindowWithBoot(path, opts.homeAgentBoot);
+          if (!opened) navigate(path);
           return;
         }
         // Do not pass `noopener` to window.open — it makes the return value null in
         // Chromium even when the tab opens, and we would wrongly navigate this window.
-        const win = window.open(dest, '_blank');
+        const win = window.open(path, '_blank');
         if (win) {
           win.opener = null;
           return;
         }
         // Popup blocked — fall back to same-tab navigation.
-        navigate(dest);
+        navigate(path);
         return;
       }
       if (opts?.homeAgentBoot) saveHomeAgentBoot(opts.homeAgentBoot);
-      navigate(dest);
+      navigate(path);
     },
     [user, navigate]
   );

--- a/deploy/docker/Dockerfile.api
+++ b/deploy/docker/Dockerfile.api
@@ -1,13 +1,20 @@
 FROM python:3.11-slim
 WORKDIR /app
 
-# poppler: pdf2image | libreoffice: docx→pdf | libgl: opencv
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    libreoffice-writer \
-    poppler-utils \
-    libgl1 \
-    libglib2.0-0 \
-    && rm -rf /var/lib/apt/lists/*
+# Faster apt in CN. poppler: pdf2image | libreoffice: docx→pdf | libgl: opencv
+RUN set -eux; \
+    . /etc/os-release; \
+    printf 'deb http://mirrors.aliyun.com/debian %s main contrib non-free non-free-firmware\n' "$VERSION_CODENAME" > /etc/apt/sources.list; \
+    printf 'deb http://mirrors.aliyun.com/debian %s-updates main contrib non-free non-free-firmware\n' "$VERSION_CODENAME" >> /etc/apt/sources.list; \
+    printf 'deb http://mirrors.aliyun.com/debian-security %s-security main contrib non-free non-free-firmware\n' "$VERSION_CODENAME" >> /etc/apt/sources.list; \
+    rm -f /etc/apt/sources.list.d/*; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends -o Acquire::Retries=5 --fix-missing \
+      libreoffice-writer \
+      poppler-utils \
+      libgl1 \
+      libglib2.0-0; \
+    rm -rf /var/lib/apt/lists/*
 
 COPY packages/scene-builder-py ./packages/scene-builder-py
 COPY apps/api ./apps/api
@@ -16,10 +23,12 @@ COPY apps/api ./apps/api
 ARG INSTALL_OCR=false
 ARG INSTALL_AV=false
 
-RUN pip install --no-cache-dir ./packages/scene-builder-py \
-    && pip install --no-cache-dir ./apps/api \
+RUN pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple --trusted-host mirrors.aliyun.com \
+      ./packages/scene-builder-py \
+    && pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple --trusted-host mirrors.aliyun.com \
+      ./apps/api \
     && if [ "$INSTALL_OCR" = "true" ]; then \
-         pip install --no-cache-dir "./apps/api[ocr]" \
+         pip install --no-cache-dir -i https://mirrors.aliyun.com/pypi/simple --trusted-host mirrors.aliyun.com "./apps/api[ocr]" \
          && pip install --no-cache-dir paddlepaddle -i https://www.paddlepaddle.org.cn/packages/stable/cpu/; \
        fi \
     && if [ "$INSTALL_AV" = "true" ]; then \

--- a/deploy/docker/Dockerfile.web
+++ b/deploy/docker/Dockerfile.web
@@ -1,12 +1,19 @@
 FROM node:20-alpine AS build
 WORKDIR /app
-COPY apps/web/package*.json ./apps/web/
-RUN cd apps/web && npm ci
+
+# Monorepo workspaces: lockfile lives at repo root; web depends on packages/*.
+COPY package.json package-lock.json ./
+COPY apps/web/package.json ./apps/web/
+COPY apps/collab/package.json ./apps/collab/
+COPY packages ./packages
+RUN npm ci --ignore-scripts
+
 COPY apps/web ./apps/web
+COPY plugins/canvas ./plugins/canvas
 # Bake collab client flag at build time (self-host default: on).
 ARG VITE_COLLAB_ENABLED=true
 ENV VITE_COLLAB_ENABLED=$VITE_COLLAB_ENABLED
-RUN cd apps/web && npm run build
+RUN npm run build --workspace=apps/web
 
 FROM nginx:alpine
 COPY deploy/nginx/default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Summary
- Guests open the in-page login modal instead of a new tab (New project / agent send / open case)
- Login art uses fixed light logo mark; Skills cards restore icon + 2-line subtitle and pack-file hint
- Docker web build uses monorepo lockfile; API image uses faster apt/pip mirrors

## Test plan
- [ ] Logged out: click New project / send home prompt → login modal on same tab
- [ ] Login dialog left mark is light plate on dark panel
- [ ] Skills toolbox cards show icon + multi-line subtitle; help tip lists required/optional pack files
- [ ] (optional) `docker compose build web api` succeeds
