### PR TITLE
fix: widen design_system_prompt.body to LONGTEXT

### DIFF
--- a/apps/api/app/alembic/versions/0013_design_system_prompt_body_text.py
+++ b/apps/api/app/alembic/versions/0013_design_system_prompt_body_text.py
@@ -1,0 +1,35 @@
+"""Widen design_system_prompt.body (MySQL VARCHAR(255) → LONGTEXT).
+
+Revision ID: 0013_design_system_prompt_body_text
+Revises: 0012_project_document_json_text
+Create Date: 2026-08-13
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0013_design_system_prompt_body_text"
+down_revision = "0012_project_document_json_text"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "mysql":
+        return
+    insp = sa.inspect(bind)
+    if "design_system_prompt" not in set(insp.get_table_names()):
+        return
+    op.execute(
+        sa.text(
+            "ALTER TABLE design_system_prompt MODIFY body LONGTEXT NOT NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    # Do not shrink LONGTEXT back to VARCHAR — would truncate production data.
+    pass

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -419,7 +419,8 @@ class DesignSystemPrompt(SQLModel, table=True):
     prompt_key: str = Field(max_length=128, unique=True)
     label: str = Field(default="", max_length=128)
     description: Optional[str] = Field(default=None)
-    body: str = Field(default="")
+    # MySQL maps bare str → VARCHAR(255); seed bodies exceed that.
+    body: str = Field(default="", sa_column=Column(Text, nullable=False))
     group_key: str = Field(default="agent_prompt", max_length=32)
     selectable: int = Field(default=0)
     sort_order: int = Field(default=0)


### PR DESCRIPTION
## Summary
- Catalog seeding failed on MySQL with Data too long for column body (VARCHAR 255)
- Model + alembic 0013 widen to LONGTEXT (prod already patched manually)

## Test plan
- [x] Prod ALTER applied; GET /api/v1/design/catalog returns 200
- [ ] Fresh MySQL migrate applies 0013

Made with [Cursor](https://cursor.com)