### PR TITLE
docs: refresh README product tagline and canvas description

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   <a href="README.ja.md"><img src="docs/assets/lang-ja.png" alt="日本語" height="28" /></a>
 </p>
 
-**Recombyn** is an **AI-native infinite vector canvas**. From web canvas to desktop app, Design Agent, backend, live collab, private deploy, and automated tests — a commercial-grade full-loop product.
+**Recombyn** is an open-source AI design workspace with an editable infinite vector canvas and a Design Agent. Use natural language to create and revise shapes, text, layouts, and styles, continue refining directly on the canvas, and self-host with Docker Compose.
 
 Built-in Design Agent (LangGraph): natural language creates layers, draws shapes, restyles, and typesets. Ships with Skills out of the box; you can also add custom Skills / AgentProfile (YAML) / prompt packs for posters, dashboards, landing pages, and more — then keep editing at vector precision.
 
@@ -39,7 +39,7 @@ Open source takes time. If Recombyn helps you, please hit **⭐ Star** in the to
 
 ## Canvas
 
-Custom **RCB** infinite canvas: the scene graph is `SceneDocument`, zoom roughly 5%–10000%. Committed nodes paint as per-node **SVG**; **Path2D** handles hit-testing and selection. Far-out geometry uses **LOD**, so large docs stay editable.
+Custom **RCB** infinite canvas: the scene graph is `SceneDocument`, with a 5%–10000% zoom range. Committed nodes normally paint as per-node **SVG**; the grid and eligible lightweight far-out nodes use Canvas2D LOD proxies. Hit testing combines the spatial index, AABB checks, and **Path2D** geometry to keep large documents responsive.
 
 Details: [docs/canvas-architecture.md](docs/canvas-architecture.md) · Scene JSON: [docs/scene-json-spec.md](docs/scene-json-spec.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,7 +22,7 @@
   <a href="README.ja.md"><img src="docs/assets/lang-ja.png" alt="日本語" height="28" /></a>
 </p>
 
-**Recombyn** 是 **AI Native 的无限矢量画布**。它从网页画布到桌面客户端、Design Agent、后端服务、多人协作、私有化部署和自动化测试，全链路闭环的商用级完整产品。
+**Recombyn** 是一个开源的 AI 设计工作台，提供可编辑的无限矢量画布与 Design Agent。你可以用自然语言创建和修改图形、文字、布局与样式，也可以在画布中继续精细编辑，并通过 Docker Compose 自托管。
 
 内置 Design Agent（LangGraph）：自然语言就能建图层、画图形、改样式、排版布局。自带多套 Skill，也可自定义 Skill / AgentProfile（YAML）/ 提示词包，扩展海报、仪表盘、落地页等品类；做完后仍可在矢量画布上精细改。
 
@@ -38,7 +38,7 @@
 
 ## 画布
 
-自研 **RCB** 无限画布：场景图是 `SceneDocument`，缩放大约 5%–10000%。已提交的图元按节点用 **SVG** 画出来，**Path2D** 负责点选和选区；远处用 **LOD** 简化，大文档也能流畅编辑。
+自研 **RCB** 无限画布：场景图是 `SceneDocument`，缩放范围为 5%–10000%。已提交图元默认按节点使用 **SVG** 绘制；网格和符合条件的远距离轻量图元使用 Canvas2D LOD 代理。命中采用空间索引、AABB 与 **Path2D** 几何协同处理，降低大文档的渲染与交互成本。
 
 工程细节：[docs/canvas-architecture.md](docs/canvas-architecture.md) · Scene JSON：[docs/scene-json-spec.md](docs/scene-json-spec.md)。
 


### PR DESCRIPTION
## Summary
- Update EN/ZH README intros for open-source AI design workspace + Design Agent + Docker Compose self-host
- Clarify RCB canvas paint / LOD / hit-testing wording so the GitHub homepage shows the new copy

## Test plan
- [x] Confirm README.md and README.zh-CN.md only
- [ ] Check github.com/recombyn/recombyn homepage after merge