### PR TITLE
fix: persist line/arrow angle when dragging endpoints

### DIFF
--- a/apps/web/src/components/editor/canvas/__tests__/mergeLiveAnglesIntoDoc.test.ts
+++ b/apps/web/src/components/editor/canvas/__tests__/mergeLiveAnglesIntoDoc.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { mergeLiveAnglesIntoDoc } from '../canvasSession';
+import type { SceneDocument } from '@/components/rcb/scene/document/sceneDocument';
+
+function docWithAngle(nodeId: string, angle: number): SceneDocument {
+  return {
+    deltaSetLike: {
+      ROOT: { key: 'root', children: [nodeId] },
+      [nodeId]: {
+        key: 'shape',
+        width: 120,
+        height: 1,
+        attrs: { shapeType: 'arrow', angle },
+      },
+    },
+    frames: [],
+  } as SceneDocument;
+}
+
+describe('mergeLiveAnglesIntoDoc', () => {
+  it('copies preview angle from live doc onto committed base', () => {
+    const committed = docWithAngle('n1', 0);
+    const live = docWithAngle('n1', 45);
+    const merged = mergeLiveAnglesIntoDoc(committed, live, ['n1']);
+    expect(merged.deltaSetLike?.n1?.attrs?.angle).toBe(45);
+    expect(committed.deltaSetLike?.n1?.attrs?.angle).toBe(0);
+  });
+
+  it('leaves base unchanged when angles already match', () => {
+    const committed = docWithAngle('n1', 30);
+    const live = docWithAngle('n1', 30);
+    expect(mergeLiveAnglesIntoDoc(committed, live, ['n1'])).toBe(committed);
+  });
+});

--- a/apps/web/src/components/editor/canvas/canvasSession.ts
+++ b/apps/web/src/components/editor/canvas/canvasSession.ts
@@ -168,6 +168,38 @@ export function toGeometryPatches(doc: SceneDocument | null | undefined, patches
   });
 }
 
+/**
+ * Merge live preview angles from documentRef into the committed Redux base.
+ * Line/arrow endpoint drags update angle only on the live doc until commit.
+ */
+export function mergeLiveAnglesIntoDoc(
+  base: SceneDocument,
+  live: SceneDocument | null | undefined,
+  nodeIds: string[]
+): SceneDocument {
+  if (!live?.deltaSetLike || !nodeIds.length) return base;
+  let deltaSetLike = base.deltaSetLike;
+  let changed = false;
+  for (const nodeId of nodeIds) {
+    const liveNode = live.deltaSetLike[nodeId];
+    const node = deltaSetLike?.[nodeId];
+    if (!liveNode || !node) continue;
+    const liveAngle = Number(liveNode.attrs?.angle);
+    if (!Number.isFinite(liveAngle)) continue;
+    const curAngle = Number(node.attrs?.angle) || 0;
+    if (Math.abs(curAngle - liveAngle) < 1e-6) continue;
+    if (!changed) {
+      deltaSetLike = { ...deltaSetLike };
+      changed = true;
+    }
+    deltaSetLike[nodeId] = {
+      ...node,
+      attrs: { ...node.attrs, angle: liveAngle },
+    };
+  }
+  return changed ? { ...base, deltaSetLike } : base;
+}
+
 /** Line/arrow keep a 1px geometry height — hit tolerance is handled separately. */
 export function normalizeGeomPatches(doc: SceneDocument | null | undefined, patches: GeomPatch[]): GeomPatch[] {
   return patches.map((p) => {
@@ -634,13 +666,14 @@ export function createCanvasSession(deps: CanvasSessionDeps): CanvasSession {
     // is intentionally not synced from Redux — writing it back would revive
     // attrs cleared mid-drag (e.g. processStatus after upload finishes).
     const committed = deps.getCommittedDocument?.() ?? null;
-    const doc = committed || deps.getDocument();
+    const live = deps.getDocument();
     const board = deps.getBoard();
-    if (!doc || deps.isReadOnly() || !patches.length) return;
+    if ((!committed && !live) || deps.isReadOnly() || !patches.length) return;
     const { nodePatches, frames } = applyFrameGeometryPatches(patches);
     const touchedNodeIds = nodePatches
       .map((p) => String(p.nodeId || '').trim())
       .filter(Boolean);
+    const doc = mergeLiveAnglesIntoDoc(committed || live!, live, touchedNodeIds);
     let next = doc;
     if (nodePatches.length) {
       const normalized = normalizeGeomPatches(doc, toGeometryPatches(doc, nodePatches));


### PR DESCRIPTION
## Summary
- Fix line/arrow endpoint drags snapping back on pointer up by merging live preview angles into geometry commit
- Add unit test for `mergeLiveAnglesIntoDoc`

## Test plan
- [x] `vitest run src/components/editor/canvas/__tests__/mergeLiveAnglesIntoDoc.test.ts`
- [ ] Drag line/arrow endpoints on canvas; position persists after release