### PR TITLE
feat: prefer SAM soft masks and LaMa for image layer decompose

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -7,10 +7,11 @@ OCR_LANG=ch
 SCENE_TARGET_WIDTH=794
 PALETTE_K=5
 EXPAND_TABLE_CELLS=true
-ENABLE_SAM=false
+ENABLE_SAM=true
+# Required for multi-instance layers (MobileSAM / segment_anything):
 # SAM_CHECKPOINT=/models/mobile_sam.pt
 # SAM_MODEL_TYPE=vit_t
-ENABLE_LAMA=false
+ENABLE_LAMA=true
 LAMA_USE_SAM_MASK=true
 
 # Object storage (S3-style). Empty = local disk.

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -77,8 +77,10 @@ class Settings(BaseSettings):
     ocr_lang: str = "ch"
     scene_target_width: int = 794
     palette_k: int = 5
-    enable_sam: bool = False
-    enable_lama: bool = False
+    # Prefer multi-instance SAM + LaMa when deps/checkpoint are present;
+    # paths no-op cleanly when unavailable (rembg / Telea fallback).
+    enable_sam: bool = True
+    enable_lama: bool = True
 
     s3_enabled: bool = False
     s3_endpoint_url: str | None = None

--- a/apps/api/app/services/vision/image_edit.py
+++ b/apps/api/app/services/vision/image_edit.py
@@ -6,9 +6,10 @@ editText
   - Does NOT split other visual subjects
 
 editElements
-  - Subjects (SAM / layout heuristics) as transparent PNG crops
+  - Subjects: SAM soft masks (primary) / rembg single-fg fallback → transparent PNG
+  - Edge refine + defringe on soft alpha before encode
   - OCR text layers
-  - Background = original with text + subjects inpainted
+  - Background = LaMa (default) or Telea inpaint of text ∪ subjects
   - Canvas places layers at source coords so the stack still reads as one picture
 """
 
@@ -88,6 +89,56 @@ def _bgr_to_data_url(bgr) -> str:
     return f"data:image/png;base64,{b64}"
 
 
+def _refine_layer_alpha(bgr_crop, alpha):
+    """Edge-aware soft alpha + defringe for transparent PNG layers."""
+    import cv2
+    import numpy as np
+
+    a = np.asarray(alpha, dtype=np.float32)
+    if a.ndim != 2 or a.shape[:2] != bgr_crop.shape[:2]:
+        return None
+    if float(a.max()) < 8:
+        return None
+
+    # Bilateral on alpha keeps soft hair while reducing mask noise.
+    a_u8 = np.clip(a, 0, 255).astype(np.uint8)
+    a_soft = cv2.bilateralFilter(a_u8, d=5, sigmaColor=48, sigmaSpace=48).astype(np.float32)
+
+    # Narrow-band: pull RGB from solid interior to kill color spill / white fringe.
+    rgb = bgr_crop.astype(np.float32)
+    solid = (a_soft >= 240).astype(np.uint8)
+    if solid.max() == 0:
+        solid = (a_soft >= 180).astype(np.uint8)
+    if solid.max() > 0:
+        seed = np.zeros_like(rgb)
+        known = solid.astype(bool)
+        seed[known] = rgb[known]
+        grown = (solid * 255).astype(np.uint8)
+        filled = seed.copy()
+        dil_k = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3, 3))
+        for _ in range(4):
+            grown_next = cv2.dilate(grown, dil_k, iterations=1)
+            for c in range(3):
+                ch = filled[:, :, c]
+                ch_dil = cv2.dilate(ch, dil_k, iterations=1)
+                newly = (grown_next > 0) & (grown == 0)
+                ch[newly] = ch_dil[newly]
+                filled[:, :, c] = ch
+            grown = grown_next
+        edge = (a_soft > 2) & (a_soft < 240)
+        if edge.any():
+            t = np.clip((240.0 - a_soft) / 240.0, 0.0, 1.0)
+            t = np.where(edge, np.minimum(t * 1.25, 1.0), 0.0)[..., None]
+            rgb = rgb * (1.0 - t) + filled * t
+
+    a_out = np.where(a_soft < 4, 0, a_soft).astype(np.uint8)
+    rgb_u8 = np.clip(rgb, 0, 255).astype(np.uint8)
+    rgb_u8[a_out == 0] = 0
+    rgba = cv2.cvtColor(rgb_u8, cv2.COLOR_BGR2BGRA)
+    rgba[:, :, 3] = a_out
+    return rgba
+
+
 def _rgba_crop_data_url(bgr, region: dict[str, Any], pad: int = 2) -> str | None:
     """Crop with soft edge; keep RGB (canvas images). Prefer transparent when mask present."""
     import cv2
@@ -110,8 +161,10 @@ def _rgba_crop_data_url(bgr, region: dict[str, Any], pad: int = 2) -> str | None
             m = np.asarray(mask)
             if m.ndim == 2 and m.shape[0] == h and m.shape[1] == w:
                 m_crop = m[y:y2, x:x2]
-                rgba = cv2.cvtColor(crop, cv2.COLOR_BGR2BGRA)
-                rgba[:, :, 3] = m_crop
+                rgba = _refine_layer_alpha(crop, m_crop)
+                if rgba is None:
+                    rgba = cv2.cvtColor(crop, cv2.COLOR_BGR2BGRA)
+                    rgba[:, :, 3] = m_crop
                 ok, buf = cv2.imencode(".png", rgba)
                 if ok:
                     b64 = base64.b64encode(buf.tobytes()).decode("ascii")
@@ -221,8 +274,8 @@ def _estimate_font(block: dict[str, Any], fill: str) -> dict[str, Any]:
     }
 
 
-def _rembg_subject_regions(bgr, max_regions: int = 3) -> list[dict[str, Any]]:
-    """Photo / product main subject via rembg alpha (works without SAM)."""
+def _rembg_subject_regions(bgr, max_regions: int = 8) -> list[dict[str, Any]]:
+    """Single-foreground rembg cutout — fallback when SAM has no instances."""
     import cv2
     import numpy as np
 
@@ -238,7 +291,7 @@ def _rembg_subject_regions(bgr, max_regions: int = 3) -> list[dict[str, Any]]:
         return []
     raw = buf.tobytes()
     rgba = None
-    for mode in ("product", "hair"):
+    for mode in ("hair", "product"):
         try:
             rgba = cutout_rgba_from_bytes(raw, mode=mode)  # type: ignore[arg-type]
             break
@@ -346,44 +399,69 @@ def _opencv_subject_regions(bgr, texts: list[dict[str, Any]], max_regions: int =
     return kept
 
 
-def _inpaint_regions(bgr, regions: list[dict[str, Any]]):
-    """Remove listed regions via LaMa or OpenCV Telea."""
+def _union_erase_mask(h: int, w: int, regions: list[dict[str, Any]]):
+    """Soft-mask union (preferred) or padded bboxes for erase / Telea."""
     import cv2
     import numpy as np
 
-    if not regions:
-        return bgr.copy()
-    h, w = bgr.shape[:2]
     mask = np.zeros((h, w), dtype=np.uint8)
     pad = 3
     for region in regions:
+        soft = region.get("mask")
+        used_soft = False
+        if soft is not None:
+            try:
+                m = np.asarray(soft)
+                if m.ndim == 2 and m.shape[0] == h and m.shape[1] == w:
+                    mask = np.maximum(mask, (m > 8).astype(np.uint8) * 255)
+                    used_soft = True
+            except Exception:
+                used_soft = False
+        if used_soft:
+            continue
         x = int(max(0, _num(region.get("x")) - pad))
         y = int(max(0, _num(region.get("y")) - pad))
         bw = int(max(1, _num(region.get("width"), 1) + pad * 2))
         bh = int(max(1, _num(region.get("height"), 1) + pad * 2))
         mask[y : min(h, y + bh), x : min(w, x + bw)] = 255
-
     if mask.max() == 0:
-        return bgr.copy()
+        return mask
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (5, 5))
+    return cv2.dilate(mask, kernel, iterations=1)
 
-    # Try file-based lama path
-    try:
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_dir = Path(tmp)
-            src = tmp_dir / "src.png"
-            write_temp_png(bgr, src)
-            out = lama_mod.inpaint(src, regions=regions)
-            if out is not None and out.is_file():
-                painted = cv2.imread(str(out))
-                if painted is not None:
-                    return painted
-    except Exception:
-        pass
+
+def _inpaint_regions(bgr, regions: list[dict[str, Any]]) -> tuple[Any, str]:
+    """Remove listed regions via LaMa (default) then OpenCV Telea.
+
+    Returns ``(bgr, engine)`` where engine is ``lama`` | ``telea`` | ``none``.
+    """
+    import cv2
+
+    if not regions:
+        return bgr.copy(), "none"
+    h, w = bgr.shape[:2]
+    mask = _union_erase_mask(h, w, regions)
+    if mask.max() == 0:
+        return bgr.copy(), "none"
+
+    if settings.enable_lama and lama_mod.available():
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                tmp_dir = Path(tmp)
+                src = tmp_dir / "src.png"
+                write_temp_png(bgr, src)
+                out = lama_mod.inpaint(src, regions=regions)
+                if out is not None and out.is_file():
+                    painted = cv2.imread(str(out))
+                    if painted is not None:
+                        return painted, "lama"
+        except Exception:
+            pass
 
     try:
-        return cv2.inpaint(bgr, mask, 3, cv2.INPAINT_TELEA)
+        return cv2.inpaint(bgr, mask, 3, cv2.INPAINT_TELEA), "telea"
     except Exception:
-        return bgr.copy()
+        return bgr.copy(), "none"
 
 
 def _collect_text_blocks(path: Path) -> tuple[list[dict[str, Any]], str]:
@@ -430,22 +508,49 @@ def _enrich_texts(bgr, texts: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 def _collect_subjects(bgr, path: Path, texts: list[dict[str, Any]], mixed_blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """
-    Subject proposals for editElements — ordered by reliability for photos:
+    Subject proposals for editElements — multi-instance first:
 
-    1. rembg cutout (dogs / products / people) — works without SAM
-    2. document layout figures (PPT / posters)
-    3. SAM automatic masks when ENABLE_SAM + checkpoint
+    1. SAM automatic soft masks when ENABLE_SAM + checkpoint (primary)
+    2. rembg cutout only when SAM empty (single-foreground fast path)
+    3. document layout figures (PPT / posters)
     4. OpenCV edges only if still empty
     """
     subjects: list[dict[str, Any]] = []
+    sam_hit = False
 
-    # 1) Photo main subject (rembg) — primary path for canvas photos.
-    try:
-        subjects.extend(_rembg_subject_regions(bgr))
-    except Exception:
-        pass
+    # 1) SAM multi-instance soft masks (needs checkpoint; no-op when missing)
+    if settings.enable_sam:
+        try:
+            for region in sam_mod.segment_regions(path) or []:
+                item = {
+                    "x": _num(region.get("x")),
+                    "y": _num(region.get("y")),
+                    "width": max(1.0, _num(region.get("width"), 1)),
+                    "height": max(1.0, _num(region.get("height"), 1)),
+                    "source": "sam",
+                    "layout_type": "subject",
+                    "name": "主体",
+                    "area": _num(region.get("area")),
+                    "score": _num(region.get("score")),
+                }
+                if region.get("mask") is not None:
+                    item["mask"] = region["mask"]
+                if _overlaps_text(item, texts, 0.55):
+                    continue
+                subjects.append(item)
+                sam_hit = True
+        except Exception:
+            pass
 
-    # 2) Layout figures (document / poster analysis)
+    # 2) rembg — only when SAM did not propose instances
+    if not sam_hit:
+        try:
+            max_r = int(getattr(settings, "sam_max_regions", 8) or 8)
+            subjects.extend(_rembg_subject_regions(bgr, max_regions=max_r))
+        except Exception:
+            pass
+
+    # 3) Layout figures (document / poster analysis)
     for b in mixed_blocks:
         if str(b.get("type") or "") == "text":
             continue
@@ -464,36 +569,19 @@ def _collect_subjects(bgr, path: Path, texts: list[dict[str, Any]], mixed_blocks
         if not _overlaps_text(region, texts, 0.6):
             subjects.append(region)
 
-    # 3) SAM (optional, needs checkpoint)
-    if settings.enable_sam:
-        try:
-            for region in sam_mod.segment_regions(path) or []:
-                item = {
-                    "x": _num(region.get("x")),
-                    "y": _num(region.get("y")),
-                    "width": max(1.0, _num(region.get("width"), 1)),
-                    "height": max(1.0, _num(region.get("height"), 1)),
-                    "source": "sam",
-                    "layout_type": "subject",
-                    "name": "主体",
-                    "area": _num(region.get("area")),
-                }
-                if _overlaps_text(item, texts, 0.55):
-                    continue
-                subjects.append(item)
-        except Exception:
-            pass
-
     # 4) OpenCV edges — last resort only
     if not subjects:
         subjects.extend(_opencv_subject_regions(bgr, texts))
 
-    # Prefer rembg/SAM over layout/opencv when boxes overlap.
-    def _rank(r: dict[str, Any]) -> tuple[float, float]:
+    # Prefer SAM (+ soft mask) over rembg / layout / opencv when boxes overlap.
+    def _rank(r: dict[str, Any]) -> tuple[float, float, float]:
         src = str(r.get("source") or "")
-        pri = {"rembg": 3.0, "sam": 2.5, "layout": 1.5, "opencv": 1.0}.get(src, 1.0)
+        pri = {"sam": 4.0, "rembg": 2.5, "layout": 1.5, "opencv": 1.0}.get(src, 1.0)
+        if r.get("mask") is not None:
+            pri += 0.5
         area = _num(r.get("area")) or (_num(r.get("width")) * _num(r.get("height")))
-        return (pri, area)
+        score = _num(r.get("score"))
+        return (pri, score, area)
 
     subjects.sort(key=_rank, reverse=True)
     kept: list[dict[str, Any]] = []
@@ -575,16 +663,16 @@ async def decompose_image(
                     engines.append("subjects:" + "+".join(sources))
             else:
                 warnings.append(
-                    "未识别到可拆分主体（需 rembg 或开启 SAM），仅拆出文字与背景"
+                    "未识别到可拆分主体（需 SAM_CHECKPOINT 或 rembg），仅拆出文字与背景"
                 )
 
         # Background: inpaint text always; also subjects for editElements
         erase = list(texts_raw)
         if kind == "editElements":
             erase = erase + subject_regions
-        bg_bgr = _inpaint_regions(bgr, erase)
-        if erase:
-            engines.append("inpaint")
+        bg_bgr, inpaint_engine = _inpaint_regions(bgr, erase)
+        if erase and inpaint_engine != "none":
+            engines.append(f"inpaint:{inpaint_engine}")
         bg_src = _bgr_to_data_url(bg_bgr)
 
     layers: list[dict[str, Any]] = [

--- a/apps/api/app/services/vision/lama.py
+++ b/apps/api/app/services/vision/lama.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from app.core.config import settings
-
 
 def available() -> bool:
     try:
@@ -21,20 +19,42 @@ def available() -> bool:
 
 
 def _build_mask_from_regions(image_shape: tuple[int, int], regions: list[dict]) -> Any | None:
+    """Union soft masks when present; else padded bboxes. Dilate slightly for clean fill."""
     try:
+        import cv2
         import numpy as np
     except ImportError:
         return None
     h, w = image_shape
     mask = np.zeros((h, w), dtype=np.uint8)
     for region in regions or []:
+        soft = region.get("mask")
+        used_soft = False
+        if soft is not None:
+            try:
+                m = np.asarray(soft)
+                if m.ndim == 2 and m.shape[0] == h and m.shape[1] == w:
+                    mask = np.maximum(mask, (m > 8).astype(np.uint8) * 255)
+                    used_soft = True
+            except Exception:
+                used_soft = False
+        if used_soft:
+            continue
         x = int(max(0, region.get("x") or 0))
         y = int(max(0, region.get("y") or 0))
         bw = int(max(1, region.get("width") or 1))
         bh = int(max(1, region.get("height") or 1))
-        mask[y : min(h, y + bh), x : min(w, x + bw)] = 255
+        pad = 3
+        x0 = max(0, x - pad)
+        y0 = max(0, y - pad)
+        x1 = min(w, x + bw + pad)
+        y1 = min(h, y + bh + pad)
+        mask[y0:y1, x0:x1] = 255
     if mask.max() == 0:
         return None
+    # Slight dilate so inpaint covers fringe / anti-aliased edges
+    kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (5, 5))
+    mask = cv2.dilate(mask, kernel, iterations=1)
     return mask
 
 
@@ -45,7 +65,7 @@ def inpaint(
     regions: list[dict] | None = None,
 ) -> Path | None:
     """
-    Inpaint using mask file or SAM region boxes.
+    Inpaint using mask file or region soft masks / boxes.
     Returns output path or None when unavailable / no mask.
     """
     if not available():
@@ -72,7 +92,6 @@ def inpaint(
 
     dest = out_path or image_path.with_name(f"{image_path.stem}_inpainted{image_path.suffix}")
 
-    # Prefer simple-lama-inpainting
     try:
         from simple_lama_inpainting import SimpleLama
         from PIL import Image
@@ -81,14 +100,6 @@ def inpaint(
         rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         result = lama(Image.fromarray(rgb), Image.fromarray(mask))
         out_bgr = cv2.cvtColor(np.array(result), cv2.COLOR_RGB2BGR)
-        cv2.imwrite(str(dest), out_bgr)
-        return dest
-    except Exception:
-        pass
-
-    # OpenCV Telea fallback (no external LaMa weights)
-    try:
-        out_bgr = cv2.inpaint(image, mask, 3, cv2.INPAINT_TELEA)
         cv2.imwrite(str(dest), out_bgr)
         return dest
     except Exception:

--- a/apps/api/app/services/vision/sam.py
+++ b/apps/api/app/services/vision/sam.py
@@ -30,10 +30,29 @@ def _checkpoint() -> Path | None:
     return path if path.is_file() else None
 
 
+def _soft_mask_from_segmentation(seg, h: int, w: int):
+    """Boolean / uint8 SAM segmentation → soft alpha (full image HxW)."""
+    import cv2
+    import numpy as np
+
+    m = np.asarray(seg)
+    if m.ndim != 2 or m.shape[0] != h or m.shape[1] != w:
+        return None
+    if m.dtype == np.bool_ or m.max() <= 1:
+        soft = (m.astype(np.uint8) * 255)
+    else:
+        soft = np.clip(m, 0, 255).astype(np.uint8)
+    if int(soft.max()) < 8:
+        return None
+    # Light feather so crop/inpaint keep hair / soft edges (not binary hard cut).
+    soft = cv2.GaussianBlur(soft, (3, 3), 0)
+    return soft
+
+
 def segment_regions(image_path: Path) -> list[dict[str, Any]]:
     """
-    Return top mask proposals as axis-aligned boxes when SAM + checkpoint are ready.
-    Each item: {x,y,width,height,score,area}
+    Return top mask proposals when SAM + checkpoint are ready.
+    Each item: {x,y,width,height,score,area,mask?} with soft alpha mask when available.
     """
     ckpt = _checkpoint()
     if not available() or ckpt is None:
@@ -79,25 +98,30 @@ def segment_regions(image_path: Path) -> list[dict[str, Any]]:
 
     h, w = image.shape[:2]
     min_area = max(256, int(h * w * settings.sam_min_area_ratio))
+    max_area = int(h * w * 0.92)
     regions: list[dict[str, Any]] = []
     for mask in masks or []:
         area = float(mask.get("area") or 0)
-        if area < min_area:
+        if area < min_area or area > max_area:
             continue
         bbox = mask.get("bbox")  # XYWH
         if not bbox or len(bbox) < 4:
             continue
         x, y, bw, bh = map(float, bbox[:4])
-        regions.append(
-            {
-                "x": x,
-                "y": y,
-                "width": bw,
-                "height": bh,
-                "score": float(mask.get("predicted_iou") or mask.get("stability_score") or 0),
-                "area": area,
-            }
-        )
+        if bw < 12 or bh < 12:
+            continue
+        item: dict[str, Any] = {
+            "x": x,
+            "y": y,
+            "width": bw,
+            "height": bh,
+            "score": float(mask.get("predicted_iou") or mask.get("stability_score") or 0),
+            "area": area,
+        }
+        soft = _soft_mask_from_segmentation(mask.get("segmentation"), h, w)
+        if soft is not None:
+            item["mask"] = soft
+        regions.append(item)
 
-    regions.sort(key=lambda r: r["area"], reverse=True)
+    regions.sort(key=lambda r: (r.get("score", 0), r["area"]), reverse=True)
     return regions[: settings.sam_max_regions]

--- a/docs/import-pipeline.md
+++ b/docs/import-pipeline.md
@@ -68,15 +68,15 @@ Requires API + Redis + Celery worker running together.
 ## Stage 5: table cells + SAM/LaMa hooks
 
 1. **Tables**: layout tables are OCR’d again by default into background `rect` + editable text cells (`EXPAND_TABLE_CELLS=true`, `engines` includes `table-cells`)
-2. **SAM**: when `ENABLE_SAM=true` and `SAM_CHECKPOINT` is set, run MobileSAM / segment_anything; large regions become image layers
-3. **LaMa**: when `ENABLE_LAMA=true`, use `simple-lama-inpainting` or OpenCV Telea; default mask from SAM boxes (`LAMA_USE_SAM_MASK=true`)
+2. **SAM** (default on): when `ENABLE_SAM=true` and `SAM_CHECKPOINT` is set, run MobileSAM / segment_anything; soft masks become transparent PNG layers (rembg is single-subject fallback only)
+3. **LaMa** (default on): when `ENABLE_LAMA=true`, use `simple-lama-inpainting` with soft-mask union; OpenCV Telea if LaMa missing
 
 ```env
 EXPAND_TABLE_CELLS=true
-ENABLE_SAM=false
+ENABLE_SAM=true
 SAM_CHECKPOINT=/path/to/mobile_sam.pt
 SAM_MODEL_TYPE=vit_t
-ENABLE_LAMA=false
+ENABLE_LAMA=true
 LAMA_USE_SAM_MASK=true
 ```
 


### PR DESCRIPTION
## Summary
- Default-enable SAM/LaMa for `editElements` decompose; soft-mask SAM regions feed transparent PNG crops with edge refine + defringe
- rembg becomes single-foreground fallback only when SAM finds nothing; background erase uses soft-mask union then LaMa (Telea if unavailable)
- Update `.env.example` and import-pipeline docs to match

## Test plan
- [ ] Without `SAM_CHECKPOINT` / LaMa package: decompose still works via rembg + Telea; `engines` shows fallback paths
- [ ] With SAM checkpoint: multi-subject image yields `subjects:sam` and soft-alpha layers without hard bbox crops
- [ ] With `simple-lama-inpainting`: background shows `inpaint:lama` and fewer hole/ghost artifacts than Telea
- [ ] FE stack placement unchanged (layers still at source pixel coords)
