### PR TITLE
fix: stabilize project cloud sync and defer home-agent send during tour

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -123,6 +123,9 @@ GOOGLE_CLIENT_SECRET=
 # - Authorized JavaScript origins: http://localhost:3000
 # - Authorized redirect URIs: http://localhost:3000/login/google/callback
 #   (full-page redirect; current tab becomes Google login, then returns here)
+# If the API host cannot reach Google (common on CN VPS), set a proxy and restart:
+# GOOGLE_OAUTH_HTTP_PROXY=http://127.0.0.1:7890
+# GOOGLE_OAUTH_TIMEOUT_SEC=30
 
 # Token wallet — card keys (no WeChat/Alipay). Required before generating or redeeming keys.
 # Generate a strong secret, e.g. `python -c "import secrets; print(secrets.token_urlsafe(32))"`

--- a/apps/api/app/alembic/versions/0011_project_thumbnail_key_text.py
+++ b/apps/api/app/alembic/versions/0011_project_thumbnail_key_text.py
@@ -1,0 +1,31 @@
+"""Widen projects.thumbnail_key — collage stores ≤4 image URLs as JSON.
+
+Revision ID: 0011_project_thumbnail_key_text
+Revises: 0010_email_code_double
+Create Date: 2026-08-13
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0011_project_thumbnail_key_text"
+down_revision = "0010_email_code_double"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "mysql":
+        return
+    insp = sa.inspect(bind)
+    if "projects" not in set(insp.get_table_names()):
+        return
+    op.execute(sa.text("ALTER TABLE projects MODIFY thumbnail_key TEXT NULL"))
+
+
+def downgrade() -> None:
+    # Do not shrink TEXT back to VARCHAR — would truncate production covers.
+    pass

--- a/apps/api/app/api/routes/projects.py
+++ b/apps/api/app/api/routes/projects.py
@@ -135,7 +135,10 @@ def extract_covers(
             document=(body.document if body else None),
         )
     except ProjectNotFoundError as exc:
-        raise HTTPException(status_code=404, detail="Not found") from exc
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "project_not_found", "id": exc.project_id or project_id},
+        ) from exc
     except ProjectForbiddenError as exc:
         raise HTTPException(
             status_code=403,

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -252,6 +252,11 @@ class Settings(BaseSettings):
     # Google OAuth — Client ID on web + API; secret only for popup auth-code exchange
     google_client_id: str = ""
     google_client_secret: str = ""
+    # Token endpoint timeout (oauth2.googleapis.com). Raise if API host is slow to Google.
+    google_oauth_timeout_sec: float = 30.0
+    # Optional HTTP(S) proxy for Google token exchange (needed when API cannot reach Google,
+    # e.g. CN VPS). Example: http://127.0.0.1:7890
+    google_oauth_http_proxy: str = ""
 
     # Local-only admin OTP (apps/api/.env). Empty = disabled. Never set in production.
     super_admin_test_code: str = ""

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -177,10 +177,11 @@ class Project(SQLModel, table=True):
     """Optional team container — members may read/write per org role."""
     org_id: Optional[str] = Field(default=None, index=True, max_length=64)
     name: str = Field(default="Untitled", max_length=255)
-    thumbnail_key: Optional[str] = Field(default=None, max_length=512)
+    # Collage may store ≤4 https URLs as a JSON array — must be TEXT, not VARCHAR(512).
+    thumbnail_key: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
     thumbnail_custom: int = Field(default=0)
     document_key: Optional[str] = Field(default=None, max_length=512)
-    document_json: Optional[str] = Field(default=None)
+    document_json: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
     revision: int = Field(default=1)
     updated_at: float = Field(default=0.0)
     created_at: float = Field(default=0.0)

--- a/apps/api/app/services/auth/google.py
+++ b/apps/api/app/services/auth/google.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from urllib.parse import urlparse
 
 import httpx
@@ -15,6 +16,7 @@ _VALID_ISSUERS = frozenset({"accounts.google.com", "https://accounts.google.com"
 # GIS popup code client uses this redirect_uri (not a real browser redirect).
 _POPUP_REDIRECT_URI = "postmessage"
 _REDIRECT_PATH = "/login/google/callback"
+_TOKEN_URL = "https://oauth2.googleapis.com/token"
 
 
 def _session_from_id_token(credential: str) -> tuple[SessionUser, str]:
@@ -72,6 +74,45 @@ def _resolve_redirect_uri(redirect_uri: str | None) -> str:
     return uri
 
 
+def _google_httpx_client() -> httpx.Client:
+    timeout = float(settings.google_oauth_timeout_sec or 30.0)
+    proxy = (settings.google_oauth_http_proxy or "").strip() or None
+    return httpx.Client(timeout=timeout, proxy=proxy)
+
+
+def _exchange_timeout_hint(err: BaseException) -> str:
+    proxy = (settings.google_oauth_http_proxy or "").strip()
+    base = (
+        "Google token exchange timed out — this API host cannot reach "
+        "oauth2.googleapis.com within the deadline"
+    )
+    if proxy:
+        return f"{base} (proxy={proxy}). Check the proxy and try again."
+    return (
+        f"{base}. If the server is in a restricted network, set "
+        "GOOGLE_OAUTH_HTTP_PROXY (e.g. http://127.0.0.1:7890) and restart the API."
+    )
+
+
+def _post_google_token(data: dict[str, str]) -> httpx.Response:
+    """POST to Google's token endpoint; one retry on transient timeout/connect errors."""
+    last_err: BaseException | None = None
+    for attempt in range(2):
+        try:
+            with _google_httpx_client() as client:
+                return client.post(_TOKEN_URL, data=data)
+        except (httpx.TimeoutException, httpx.NetworkError, httpx.TransportError) as err:
+            last_err = err
+            if attempt == 0:
+                time.sleep(0.4)
+                continue
+            if isinstance(err, httpx.TimeoutException):
+                raise ValueError(_exchange_timeout_hint(err)) from err
+            raise ValueError(f"Google token exchange failed: {err}") from err
+    assert last_err is not None
+    raise ValueError(f"Google token exchange failed: {last_err}") from last_err
+
+
 def login_with_google_auth_code(
     code: str,
     redirect_uri: str | None = None,
@@ -94,17 +135,17 @@ def login_with_google_auth_code(
     resolved_redirect = _resolve_redirect_uri(redirect_uri)
 
     try:
-        with httpx.Client(timeout=20.0) as client:
-            token_res = client.post(
-                "https://oauth2.googleapis.com/token",
-                data={
-                    "code": code,
-                    "client_id": client_id,
-                    "client_secret": client_secret,
-                    "redirect_uri": resolved_redirect,
-                    "grant_type": "authorization_code",
-                },
-            )
+        token_res = _post_google_token(
+            {
+                "code": code,
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "redirect_uri": resolved_redirect,
+                "grant_type": "authorization_code",
+            }
+        )
+    except ValueError:
+        raise
     except Exception as err:
         raise ValueError(f"Google token exchange failed: {err}") from err
 

--- a/apps/api/app/services/projects.py
+++ b/apps/api/app/services/projects.py
@@ -239,7 +239,18 @@ def _encode_thumb_entries(entries: list[str] | None) -> str | None:
         return None
     if len(cleaned) == 1:
         return cleaned[0]
-    return json.dumps(cleaned, ensure_ascii=False)
+    encoded = json.dumps(cleaned, ensure_ascii=False)
+    # Legacy MySQL VARCHAR(512) — prefer a shorter collage over failing PUT /projects.
+    if len(encoded) <= 500:
+        return encoded
+    for n in range(len(cleaned) - 1, 0, -1):
+        trimmed = cleaned[:n]
+        if len(trimmed) == 1:
+            return trimmed[0]
+        again = json.dumps(trimmed, ensure_ascii=False)
+        if len(again) <= 500:
+            return again
+    return cleaned[0][:500] if cleaned else None
 
 
 def _is_project_owned_thumb_key(entry: str) -> bool:
@@ -1155,17 +1166,27 @@ def upsert_project(
                 next_doc_key = None
             if document is not None and next_doc_key:
                 next_doc_json = None
-            next_thumb, next_custom = _next_thumbnail(
-                owner_id,
-                pid,
-                thumbnail_data_url,
-                existing.thumbnail_key,
-                existing_custom=_row_thumb_custom(existing),
-                mark_custom=thumbnail_custom,
-                thumbnail_data_urls=thumbnail_data_urls,
-                thumbnail_urls=thumbnail_urls,
-                document=document,
-            )
+            try:
+                next_thumb, next_custom = _next_thumbnail(
+                    owner_id,
+                    pid,
+                    thumbnail_data_url,
+                    existing.thumbnail_key,
+                    existing_custom=_row_thumb_custom(existing),
+                    mark_custom=thumbnail_custom,
+                    thumbnail_data_urls=thumbnail_data_urls,
+                    thumbnail_urls=thumbnail_urls,
+                    document=document,
+                )
+            except Exception as exc:
+                # Cover rebuild must not block document save (COS / URL collage).
+                print(
+                    f"[projects.thumb] upsert keep existing project={pid} err={exc!r}",
+                    flush=True,
+                )
+                next_thumb, next_custom = existing.thumbnail_key, _row_thumb_custom(
+                    existing
+                )
             old_doc_key = existing.document_key
             ok = crud.update_project_if_revision_accessible(
                 session=session,
@@ -1211,17 +1232,24 @@ def upsert_project(
                 raise ProjectForbiddenError(pid)
             if want_org:
                 _require_org_project_write(user_id=user_id, org_id=want_org)
-            thumb_key, thumb_custom = _next_thumbnail(
-                user_id,
-                pid,
-                thumbnail_data_url,
-                None,
-                existing_custom=False,
-                mark_custom=thumbnail_custom,
-                thumbnail_data_urls=thumbnail_data_urls,
-                thumbnail_urls=thumbnail_urls,
-                document=document,
-            )
+            try:
+                thumb_key, thumb_custom = _next_thumbnail(
+                    user_id,
+                    pid,
+                    thumbnail_data_url,
+                    None,
+                    existing_custom=False,
+                    mark_custom=thumbnail_custom,
+                    thumbnail_data_urls=thumbnail_data_urls,
+                    thumbnail_urls=thumbnail_urls,
+                    document=document,
+                )
+            except Exception as exc:
+                print(
+                    f"[projects.thumb] create skip cover project={pid} err={exc!r}",
+                    flush=True,
+                )
+                thumb_key, thumb_custom = None, False
             crud.create_project(
                 session=session,
                 project=Project(

--- a/apps/web/src/components/editor/chrome/EditorOnboardingTour.tsx
+++ b/apps/web/src/components/editor/chrome/EditorOnboardingTour.tsx
@@ -91,6 +91,8 @@ type Props = {
   forceOpen?: boolean;
   onForceOpenConsumed?: () => void;
   onOpenAgent: () => void;
+  /** Notify parent when the tour overlay is shown/hidden (home-agent auto-send waits). */
+  onActiveChange?: (active: boolean) => void;
   className?: string;
 };
 
@@ -199,6 +201,7 @@ function EditorOnboardingTour({
   forceOpen = false,
   onForceOpenConsumed,
   onOpenAgent,
+  onActiveChange,
   className,
 }: Props) {
   const { t } = useTranslation();
@@ -213,6 +216,12 @@ function EditorOnboardingTour({
   onOpenAgentRef.current = onOpenAgent;
   const onForceOpenConsumedRef = useRef(onForceOpenConsumed);
   onForceOpenConsumedRef.current = onForceOpenConsumed;
+  const onActiveChangeRef = useRef(onActiveChange);
+  onActiveChangeRef.current = onActiveChange;
+
+  useEffect(() => {
+    onActiveChangeRef.current?.(active);
+  }, [active]);
 
   useEffect(() => {
     if (!ready) return;

--- a/apps/web/src/components/editor/panels/AgentDock.tsx
+++ b/apps/web/src/components/editor/panels/AgentDock.tsx
@@ -363,6 +363,11 @@ type AgentDockProps = {
   draftPrompt?: string | null;
   /** When true with draftPrompt, auto-send after models are ready (home → editor). */
   autoSubmitDraft?: boolean;
+  /**
+   * Hold home-agent auto-send (boot overlay / first-run tour still open).
+   * Prompt stays queued in the composer until this clears.
+   */
+  holdAutoSubmit?: boolean;
   onDraftConsumed?: () => void;
   draftAttachments?: ComposerContext[];
   /** Home → editor: inline skill / context pills (e.g. plaza 「做同款」). */
@@ -587,6 +592,7 @@ function AgentDock({
   allowedInteractionModes,
   draftPrompt,
   autoSubmitDraft = false,
+  holdAutoSubmit = false,
   onDraftConsumed,
   draftAttachments,
   draftContexts,
@@ -2737,6 +2743,7 @@ function AgentDock({
   /** Flush home-agent auto-submit once model list has settled (ready or error). */
   useEffect(() => {
     if (!open) return;
+    if (holdAutoSubmit) return;
     if (new URLSearchParams(location.search).get('createNew') === '1') return;
     // Prefer scoped project id so the user message is not wiped by createTemplate scope switch.
     const routeId = decodeURIComponent((routeProjectId || '').trim());
@@ -2747,7 +2754,15 @@ function AgentDock({
     pendingAutoSubmitRef.current = null;
     send(text);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, modelsStatus, draftPrompt, location.search, currentId, routeProjectId]);
+  }, [
+    open,
+    holdAutoSubmit,
+    modelsStatus,
+    draftPrompt,
+    location.search,
+    currentId,
+    routeProjectId,
+  ]);
 
   const dismissPendingReview = (opts?: { dropCheckpoint?: boolean }) => {
     if (opts?.dropCheckpoint && pendingReview) {

--- a/apps/web/src/components/editor/panels/ShareDialog.tsx
+++ b/apps/web/src/components/editor/panels/ShareDialog.tsx
@@ -16,6 +16,7 @@ import { getToken } from '@/utils/token';
 import { buildLoginUrl } from '@/utils/authReturnTo';
 import { useNavigate } from 'react-router-dom';
 import { setTemplateThumbnail } from '@/store/modules/editor';
+import { flushCurrentProjectNow } from '@/components/editor/useProjectCloudSync';
 
 type Props = {
   open: boolean;
@@ -300,6 +301,12 @@ function ShareDialog({ open, onClose }: Props) {
     if (coversInflightRef.current) return;
     async function refreshCovers() {
       try {
+        // Covers require a cloud project row — flush first if local-only / failed sync.
+        try {
+          await flushCurrentProjectNow({ force: true });
+        } catch {
+          /* still try covers; API returns project_not_found if missing */
+        }
         const res = await extractCoversMutation.mutateAsync({
           projectId: currentId!,
           document: document != null ? (document as Record<string, unknown>) : undefined,

--- a/apps/web/src/components/editor/panels/agent/ChatTurnList.tsx
+++ b/apps/web/src/components/editor/panels/agent/ChatTurnList.tsx
@@ -1047,15 +1047,15 @@ function AssistantTurn({
       ) : null}
 
       {!streaming && assistant.canResume && assistant.designTaskId && onResume ? (
-        <div className="flex items-center gap-1 px-0.5">
+        <div className="flex justify-start px-0.5">
           <button
             type="button"
             disabled={sending}
             onClick={() => onResume(assistant.id)}
             className={cn(
-              'inline-flex h-7 items-center gap-1 rounded-full px-2.5 text-[12px] text-[var(--muted)]',
-              'hover:bg-[var(--accent-soft)] hover:text-[var(--ink)]',
-              'disabled:cursor-not-allowed disabled:opacity-40'
+              'inline-flex items-center gap-1 border-0 bg-transparent p-0 text-[12px] text-[var(--muted)]',
+              'hover:text-[var(--ink)] hover:underline',
+              'disabled:cursor-not-allowed disabled:opacity-40 disabled:no-underline'
             )}
           >
             <HiOutlinePlay className="h-3.5 w-3.5" aria-hidden />

--- a/apps/web/src/components/editor/useProjectCloudSync.ts
+++ b/apps/web/src/components/editor/useProjectCloudSync.ts
@@ -39,6 +39,23 @@ const DEBOUNCE_MS = 800;
 const MANUAL_SAVE_DEBOUNCE_MS = 300;
 /** Delete / structural edits should hit the cloud ASAP (refresh must not restore old nodes). */
 const FLUSH_NOW_EVENT = 'resume:flush-project';
+/**
+ * After a failed PUT/PATCH, do not hammer the API every debounce tick.
+ * Pause auto-retry for the same document hash once this ladder is exhausted.
+ */
+const CLOUD_FAIL_BACKOFF_MS = [2_000, 5_000, 15_000, 45_000] as const;
+
+function cloudFailRetryDelayMs(failCount: number): number {
+  const idx = Math.max(
+    0,
+    Math.min(failCount - 1, CLOUD_FAIL_BACKOFF_MS.length - 1)
+  );
+  return CLOUD_FAIL_BACKOFF_MS[idx];
+}
+
+function shouldPauseCloudAutoRetry(failCount: number): boolean {
+  return failCount >= CLOUD_FAIL_BACKOFF_MS.length;
+}
 
 /** Latest in-flight / queued editor flush — Home awaits this before re-listing projects. */
 let flushChain: Promise<void> = Promise.resolve();
@@ -530,6 +547,9 @@ export function useProjectCloudSync() {
   const flushingRef = useRef(false);
   /** Delete/edit while a flush is in-flight — run again after current finishes. */
   const pendingFlushRef = useRef(false);
+  /** Consecutive cloud write failures for the current document hash. */
+  const cloudFailCountRef = useRef(0);
+  const cloudFailHashRef = useRef<string | null>(null);
   const dirtyRef = useRef(dirty);
   dirtyRef.current = dirty;
 
@@ -559,6 +579,9 @@ export function useProjectCloudSync() {
       return;
     }
     flushingRef.current = true;
+    let cloudAttempted = false;
+    let cloudOk = false;
+    let pauseAutoRetry = false;
 
     try {
       dispatch(persistCurrent({ keepDirty: true }));
@@ -575,6 +598,12 @@ export function useProjectCloudSync() {
       });
       const contentHash = draft?.contentHash || hashDocument(pushedDoc);
 
+      // New edits unlock a previously paused failure streak.
+      if (cloudFailHashRef.current && cloudFailHashRef.current !== contentHash) {
+        cloudFailCountRef.current = 0;
+        cloudFailHashRef.current = null;
+      }
+
       if (!force && isDraftAlreadyAcked(draft, contentHash, name)) {
         clearDirtyIfSameDoc(dispatch, pushedDoc);
         return;
@@ -584,6 +613,17 @@ export function useProjectCloudSync() {
         return;
       }
 
+      // Same doc already failed the backoff ladder — wait for edits or force save.
+      if (
+        !force &&
+        shouldPauseCloudAutoRetry(cloudFailCountRef.current) &&
+        cloudFailHashRef.current === contentHash
+      ) {
+        pauseAutoRetry = true;
+        return;
+      }
+
+      cloudAttempted = true;
       const written = await syncOwnedDocumentToCloud({
         id,
         name,
@@ -592,6 +632,9 @@ export function useProjectCloudSync() {
         baseDoc: draft?.baseDocument ?? null,
       });
       if (written.status === 'ok') {
+        cloudOk = true;
+        cloudFailCountRef.current = 0;
+        cloudFailHashRef.current = null;
         await applyCloudAck({
           dispatch,
           projectId: id,
@@ -602,6 +645,8 @@ export function useProjectCloudSync() {
         return;
       }
       if (written.status === 'conflict') {
+        cloudFailCountRef.current = 0;
+        cloudFailHashRef.current = null;
         await handleFlushConflict({
           dispatch,
           projectId: id,
@@ -610,15 +655,36 @@ export function useProjectCloudSync() {
           contentHash,
           conflict: written.conflict,
         });
+        return;
       }
-      // failed → stay dirty for debounce / hide / delete flush retry
+      cloudFailCountRef.current += 1;
+      cloudFailHashRef.current = contentHash;
+      if (shouldPauseCloudAutoRetry(cloudFailCountRef.current)) {
+        pauseAutoRetry = true;
+      }
+      if (import.meta.env.DEV) {
+        console.warn('[project-sync] cloud write failed', {
+          id,
+          fails: cloudFailCountRef.current,
+          paused: pauseAutoRetry,
+        });
+      }
     } finally {
       flushingRef.current = false;
       const still = store.getState().editor as { dirty: boolean; currentId: string | null };
       const queued = pendingFlushRef.current;
       pendingFlushRef.current = false;
-      if (still.currentId === id && (queued || still.dirty)) {
-        scheduleFlush(queued ? 0 : DEBOUNCE_MS);
+      // No `return` in finally — eslint no-unsafe-finally.
+      if (still.currentId === id) {
+        if (queued) {
+          scheduleFlush(0);
+        } else if (still.dirty && !pauseAutoRetry) {
+          if (cloudAttempted && !cloudOk && cloudFailCountRef.current > 0) {
+            scheduleFlush(cloudFailRetryDelayMs(cloudFailCountRef.current));
+          } else {
+            scheduleFlush(DEBOUNCE_MS);
+          }
+        }
       }
     }
   }, [dispatch, scheduleFlush]);

--- a/apps/web/src/pages/EditorPage.tsx
+++ b/apps/web/src/pages/EditorPage.tsx
@@ -80,7 +80,9 @@ import {
   parseFillType,
   type FillType,
 } from '@/components/rcb/scene/document/sceneFill';
-import EditorOnboardingTour from '@/components/editor/chrome/EditorOnboardingTour';
+import EditorOnboardingTour, {
+  hasCompletedEditorTour,
+} from '@/components/editor/chrome/EditorOnboardingTour';
 import EditorTopChrome, { flushAndGoHome } from '@/components/editor/page/EditorTopChrome';
 import EditorToolDocks from '@/components/editor/page/EditorToolDocks';
 import EditorBottomHud, { isThemeFollowCanvasBg } from '@/components/editor/page/EditorBottomHud';
@@ -577,6 +579,7 @@ function EditorPage() {
   const [bootOpen, setBootOpen] = useState(true);
   const [bootExiting, setBootExiting] = useState(false);
   const [bootProgress, setBootProgress] = useState(8);
+  const [tourActive, setTourActive] = useState(false);
   const bootStartedAt = useRef(Date.now());
   const bootOpenRef = useRef(true);
   const bootFinishingRef = useRef(false);
@@ -608,6 +611,7 @@ function EditorPage() {
     (state: any) => (state.editor.selectedFrameIds as string[]) ?? EMPTY_ID_LIST
   );
   const currentId = useSelector((state: any) => state.editor.currentId as string | null);
+  const authUserId = useSelector((s: any) => s.auth?.user?.id as string | undefined);
   const templates = useSelector((state: any) => state.editor.templates as any[]);
   const currentTemplate = useSelector((state: any) =>
     state.editor.templates.find((item: any) => item.id === state.editor.currentId)
@@ -1002,6 +1006,9 @@ function EditorPage() {
   const clearAttachToChat = useCallback(() => {
     setAttachToChat(null);
   }, []);
+
+  const holdHomeAgentSubmit =
+    bootOpen || tourActive || !hasCompletedEditorTour(authUserId);
 
   const goHomeFromEditor = useCallback(() => {
     void flushAndGoHome(navigate);
@@ -1615,6 +1622,7 @@ function EditorPage() {
               }
               draftPrompt={agentDraft}
               autoSubmitDraft={agentAutoSubmit}
+              holdAutoSubmit={holdHomeAgentSubmit}
               draftAttachments={agentDraftAttachments}
               draftContexts={agentDraftContexts}
               draftModelId={agentDraftModelId}
@@ -1729,6 +1737,7 @@ function EditorPage() {
         <EditorOnboardingTour
           ready={!bootOpen}
           onOpenAgent={openAgentForTour}
+          onActiveChange={setTourActive}
         />
       </div>
     </CollabRoomProvider>


### PR DESCRIPTION
## Summary
- Fix PUT `/projects` 500s from oversized collage `thumbnail_key` (migration 0011 + URL clamp); cover rebuild errors no longer block document save
- Stop infinite cloud-sync retries: exponential backoff then pause until edit / force save
- Hold home→editor auto-submit until onboarding tour finishes or is skipped
- Share dialog flushes project before covers; clearer `project_not_found` on covers 404
- Harden Google OAuth token exchange (timeout/proxy) for restricted API hosts

## Test plan
- [x] `npm run test:api:unit` (full unit suite green)
- [x] `apps/web` `tsc --noEmit`
- [x] Thumb encode clamp stays ≤500 chars
- [ ] After deploy: create project with multiple image URLs → PUT `/projects` 200; covers/share work
- [ ] First-visit home→editor: tour completes before auto-send