### PR TITLE
fix: restore CI typecheck and web-unit on main

### DIFF
--- a/apps/web/src/components/editor/canvas/SvgCanvas.tsx
+++ b/apps/web/src/components/editor/canvas/SvgCanvas.tsx
@@ -82,6 +82,7 @@ import {
   cssPreviewForGradient,
   parseFillGradient,
   parseFillType,
+  parseFillImageAdjust,
   serializeFillImageAttrs,
 } from '@/components/rcb/scene/document/sceneFill';
 import { cssSolidWithOpacity } from '@/components/base/colorPanel';
@@ -1129,7 +1130,20 @@ function SvgCanvas({
         attrs['fill-gradient'] = undefined;
       }
       if (fillType === 'image') {
-        Object.assign(attrs, serializeFillImageAttrs(fill));
+        Object.assign(
+          attrs,
+          serializeFillImageAttrs({
+            fillImageSrc: fill.fillImageSrc,
+            fillImageFit: fill.fillImageFit,
+            fillImageRotate: fill.fillImageRotate,
+            fillImageScale: fill.fillImageScale,
+            fillImageOffsetX: fill.fillImageOffsetX,
+            fillImageOffsetY: fill.fillImageOffsetY,
+            ...(fill.fillImageAdjust != null
+              ? { fillImageAdjust: parseFillImageAdjust(fill.fillImageAdjust) }
+              : {}),
+          })
+        );
       }
       dispatch(
         patchDocumentNode({

--- a/apps/web/src/components/editor/canvas/__tests__/mergeLiveAnglesIntoDoc.test.ts
+++ b/apps/web/src/components/editor/canvas/__tests__/mergeLiveAnglesIntoDoc.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { mergeLiveAnglesIntoDoc } from '../canvasSession';
-import type { SceneDocument } from '@/components/rcb/scene/document/sceneDocument';
+import type { SceneDocument } from '@/components/rcb/sceneNode';
 
 function docWithAngle(nodeId: string, angle: number): SceneDocument {
   return {
@@ -14,7 +14,7 @@ function docWithAngle(nodeId: string, angle: number): SceneDocument {
       },
     },
     frames: [],
-  } as SceneDocument;
+  } as unknown as SceneDocument;
 }
 
 describe('mergeLiveAnglesIntoDoc', () => {

--- a/apps/web/src/components/rcb/shapes/__tests__/shapeHostProps.test.ts
+++ b/apps/web/src/components/rcb/shapes/__tests__/shapeHostProps.test.ts
@@ -35,8 +35,14 @@ describe('shapeHostPropsEqual', () => {
       attrs: { processStatus: 'running', processLabel: 'Uploading' },
     };
     const before = { deltaSetLike: { 'brush-a': image } };
-    image.attrs = { src: 'https://cdn.example.com/a.png' };
-    const after = { deltaSetLike: { 'brush-a': image } };
+    const after = {
+      deltaSetLike: {
+        'brush-a': {
+          ...image,
+          attrs: { src: 'https://cdn.example.com/a.png' },
+        },
+      },
+    };
 
     expect(shapeHostPropsEqual(props(before), props(after))).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Fix `SvgCanvas` bucket-fill image attr typing for `serializeFillImageAttrs`
- Fix `shapeHostProps` test to use immutable before/after snapshots
- Fix `mergeLiveAnglesIntoDoc` test import for `SceneDocument`

## Test plan
- [x] `npm run typecheck` (apps/web)
- [x] `vitest run` for affected test files