### PR TITLE
ci: strip Cursor co-author locally and sync CONTRIBUTING to main

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,2 +1,4 @@
 #!/usr/bin/env sh
-npx --no -- commitlint --edit "$1"
+npx --no -- commitlint --edit "$1" || exit $?
+# CI `/no-cursor-coauthor` rejects this trailer. Strip it here so local commits match GitHub.
+node -e "const fs=require('fs'); const p=process.argv[2]; const s=fs.readFileSync(p,'utf8'); const n=s.split(/\r?\n/).filter((l)=>!/^Co-authored-by:\\s*Cursor\\b/i.test(l)).join('\\n'); if (n!==s) fs.writeFileSync(p, n.endsWith('\\n')||n===''?n:n+'\\n');" "$1"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+# Last local gate for Co-authored-by: Cursor (same as .github/workflows/block-cursor-coauthor.yml).
+zero=0000000000000000000000000000000000000000
+fail=0
+while read local_ref local_sha remote_ref remote_sha
+do
+  [ -n "$local_sha" ] || continue
+  if [ "$local_sha" = "$zero" ]; then
+    continue
+  fi
+  if [ "$remote_sha" = "$zero" ] || [ -z "$remote_sha" ]; then
+    if git rev-parse --verify origin/main >/dev/null 2>&1; then
+      range="origin/main..$local_sha"
+    else
+      range="$local_sha"
+    fi
+  else
+    range="$remote_sha..$local_sha"
+  fi
+  if git log --format=%B "$range" 2>/dev/null | grep -F 'Co-authored-by: Cursor' >/dev/null; then
+    echo "error: push blocked — commits contain 'Co-authored-by: Cursor'." >&2
+    echo "Rewrite the message without that trailer, then push. CI check: no-cursor-coauthor." >&2
+    fail=1
+  fi
+done
+exit "$fail"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Useful scripts:
 
 Use [Conventional Commits](https://www.conventionalcommits.org/): `feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`.
 
-`husky` + `commitlint` run on `commit-msg`. Examples:
+`husky` + `commitlint` run on `commit-msg` (also **strips** `Co-authored-by: Cursor`). `pre-push` **rejects** that trailer if it still lands — same as GitHub `no-cursor-coauthor`. Examples:
 
 ```bash
 feat(canvas): show mark-region live preview while dragging
@@ -61,9 +61,12 @@ Cross-cutting changes need an ADR under [`docs/adr/`](./docs/adr/README.md) (cop
 1. **Sync default branch**
 
 ```bash
-git checkout master
-git pull origin master
+git fetch origin main
+git checkout main
+git pull origin main
 ```
+
+Work from **this** `main` (or a branch created from `origin/main`). A local `main` that lagged remote is not “latest.” GitHub CI only runs **pushed commits**; untracked `??` files under `apps/` never reach CI.
 
 2. **Create a topic branch**
 
@@ -139,7 +142,7 @@ EOF
 
 Use the checklist in [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md).
 
-8. **Address review**, then push again on the same branch (`git push`). Prefer **rebase** onto `master` if asked; avoid rewriting commits that others already based work on.
+8. **Address review**, then push again on the same branch (`git push`). Prefer **rebase** onto `main` if asked; avoid rewriting commits that others already based work on.
 
 ## Do / don’t
 
@@ -147,7 +150,7 @@ Use the checklist in [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST
 |----|--------|
 | Small, focused PRs | Mix unrelated refactors with features |
 | Verify email before first push | Commit `.env`, keys, or local IDE folders (`.cursor/`) |
-| Link issues in the PR body | Force-push `master` / rewrite published history without maintainers |
+| Link issues in the PR body | Force-push `main` / rewrite published history without maintainers |
 | Update docs when behavior changes | Leave failing tests on the default branch |
 | Document open protocols / SDKs / BasicLocal | Document proprietary intelligence backends, private datasets, closed prompts, or private service layouts in this repo |
 


### PR DESCRIPTION
## Summary
- Husky commit-msg strips Co-authored-by: Cursor; pre-push rejects it if it still lands
- CONTRIBUTING uses main instead of master

## Test plan
- [ ] commit-msg / pre-push still run via husky
- [ ] no-cursor-coauthor CI stays green

Made with [Cursor](https://cursor.com)