### PR TITLE
fix: expose get_design_task_for_update on design_tasks repository

### DIFF
--- a/apps/api/app/repositories/design_tasks.py
+++ b/apps/api/app/repositories/design_tasks.py
@@ -40,6 +40,19 @@ def get_design_task(*, session: Session, task_id: str) -> DesignTask | None:
     return session.get(DesignTask, tid)
 
 
+def get_design_task_for_update(*, session: Session, task_id: str) -> DesignTask | None:
+    """Load task row with ``FOR UPDATE`` when the dialect supports it."""
+    tid = (task_id or "").strip()
+    if not tid:
+        return None
+    stmt = select(DesignTask).where(DesignTask.id == tid)
+    try:
+        stmt = stmt.with_for_update()
+        return session.exec(stmt).first()
+    except Exception:
+        return session.get(DesignTask, tid)
+
+
 def create_design_task(*, session: Session, row: dict[str, Any]) -> DesignTask:
     task = DesignTask(
         id=str(row["id"]),


### PR DESCRIPTION
## Summary
- Add `get_design_task_for_update` to `apps/api/app/repositories/design_tasks.py` so `task_store` can lock design-run rows after #124
- Unblocks CI integration tests that currently raise AttributeError

## Test plan
- [x] Confirm GitHub `main` callers use `design_tasks.get_design_task_for_update`
- [ ] API Tests / pytest integration suite on this PR