### PR TITLE
fix: email OTP BIGINT timestamps and Google client id in web image

### DIFF
--- a/apps/api/app/alembic/versions/0010_email_code_double.py
+++ b/apps/api/app/alembic/versions/0010_email_code_double.py
@@ -1,0 +1,42 @@
+"""Email OTP timestamps: MySQL FLOAT/DOUBLE to BIGINT unix seconds.
+
+Revision ID: 0010_email_code_double
+Revises: 0009_design_text_columns
+Create Date: 2026-08-13
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0010_email_code_double"
+down_revision = "0009_design_text_columns"
+branch_labels = None
+depends_on = None
+
+# Keep revision id for servers that already applied an earlier DOUBLE draft of 0010;
+# upgrading FLOAT or DOUBLE to BIGINT is idempotent for OTP tables.
+_MYSQL_ALTERS = (
+    "ALTER TABLE email_codes MODIFY sent_at BIGINT NOT NULL DEFAULT 0",
+    "ALTER TABLE email_codes MODIFY expires_at BIGINT NOT NULL DEFAULT 0",
+    "ALTER TABLE email_tickets MODIFY expires_at BIGINT NOT NULL DEFAULT 0",
+    "ALTER TABLE email_activate_tokens MODIFY expires_at BIGINT NOT NULL DEFAULT 0",
+    "ALTER TABLE email_activate_tokens MODIFY created_at BIGINT NOT NULL DEFAULT 0",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "mysql":
+        return
+    insp = sa.inspect(bind)
+    tables = set(insp.get_table_names())
+    for stmt in _MYSQL_ALTERS:
+        table = stmt.split()[2]
+        if table in tables:
+            op.execute(sa.text(stmt))
+
+
+def downgrade() -> None:
+    pass

--- a/apps/api/app/crud.py
+++ b/apps/api/app/crud.py
@@ -926,22 +926,22 @@ def upsert_email_code(
     session: Session,
     email: str,
     code_hash: str,
-    expires_at: float,
-    sent_at: float,
+    expires_at: int,
+    sent_at: int,
 ) -> EmailCode:
     email_n = email.strip().lower()
     row = get_email_code(session=session, email=email_n)
     if row:
         row.code_hash = code_hash
-        row.expires_at = expires_at
-        row.sent_at = sent_at
+        row.expires_at = int(expires_at)
+        row.sent_at = int(sent_at)
         row.attempts = 0
     else:
         row = EmailCode(
             email=email_n,
             code_hash=code_hash,
-            expires_at=expires_at,
-            sent_at=sent_at,
+            expires_at=int(expires_at),
+            sent_at=int(sent_at),
             attempts=0,
         )
     session.add(row)
@@ -962,9 +962,11 @@ def create_email_ticket(
     session: Session,
     ticket: str,
     email: str,
-    expires_at: float,
+    expires_at: int,
 ) -> EmailTicket:
-    row = EmailTicket(ticket=ticket, email=email.strip().lower(), expires_at=expires_at)
+    row = EmailTicket(
+        ticket=ticket, email=email.strip().lower(), expires_at=int(expires_at)
+    )
     session.add(row)
     session.commit()
     return row
@@ -981,7 +983,7 @@ def delete_email_ticket(*, session: Session, ticket: str) -> None:
         session.commit()
 
 
-def latest_activate_token_created_at(*, session: Session, email: str) -> float | None:
+def latest_activate_token_created_at(*, session: Session, email: str) -> int | None:
     email_n = (email or "").strip().lower()
     row = session.exec(
         select(EmailActivateToken)
@@ -989,7 +991,7 @@ def latest_activate_token_created_at(*, session: Session, email: str) -> float |
         .order_by(col(EmailActivateToken.created_at).desc())
         .limit(1)
     ).first()
-    return float(row.created_at) if row else None
+    return int(row.created_at) if row else None
 
 
 def replace_activate_token(
@@ -997,8 +999,8 @@ def replace_activate_token(
     session: Session,
     email: str,
     token_id: str,
-    expires_at: float,
-    created_at: float,
+    expires_at: int,
+    created_at: int,
 ) -> EmailActivateToken:
     email_n = email.strip().lower()
     old = list(
@@ -1013,8 +1015,8 @@ def replace_activate_token(
     row = EmailActivateToken(
         token_id=token_id,
         email=email_n,
-        expires_at=expires_at,
-        created_at=created_at,
+        expires_at=int(expires_at),
+        created_at=int(created_at),
     )
     session.add(row)
     session.commit()

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, Optional
 
 from pydantic import ConfigDict
-from sqlalchemy import Column, LargeBinary, Text
+from sqlalchemy import BigInteger, Column, LargeBinary, Text
 from sqlmodel import Field, SQLModel
 
 
@@ -266,8 +266,10 @@ class EmailCode(SQLModel, table=True):
 
     email: str = Field(primary_key=True, max_length=320)
     code_hash: str = Field(max_length=128)
-    expires_at: float = 0.0
-    sent_at: float = 0.0
+    # Unix seconds as BIGINT — MySQL FLOAT lacks second precision; DOUBLE is ok but
+    # integer seconds match the OTP TTL math and avoid float edge cases.
+    expires_at: int = Field(default=0, sa_column=Column(BigInteger, nullable=False))
+    sent_at: int = Field(default=0, sa_column=Column(BigInteger, nullable=False))
     attempts: int = Field(default=0)
 
 
@@ -276,7 +278,7 @@ class EmailTicket(SQLModel, table=True):
 
     ticket: str = Field(primary_key=True, max_length=128)
     email: str = Field(max_length=320)
-    expires_at: float = 0.0
+    expires_at: int = Field(default=0, sa_column=Column(BigInteger, nullable=False))
 
 
 class EmailActivateToken(SQLModel, table=True):
@@ -284,8 +286,8 @@ class EmailActivateToken(SQLModel, table=True):
 
     token_id: str = Field(primary_key=True, max_length=64)
     email: str = Field(index=True, max_length=320)
-    expires_at: float = 0.0
-    created_at: float = 0.0
+    expires_at: int = Field(default=0, sa_column=Column(BigInteger, nullable=False))
+    created_at: int = Field(default=0, sa_column=Column(BigInteger, nullable=False))
 
 
 class CardKey(SQLModel, table=True):

--- a/apps/api/app/services/auth/email_store.py
+++ b/apps/api/app/services/auth/email_store.py
@@ -628,13 +628,13 @@ def store_code(email: str, code: str) -> None:
 
     init_auth_db()
     email_n = email.strip().lower()
-    now = time.time()
+    now = int(time.time())
     with Session(engine) as session:
         crud.upsert_email_code(
             session=session,
             email=email_n,
             code_hash=hash_code(email_n, code),
-            expires_at=now + _CODE_TTL_SECONDS,
+            expires_at=now + int(_CODE_TTL_SECONDS),
             sent_at=now,
         )
 
@@ -652,7 +652,7 @@ def verify_and_issue_ticket(email: str, code: str) -> str:
         row = crud.get_email_code(session=session, email=email_n)
         if not row:
             raise ValueError("code_missing")
-        if float(row.expires_at) < time.time():
+        if int(row.expires_at) < int(time.time()):
             session.delete(row)
             session.commit()
             raise ValueError("code_expired")
@@ -671,7 +671,7 @@ def verify_and_issue_ticket(email: str, code: str) -> str:
             session=session,
             ticket=ticket,
             email=email_n,
-            expires_at=time.time() + _TICKET_TTL_SECONDS,
+            expires_at=int(time.time()) + int(_TICKET_TTL_SECONDS),
         )
         return ticket
 
@@ -690,7 +690,7 @@ def consume_ticket(email: str, ticket: str) -> bool:
             return False
         session.delete(row)
         session.commit()
-        if float(row.expires_at) < time.time():
+        if int(row.expires_at) < int(time.time()):
             return False
         return str(row.email).lower() == email_n
 
@@ -736,14 +736,14 @@ def create_activate_token(email: str) -> str:
 
     init_auth_db()
     email_n = email.strip().lower()
-    now = time.time()
+    now = int(time.time())
     token_id = secrets.token_urlsafe(24)
     with Session(engine) as session:
         crud.replace_activate_token(
             session=session,
             email=email_n,
             token_id=token_id,
-            expires_at=now + _ACTIVATE_TTL_SECONDS,
+            expires_at=now + int(_ACTIVATE_TTL_SECONDS),
             created_at=now,
         )
     return token_id
@@ -765,7 +765,7 @@ def consume_activate_token(token_id: str) -> str:
         if not row:
             raise ValueError("link_invalid")
         email = str(row.email).strip().lower()
-        expired = float(row.expires_at) < time.time()
+        expired = int(row.expires_at) < int(time.time())
         session.delete(row)
         session.commit()
         if expired:

--- a/deploy/docker/Dockerfile.web
+++ b/deploy/docker/Dockerfile.web
@@ -13,6 +13,11 @@ COPY plugins/canvas ./plugins/canvas
 # Bake collab client flag at build time (self-host default: on).
 ARG VITE_COLLAB_ENABLED=true
 ENV VITE_COLLAB_ENABLED=$VITE_COLLAB_ENABLED
+# Google OAuth client id must be present at Vite build time (__GOOGLE_CLIENT_ID__).
+ARG GOOGLE_CLIENT_ID=
+ENV GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID
+ARG VITE_GOOGLE_CLIENT_ID=
+ENV VITE_GOOGLE_CLIENT_ID=$VITE_GOOGLE_CLIENT_ID
 RUN npm run build --workspace=apps/web
 
 FROM nginx:alpine


### PR DESCRIPTION
## Summary
- Store email OTP / ticket / activate-token timestamps as MySQL BIGINT unix seconds (fixes FLOAT precision expiry bugs).
- Align auth store/crud to integer second math.
- Bake GOOGLE_CLIENT_ID into the web Docker image at build time so production Google login is not empty.

## Test plan
- [ ] Apply alembic 0010 (or equivalent ALTER) on MySQL; confirm email_codes.sent_at/expires_at are bigint
- [ ] Request email OTP on production domain; code should verify within TTL
- [ ] Rebuild web image with GOOGLE_CLIENT_ID; Google button works on https://recombyn.com
