### PR TITLE
fix: harden cloud MySQL text columns and production web chrome

### DIFF
--- a/apps/api/app/alembic/versions/0009_design_text_columns.py
+++ b/apps/api/app/alembic/versions/0009_design_text_columns.py
@@ -1,0 +1,50 @@
+"""Widen design prompt/skill text columns (MySQL VARCHAR(255) → TEXT).
+
+Revision ID: 0009_design_text_columns
+Revises: 0008_org_invites
+Create Date: 2026-08-13
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0009_design_text_columns"
+down_revision = "0008_org_invites"
+branch_labels = None
+depends_on = None
+
+_MYSQL_ALTERS = (
+    "ALTER TABLE design_prompt_pack MODIFY body LONGTEXT NOT NULL",
+    "ALTER TABLE design_prompt_pack MODIFY when_to_use TEXT NULL",
+    "ALTER TABLE design_skill MODIFY prompt_positive LONGTEXT NOT NULL",
+    "ALTER TABLE design_skill MODIFY prompt_negative LONGTEXT NULL",
+    "ALTER TABLE design_skill MODIFY when_to_use TEXT NULL",
+    "ALTER TABLE design_skill MODIFY preferred_tools TEXT NULL",
+    "ALTER TABLE design_skill MODIFY allowed_resources TEXT NULL",
+    "ALTER TABLE design_skill MODIFY triggers TEXT NULL",
+    "ALTER TABLE design_skill MODIFY description TEXT NULL",
+    "ALTER TABLE design_skill MODIFY logo LONGTEXT NULL",
+    "ALTER TABLE design_skill MODIFY locales TEXT NULL",
+    "ALTER TABLE design_skill MODIFY input_schema TEXT NULL",
+    "ALTER TABLE design_skill MODIFY output_schema TEXT NULL",
+    "ALTER TABLE design_skill_revision MODIFY snapshot LONGTEXT NOT NULL",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "mysql":
+        return
+    insp = sa.inspect(bind)
+    tables = set(insp.get_table_names())
+    for stmt in _MYSQL_ALTERS:
+        table = stmt.split()[2]
+        if table in tables:
+            op.execute(sa.text(stmt))
+
+
+def downgrade() -> None:
+    # Do not shrink TEXT back to VARCHAR — would truncate production data.
+    pass

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, Optional
 
 from pydantic import ConfigDict
-from sqlalchemy import Column, LargeBinary
+from sqlalchemy import Column, LargeBinary, Text
 from sqlmodel import Field, SQLModel
 
 
@@ -432,8 +432,9 @@ class DesignPromptPack(SQLModel, table=True):
     kind: str = Field(max_length=128)
     pack_type: str = Field(default="need", max_length=32)
     title: str = Field(max_length=128)
-    body: str = Field(default="")
-    when_to_use: Optional[str] = Field(default=None)
+    # MySQL maps bare str → VARCHAR(255); packs/skills need TEXT.
+    body: str = Field(default="", sa_column=Column(Text, nullable=False))
+    when_to_use: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
     scenes: str = Field(default="all", max_length=128)
     used_by: str = Field(default="", max_length=256)
     sort_order: int = Field(default=0)
@@ -449,23 +450,23 @@ class DesignSkill(SQLModel, table=True):
     name: str = Field(max_length=128)
     skill_key: Optional[str] = Field(default=None, max_length=64)
     category: str = Field(max_length=32)
-    prompt_positive: str = Field(default="")
-    prompt_negative: Optional[str] = Field(default=None)
-    when_to_use: Optional[str] = Field(default=None)
-    preferred_tools: Optional[str] = Field(default=None)
-    allowed_resources: Optional[str] = Field(default=None)
-    triggers: Optional[str] = Field(default=None)
+    prompt_positive: str = Field(default="", sa_column=Column(Text, nullable=False))
+    prompt_negative: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
+    when_to_use: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
+    preferred_tools: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
+    allowed_resources: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
+    triggers: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
     mutex_group: Optional[str] = Field(default=None, max_length=64)
     version: int = Field(default=1)
     pack_version: Optional[str] = Field(default=None, max_length=32)
-    description: Optional[str] = Field(default=None)
-    logo: Optional[str] = Field(default=None)
-    locales: Optional[str] = Field(default=None)
+    description: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
+    logo: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
+    locales: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
     source: str = Field(default="admin", max_length=16)
     namespace: str = Field(default="user", max_length=16)
     owner_user_id: Optional[str] = Field(default=None, max_length=64)
-    input_schema: Optional[str] = Field(default=None)
-    output_schema: Optional[str] = Field(default=None)
+    input_schema: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
+    output_schema: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
     sort_weight: int = Field(default=0)
     scenes: str = Field(default="all", max_length=128)
     default_model: str = Field(default="doubao", max_length=32)
@@ -486,7 +487,7 @@ class DesignSkillRevision(SQLModel, table=True):
     namespace: str = Field(default="user", max_length=16)
     version: int = Field(default=1)
     pack_version: Optional[str] = Field(default=None, max_length=32)
-    snapshot: str = Field(default="")
+    snapshot: str = Field(default="", sa_column=Column(Text, nullable=False))
     source: str = Field(default="admin", max_length=16)
     created_at: float = Field(default=0.0)
 

--- a/apps/web/src/components/base/AppLogo.tsx
+++ b/apps/web/src/components/base/AppLogo.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/utils/classnames';
 
@@ -10,33 +10,61 @@ type Props = {
   className?: string;
   bordered?: boolean;
   /**
-   * `dark` — white feather on dark plate (`/logo-mark.png`), for light rails.
-   * `light` — dark feather on light plate (`/logo-mark-light.png`), for dark rails (e.g. login art).
-   * `auto` / omit — same as `dark`.
+   * `dark` — white feather on dark plate (`/logo-mark.png`), for light chrome.
+   * `light` — dark feather on light plate (`/logo-mark-light.png`), for dark chrome.
+   * `auto` / omit — follow `html[data-theme]` (light UI → dark plate, dark UI → light plate).
    */
   scheme?: LogoScheme | 'auto';
 };
 
-function markSrc(scheme: LogoScheme | 'auto' | undefined): string {
-  if (scheme === 'light') return '/logo-mark-light.png';
-  return '/logo-mark.png';
+function readUiTheme(): 'light' | 'dark' {
+  if (typeof document === 'undefined') return 'light';
+  return document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+}
+
+function useUiTheme(): 'light' | 'dark' {
+  const [theme, setTheme] = useState<'light' | 'dark'>(readUiTheme);
+  useEffect(() => {
+    const sync = () => setTheme(readUiTheme());
+    sync();
+    const root = document.documentElement;
+    const obs = new MutationObserver(sync);
+    obs.observe(root, { attributes: true, attributeFilter: ['data-theme', 'class'] });
+    return () => obs.disconnect();
+  }, []);
+  return theme;
+}
+
+function resolveScheme(
+  scheme: LogoScheme | 'auto' | undefined,
+  uiTheme: 'light' | 'dark',
+): LogoScheme {
+  if (scheme === 'dark' || scheme === 'light') return scheme;
+  // Dark UI chrome → light plate mark; light UI → dark plate mark.
+  return uiTheme === 'dark' ? 'light' : 'dark';
+}
+
+function markSrc(scheme: LogoScheme): string {
+  return scheme === 'light' ? '/logo-mark-light.png' : '/logo-mark.png';
 }
 
 /**
- * Brand mark — scheme picks the fixed plate (not CSS theme).
- * Used by: HomeBody, LoginDialog, EditorBootOverlay.
+ * Brand mark — scheme picks the fixed plate (or follows theme when `auto`).
+ * Used by: HomeBody, LoginDialog, EditorBootOverlay, DesktopTitlebar.
  */
 function AppLogo({
   size = 36,
   className,
   bordered = false,
-  scheme = 'dark',
+  scheme = 'auto',
 }: Props) {
   const { t } = useTranslation();
+  const uiTheme = useUiTheme();
+  const resolved = resolveScheme(scheme, uiTheme);
 
   return (
     <img
-      src={markSrc(scheme)}
+      src={markSrc(resolved)}
       alt={t('app.name')}
       width={size}
       height={size}

--- a/apps/web/src/plugins/canvas/host.ts
+++ b/apps/web/src/plugins/canvas/host.ts
@@ -171,13 +171,17 @@ export function buildCanvasPluginRuntime(
 export async function ensureCanvasPlugins(): Promise<void> {
   if (bootstrapped) return;
   bootstrapped = true;
-  try {
-    const mod = await import('@canvas-plugins/watermark');
-    const pack = (mod as { default?: unknown }).default as
-      | CanvasPluginModule
-      | undefined;
-    if (pack?.manifest) installCanvasPlugin(pack);
-  } catch (err) {
-    console.warn('[canvas-plugin] builtin watermark failed to load', err);
+  // Sample watermark toolbar button is a local demo only — never ship on Cloud / prod.
+  if (import.meta.env.DEV) {
+    try {
+      const mod = await import('@canvas-plugins/watermark');
+      const pack = (mod as { default?: unknown }).default as
+        | CanvasPluginModule
+        | undefined;
+      if (pack?.manifest) installCanvasPlugin(pack);
+    } catch (err) {
+      console.warn('[canvas-plugin] builtin watermark failed to load', err);
+    }
   }
+  // Cloud-safe first-party packs can register below (unconditional).
 }

--- a/deploy/caddy/Caddyfile.recombyn
+++ b/deploy/caddy/Caddyfile.recombyn
@@ -1,0 +1,19 @@
+# HTTP by IP (no TLS for bare IP)
+http://43.143.230.24 {
+	encode gzip
+	reverse_proxy 127.0.0.1:3000
+}
+
+recombyn.com, www.recombyn.com {
+	encode gzip
+
+	header {
+		X-Content-Type-Options nosniff
+		X-Frame-Options SAMEORIGIN
+		Referrer-Policy strict-origin-when-cross-origin
+		Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()"
+		-Server
+	}
+
+	reverse_proxy 127.0.0.1:3000
+}

--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -18,7 +18,8 @@ server {
   add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
   # XSS defense-in-depth (DOMPurify + rehype-sanitize also on the client).
   # 'unsafe-inline' script: index.html bootstrap snippet; styles: Tailwind/runtime.
-  add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self' https://accounts.google.com; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: blob: https:; media-src 'self' data: blob: https:; connect-src 'self' https: wss: ws: blob:; worker-src 'self' blob:; child-src 'self' blob:; frame-src 'self'; upgrade-insecure-requests" always;
+  # No upgrade-insecure-requests: IP/HTTP self-host and Caddy HTTPS must both work.
+  add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self' https://accounts.google.com; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: blob: https:; media-src 'self' data: blob: https:; connect-src 'self' https: wss: ws: blob:; worker-src 'self' blob:; child-src 'self' blob:; frame-src 'self'" always;
 
   location /api/ {
     proxy_pass http://api:8000/api/;


### PR DESCRIPTION
## Summary
- Widen MySQL prompt/skill columns from VARCHAR(255) to TEXT/LONGTEXT (migration 0009) so cloud skill seeding works
- AppLogo follows `data-theme` so the rail mark is visible in dark mode
- Load sample canvas watermark toolbar plugin only in DEV (not production)
- Drop CSP `upgrade-insecure-requests`; add Caddyfile sample for IP HTTP + domain HTTPS

## Test plan
- [ ] Open https://recombyn.com — site loads over HTTPS
- [ ] Dark mode: sidebar logo uses light plate
- [ ] Skill toolbox lists official skills
- [ ] Production editor toolbar has no sample watermark button
