### PR TITLE
fix: restore canvas tool seed allowlist for empty DB

### DIFF
--- a/apps/api/app/services/design/ops/tool_ops_contract.py
+++ b/apps/api/app/services/design/ops/tool_ops_contract.py
@@ -75,8 +75,47 @@ def _validate_shape_fill_args(name: str, args: dict[str, Any]) -> str | None:
     return None
 
 
+def _tools_from_seed(*, enabled_only: bool = True) -> list[dict[str, Any]]:
+    """Cold-start / unit-test catalog when ``design_canvas_tool`` is empty."""
+    try:
+        from app.services.design.ops.action_registry import default_canvas_actions
+    except Exception:
+        return []
+    out: list[dict[str, Any]] = []
+    for item in default_canvas_actions():
+        if not isinstance(item, dict):
+            continue
+        key = str(item.get("op_key") or "").strip()
+        if not key:
+            continue
+        enabled = item.get("enabled", True)
+        if enabled_only and not enabled:
+            continue
+        schema = item.get("args_schema")
+        if isinstance(schema, dict):
+            try:
+                schema_s = json.dumps(schema, ensure_ascii=False)
+            except Exception:
+                schema_s = ""
+        else:
+            schema_s = str(schema or "").strip()
+        out.append(
+            {
+                "op_key": key,
+                "kind": str(item.get("kind") or "").strip() or "create",
+                "label": str(item.get("label") or "").strip(),
+                "model_hint": str(item.get("model_hint") or "").strip(),
+                "args_schema": schema_s,
+                "enabled": bool(enabled),
+                "sort_order": int(item.get("sort_order") or 0),
+            }
+        )
+    out.sort(key=lambda t: (int(t.get("sort_order") or 0), str(t.get("op_key") or "")))
+    return out
+
+
 def list_canvas_tools(*, enabled_only: bool = True) -> list[dict[str, Any]]:
-    """Rows from ``design_canvas_tool`` only (empty table → empty list)."""
+    """Rows from ``design_canvas_tool``; seed JSON if the table is empty."""
     try:
         from sqlmodel import Session
 
@@ -103,14 +142,15 @@ def list_canvas_tools(*, enabled_only: bool = True) -> list[dict[str, Any]]:
                     "sort_order": int(r.sort_order or 0),
                 }
             )
-        return out
+        if out:
+            return out
     except Exception:
         logger.debug("list_canvas_tools unavailable", exc_info=True)
-        return []
+    return _tools_from_seed(enabled_only=enabled_only)
 
 
 def allowed_canvas_tool_keys() -> frozenset[str]:
-    """Enabled op_keys from ``design_canvas_tool``."""
+    """Enabled op_keys from DB, else ``canvas_actions_seed.json``."""
     return frozenset(
         t["op_key"] for t in list_canvas_tools(enabled_only=True) if t.get("op_key")
     )

--- a/apps/api/app/services/design/prompts/skill_store/pack_io.py
+++ b/apps/api/app/services/design/prompts/skill_store/pack_io.py
@@ -438,7 +438,6 @@ def _skill_item_from_parts(
             "skill_key": storage_key,
             "name": display,
             "prompt_positive": pos,
-            "scenes": str(meta.get("scenes") or "").strip(),
             "preferred_tools": meta.get("preferred_tools") or meta.get("preferredTools") or [],
             "allowed_resources": meta.get("allowed_resources")
             or meta.get("allowedResources"),
@@ -459,7 +458,7 @@ def _skill_item_from_parts(
         "when_to_use": when,
         "prompt_positive": pos,
         "prompt_negative": str(meta.get("prompt_negative") or meta.get("promptNegative") or "").strip(),
-        "scenes": str(meta.get("scenes") or "").strip(),
+        "scenes": str(meta.get("scenes") or "all").strip() or "all",
         "sort_weight": int(meta.get("sort_weight") or meta.get("sortWeight") or 0),
         "preferred_tools": meta.get("preferred_tools") or meta.get("preferredTools") or [],
         "allowed_resources": meta.get("allowed_resources")

--- a/apps/api/app/services/design/prompts/skill_store/schema.py
+++ b/apps/api/app/services/design/prompts/skill_store/schema.py
@@ -105,9 +105,6 @@ def validate_skill_meta(item: dict[str, Any], *, source: str) -> list[str]:
     body = str(item.get("prompt_positive") or item.get("promptPositive") or "").strip()
     if not body:
         errs.append("prompt_positive_required")
-    scenes = str(item.get("scenes") or "").strip()
-    if not scenes:
-        errs.append("scenes_required")
     ns = _normalize_namespace(
         item.get("namespace"), source=source
     )


### PR DESCRIPTION
## Summary
- Restore `canvas_actions_seed.json` as the canvas tool allowlist when `design_canvas_tool` is empty (unit tests / cold start)
- Default skill-pack `scenes` to `all` so plugin packs without that field still load

## Test plan
- [x] `npm run test:api:unit` (357 passed)
- [ ] CI api-unit / pytest green

Made with [Cursor](https://cursor.com)