### PR TITLE
fix: widen chat session/message columns to LONGTEXT

### DIFF
--- a/apps/api/app/alembic/versions/0014_chat_session_message_text.py
+++ b/apps/api/app/alembic/versions/0014_chat_session_message_text.py
@@ -1,0 +1,40 @@
+"""Widen chat session/message text columns (MySQL VARCHAR(255) → LONGTEXT).
+
+Revision ID: 0014_chat_session_message_text
+Revises: 0013_design_system_prompt_body_text
+Create Date: 2026-08-13
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0014_chat_session_message_text"
+down_revision = "0013_design_system_prompt_body_text"
+branch_labels = None
+depends_on = None
+
+_MYSQL_ALTERS = (
+    "ALTER TABLE chat_messages MODIFY content LONGTEXT NOT NULL",
+    "ALTER TABLE chat_messages MODIFY thinking LONGTEXT NULL",
+    "ALTER TABLE chat_messages MODIFY meta_json LONGTEXT NULL",
+    "ALTER TABLE chat_sessions MODIFY meta_json LONGTEXT NULL",
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != "mysql":
+        return
+    insp = sa.inspect(bind)
+    tables = set(insp.get_table_names())
+    for stmt in _MYSQL_ALTERS:
+        table = stmt.split()[2]
+        if table in tables:
+            op.execute(sa.text(stmt))
+
+
+def downgrade() -> None:
+    # Do not shrink LONGTEXT back to VARCHAR — would truncate production data.
+    pass

--- a/apps/api/app/alembic/versions/0014_chat_session_message_text.py
+++ b/apps/api/app/alembic/versions/0014_chat_session_message_text.py
@@ -20,6 +20,8 @@ _MYSQL_ALTERS = (
     "ALTER TABLE chat_messages MODIFY thinking LONGTEXT NULL",
     "ALTER TABLE chat_messages MODIFY meta_json LONGTEXT NULL",
     "ALTER TABLE chat_sessions MODIFY meta_json LONGTEXT NULL",
+    "ALTER TABLE design_global_rule MODIFY rule_value LONGTEXT NOT NULL",
+    "ALTER TABLE design_global_rule MODIFY description LONGTEXT NULL",
 )
 
 

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -563,7 +563,8 @@ class ChatSession(SQLModel, table=True):
     title: str = Field(default="", max_length=255)
     updated_at: float = Field(default=0.0)
     created_at: float = Field(default=0.0)
-    meta_json: Optional[str] = Field(default=None)
+    # MySQL maps bare str → VARCHAR(255); session task_state JSON needs TEXT.
+    meta_json: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
 
 
 class ChatMessage(SQLModel, table=True):
@@ -572,9 +573,10 @@ class ChatMessage(SQLModel, table=True):
     id: str = Field(primary_key=True, max_length=64)
     session_id: str = Field(index=True, max_length=64)
     role: str = Field(max_length=16)
-    content: str = Field(default="")
-    thinking: Optional[str] = Field(default=None)
-    meta_json: Optional[str] = Field(default=None)
+    # Bare str → VARCHAR(255); messages + context thumbs exceed that on MySQL.
+    content: str = Field(default="", sa_column=Column(Text, nullable=False))
+    thinking: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
+    meta_json: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
     created_at: float = Field(default=0.0)
     sort_order: int = Field(default=0)
 

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -613,8 +613,9 @@ class DesignGlobalRule(SQLModel, table=True):
 
     id: Optional[int] = Field(default=None, primary_key=True)
     rule_key: str = Field(max_length=64, unique=True)
-    rule_value: str = Field(default="")
-    description: Optional[str] = Field(default=None)
+    # MySQL maps bare str → VARCHAR(255); stage rules / JSON payloads exceed that.
+    rule_value: str = Field(default="", sa_column=Column(Text, nullable=False))
+    description: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
     enabled: int = Field(default=1)
     updated_at: float = Field(default=0.0)
 


### PR DESCRIPTION
## Summary
- PUT /chat-sessions/sessions 500 on MySQL VARCHAR(255) meta_json/content
- Model + alembic 0014; prod already ALTERed

## Test plan
- [x] Prod columns are LONGTEXT
- [ ] Save session with context chip thumb returns 200

Made with [Cursor](https://cursor.com)