### PR TITLE
feat: restore intelligence vision and mockup for local dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
           --cov-fail-under=95
       - name: API unit tests
         run: python -m pytest tests/unit_tests -n auto
+      - name: ILP BFF routing smoke (offline)
+        run: python scripts/test_ilp_bff_smoke.py --mock
 
   build-web:
     runs-on: ubuntu-latest

--- a/apps/api/app/api/main.py
+++ b/apps/api/app/api/main.py
@@ -19,6 +19,7 @@ from app.api.routes import (
     chat_video_jobs,
     chat_audio_jobs,
     me,
+    mockup,
     notices,
     orgs,
     plaza,
@@ -54,4 +55,5 @@ api_router.include_router(chat_video_jobs.router)
 api_router.include_router(chat_audio_jobs.router)
 api_router.include_router(chat.router)
 api_router.include_router(image_tools.router)
+api_router.include_router(mockup.router)
 api_router.include_router(design.router)

--- a/apps/api/app/api/routes/health.py
+++ b/apps/api/app/api/routes/health.py
@@ -1,4 +1,4 @@
-"""Health / readiness checks for API, Redis, worker."""
+"""Health / readiness checks for API, Redis, worker, intelligence."""
 
 from fastapi import APIRouter
 
@@ -28,6 +28,15 @@ def _check_worker() -> bool:
         return False
 
 
+def _check_intelligence() -> bool:
+    try:
+        from app.services.vision.ilp_client import ilp_enabled
+
+        return ilp_enabled()
+    except Exception:
+        return False
+
+
 def _check_db() -> dict:
     try:
         from sqlalchemy import text
@@ -48,6 +57,7 @@ def _check_db() -> dict:
 def health():
     redis_ok = _check_redis()
     worker_ok = _check_worker() if redis_ok else False
+    intelligence_ok = _check_intelligence()
     db = _check_db()
 
     checks = {
@@ -55,6 +65,7 @@ def health():
         "database": db,
         "redis": redis_ok,
         "worker": worker_ok,
+        "intelligence": intelligence_ok,
         "use_vision": settings.use_vision,
         "s3": settings.s3_enabled,
     }

--- a/apps/api/app/api/routes/image_tools.py
+++ b/apps/api/app/api/routes/image_tools.py
@@ -20,10 +20,15 @@ from app.services.wallet.db import is_wallet_billing_enabled, spend_credits
 router = APIRouter(prefix="/image", tags=["image-tools"])
 
 # Wallet 积分 charged per LLM image tool when not tied to a Seedream catalog price.
+# Local CV kinds (removeBg / editText / editElements) are always 0.
 _KIND_CREDIT_COST: dict[str, int] = {
     "upscale": 20,
+    "removeBg": 0,
     "multiAngle": 30,
     "expand": 30,
+    "editText": 0,
+    "editElements": 0,
+    "detectRegions": 0,
     "replaceText": 30,
     "vector": 20,
     "adjust": 0,  # FE uses CSS filters; API adjust is unused
@@ -31,7 +36,7 @@ _KIND_CREDIT_COST: dict[str, int] = {
 
 
 class ImageProcessIn(BaseModel):
-    kind: str = Field(..., min_length=1, description="upscale | multiAngle | expand | ...")
+    kind: str = Field(..., min_length=1, description="removeBg | upscale | multiAngle | ...")
     image: str = Field(..., min_length=1, description="Source image data URL or https URL")
     meta: dict[str, Any] | None = None
     aspect_ratio: str | None = None
@@ -75,11 +80,33 @@ def credit_cost_for_kind(
 
 @router.get("/tools")
 def list_image_tools() -> dict[str, Any]:
+    from app.services.llm.image_tools import ilp_supports
+    from app.services.mockup.mockup_client import mockup_enabled
+    from app.services.vision.ilp_client import ilp_enabled
+
     kinds = sorted(IMAGE_PROCESS_KINDS)
     costs = {k: credit_cost_for_kind(k) for k in kinds}
+    ilp_on = ilp_enabled()
+    mockup_on = mockup_enabled()
+    mockup_block: dict[str, Any] = {"enabled": mockup_on}
+    if mockup_on:
+        mockup_block["templates"] = [
+            {
+                "id": "demo-cylinder",
+                "name": "Demo cylinder mug",
+                "kind": "builtin",
+                "width": 720,
+                "height": 960,
+            }
+        ]
     return {
         "kinds": kinds,
         "credits": costs,
+        "ilp": {
+            "enabled": ilp_on,
+            "supports": ilp_supports(),
+        },
+        "mockup": mockup_block,
     }
 
 

--- a/apps/api/app/api/routes/mockup.py
+++ b/apps/api/app/api/routes/mockup.py
@@ -1,0 +1,89 @@
+"""Mockup render API — BFF proxy to closed-source Recombyn Intelligence."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from app.api.deps import CurrentUser
+from app.services.mockup.mockup_client import (
+    mockup_enabled,
+    list_mockup_templates,
+    render_mockup_batch_via_intelligence,
+    render_mockup_via_intelligence,
+)
+
+router = APIRouter(prefix="/mockup", tags=["mockup"])
+
+
+class MockupRenderIn(BaseModel):
+    image: str = Field(..., min_length=1, description="Design image data URL or https URL")
+    template_id: str = Field("demo-cylinder", min_length=1)
+
+
+class MockupBatchItemIn(BaseModel):
+    image: str = Field(..., min_length=1)
+    template_id: str = Field("demo-cylinder", min_length=1)
+    name: str = ""
+
+
+class MockupBatchIn(BaseModel):
+    items: list[MockupBatchItemIn] = Field(..., min_length=1, max_length=64)
+
+
+@router.get("/tools")
+async def list_mockup_tools() -> dict[str, Any]:
+    enabled = mockup_enabled()
+    templates: list[dict[str, Any]] = []
+    if enabled:
+        try:
+            templates = await list_mockup_templates()
+        except Exception:
+            templates = [{"id": "demo-cylinder", "name": "Demo cylinder mug", "kind": "builtin"}]
+    return {
+        "mockup": {
+            "enabled": enabled,
+            "templates": templates,
+        }
+    }
+
+
+@router.post("/render")
+async def post_mockup_render(
+    _current_user: CurrentUser,
+    body: MockupRenderIn,
+) -> dict[str, Any]:
+    if not mockup_enabled():
+        raise HTTPException(
+            status_code=503,
+            detail="样机渲染需要接入 Recombyn Intelligence（设置 RECOMBYN_INTELLIGENCE_URL）",
+        )
+    try:
+        return await render_mockup_via_intelligence(
+            body.image.strip(),
+            template_id=body.template_id.strip() or "demo-cylinder",
+        )
+    except ValueError as err:
+        raise HTTPException(status_code=400, detail=str(err)) from err
+    except RuntimeError as err:
+        raise HTTPException(status_code=502, detail=str(err)) from err
+
+
+@router.post("/render/batch")
+async def post_mockup_batch_render(
+    _current_user: CurrentUser,
+    body: MockupBatchIn,
+) -> dict[str, Any]:
+    if not mockup_enabled():
+        raise HTTPException(
+            status_code=503,
+            detail="样机渲染需要接入 Recombyn Intelligence（设置 RECOMBYN_INTELLIGENCE_URL）",
+        )
+    try:
+        return await render_mockup_batch_via_intelligence(
+            [i.model_dump() for i in body.items]
+        )
+    except RuntimeError as err:
+        raise HTTPException(status_code=502, detail=str(err)) from err

--- a/apps/api/app/services/design/img_layers/decompose.py
+++ b/apps/api/app/services/design/img_layers/decompose.py
@@ -1,4 +1,4 @@
-"""Decompose a board raster into layers (OSS: single-image fallback)."""
+"""Decompose a board raster into vision layers via Recombyn Intelligence."""
 
 from __future__ import annotations
 
@@ -9,24 +9,57 @@ _log = logging.getLogger(__name__)
 
 
 async def decompose_board_layers(*, image: str) -> dict[str, Any]:
-    """Return one raster layer when industrial decompose is unavailable."""
-    _log.info("img_layers: single-image fallback")
-    return {
-        "image": image,
-        "layers": [
-            {
-                "type": "image",
-                "src": image,
-                "x": 0,
-                "y": 0,
-                "width": 0,
-                "height": 0,
-                "name": "整板",
-            }
-        ],
-        "kind": "editElements",
-        "width": 0,
-        "height": 0,
-        "engines": ["fallback:single"],
-        "warnings": [],
-    }
+    """
+    Full editElements split when intelligence is available; otherwise one image layer.
+
+    Shape matches ILP decompose:
+    ``{ layers, width, height, engines, warnings, image }``.
+    """
+    from app.services.vision.ilp_client import ilp_enabled
+    from app.services.vision.ilp_decompose import decompose_via_ilp
+
+    if not ilp_enabled():
+        _log.info("img_layers: intelligence unavailable — single-image fallback")
+        return {
+            "image": image,
+            "layers": [
+                {
+                    "type": "image",
+                    "src": image,
+                    "x": 0,
+                    "y": 0,
+                    "width": 0,
+                    "height": 0,
+                    "name": "整板",
+                }
+            ],
+            "kind": "editElements",
+            "width": 0,
+            "height": 0,
+            "engines": ["fallback:single"],
+            "warnings": ["工业分层服务未配置 — 已作为单图层放置"],
+        }
+
+    try:
+        return await decompose_via_ilp(kind="editElements", image=image)
+    except Exception as err:  # noqa: BLE001
+        _log.exception("img_layers decompose failed: %s", err)
+        return {
+            "image": image,
+            "layers": [
+                {
+                    "type": "image",
+                    "src": image,
+                    "x": 0,
+                    "y": 0,
+                    "width": 0,
+                    "height": 0,
+                    "name": "整板",
+                }
+            ],
+            "kind": "editElements",
+            "width": 0,
+            "height": 0,
+            "engines": ["fallback:error"],
+            "warnings": [f"decompose failed: {err}"[:200]],
+        }

--- a/apps/api/app/services/design/ops/image_hydrate.py
+++ b/apps/api/app/services/design/ops/image_hydrate.py
@@ -87,8 +87,16 @@ def _cutout_mode_for_hydrate(args: dict[str, Any]) -> str | None:
 
 
 async def _maybe_cutout_hydrated_src(src: str, mode: str) -> tuple[str, bool]:
-    """Cutout is a commercial capability — OSS keeps the original image."""
-    _ = mode
+    """Return (src, cutout_applied). Failures keep original URL."""
+    try:
+        from app.services.vision.remove_bg import remove_background
+
+        cut = await remove_background(src, meta={"cutoutMode": mode})
+        cut_src = str((cut or {}).get("image") or "").strip()
+        if cut_src:
+            return cut_src, True
+    except Exception:
+        pass
     return src, False
 
 

--- a/apps/api/app/services/llm/image_tools.py
+++ b/apps/api/app/services/llm/image_tools.py
@@ -1,4 +1,4 @@
-"""Image toolbar AI tools — Seedream i2i."""
+"""Image toolbar AI tools — Seedream i2i + Recombyn Intelligence vision."""
 
 from __future__ import annotations
 
@@ -17,19 +17,54 @@ logger = logging.getLogger(__name__)
 IMAGE_PROCESS_KINDS = frozenset(
     {
         "upscale",
+        "removeBg",
         "multiAngle",
         "expand",
+        "editText",
+        "editElements",
+        "detectRegions",
         "replaceText",
         "vector",
         "adjust",
     }
 )
 
+# Closed-source intelligence only — hidden in UI and rejected when service is down.
+ILP_EXCLUSIVE_KINDS = frozenset({"removeBg", "editText", "editElements", "detectRegions"})
+
+DECOMPOSE_KINDS = frozenset({"editText", "editElements"})
+DETECT_KINDS = frozenset({"detectRegions"})
+CUTOUT_KINDS = frozenset({"removeBg"})
+NO_LLM_KINDS = CUTOUT_KINDS | DECOMPOSE_KINDS | DETECT_KINDS
+
+_ILP_REQUIRED_MSG = (
+    "此功能需要接入 Recombyn Intelligence 闭源服务（设置 RECOMBYN_INTELLIGENCE_URL 并启动 intelligence）"
+)
+
 
 def uses_llm_for_kind(kind: str | None) -> bool:
     """True when ``process_image_tool`` will call Seedream / image LLM."""
     k = (kind or "").strip()
-    return bool(k) and k in IMAGE_PROCESS_KINDS
+    return bool(k) and k in IMAGE_PROCESS_KINDS and k not in NO_LLM_KINDS
+
+
+def requires_ilp(kind: str | None) -> bool:
+    return (kind or "").strip() in ILP_EXCLUSIVE_KINDS
+
+
+def _require_ilp() -> None:
+    from app.services.vision.ilp_client import ilp_enabled
+
+    if not ilp_enabled():
+        raise RuntimeError(_ILP_REQUIRED_MSG)
+
+
+def ilp_supports() -> list[str]:
+    from app.services.vision.ilp_client import ilp_enabled
+
+    if not ilp_enabled():
+        return []
+    return ["removeBg", "editText", "editElements", "detectRegions"]
 
 
 def _prompt_for(
@@ -38,6 +73,8 @@ def _prompt_for(
     meta: dict[str, Any] | None = None,
 ) -> str:
     m = meta or {}
+    if kind == "removeBg":
+        return "unused"
     if kind == "upscale":
         return (
             "Upscale this image to high resolution. Enhance sharpness and fine detail, "
@@ -85,6 +122,8 @@ def _prompt_for(
             f"Continue the scene naturally beyond the edges; match lighting, perspective, and style. "
             f"Do not distort the original subject."
         )
+    if kind in ("editText", "editElements", "detectRegions"):
+        return "unused"
     if kind == "replaceText":
         original = str(m.get("originalText") or "").strip()
         new = str(m.get("newText") or "").strip()
@@ -146,9 +185,12 @@ async def process_image_tool(
     model: str | None = None,
 ) -> dict[str, Any]:
     """
-    Run a toolbar image tool via Seedream image-to-image.
+    Run a toolbar image tool.
 
-    Returns ``{ image, text?, kind, model? }``.
+    - ``removeBg`` / ``editText`` / ``editElements`` → Recombyn Intelligence only
+    - other kinds → Seedream image-to-image
+
+    Returns ``{ image, layers?, text?, kind, model?, width?, height?, warnings? }``.
     """
     k = (kind or "").strip()
     if k not in IMAGE_PROCESS_KINDS:
@@ -156,6 +198,29 @@ async def process_image_tool(
     src = (image or "").strip()
     if not src:
         raise ValueError("image is required")
+
+    if requires_ilp(k):
+        _require_ilp()
+
+    if k in CUTOUT_KINDS:
+        from app.services.vision.remove_bg import remove_background
+
+        return await remove_background(src, meta=meta)
+
+    if k == "editElements":
+        from app.services.vision.ilp_decompose import decompose_via_ilp
+
+        return await decompose_via_ilp(kind="editElements", image=src)
+
+    if k == "editText":
+        from app.services.vision.ilp_text_decompose import decompose_text_via_ilp
+
+        return await decompose_text_via_ilp(kind="editText", image=src)
+
+    if k in DETECT_KINDS:
+        from app.services.vision.ilp_detect_regions import detect_regions_via_ilp_adapter
+
+        return await detect_regions_via_ilp_adapter(image=src)
 
     prompt = _prompt_for(k, meta=meta)
     result = await generate_image(

--- a/apps/api/app/services/mockup/__init__.py
+++ b/apps/api/app/services/mockup/__init__.py
@@ -1,0 +1,5 @@
+"""Mockup service package."""
+
+from app.services.mockup.mockup_client import mockup_enabled, render_mockup_via_intelligence
+
+__all__ = ["mockup_enabled", "render_mockup_via_intelligence"]

--- a/apps/api/app/services/mockup/mockup_client.py
+++ b/apps/api/app/services/mockup/mockup_client.py
@@ -1,0 +1,110 @@
+"""HTTP client for closed-source intelligence mockup rendering."""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import httpx
+
+from app.services.vision.ilp_client import _base_url, _headers, _load_bytes, _timeout, ilp_enabled
+
+
+def mockup_enabled() -> bool:
+    return ilp_enabled()
+
+
+async def list_mockup_templates() -> list[dict[str, Any]]:
+    base = _base_url()
+    if not base:
+        raise RuntimeError(
+            "Mockup service is not configured (set RECOMBYN_INTELLIGENCE_URL)"
+        )
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        resp = await client.get(f"{base}/api/v1/mockup/templates", headers=_headers())
+        if resp.status_code >= 400:
+            raise RuntimeError(f"mockup templates failed ({resp.status_code}): {resp.text[:300]}")
+        data = resp.json()
+        templates = data.get("templates") if isinstance(data, dict) else None
+        return list(templates or [])
+
+
+async def render_mockup_via_intelligence(
+    image_ref: str,
+    *,
+    template_id: str = "demo-cylinder",
+) -> dict[str, Any]:
+    """Render design onto mockup; returns data URL + metadata."""
+    base = _base_url()
+    if not base:
+        raise RuntimeError(
+            "Mockup service is not configured (set RECOMBYN_INTELLIGENCE_URL)"
+        )
+
+    content, filename = await _load_bytes(image_ref)
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        resp = await client.post(
+            f"{base}/api/v1/mockup/render",
+            files={"file": (filename, content, "application/octet-stream")},
+            data={
+                "template_id": template_id.strip() or "demo-cylinder",
+                "return_meta": "true",
+            },
+            headers=_headers(),
+        )
+        if resp.status_code >= 400:
+            raise RuntimeError(f"mockup render failed ({resp.status_code}): {resp.text[:300]}")
+        b64 = base64.b64encode(resp.content).decode("ascii")
+        meta_raw = resp.headers.get("X-Mockup-Meta") or "{}"
+        try:
+            import json
+
+            meta = json.loads(meta_raw)
+        except Exception:
+            meta = {}
+        return {
+            "image": f"data:image/png;base64,{b64}",
+            "kind": "mockup",
+            "template_id": meta.get("template_id") or template_id,
+            "width": meta.get("width"),
+            "height": meta.get("height"),
+            "engines": [str(meta.get("engine") or "mockup:2.5d-pbr")],
+            "elapsed_ms": meta.get("elapsed_ms"),
+            "features": meta.get("features"),
+            "warnings": [],
+        }
+
+
+async def render_mockup_batch_via_intelligence(
+    items: list[dict[str, str]],
+) -> dict[str, Any]:
+    """Sync batch render via intelligence (≤64 items)."""
+    base = _base_url()
+    if not base:
+        raise RuntimeError(
+            "Mockup service is not configured (set RECOMBYN_INTELLIGENCE_URL)"
+        )
+    payload_items = []
+    for row in items:
+        content, _ = await _load_bytes(row["image"])
+        payload_items.append(
+            {
+                "design_b64": base64.b64encode(content).decode("ascii"),
+                "template_id": row.get("template_id") or "demo-cylinder",
+                "name": row.get("name") or "",
+            }
+        )
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        resp = await client.post(
+            f"{base}/api/v1/mockup/render/batch",
+            json={"items": payload_items},
+            headers=_headers(),
+        )
+        if resp.status_code >= 400:
+            raise RuntimeError(f"mockup batch failed ({resp.status_code}): {resp.text[:300]}")
+        data = resp.json()
+        for item in data.get("items") or []:
+            b64 = str(item.get("image_b64") or "")
+            if b64:
+                item["image"] = f"data:image/png;base64,{b64}"
+        return data

--- a/apps/api/app/services/vision/ilp_client.py
+++ b/apps/api/app/services/vision/ilp_client.py
@@ -1,0 +1,317 @@
+"""HTTP client for the closed-source Image Layer Pipeline microservice."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import re
+import time
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+
+_TERMINAL = frozenset({"needs_review", "done", "failed", "cancelled"})
+_DATA_URL_RE = re.compile(r"^data:([^;,]+)?(?:;base64)?,(.+)$", re.DOTALL)
+
+
+def ilp_enabled() -> bool:
+    return bool(_base_url())
+
+
+def _base_url() -> str:
+    explicit = str(getattr(settings, "image_layer_pipeline_url", "") or "").strip().rstrip("/")
+    if explicit:
+        return explicit
+    mode = str(getattr(settings, "intelligence_provider", "") or "").strip().lower()
+    intel_url = str(getattr(settings, "intelligence_remote_url", "") or "").strip().rstrip("/")
+    if intel_url and mode in {"remote", "cloud"}:
+        return intel_url
+    return ""
+
+
+def _headers() -> dict[str, str]:
+    key = str(getattr(settings, "image_layer_pipeline_api_key", "") or "").strip()
+    if not key:
+        key = str(getattr(settings, "intelligence_remote_api_key", "") or "").strip()
+    if not key:
+        return {}
+    return {"Authorization": f"Bearer {key}"}
+
+
+def _timeout() -> httpx.Timeout:
+    sec = float(getattr(settings, "image_layer_pipeline_timeout_sec", 300.0) or 300.0)
+    return httpx.Timeout(sec, connect=min(30.0, sec))
+
+
+async def _load_bytes(image_ref: str) -> tuple[bytes, str]:
+    ref = (image_ref or "").strip()
+    if not ref:
+        raise ValueError("image is required")
+
+    if ref.startswith("data:"):
+        match = _DATA_URL_RE.match(ref)
+        if not match:
+            raise ValueError("invalid data URL")
+        b64 = match.group(2)
+        return base64.b64decode(b64), "upload.png"
+
+    if ref.startswith("http://") or ref.startswith("https://"):
+        async with httpx.AsyncClient(timeout=httpx.Timeout(60.0, connect=20.0)) as client:
+            resp = await client.get(ref)
+            if resp.status_code >= 400:
+                raise ValueError(f"failed to download image ({resp.status_code})")
+            name = "upload.png"
+            if "png" in (resp.headers.get("content-type") or ""):
+                name = "upload.png"
+            elif "jpeg" in (resp.headers.get("content-type") or "") or "jpg" in (
+                resp.headers.get("content-type") or ""
+            ):
+                name = "upload.jpg"
+            return resp.content, name
+
+    raise ValueError("image must be a data URL or https URL")
+
+
+async def create_job(image_ref: str) -> str:
+    base = _base_url()
+    if not base:
+        raise RuntimeError(
+            "Depth layering service is not configured (set RECOMBYN_INTELLIGENCE_URL or IMAGE_LAYER_PIPELINE_URL)"
+        )
+
+    content, filename = await _load_bytes(image_ref)
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        resp = await client.post(
+            f"{base}/api/v1/pipeline/jobs",
+            files={"file": (filename, content, "application/octet-stream")},
+            headers=_headers(),
+        )
+        if resp.status_code >= 400:
+            raise RuntimeError(f"ILP create job failed ({resp.status_code}): {resp.text[:300]}")
+        data = resp.json()
+        job_id = str(data.get("job_id") or "").strip()
+        if not job_id:
+            raise RuntimeError("ILP create job returned no job_id")
+        return job_id
+
+
+async def wait_for_job(job_id: str) -> dict[str, Any]:
+    base = _base_url()
+    if not base:
+        raise RuntimeError(
+            "Depth layering service is not configured (set RECOMBYN_INTELLIGENCE_URL or IMAGE_LAYER_PIPELINE_URL)"
+        )
+
+    interval = float(getattr(settings, "image_layer_pipeline_poll_sec", 1.0) or 1.0)
+    deadline = time.monotonic() + float(
+        getattr(settings, "image_layer_pipeline_timeout_sec", 300.0) or 300.0
+    )
+    async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=10.0)) as client:
+        while time.monotonic() < deadline:
+            resp = await client.get(
+                f"{base}/api/v1/pipeline/jobs/{job_id}",
+                headers=_headers(),
+            )
+            if resp.status_code >= 400:
+                raise RuntimeError(f"ILP job poll failed ({resp.status_code}): {resp.text[:300]}")
+            job = resp.json()
+            status = str(job.get("status") or "")
+            if status in _TERMINAL:
+                return job
+            await asyncio.sleep(max(0.25, interval))
+    raise TimeoutError(f"ILP job {job_id} timed out")
+
+
+async def segment_foreground_via_ilp(
+    image_ref: str,
+    *,
+    model: str = "birefnet-general",
+    decontaminate: float = 0.65,
+) -> tuple[bytes, str]:
+    """Matting-only — BiRefNet + decontaminate on the intelligence service."""
+    base = _base_url()
+    if not base:
+        raise RuntimeError(
+            "Depth layering service is not configured (set RECOMBYN_INTELLIGENCE_URL or IMAGE_LAYER_PIPELINE_URL)"
+        )
+
+    content, filename = await _load_bytes(image_ref)
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        resp = await client.post(
+            f"{base}/api/v1/pipeline/segment",
+            files={"file": (filename, content, "application/octet-stream")},
+            data={
+                "model": model.strip() or "birefnet-general",
+                "decontaminate": str(max(0.0, min(1.0, float(decontaminate)))),
+            },
+            headers=_headers(),
+        )
+        if resp.status_code >= 400:
+            raise RuntimeError(f"ILP segment failed ({resp.status_code}): {resp.text[:300]}")
+        ctype = (resp.headers.get("content-type") or "image/png").split(";")[0].strip()
+        return resp.content, ctype
+
+
+async def text_decompose_via_ilp(
+    image_ref: str,
+    *,
+    lang: str = "ch",
+    min_confidence: float = 0.72,
+) -> dict[str, Any]:
+    """editText OCR + inpaint on intelligence."""
+    base = _base_url()
+    if not base:
+        raise RuntimeError(
+            "Depth layering service is not configured (set RECOMBYN_INTELLIGENCE_URL or IMAGE_LAYER_PIPELINE_URL)"
+        )
+
+    content, filename = await _load_bytes(image_ref)
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        resp = await client.post(
+            f"{base}/api/v1/pipeline/text-decompose",
+            files={"file": (filename, content, "application/octet-stream")},
+            data={
+                "lang": lang.strip() or "ch",
+                "min_confidence": str(max(0.0, min(1.0, float(min_confidence)))),
+            },
+            headers=_headers(),
+        )
+        if resp.status_code >= 400:
+            raise RuntimeError(f"ILP text-decompose failed ({resp.status_code}): {resp.text[:300]}")
+        data = resp.json()
+        if not isinstance(data, dict):
+            raise RuntimeError("ILP text-decompose returned invalid JSON")
+        return data
+
+
+async def detect_regions_via_ilp(
+    image_ref: str,
+    *,
+    lang: str = "ch",
+    model: str = "birefnet-general",
+) -> dict[str, Any]:
+    """Mark tool — OCR text boxes + foreground bbox on intelligence."""
+    base = _base_url()
+    if not base:
+        raise RuntimeError(
+            "Depth layering service is not configured (set RECOMBYN_INTELLIGENCE_URL or IMAGE_LAYER_PIPELINE_URL)"
+        )
+
+    content, filename = await _load_bytes(image_ref)
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        resp = await client.post(
+            f"{base}/api/v1/pipeline/detect-regions",
+            files={"file": (filename, content, "application/octet-stream")},
+            data={
+                "lang": lang.strip() or "ch",
+                "model": model.strip() or "birefnet-general",
+            },
+            headers=_headers(),
+        )
+        if resp.status_code >= 400:
+            raise RuntimeError(f"ILP detect-regions failed ({resp.status_code}): {resp.text[:300]}")
+        data = resp.json()
+        if not isinstance(data, dict):
+            raise RuntimeError("ILP detect-regions returned invalid JSON")
+        return data
+
+
+async def inpaint_image_via_ilp(
+    image_bytes: bytes,
+    mask_bytes: bytes,
+    *,
+    backend: str = "lama",
+) -> bytes:
+    """Stateless LaMa inpaint on intelligence — for editText background erase."""
+    base = _base_url()
+    if not base:
+        raise RuntimeError(
+            "Depth layering service is not configured (set RECOMBYN_INTELLIGENCE_URL or IMAGE_LAYER_PIPELINE_URL)"
+        )
+
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        resp = await client.post(
+            f"{base}/api/v1/pipeline/inpaint",
+            files={
+                "file": ("image.png", image_bytes, "image/png"),
+                "mask": ("mask.png", mask_bytes, "image/png"),
+            },
+            data={"backend": backend.strip() or "lama"},
+            headers=_headers(),
+        )
+        if resp.status_code >= 400:
+            raise RuntimeError(f"ILP inpaint failed ({resp.status_code}): {resp.text[:300]}")
+        return resp.content
+
+
+def analyze_pages_via_ilp(
+    page_paths: list,
+    *,
+    lang: str = "ch",
+    target_width: int = 794,
+    palette_k: int = 5,
+    expand_table_cells: bool = True,
+) -> dict[str, Any]:
+    """Document import — OCR/layout on intelligence (sync)."""
+    from pathlib import Path
+
+    base = _base_url()
+    if not base:
+        raise RuntimeError(
+            "Depth layering service is not configured (set RECOMBYN_INTELLIGENCE_URL or IMAGE_LAYER_PIPELINE_URL)"
+        )
+
+    files: list[tuple[str, tuple[str, bytes, str]]] = []
+    for idx, path in enumerate(page_paths):
+        p = Path(path)
+        raw = p.read_bytes()
+        suffix = p.suffix.lower() or ".png"
+        ctype = "image/png" if suffix == ".png" else "application/octet-stream"
+        files.append(("files", (f"page_{idx:04d}{suffix}", raw, ctype)))
+
+    with httpx.Client(timeout=_timeout()) as client:
+        resp = client.post(
+            f"{base}/api/v1/pipeline/analyze-pages",
+            files=files,
+            data={
+                "lang": lang.strip() or "ch",
+                "target_width": str(int(target_width)),
+                "palette_k": str(int(palette_k)),
+                "expand_table_cells": "true" if expand_table_cells else "false",
+            },
+            headers=_headers(),
+        )
+        if resp.status_code >= 400:
+            raise RuntimeError(f"ILP analyze-pages failed ({resp.status_code}): {resp.text[:300]}")
+        data = resp.json()
+        if not isinstance(data, dict):
+            raise RuntimeError("ILP analyze-pages returned invalid JSON")
+        return data
+
+
+async def fetch_file_bytes(relative_or_absolute_url: str) -> tuple[bytes, str]:
+    base = _base_url()
+    url = (relative_or_absolute_url or "").strip()
+    if not url:
+        raise ValueError("empty url")
+    if url.startswith("/"):
+        if not base:
+            raise RuntimeError(
+            "Depth layering service is not configured (set RECOMBYN_INTELLIGENCE_URL or IMAGE_LAYER_PIPELINE_URL)"
+        )
+        url = f"{base}{url}"
+
+    async with httpx.AsyncClient(timeout=_timeout()) as client:
+        resp = await client.get(url, headers=_headers())
+        if resp.status_code >= 400:
+            raise RuntimeError(f"ILP file fetch failed ({resp.status_code})")
+        ctype = (resp.headers.get("content-type") or "image/png").split(";")[0].strip()
+        return resp.content, ctype
+
+
+def bytes_to_data_url(content: bytes, content_type: str = "image/png") -> str:
+    b64 = base64.b64encode(content).decode("ascii")
+    ctype = content_type if content_type.startswith("image/") else "image/png"
+    return f"data:{ctype};base64,{b64}"

--- a/apps/api/app/services/vision/ilp_decompose.py
+++ b/apps/api/app/services/vision/ilp_decompose.py
@@ -1,0 +1,100 @@
+"""Map Image Layer Pipeline job output → editElements decompose response."""
+
+from __future__ import annotations
+
+import io
+import logging
+from typing import Any, Literal
+
+from PIL import Image
+
+from app.services.vision.ilp_client import (
+    bytes_to_data_url,
+    create_job,
+    fetch_file_bytes,
+    ilp_enabled,
+    wait_for_job,
+)
+
+logger = logging.getLogger(__name__)
+
+EditMode = Literal["editElements", "editText"]
+
+_LAYER_SPECS: tuple[tuple[str, str], ...] = (
+    ("far_background", "远景底图"),
+    ("midground", "中景"),
+    ("foreground", "前景"),
+)
+
+
+def _size_from_meta(meta: dict[str, Any]) -> tuple[int, int]:
+    size = meta.get("size") or []
+    if isinstance(size, (list, tuple)) and len(size) >= 2:
+        h = int(size[0] or 0)
+        w = int(size[1] or 0)
+        if w > 0 and h > 0:
+            return w, h
+    return 0, 0
+
+
+def _size_from_bytes(content: bytes) -> tuple[int, int]:
+    with Image.open(io.BytesIO(content)) as img:
+        return int(img.width), int(img.height)
+
+
+async def decompose_via_ilp(*, kind: EditMode, image: str) -> dict[str, Any]:
+    """
+    Run depth/matting/inpaint pipeline and return the same shape as ``decompose_image``.
+
+    Returns ``{ image, layers, kind, width, height, engines, warnings }``.
+    """
+    if kind != "editElements":
+        raise ValueError("ILP decompose only supports editElements")
+    if not ilp_enabled():
+        raise RuntimeError("Depth layering service is not configured (set RECOMBYN_INTELLIGENCE_URL or IMAGE_LAYER_PIPELINE_URL)")
+
+    job_id = await create_job(image)
+    logger.info("ILP job created: %s", job_id)
+    job = await wait_for_job(job_id)
+    status = str(job.get("status") or "")
+    if status == "failed":
+        raise RuntimeError(str(job.get("error") or "ILP job failed"))
+    if status not in ("needs_review", "done"):
+        raise RuntimeError(f"unexpected ILP status: {status}")
+
+    meta = job.get("meta") if isinstance(job.get("meta"), dict) else {}
+    w, h = _size_from_meta(meta)
+    urls = job.get("urls") if isinstance(job.get("urls"), dict) else {}
+
+    layers: list[dict[str, Any]] = []
+    for key, name in _LAYER_SPECS:
+        rel = urls.get(key)
+        if not rel:
+            continue
+        content, ctype = await fetch_file_bytes(str(rel))
+        if w <= 0 or h <= 0:
+            w, h = _size_from_bytes(content)
+        layers.append(
+            {
+                "type": "image",
+                "src": bytes_to_data_url(content, ctype),
+                "x": 0.0,
+                "y": 0.0,
+                "width": float(w),
+                "height": float(h),
+                "name": name,
+            }
+        )
+
+    if not layers:
+        raise RuntimeError("ILP returned no exportable layers")
+
+    return {
+        "image": layers[0]["src"],
+        "layers": layers,
+        "kind": kind,
+        "width": w,
+        "height": h,
+        "engines": ["ilp:depth+birefnet+lama"],
+        "warnings": [],
+    }

--- a/apps/api/app/services/vision/ilp_detect_regions.py
+++ b/apps/api/app/services/vision/ilp_detect_regions.py
@@ -1,0 +1,61 @@
+"""Map intelligence detect-regions output → Mark tool response."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.core.config import settings
+from app.services.vision.ilp_client import detect_regions_via_ilp, ilp_enabled
+
+logger = logging.getLogger(__name__)
+
+
+async def detect_regions_via_ilp_adapter(*, image: str) -> dict[str, Any]:
+    """
+    Propose text/subject boxes for the Mark tool.
+
+    Returns ``{ image, layers, kind, width, height, engines, warnings }``.
+    """
+    if not ilp_enabled():
+        raise RuntimeError(
+            "Depth layering service is not configured (set RECOMBYN_INTELLIGENCE_URL or IMAGE_LAYER_PIPELINE_URL)"
+        )
+
+    lang = str(getattr(settings, "ocr_lang", "ch") or "ch")
+    payload = await detect_regions_via_ilp(image, lang=lang)
+    logger.info(
+        "ILP detect-regions: %sx%s layers=%s",
+        payload.get("width"),
+        payload.get("height"),
+        len(payload.get("layers") or []),
+    )
+
+    w = int(payload.get("width") or 0)
+    h = int(payload.get("height") or 0)
+    layers_in = payload.get("layers") if isinstance(payload.get("layers"), list) else []
+    layers: list[dict[str, Any]] = []
+    for layer in layers_in:
+        if not isinstance(layer, dict):
+            continue
+        item: dict[str, Any] = {
+            "type": str(layer.get("type") or "image"),
+            "x": float(layer.get("x") or 0),
+            "y": float(layer.get("y") or 0),
+            "width": max(1.0, float(layer.get("width") or 1)),
+            "height": max(1.0, float(layer.get("height") or 1)),
+            "name": str(layer.get("name") or "区域"),
+        }
+        if item["type"] == "text":
+            item["text"] = str(layer.get("text") or "").strip() or None
+        layers.append(item)
+
+    return {
+        "image": image,
+        "layers": layers,
+        "kind": "detectRegions",
+        "width": w,
+        "height": h,
+        "engines": ["ilp:detect-regions"] + list(payload.get("engines") or []),
+        "warnings": list(payload.get("warnings") or []),
+    }

--- a/apps/api/app/services/vision/ilp_text_decompose.py
+++ b/apps/api/app/services/vision/ilp_text_decompose.py
@@ -1,0 +1,132 @@
+"""Map intelligence text-decompose output → editText decompose response."""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import Any, Literal
+
+from app.core.config import settings
+from app.services.vision.ilp_client import (
+    bytes_to_data_url,
+    ilp_enabled,
+    text_decompose_via_ilp,
+)
+from app.services.vision.text_layer_style import enrich_text_layers, load_bgr
+
+logger = logging.getLogger(__name__)
+
+EditMode = Literal["editElements", "editText"]
+
+
+async def decompose_text_via_ilp(*, kind: EditMode, image: str) -> dict[str, Any]:
+    """
+    Run OCR + inpaint on intelligence and return the same shape as ``decompose_image``.
+
+    Font/color enrichment still runs locally on the original image.
+    """
+    if kind != "editText":
+        raise ValueError("ILP text decompose only supports editText")
+    if not ilp_enabled():
+        raise RuntimeError(
+            "Depth layering service is not configured (set RECOMBYN_INTELLIGENCE_URL or IMAGE_LAYER_PIPELINE_URL)"
+        )
+
+    min_conf = float(getattr(settings, "ocr_text_min_confidence", 0.72) or 0.72)
+    lang = str(getattr(settings, "ocr_lang", "ch") or "ch")
+
+    payload = await text_decompose_via_ilp(
+        image,
+        lang=lang,
+        min_confidence=min_conf,
+    )
+    logger.info("ILP text-decompose: %sx%s blocks=%s raster=%s", payload.get("width"), payload.get("height"), len(payload.get("editable_blocks") or []), len(payload.get("raster_layers") or []))
+
+    w = int(payload.get("width") or 0)
+    h = int(payload.get("height") or 0)
+    bg_b64 = str(payload.get("background_b64") or "")
+    if not bg_b64:
+        raise RuntimeError("ILP text-decompose returned no background")
+
+    bgr = await load_bgr(image)
+    editable_blocks = payload.get("editable_blocks") if isinstance(payload.get("editable_blocks"), list) else []
+    text_layers = enrich_text_layers(
+        bgr,
+        [
+            {
+                "type": "text",
+                "text": str(b.get("text") or ""),
+                "x": b.get("x"),
+                "y": b.get("y"),
+                "width": b.get("width"),
+                "height": b.get("height"),
+                "font_size": b.get("font_size"),
+            }
+            for b in editable_blocks
+            if str(b.get("text") or "").strip()
+        ],
+    )
+
+    raster_layers: list[dict[str, Any]] = []
+    for layer in payload.get("raster_layers") or []:
+        if not isinstance(layer, dict):
+            continue
+        png_b64 = str(layer.get("png_b64") or "").strip()
+        if not png_b64:
+            continue
+        raster_layers.append(
+            {
+                "type": "image",
+                "src": bytes_to_data_url(base64.b64decode(png_b64), "image/png"),
+                "x": float(layer.get("x") or 0),
+                "y": float(layer.get("y") or 0),
+                "width": max(1.0, float(layer.get("width") or 1)),
+                "height": max(1.0, float(layer.get("height") or 1)),
+                "name": str(layer.get("name") or "文字图"),
+                "letteringText": layer.get("letteringText"),
+                "ocrScore": layer.get("ocrScore"),
+            }
+        )
+
+    bg_src = bytes_to_data_url(base64.b64decode(bg_b64), "image/png")
+    layers: list[dict[str, Any]] = [
+        {
+            "type": "image",
+            "src": bg_src,
+            "x": 0.0,
+            "y": 0.0,
+            "width": float(w),
+            "height": float(h),
+            "name": "背景",
+        }
+    ]
+    layers.extend(raster_layers)
+    layers.extend(text_layers)
+
+    warnings = list(payload.get("warnings") or [])
+    engines = list(payload.get("engines") or [])
+    if text_layers:
+        engines.append("text-style")
+
+    if not text_layers and not raster_layers:
+        layers = [
+            {
+                "type": "image",
+                "src": bytes_to_data_url(base64.b64decode(bg_b64), "image/png"),
+                "x": 0.0,
+                "y": 0.0,
+                "width": float(w),
+                "height": float(h),
+                "name": "原图",
+            }
+        ]
+
+    return {
+        "image": bg_src if text_layers or raster_layers else layers[0]["src"],
+        "layers": layers,
+        "kind": kind,
+        "width": w,
+        "height": h,
+        "engines": ["ilp:text-decompose"] + engines,
+        "warnings": warnings,
+    }

--- a/apps/api/app/services/vision/page_analyzer.py
+++ b/apps/api/app/services/vision/page_analyzer.py
@@ -36,7 +36,44 @@ def analyze_page_images(page_paths: list[Path]) -> dict[str, Any]:
 
     Returns blocks (text merged, figures cropped, tables as cells), page size, palette, engines, warnings.
     """
-    warnings: list[str] = []
+    from app.services.vision.ilp_client import analyze_pages_via_ilp, ilp_enabled
+
+    ilp_fallback_warnings: list[str] = []
+    if ilp_enabled():
+        try:
+            result = analyze_pages_via_ilp(
+                page_paths,
+                lang=settings.ocr_lang,
+                target_width=settings.scene_target_width,
+                palette_k=settings.palette_k,
+                expand_table_cells=settings.expand_table_cells,
+            )
+            engines = list(result.get("engines") or [])
+            if "ilp:analyze-pages" not in engines:
+                engines.insert(0, "ilp:analyze-pages")
+            result["engines"] = engines
+            return result
+        except Exception as exc:  # noqa: BLE001
+            ilp_fallback_warnings.append(f"intelligence analyze-pages failed: {exc}")
+            empty_w = settings.scene_target_width
+            empty_h = int(empty_w * 1.414)
+            if not ocr_available():
+                ilp_fallback_warnings.append(
+                    "local OCR unavailable; import will use raster fallback "
+                    "(pip install -e '.[ocr]' or fix intelligence)"
+                )
+                return {
+                    "blocks": [],
+                    "width": empty_w,
+                    "height": empty_h,
+                    "palette": [],
+                    "engines": [],
+                    "warnings": ilp_fallback_warnings,
+                    "sam_regions": [],
+                    "lama_applied": False,
+                }
+
+    warnings: list[str] = list(ilp_fallback_warnings)
     engines: list[str] = []
     all_blocks: list[dict] = []
     palette: list[str] = []

--- a/apps/api/app/services/vision/remove_bg.py
+++ b/apps/api/app/services/vision/remove_bg.py
@@ -1,0 +1,68 @@
+"""Background removal (抠图) — Recombyn Intelligence industrial matting only."""
+
+from __future__ import annotations
+
+import base64
+import io
+import logging
+from typing import Any
+
+from PIL import Image
+
+from app.services.vision.ilp_client import ilp_enabled, segment_foreground_via_ilp
+
+logger = logging.getLogger(__name__)
+
+_ILP_REQUIRED_MSG = (
+    "工业抠图需要接入 Recombyn Intelligence 闭源服务（设置 RECOMBYN_INTELLIGENCE_URL 并启动 intelligence）"
+)
+
+
+def _png_data_url_from_pil(img: Image.Image) -> str:
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{b64}"
+
+
+def _trim_transparent(img: Image.Image) -> Image.Image:
+    if img.mode != "RGBA":
+        img = img.convert("RGBA")
+    bbox = img.getbbox()
+    if not bbox:
+        return img
+    l, t, r, b = bbox
+    pad = 2
+    l = max(0, l - pad)
+    t = max(0, t - pad)
+    r = min(img.width, r + pad)
+    b = min(img.height, b + pad)
+    return img.crop((l, t, r, b))
+
+
+async def remove_background(
+    image: str,
+    *,
+    meta: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """
+    Cut out the main subject via intelligence BiRefNet matting.
+
+    Returns ``{ image, kind, engine, model, mode, width, height }``.
+    """
+    if not ilp_enabled():
+        raise RuntimeError(_ILP_REQUIRED_MSG)
+
+    model_name = str((meta or {}).get("segmentationModel") or "birefnet-general").strip() or "birefnet-general"
+    png_bytes, _ctype = await segment_foreground_via_ilp(image, model=model_name)
+    rgba = Image.open(io.BytesIO(png_bytes)).convert("RGBA")
+    rgba = _trim_transparent(rgba)
+    return {
+        "image": _png_data_url_from_pil(rgba),
+        "kind": "removeBg",
+        "engine": "ilp:birefnet",
+        "model": model_name,
+        "mode": "ilp",
+        "width": int(rgba.width),
+        "height": int(rgba.height),
+    }

--- a/apps/api/scripts/test_ilp_bff_smoke.py
+++ b/apps/api/scripts/test_ilp_bff_smoke.py
@@ -1,0 +1,75 @@
+"""Smoke test: web BFF exposes ILP vision tools only when intelligence is configured.
+
+Use --mock for offline routing checks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+_API_ROOT = Path(__file__).resolve().parents[1]
+if str(_API_ROOT) not in sys.path:
+    sys.path.insert(0, str(_API_ROOT))
+
+
+def test_routing_offline() -> bool:
+    from app.services.llm.image_tools import ilp_supports, requires_ilp
+
+    import app.services.vision.ilp_client as ilp
+
+    old_enabled = ilp.ilp_enabled
+    try:
+        ilp.ilp_enabled = lambda: False  # type: ignore[method-assign]
+        assert requires_ilp("removeBg") is True
+        assert ilp_supports() == []
+        print("routing OK: ILP-exclusive tools hidden when service off")
+
+        ilp.ilp_enabled = lambda: True  # type: ignore[method-assign]
+        assert ilp_supports() == ["removeBg", "editText", "editElements", "detectRegions"]
+        print("routing OK: ILP tools advertised when service on")
+        return True
+    finally:
+        ilp.ilp_enabled = old_enabled  # type: ignore[method-assign]
+
+
+async def test_live_api(base: str, token: str) -> bool:
+    import httpx
+
+    headers = {"Authorization": f"Bearer {token}"}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        tools = await client.get(f"{base.rstrip('/')}/api/v1/image/tools", headers=headers)
+        if tools.status_code >= 400:
+            print("tools failed:", tools.status_code, tools.text[:300])
+            return False
+        body = tools.json()
+        ilp = body.get("ilp") or {}
+        print("ilp:", ilp)
+        if not ilp.get("enabled"):
+            print("ILP not enabled on API — check RECOMBYN_INTELLIGENCE_URL")
+            return False
+        supports = ilp.get("supports") or []
+        if not supports:
+            print("ILP enabled but supports empty")
+            return False
+        print("live API OK: ILP enabled on BFF")
+        return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mock", action="store_true", help="offline routing checks only")
+    parser.add_argument("--base", default="http://127.0.0.1:8000")
+    parser.add_argument("--token", default="")
+    args = parser.parse_args()
+
+    if args.mock or not args.token:
+        return 0 if test_routing_offline() else 1
+    ok = asyncio.run(test_live_api(args.base, args.token))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/api/tests/unit_tests/test_ilp_decompose.py
+++ b/apps/api/tests/unit_tests/test_ilp_decompose.py
@@ -1,0 +1,78 @@
+"""Unit tests for ILP-only image tool routing."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.services.llm.image_tools import ilp_supports, requires_ilp
+
+
+def test_requires_ilp_kinds():
+    assert requires_ilp("removeBg") is True
+    assert requires_ilp("editText") is True
+    assert requires_ilp("editElements") is True
+    assert requires_ilp("upscale") is False
+
+
+def test_ilp_supports_empty_when_off(monkeypatch):
+    monkeypatch.setattr("app.services.vision.ilp_client.ilp_enabled", lambda: False)
+    assert ilp_supports() == []
+
+
+def test_ilp_supports_when_on(monkeypatch):
+    monkeypatch.setattr("app.services.vision.ilp_client.ilp_enabled", lambda: True)
+    assert ilp_supports() == ["removeBg", "editText", "editElements", "detectRegions"]
+
+
+def test_process_image_tool_rejects_ilp_kind_when_off(monkeypatch):
+    monkeypatch.setattr("app.services.vision.ilp_client.ilp_enabled", lambda: False)
+    from app.services.llm.image_tools import process_image_tool
+
+    with pytest.raises(RuntimeError, match="Recombyn Intelligence"):
+        asyncio.run(process_image_tool(kind="removeBg", image="data:image/png;base64,abc"))
+
+
+def test_decompose_via_ilp_maps_layers(monkeypatch):
+    import io
+
+    from PIL import Image
+
+    png = io.BytesIO()
+    Image.new("RGB", (64, 48), color=(10, 20, 30)).save(png, format="PNG")
+    blob = png.getvalue()
+
+    async def fake_create(_image: str) -> str:
+        return "job-1"
+
+    async def fake_wait(_job_id: str) -> dict:
+        return {
+            "status": "needs_review",
+            "meta": {"size": [48, 64]},
+            "urls": {
+                "far_background": "/files/outputs/job-1/far.png",
+                "midground": "/files/outputs/job-1/mid.png",
+                "foreground": "/files/outputs/job-1/fg.png",
+            },
+        }
+
+    async def fake_fetch(_url: str) -> tuple[bytes, str]:
+        return blob, "image/png"
+
+    monkeypatch.setattr("app.services.vision.ilp_decompose.create_job", fake_create)
+    monkeypatch.setattr("app.services.vision.ilp_decompose.wait_for_job", fake_wait)
+    monkeypatch.setattr("app.services.vision.ilp_decompose.fetch_file_bytes", fake_fetch)
+    monkeypatch.setattr("app.services.vision.ilp_decompose.ilp_enabled", lambda: True)
+
+    from app.services.vision.ilp_decompose import decompose_via_ilp
+
+    result = asyncio.run(
+        decompose_via_ilp(kind="editElements", image="data:image/png;base64,abc")
+    )
+    assert result["kind"] == "editElements"
+    assert result["width"] == 64
+    assert result["height"] == 48
+    assert len(result["layers"]) == 3
+    assert result["layers"][0]["name"] == "远景底图"
+    assert str(result["layers"][0]["src"]).startswith("data:image/png;base64,")

--- a/apps/api/tests/unit_tests/test_ilp_detect_regions.py
+++ b/apps/api/tests/unit_tests/test_ilp_detect_regions.py
@@ -1,0 +1,59 @@
+"""Unit tests for ILP detect-regions BFF adapter."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+def test_detect_regions_adapter_maps_layers(monkeypatch):
+    async def fake_detect(_image: str, *, lang: str = "ch", model: str = "birefnet-general"):
+        return {
+            "width": 800,
+            "height": 600,
+            "layers": [
+                {
+                    "type": "text",
+                    "text": "标题",
+                    "x": 10.0,
+                    "y": 20.0,
+                    "width": 100.0,
+                    "height": 30.0,
+                    "name": "文字",
+                },
+                {
+                    "type": "image",
+                    "x": 50.0,
+                    "y": 80.0,
+                    "width": 200.0,
+                    "height": 150.0,
+                    "name": "主体",
+                },
+            ],
+            "engines": ["paddleocr", "birefnet"],
+            "warnings": [],
+        }
+
+    monkeypatch.setattr("app.services.vision.ilp_detect_regions.ilp_enabled", lambda: True)
+    monkeypatch.setattr("app.services.vision.ilp_detect_regions.detect_regions_via_ilp", fake_detect)
+
+    from app.services.vision.ilp_detect_regions import detect_regions_via_ilp_adapter
+
+    result = asyncio.run(
+        detect_regions_via_ilp_adapter(image="data:image/png;base64,abc")
+    )
+    assert result["kind"] == "detectRegions"
+    assert result["width"] == 800
+    assert len(result["layers"]) == 2
+    assert result["layers"][0]["type"] == "text"
+    assert result["layers"][0]["text"] == "标题"
+    assert "ilp:detect-regions" in result["engines"][0]
+
+
+def test_process_image_tool_detect_regions_requires_ilp(monkeypatch):
+    monkeypatch.setattr("app.services.vision.ilp_client.ilp_enabled", lambda: False)
+    from app.services.llm.image_tools import process_image_tool
+
+    with pytest.raises(RuntimeError, match="Recombyn Intelligence"):
+        asyncio.run(process_image_tool(kind="detectRegions", image="data:image/png;base64,x"))

--- a/apps/api/tests/unit_tests/test_ilp_text_decompose.py
+++ b/apps/api/tests/unit_tests/test_ilp_text_decompose.py
@@ -1,0 +1,65 @@
+"""Unit tests for ILP text-decompose BFF adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+
+import numpy as np
+import pytest
+from PIL import Image
+
+
+def _tiny_png_data_url() -> str:
+    img = Image.new("RGB", (64, 48), color=(200, 210, 220))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return f"data:image/png;base64,{base64.b64encode(buf.getvalue()).decode('ascii')}"
+
+
+def test_decompose_text_via_ilp_maps_layers(monkeypatch):
+    bg = base64.b64encode(b"png-bytes").decode("ascii")
+
+    async def fake_text_decompose(_image: str, *, lang: str = "ch", min_confidence: float = 0.72):
+        return {
+            "width": 64,
+            "height": 48,
+            "background_b64": bg,
+            "editable_blocks": [
+                {
+                    "text": "Hello",
+                    "x": 5.0,
+                    "y": 6.0,
+                    "width": 40.0,
+                    "height": 12.0,
+                    "font_size": 11.0,
+                }
+            ],
+            "raster_layers": [],
+            "engines": ["paddleocr", "lama"],
+            "warnings": [],
+        }
+
+    monkeypatch.setattr("app.services.vision.ilp_text_decompose.ilp_enabled", lambda: True)
+    monkeypatch.setattr("app.services.vision.ilp_text_decompose.text_decompose_via_ilp", fake_text_decompose)
+
+    bgr = np.full((48, 64, 3), 200, dtype=np.uint8)
+
+    async def fake_load(_ref: str):
+        return bgr
+
+    monkeypatch.setattr("app.services.vision.ilp_text_decompose.load_bgr", fake_load)
+
+    from app.services.vision.ilp_text_decompose import decompose_text_via_ilp
+
+    result = asyncio.run(
+        decompose_text_via_ilp(kind="editText", image=_tiny_png_data_url())
+    )
+    assert result["kind"] == "editText"
+    assert result["width"] == 64
+    assert len(result["layers"]) >= 2
+    text_layers = [l for l in result["layers"] if l.get("type") == "text"]
+    assert len(text_layers) == 1
+    assert text_layers[0]["text"] == "Hello"
+    assert "ilp:text-decompose" in result["engines"][0]

--- a/apps/api/tests/unit_tests/test_mockup_client.py
+++ b/apps/api/tests/unit_tests/test_mockup_client.py
@@ -1,0 +1,12 @@
+"""Unit tests for mockup BFF routing."""
+
+from __future__ import annotations
+
+
+def test_mockup_enabled_follows_intelligence(monkeypatch):
+    from app.services.mockup.mockup_client import mockup_enabled
+
+    monkeypatch.setattr("app.services.mockup.mockup_client.ilp_enabled", lambda: False)
+    assert mockup_enabled() is False
+    monkeypatch.setattr("app.services.mockup.mockup_client.ilp_enabled", lambda: True)
+    assert mockup_enabled() is True

--- a/apps/api/tests/unit_tests/test_page_analyzer_ilp.py
+++ b/apps/api/tests/unit_tests/test_page_analyzer_ilp.py
@@ -1,0 +1,51 @@
+"""Unit tests for page_analyzer intelligence routing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_analyze_page_images_uses_ilp_when_enabled(tmp_path, monkeypatch):
+    img = tmp_path / "page.png"
+    img.write_bytes(b"fake-png")
+
+    monkeypatch.setattr("app.services.vision.ilp_client.ilp_enabled", lambda: True)
+
+    def fake_analyze(paths, **kwargs):
+        assert len(paths) == 1
+        return {
+            "blocks": [{"type": "text", "text": "Hi", "x": 1, "y": 2, "width": 10, "height": 12}],
+            "width": 794,
+            "height": 1123,
+            "palette": ["#FFFFFF"],
+            "engines": ["paddleocr"],
+            "warnings": [],
+            "sam_regions": [],
+            "lama_applied": False,
+        }
+
+    monkeypatch.setattr("app.services.vision.ilp_client.analyze_pages_via_ilp", fake_analyze)
+
+    from app.services.vision.page_analyzer import analyze_page_images
+
+    out = analyze_page_images([Path(img)])
+    assert out["engines"][0] == "ilp:analyze-pages"
+    assert out["blocks"][0]["text"] == "Hi"
+
+
+def test_analyze_page_images_ilp_failure_no_local_ocr(tmp_path, monkeypatch):
+    img = tmp_path / "page.png"
+    img.write_bytes(b"fake-png")
+
+    monkeypatch.setattr("app.services.vision.ilp_client.ilp_enabled", lambda: True)
+    monkeypatch.setattr(
+        "app.services.vision.ilp_client.analyze_pages_via_ilp",
+        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("down")),
+    )
+    monkeypatch.setattr("app.services.vision.page_analyzer.ocr_available", lambda: False)
+
+    from app.services.vision.page_analyzer import analyze_page_images
+
+    out = analyze_page_images([Path(img)])
+    assert out["blocks"] == []
+    assert any("intelligence analyze-pages failed" in w for w in out["warnings"])

--- a/apps/api/tests/unit_tests/test_remove_bg_ilp.py
+++ b/apps/api/tests/unit_tests/test_remove_bg_ilp.py
@@ -1,0 +1,42 @@
+"""Unit tests for ILP-only remove background."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+
+import pytest
+from PIL import Image
+
+from app.services.vision.remove_bg import remove_background
+
+
+def _tiny_png() -> str:
+    buf = io.BytesIO()
+    Image.new("RGB", (8, 8), color=(10, 20, 30)).save(buf, format="PNG")
+    import base64
+
+    return f"data:image/png;base64,{base64.b64encode(buf.getvalue()).decode('ascii')}"
+
+
+def test_remove_background_requires_ilp(monkeypatch):
+    monkeypatch.setattr("app.services.vision.remove_bg.ilp_enabled", lambda: False)
+    with pytest.raises(RuntimeError, match="Recombyn Intelligence"):
+        asyncio.run(remove_background(_tiny_png()))
+
+
+def test_remove_background_uses_ilp(monkeypatch):
+    monkeypatch.setattr("app.services.vision.remove_bg.ilp_enabled", lambda: True)
+
+    rgba = io.BytesIO()
+    Image.new("RGBA", (8, 8), color=(10, 20, 30, 200)).save(rgba, format="PNG")
+
+    async def fake_segment(_image, *, model="birefnet-general"):
+        return rgba.getvalue(), "image/png"
+
+    monkeypatch.setattr("app.services.vision.remove_bg.segment_foreground_via_ilp", fake_segment)
+
+    result = asyncio.run(remove_background(_tiny_png()))
+    assert result["kind"] == "removeBg"
+    assert result["engine"] == "ilp:birefnet"
+    assert str(result["image"]).startswith("data:image/png;base64,")

--- a/apps/web/src/components/editor/nodes/ImageNode/ImageDecomposeMenu.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageDecomposeMenu.tsx
@@ -1,0 +1,19 @@
+import { memo, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { HiOutlineSquare2Stack } from 'react-icons/hi2';
+import { imageToolBtn } from './imageToolbarShared';
+
+export type DecomposeMode = 'depth';
+
+/** Depth-based industrial layering — only shown when intelligence is connected. */
+function ImageDecomposeMenu({ onPick }: { onPick: (mode: DecomposeMode) => void }): ReactNode {
+  const { t } = useTranslation();
+  return (
+    <button type="button" className={imageToolBtn} onClick={() => onPick('depth')}>
+      <HiOutlineSquare2Stack className="h-4 w-4" />
+      <span>{t('editor.imageToolbar.editElements')}</span>
+    </button>
+  );
+}
+
+export default memo(ImageDecomposeMenu);

--- a/apps/web/src/components/editor/nodes/ImageNode/ImageProcessWatcher.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageProcessWatcher.tsx
@@ -9,11 +9,16 @@ import type { SceneNode, SceneNodeInput } from '@/components/rcb/sceneNode';
 
 const AI_KINDS = new Set([
   'upscale',
+  'removeBg',
   'multiAngle',
   'expand',
+  'editText',
+  'editElements',
   'replaceText',
   'adjust',
 ]);
+
+const DECOMPOSE_KINDS = new Set(['editText', 'editElements']);
 
 function parseMeta(raw: unknown): Record<string, unknown> {
   if (!raw) return {};
@@ -60,6 +65,7 @@ async function persistProcessedSrc(src: string, filename: string): Promise<strin
 
 async function refreshWallet() {
   try {
+    // Force refresh after spend — share cache key with App / AccountSettings.
     await queryClient.fetchQuery({
       ...apiQuery.walletWalletMe.queryOptions(),
       staleTime: 0,
@@ -76,7 +82,7 @@ function processFailMessage(err: unknown): string {
     return '积分不足，请充值后再试';
   if (status === 401) return '请先登录后再使用 AI 工具';
   if (/timeout/i.test(msg) || (err as { code?: string })?.code === 'ECONNABORTED')
-    return '图片处理超时，请稍后重试';
+    return '图片分层超时，请稍后重试（大图首次加载模型会更慢）';
   if (msg.trim()) return msg;
   return '图片处理失败';
 }
@@ -88,6 +94,9 @@ function buildFinishAttrsForKind(
     replacedCopy?: string;
   }
 ): Record<string, unknown> | undefined {
+  if (kind === 'removeBg') {
+    return { cutout: 'true', name: '抠图' };
+  }
   if (kind === 'replaceText' && opts.replacedCopy) {
     return {
       letteringText: opts.replacedCopy,
@@ -102,6 +111,7 @@ function buildFinishAttrsForKind(
 /**
  * Completes spawned image process jobs via backend AI (`POST /api/v1/image/process`).
  * Results are uploaded to our file server so the canvas / export use our URLs.
+ * Import / upload placeholders are finished by their own flows.
  */
 function ImageProcessWatcher() {
   const dispatch = useDispatch();
@@ -116,6 +126,7 @@ function ImageProcessWatcher() {
     const doc = documentRef.current;
     const node = doc?.deltaSetLike?.[pendingId];
     const kind = String(node?.attrs?.processKind || '');
+    // Local eraser finishes via ImageToolPanelHost (spawn + upload); do not auto-clear.
     if (kind === 'import' || kind === 'upload' || kind === 'eraser') return undefined;
 
     let cancelled = false;
@@ -129,6 +140,7 @@ function ImageProcessWatcher() {
 
     const run = async () => {
       if (!AI_KINDS.has(kind)) {
+        // Local-only kinds (eraser etc.) should not land here.
         await new Promise((r) => window.setTimeout(r, 400));
         if (!cancelled) dispatch(finishImageProcess({ nodeId: pendingId }));
         return;
@@ -169,6 +181,45 @@ function ImageProcessWatcher() {
         const res = await processImageTool(processBody, { signal: ac.signal });
         if (cancelled) return;
 
+        const layers = Array.isArray(res?.layers) ? res.layers : [];
+        if (layers.length > 0 && DECOMPOSE_KINDS.has(kind)) {
+          const persisted = await Promise.all(
+            layers.map(async (layer: any, i: number) => {
+              const src = String(layer?.src || '').trim();
+              if (!src || String(layer?.type) === 'text') return layer;
+              const url = await persistProcessedSrc(src, `${kind}-layer-${i + 1}.png`);
+              return { ...layer, src: url };
+            })
+          );
+          if (cancelled) return;
+          dispatch(
+            finishImageProcess({
+              nodeId: pendingId,
+              layers: persisted,
+              sourceWidth: Number(res.width) || undefined,
+              sourceHeight: Number(res.height) || undefined,
+            })
+          );
+          const warn = Array.isArray(res.warnings) ? res.warnings.filter(Boolean) : [];
+          if (warn.length) {
+            message.warning(warn.slice(0, 3).join('；'));
+          } else {
+            const textCount = layers.filter((l: any) => String(l?.type) === 'text').length;
+            const rasterCount = layers.filter((l: any) => l?.letteringText).length;
+            if (kind === 'editElements') {
+              message.success('图片分层完成（可单独改主体/文字）');
+            } else if (rasterCount > 0 && textCount > 0) {
+              message.success(`文字识别完成（${textCount} 处可编辑，${rasterCount} 处艺术字保留为图片）`);
+            } else if (textCount > 0) {
+              message.success(`文字识别完成（${textCount} 处可编辑）`);
+            } else {
+              message.success('文字识别完成');
+            }
+          }
+          await refreshWallet();
+          return;
+        }
+
         if (!res?.image) {
           fail('图片处理未返回结果');
           return;
@@ -189,9 +240,12 @@ function ImageProcessWatcher() {
           })
         );
         const labels: Record<string, string> = {
+          removeBg: '抠图完成（透明 PNG）',
           upscale: '高清放大完成',
           multiAngle: '多角度生成完成',
           expand: '扩展完成',
+          editText: '编辑文字完成',
+          editElements: '图片分层完成',
           replaceText: '文案替换完成',
           vector: '矢量化完成',
           adjust: '调整完成',
@@ -209,6 +263,7 @@ function ImageProcessWatcher() {
       cancelled = true;
       ac.abort();
     };
+    // Only re-run when a new job id is pending — not on every document edit.
   }, [pendingId, dispatch]);
 
   return null;

--- a/apps/web/src/components/editor/nodes/ImageNode/ImageRemoveBgMenu.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageRemoveBgMenu.tsx
@@ -1,0 +1,52 @@
+import { memo, type ReactNode } from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import { Icon } from '@/components/base';
+
+import { imageToolBtn } from './imageToolbarShared';
+
+
+
+const TOOL_ICON_SIZE = 16;
+
+
+
+export type RemoveBgMode = 'ilp';
+
+
+
+/** Industrial matting — only shown when intelligence is connected. */
+
+function ImageRemoveBgMenu({ onPick }: { onPick: (mode: RemoveBgMode) => void }): ReactNode {
+
+  const { t } = useTranslation();
+
+  return (
+
+    <button type="button" className={imageToolBtn} onClick={() => onPick('ilp')}>
+
+      <Icon
+
+        name="editor-remove_bg"
+
+        width={TOOL_ICON_SIZE}
+
+        height={TOOL_ICON_SIZE}
+
+        className="text-current"
+
+      />
+
+      <span>{t('editor.imageToolbar.removeBg')}</span>
+
+    </button>
+
+  );
+
+}
+
+
+
+export default memo(ImageRemoveBgMenu);
+

--- a/apps/web/src/components/editor/nodes/ImageNode/ImageToolbarEditTools.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageToolbarEditTools.tsx
@@ -2,83 +2,211 @@ import { memo, type ReactNode } from 'react';
 
 import { useTranslation } from 'react-i18next';
 
-import { HiOutlineCube, HiOutlineLanguage } from 'react-icons/hi2';
+import { HiOutlineCube, HiOutlineLanguage, HiOutlinePencilSquare } from 'react-icons/hi2';
 
-import { LuEraser } from 'react-icons/lu';
+import { LuCrosshair, LuEraser, LuPackage } from 'react-icons/lu';
 
 import { Icon } from '@/components/base';
 
 import { cn } from '@/utils/classnames';
 
+import ImageRemoveBgMenu, { type RemoveBgMode } from './ImageRemoveBgMenu';
+
+import ImageDecomposeMenu, { type DecomposeMode } from './ImageDecomposeMenu';
+
 import { ImageToolSep, imageToolBtn } from './imageToolbarShared';
 
+
+
+export type { RemoveBgMode, DecomposeMode };
+
+
+
 function Tool({
+
   label,
+
   onClick,
+
   children,
+
   active,
+
 }: {
+
   label: string;
+
   onClick?: () => void;
+
   children: ReactNode;
+
   active?: boolean;
+
 }) {
+
   return (
+
     <button
+
       type="button"
+
       className={cn(imageToolBtn, 'relative', active && 'bg-[var(--accent-soft)]')}
+
       onClick={onClick}
+
     >
+
       {children}
+
       <span>{label}</span>
+
     </button>
+
   );
+
 }
 
+
+
 /** Image selection toolbar edit actions (AI tools + optional trailing slots). */
+
 function ImageToolbarEditTools({
+
   onUpscale,
+
+  onRemoveBg,
+
   onEraser,
+
+  onMark,
+
   onReplaceText,
+
+  onEditText,
+
+  onEditElements,
+
+  onMockup,
+
   onMultiAngle,
+
   previewSlot,
+
   downloadSlot,
+
 }: {
+
   onUpscale: () => void;
+
+  onRemoveBg?: (mode: RemoveBgMode) => void;
+
   onEraser: () => void;
+
+  onMark?: () => void;
+
   onReplaceText?: () => void;
+
+  onEditText?: () => void;
+
+  onEditElements?: (mode: DecomposeMode) => void;
+
+  onMockup?: () => void;
+
   onMultiAngle: () => void;
+
   previewSlot?: ReactNode;
+
   downloadSlot?: ReactNode;
+
 }) {
+
   const { t } = useTranslation();
+
   const hasTrailing = Boolean(previewSlot || downloadSlot);
 
   return (
+
     <>
+
       <Tool label={t('editor.imageToolbar.upscale')} onClick={onUpscale}>
+
         <Icon name="editor-upscale" width={16} height={16} className="text-current" />
+
       </Tool>
+
+      {onRemoveBg ? <ImageRemoveBgMenu onPick={onRemoveBg} /> : null}
+
       <Tool label={t('editor.imageToolbar.eraser')} onClick={onEraser}>
+
         <LuEraser className="h-4 w-4" />
+
       </Tool>
+
+      {onMark ? (
+
+        <Tool label={t('editor.imageToolbar.mark')} onClick={onMark}>
+
+          <LuCrosshair className="h-4 w-4" strokeWidth={2} />
+
+        </Tool>
+
+      ) : null}
+
       {onReplaceText ? (
+
         <Tool label={t('editor.imageToolbar.replaceText')} onClick={onReplaceText}>
+
           <HiOutlineLanguage className="h-4 w-4" />
+
+        </Tool>
+
+      ) : null}
+
+      {onEditText ? (
+
+        <Tool label={t('editor.imageToolbar.editText')} onClick={onEditText}>
+
+          <HiOutlinePencilSquare className="h-4 w-4" />
+
+        </Tool>
+
+      ) : null}
+
+      {onEditElements ? <ImageDecomposeMenu onPick={onEditElements} /> : null}
+
+      {onMockup ? (
+        <Tool label={t('editor.imageToolbar.mockup')} onClick={onMockup}>
+          <LuPackage className="h-4 w-4" strokeWidth={2} />
         </Tool>
       ) : null}
+
       <Tool label={t('editor.imageToolbar.multiAngle')} onClick={onMultiAngle}>
+
         <HiOutlineCube className="h-4 w-4" />
+
       </Tool>
+
       {hasTrailing ? (
+
         <>
+
           <ImageToolSep />
+
           {previewSlot}
+
           {downloadSlot}
+
         </>
+
       ) : null}
+
     </>
+
   );
+
 }
 
+
+
 export default memo(ImageToolbarEditTools);
+

--- a/apps/web/src/components/editor/nodes/ImageNode/mark/MarkRegionOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/mark/MarkRegionOverlay.tsx
@@ -1,0 +1,336 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+  memo,
+} from 'react';
+import {
+  RcbOverlayPortal,
+  useRcbCamera,
+  rcbSceneToScreen,
+} from '@/components/rcb';
+
+/** Mark rect in image-local coords (origin = image top-left). */
+export type MarkRect = { x: number; y: number; w: number; h: number };
+
+export type MarkRegion = MarkRect & {
+  id: string;
+  /** 1-based display index. */
+  index: number;
+  label?: string;
+  kind?: 'image' | 'text' | 'manual' | string;
+  selected?: boolean;
+};
+
+/** Min size to *commit* a region (scene px). Preview uses a softer floor. */
+const MIN_MARK = 12;
+/** Live rubber-band can show as soon as the drag leaves a 1×1 cell. */
+const MIN_PREVIEW = 1;
+/** Scene px — below this, pointer-up on a hit region counts as click-select. */
+const CLICK_SLOP = 4;
+
+function clampDragBox(
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  cw: number,
+  ch: number
+): MarkRect {
+  const left = Math.max(0, Math.min(x0, x1));
+  const top = Math.max(0, Math.min(y0, y1));
+  const right = Math.min(cw, Math.max(x0, x1));
+  const bottom = Math.min(ch, Math.max(y0, y1));
+  return { x: left, y: top, w: right - left, h: bottom - top };
+}
+
+/** Rubber-band while dragging — keep tiny boxes so the preview never blinks out. */
+export function previewDragBox(
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  cw: number,
+  ch: number
+): MarkRect | null {
+  const box = clampDragBox(x0, y0, x1, y1, cw, ch);
+  if (box.w < MIN_PREVIEW && box.h < MIN_PREVIEW) return null;
+  return {
+    x: box.x,
+    y: box.y,
+    w: Math.max(MIN_PREVIEW, box.w),
+    h: Math.max(MIN_PREVIEW, box.h),
+  };
+}
+
+/** Commit gate — reject clicks / sub-threshold drags. */
+export function normalizeDragBox(
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  cw: number,
+  ch: number
+): MarkRect | null {
+  const box = clampDragBox(x0, y0, x1, y1, cw, ch);
+  if (box.w < MIN_MARK || box.h < MIN_MARK) return null;
+  return box;
+}
+
+function pointInRect(px: number, py: number, r: MarkRect): boolean {
+  return px >= r.x && py >= r.y && px <= r.x + r.w && py <= r.y + r.h;
+}
+
+type Props = {
+  imageBox: { left: number; top: number; width: number; height: number };
+  regions: MarkRegion[];
+  draft: MarkRect | null;
+  detecting?: boolean;
+  onDraftChange: (rect: MarkRect | null) => void;
+  onCommitDraft: (rect: MarkRect) => void;
+  onSelectRegion: (id: string, additive: boolean) => void;
+};
+
+/**
+ * On-image mark overlay: crosshair cursor, drag-to-box, dashed region badges.
+ */
+function MarkRegionOverlay({
+  imageBox,
+  regions,
+  draft,
+  detecting,
+  onDraftChange,
+  onCommitDraft,
+  onSelectRegion,
+}: Props): ReactNode {
+  const camera = useRcbCamera();
+  const z = Math.max(0.05, camera.zoom || 1);
+  const dragRef = useRef<{
+    x0: number;
+    y0: number;
+    pointerId: number;
+    hitId: string | null;
+    additive: boolean;
+    moved: boolean;
+  } | null>(null);
+  const [hoverId, setHoverId] = useState<string | null>(null);
+  const onDraftChangeRef = useRef(onDraftChange);
+  const onCommitDraftRef = useRef(onCommitDraft);
+  const onSelectRegionRef = useRef(onSelectRegion);
+  onDraftChangeRef.current = onDraftChange;
+  onCommitDraftRef.current = onCommitDraft;
+  onSelectRegionRef.current = onSelectRegion;
+
+  const origin = rcbSceneToScreen(camera, imageBox.left, imageBox.top);
+  const stageW = Math.max(1, imageBox.width * z);
+  const stageH = Math.max(1, imageBox.height * z);
+  const cw = imageBox.width;
+  const ch = imageBox.height;
+
+  const localFromClient = useCallback(
+    (clientX: number, clientY: number) => {
+      const lx = (clientX - origin.x) / z;
+      const ly = (clientY - origin.y) / z;
+      return {
+        x: Math.max(0, Math.min(cw, lx)),
+        y: Math.max(0, Math.min(ch, ly)),
+        inside: lx >= 0 && ly >= 0 && lx <= cw && ly <= ch,
+      };
+    },
+    [origin.x, origin.y, z, cw, ch]
+  );
+
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag || e.pointerId !== drag.pointerId) return;
+      const p = localFromClient(e.clientX, e.clientY);
+      const dist = Math.hypot(p.x - drag.x0, p.y - drag.y0);
+      if (dist >= CLICK_SLOP) drag.moved = true;
+      // Started on an existing region → click-select only, never start a new box.
+      if (drag.hitId) return;
+      // Soft preview (1px+) while dragging; commit still uses MIN_MARK on pointer-up.
+      onDraftChangeRef.current(previewDragBox(drag.x0, drag.y0, p.x, p.y, cw, ch));
+    };
+    const onUp = (e: PointerEvent) => {
+      const drag = dragRef.current;
+      if (!drag || e.pointerId !== drag.pointerId) return;
+      dragRef.current = null;
+      const p = localFromClient(e.clientX, e.clientY);
+      if (drag.hitId) {
+        onDraftChangeRef.current(null);
+        onSelectRegionRef.current(drag.hitId, drag.additive);
+        return;
+      }
+      const box = normalizeDragBox(drag.x0, drag.y0, p.x, p.y, cw, ch);
+      onDraftChangeRef.current(null);
+      if (box) onCommitDraftRef.current(box);
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onUp);
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onUp);
+    };
+  }, [localFromClient, cw, ch]);
+
+  const shellStyle: CSSProperties = {
+    position: 'absolute',
+    left: origin.x,
+    top: origin.y,
+    width: stageW,
+    height: stageH,
+    zIndex: 34,
+    cursor: 'crosshair',
+    touchAction: 'none',
+  };
+
+  const renderBox = (
+    r: MarkRect,
+    opts: {
+      id?: string;
+      index?: number;
+      label?: string;
+      selected?: boolean;
+      draft?: boolean;
+    }
+  ) => {
+    const selected = Boolean(opts.selected);
+    const isDraft = Boolean(opts.draft);
+    const hovered = opts.id != null && hoverId === opts.id;
+    const left = r.x * z;
+    const top = r.y * z;
+    const width = Math.max(1, r.w * z);
+    const height = Math.max(1, r.h * z);
+    // White strokes vanish on light photos — keep marks in the blue family.
+    const borderColor = isDraft
+      ? 'rgba(37,99,235,0.95)'
+      : selected
+        ? 'rgba(59,130,246,0.95)'
+        : hovered
+          ? 'rgba(96,165,250,0.9)'
+          : 'rgba(59,130,246,0.55)';
+    const fill =
+      isDraft || selected
+        ? 'inset 0 0 0 9999px rgba(59,130,246,0.16)'
+        : hovered
+          ? 'inset 0 0 0 9999px rgba(59,130,246,0.08)'
+          : 'inset 0 0 0 9999px rgba(59,130,246,0.04)';
+    const badgeBg = selected || isDraft ? '#2563eb' : '#60a5fa';
+
+    return (
+      <div
+        key={opts.id || 'draft'}
+        data-mark-region={opts.id || 'draft'}
+        data-mark-draft={isDraft ? '1' : undefined}
+        className="pointer-events-none absolute"
+        style={{
+          left,
+          top,
+          width,
+          height,
+          border: `${isDraft ? 2 : 1.5}px dashed ${borderColor}`,
+          boxShadow: selected
+            ? `0 0 0 1px rgba(59,130,246,0.35), ${fill}`
+            : fill,
+          boxSizing: 'border-box',
+        }}
+      >
+        {opts.index != null ? (
+          <span
+            className="pointer-events-none absolute right-0 top-1/2 flex h-5 min-w-5 -translate-y-1/2 translate-x-1/2 items-center justify-center rounded-md px-1 text-[11px] font-semibold text-white shadow-sm"
+            style={{ background: badgeBg }}
+          >
+            {opts.index}
+          </span>
+        ) : null}
+        {opts.label ? (
+          <span
+            className="pointer-events-none absolute -bottom-6 right-0 whitespace-nowrap rounded-full px-2 py-0.5 text-[11px] font-medium text-[#1e3a8a] shadow-sm"
+            style={{ background: 'rgba(191,219,254,0.95)' }}
+          >
+            {opts.label}
+          </span>
+        ) : null}
+        {isDraft ? (
+          <span
+            className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded-full px-2 py-0.5 text-[11px] font-semibold text-white shadow-sm"
+            style={{ background: 'rgba(37,99,235,0.92)' }}
+          >
+            {Math.round(r.w)} × {Math.round(r.h)}
+          </span>
+        ) : null}
+      </div>
+    );
+  };
+
+  return (
+    <RcbOverlayPortal>
+      <div
+        data-image-tool-panel
+        data-mark-overlay
+        className="pointer-events-auto absolute"
+        style={shellStyle}
+        onPointerDown={(e) => {
+          if (e.button !== 0) return;
+          e.preventDefault();
+          e.stopPropagation();
+          e.nativeEvent.stopImmediatePropagation?.();
+          const p = localFromClient(e.clientX, e.clientY);
+          if (!p.inside) return;
+
+          const hit = [...regions].reverse().find((r) => pointInRect(p.x, p.y, r));
+          dragRef.current = {
+            x0: p.x,
+            y0: p.y,
+            pointerId: e.pointerId,
+            hitId: hit?.id ?? null,
+            additive: e.shiftKey,
+            moved: false,
+          };
+          onDraftChange(null);
+          (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+        }}
+        onPointerMove={(e) => {
+          if (dragRef.current) return;
+          const p = localFromClient(e.clientX, e.clientY);
+          if (!p.inside) {
+            setHoverId(null);
+            return;
+          }
+          const hit = [...regions].reverse().find((r) => pointInRect(p.x, p.y, r));
+          setHoverId(hit?.id ?? null);
+        }}
+        onPointerLeave={() => {
+          if (!dragRef.current) setHoverId(null);
+        }}
+      >
+        {detecting ? (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/20">
+            <span className="rounded-full bg-white/90 px-3 py-1.5 text-[12px] font-medium text-[var(--ink)] shadow-sm">
+              识别主题中…
+            </span>
+          </div>
+        ) : null}
+        {regions.map((r) =>
+          renderBox(r, {
+            id: r.id,
+            index: r.index,
+            label: r.label,
+            selected: r.selected,
+          })
+        )}
+        {draft && draft.w >= 1 && draft.h >= 1
+          ? renderBox(draft, { draft: true })
+          : null}
+      </div>
+    </RcbOverlayPortal>
+  );
+}
+
+export default memo(MarkRegionOverlay);

--- a/apps/web/src/components/editor/nodes/ImageNode/mark/MarkSessionHost.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/mark/MarkSessionHost.tsx
@@ -1,0 +1,513 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+  memo,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { nanoid } from 'nanoid';
+import { rcbSceneToScreen, useRcbCamera } from '@/components/rcb';
+import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
+import {
+  closeImageToolPanel,
+  enqueueAgentContexts,
+} from '@/store/modules/editor';
+import { CONTEXT_CHIP_PILL_CLASS } from '@/components/editor/panels/AgentComposerInput';
+import { resolveChatFlyTarget } from '@/components/editor/panels/agent/composer/flyToChat';
+import { getHttpErrorMessage } from '@/service/client';
+import {
+  processImageTool,
+  useImageToolCapabilities,
+  type ImageDecomposeLayer,
+} from '@/service/imageTools';
+import { imageSrcToFile } from '@/utils/uploadImage';
+import { cn } from '@/utils/classnames';
+import MarkRegionOverlay, {
+  type MarkRect,
+  type MarkRegion,
+} from './MarkRegionOverlay';
+import type { SceneDocument, SceneNodeInput } from '@/components/rcb/sceneNode';
+
+type SceneBox = { left: number; top: number; width: number; height: number };
+
+type FlyAnim = {
+  id: string;
+  /** Fixed-viewport start (chip center). */
+  startX: number;
+  startY: number;
+  /** Fixed-viewport end (composer / dock). */
+  endX: number;
+  endY: number;
+  thumbUrl?: string;
+  label: string;
+  phase: 'ready' | 'flying' | 'done';
+};
+
+const FLY_MS = 640;
+const CHIP_W = 112;
+const CHIP_H = 28;
+
+function nodeBox(
+  document: SceneDocument,
+  node: SceneNodeInput
+): SceneBox | null {
+  if (!node) return null;
+  const { left, top } = nodeLeftTop(document, node);
+  return {
+    left,
+    top,
+    width: Math.max(1, Number(node.width) || 1),
+    height: Math.max(1, Number(node.height) || 1),
+  };
+}
+
+function regionLabel(layer: ImageDecomposeLayer, index: number): string {
+  const name = String(layer.name || '').trim();
+  if (name) return `${index} ${name}`;
+  if (layer.type === 'text') {
+    const text = String(layer.text || '').trim();
+    if (text) return `${index} ${text.slice(0, 12)}`;
+    return `${index} 文字`;
+  }
+  return `${index} 区域`;
+}
+
+/** Map API source-pixel layers → image-local mark regions. */
+function layersToRegions(
+  layers: ImageDecomposeLayer[],
+  naturalW: number,
+  naturalH: number,
+  nodeW: number,
+  nodeH: number
+): MarkRegion[] {
+  const sx = nodeW / Math.max(1, naturalW);
+  const sy = nodeH / Math.max(1, naturalH);
+  const out: MarkRegion[] = [];
+  for (const layer of layers) {
+    if (layer.type !== 'image' && layer.type !== 'text') continue;
+    const x = Number(layer.x) || 0;
+    const y = Number(layer.y) || 0;
+    const w = Math.max(1, Number(layer.width) || 1);
+    const h = Math.max(1, Number(layer.height) || 1);
+    if (w * sx >= nodeW * 0.92 && h * sy >= nodeH * 0.92) continue;
+    const index = out.length + 1;
+    out.push({
+      id: nanoid(8),
+      index,
+      x: x * sx,
+      y: y * sy,
+      w: w * sx,
+      h: h * sy,
+      kind: layer.type,
+      label: regionLabel(layer, index),
+      selected: false,
+    });
+  }
+  return out;
+}
+
+async function loadImageForCrop(
+  src: string,
+  uploadKey?: string | null
+): Promise<{ img: HTMLImageElement; revoke: () => void }> {
+  const file = await imageSrcToFile(src, 'mark-crop.png', { uploadKey });
+  const blobUrl = URL.createObjectURL(file);
+  const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+    const el = new Image();
+    el.onload = () => resolve(el);
+    el.onerror = () => {
+      URL.revokeObjectURL(blobUrl);
+      reject(new Error('image load failed'));
+    };
+    el.src = blobUrl;
+  });
+  return { img, revoke: () => URL.revokeObjectURL(blobUrl) };
+}
+
+/** Crop image-local mark rect → PNG data URL (natural pixels). */
+async function cropMarkRegionDataUrl(
+  src: string,
+  nodeW: number,
+  nodeH: number,
+  rect: MarkRect,
+  uploadKey?: string | null
+): Promise<string> {
+  const { img, revoke } = await loadImageForCrop(src, uploadKey);
+  try {
+    const nw = Math.max(1, img.naturalWidth || img.width || 1);
+    const nh = Math.max(1, img.naturalHeight || img.height || 1);
+    const sx = (rect.x / Math.max(1, nodeW)) * nw;
+    const sy = (rect.y / Math.max(1, nodeH)) * nh;
+    const sw = Math.max(1, (rect.w / Math.max(1, nodeW)) * nw);
+    const sh = Math.max(1, (rect.h / Math.max(1, nodeH)) * nh);
+    const canvas = globalThis.document.createElement('canvas');
+    canvas.width = Math.max(1, Math.round(sw));
+    canvas.height = Math.max(1, Math.round(sh));
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('canvas unsupported');
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
+    ctx.drawImage(img, sx, sy, sw, sh, 0, 0, canvas.width, canvas.height);
+    return canvas.toDataURL('image/png');
+  } finally {
+    revoke();
+  }
+}
+
+function buildMarkChipPayload(
+  nodeId: string,
+  region: MarkRegion,
+  nodeW: number,
+  nodeH: number
+): string {
+  const nx = (region.x / nodeW).toFixed(3);
+  const ny = (region.y / nodeH).toFixed(3);
+  const nw = (region.w / nodeW).toFixed(3);
+  const nh = (region.h / nodeH).toFixed(3);
+  const tag = region.kind === 'text' ? 'text' : 'subject';
+  return [
+    '[Marked image region — edit this area on the referenced image]',
+    `node_id: ${nodeId}`,
+    `region: #${region.index}(${tag}@${nx},${ny},${nw}x${nh})`,
+    `label: ${region.label || `区域 ${region.index}`}`,
+  ].join('\n');
+}
+
+/** Landing point inside the right Agent composer (fallback: dock / viewport). */
+function resolveMarkChatFlyTarget(): { x: number; y: number } {
+  return resolveChatFlyTarget({ landId: 'agent' });
+}
+
+/**
+ * Mark tool session: auto subject/text proposals + manual box select.
+ * Selecting a region flies an @ chip into the right AgentDock chat.
+ */
+function MarkSessionHost({ document }: { document: SceneDocument }): ReactNode {
+  const dispatch = useDispatch();
+  const camera = useRcbCamera();
+  const { data: imageToolCaps } = useImageToolCapabilities();
+  const ilpEnabled = imageToolCaps?.ilp?.enabled === true;
+  const panel = useSelector(
+    (s: any) =>
+      s.editor.imageToolPanel as null | { nodeId: string; kind: string }
+  );
+  const selectedNodeId = useSelector(
+    (s: any) => s.editor.selectedNodeId as string | null
+  );
+  const active = panel?.kind === 'mark' ? panel.nodeId : null;
+  const node = active ? document?.deltaSetLike?.[active] : null;
+  const box = useMemo(
+    () => (active && node ? nodeBox(document, node) : null),
+    [document, active, node]
+  );
+  const src = String(node?.attrs?.src || '').trim();
+  const uploadKey =
+    String(node?.attrs?.uploadKey || node?.attrs?.key || '').trim() || null;
+
+  const [regions, setRegions] = useState<MarkRegion[]>([]);
+  const [draft, setDraft] = useState<MarkRect | null>(null);
+  const [detecting, setDetecting] = useState(false);
+  const [flies, setFlies] = useState<FlyAnim[]>([]);
+  const abortRef = useRef<AbortController | null>(null);
+  const detectGenRef = useRef(0);
+  const inflightRef = useRef<Set<string>>(new Set());
+
+  const close = () => dispatch(closeImageToolPanel());
+
+  useEffect(() => {
+    if (!active) return;
+    if (!selectedNodeId || selectedNodeId !== active) close();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedNodeId, active]);
+
+  useEffect(() => {
+    if (!active) return;
+    if (!node || node.key !== 'image') close();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, node?.key]);
+
+  useEffect(() => {
+    if (!active) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active]);
+
+  useEffect(() => {
+    if (!active || !src || !box) return;
+    setRegions([]);
+    setDraft(null);
+    setFlies([]);
+    if (!ilpEnabled) {
+      setDetecting(false);
+      return;
+    }
+    const gen = ++detectGenRef.current;
+    setDetecting(true);
+    abortRef.current?.abort();
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    async function runDetect() {
+      try {
+        const res = await processImageTool(
+          { kind: 'detectRegions', image: src },
+          { signal: ac.signal }
+        );
+        if (gen !== detectGenRef.current) return;
+        const nw = Math.max(1, Number(res.width) || box!.width);
+        const nh = Math.max(1, Number(res.height) || box!.height);
+        const next = layersToRegions(
+          res.layers || [],
+          nw,
+          nh,
+          box!.width,
+          box!.height
+        ).map((r, i) => ({
+          ...r,
+          index: i + 1,
+          selected: false,
+        }));
+        setRegions(next);
+      } catch (err: unknown) {
+        if (ac.signal.aborted || gen !== detectGenRef.current) return;
+        const msg = getHttpErrorMessage(err, '');
+        if (msg && !/unsupported kind|detectRegions/i.test(msg)) {
+          console.warn('[mark] detect failed', msg);
+        }
+      } finally {
+        if (gen === detectGenRef.current) setDetecting(false);
+      }
+    }
+    void runDetect();
+
+    return () => {
+      ac.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, src, ilpEnabled]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const renumber = (list: MarkRegion[]): MarkRegion[] =>
+    list.map((r, i) => ({
+      ...r,
+      index: i + 1,
+      label:
+        r.kind === 'manual'
+          ? `${i + 1} 区域`
+          : r.label?.replace(/^\d+\s*/, `${i + 1} `) || `${i + 1} 区域`,
+    }));
+
+  const flyRegionToChat = async (region: MarkRegion) => {
+    if (!active || !box || !src) return;
+    if (inflightRef.current.has(region.id)) return;
+    inflightRef.current.add(region.id);
+
+    const center = rcbSceneToScreen(
+      camera,
+      box.left + region.x + region.w / 2,
+      box.top + region.y + region.h / 2
+    );
+    const target = resolveMarkChatFlyTarget();
+    const flyId = nanoid(6);
+    const label = region.label || `${region.index} 区域`;
+
+    setFlies((prev) => [
+      ...prev,
+      {
+        id: flyId,
+        startX: center.x,
+        startY: center.y,
+        endX: target.x,
+        endY: target.y,
+        label,
+        phase: 'ready',
+      },
+    ]);
+
+    const cropPromise = cropMarkRegionDataUrl(
+      src,
+      box.width,
+      box.height,
+      region,
+      uploadKey
+    ).catch(() => undefined);
+
+    // Pop-in, then fly — wait for thumb (capped) so the chip looks real mid-flight.
+    const [thumb] = await Promise.all([
+      cropPromise,
+      new Promise<void>((r) => window.setTimeout(r, 140)),
+    ]);
+
+    const land = resolveMarkChatFlyTarget();
+    setFlies((prev) =>
+      prev.map((f) =>
+        f.id === flyId
+          ? {
+              ...f,
+              thumbUrl: thumb,
+              endX: land.x,
+              endY: land.y,
+              phase: 'flying',
+            }
+          : f
+      )
+    );
+
+    // Insert into chat as the tag arrives so it feels continuous.
+    window.setTimeout(() => {
+      dispatch(
+        enqueueAgentContexts([
+          {
+            key: `mark:${active}:${region.id}`,
+            label: region.label || `区域 ${region.index}`,
+            kind: 'image',
+            payload: buildMarkChipPayload(active, region, box.width, box.height),
+            ...(thumb ? { dataUrl: thumb, thumbUrl: thumb } : {}),
+          },
+        ])
+      );
+    }, Math.round(FLY_MS * 0.78));
+
+    window.setTimeout(() => {
+      setFlies((prev) => prev.filter((f) => f.id !== flyId));
+      inflightRef.current.delete(region.id);
+    }, FLY_MS + 100);
+  };
+
+  const onCommitDraft = (rect: MarkRect) => {
+    const nextRegion: MarkRegion = {
+      id: nanoid(8),
+      index: regions.length + 1,
+      ...rect,
+      kind: 'manual',
+      label: `${regions.length + 1} 区域`,
+      selected: true,
+    };
+    setRegions((prev) => {
+      const cleared = prev.map((r) => ({ ...r, selected: false }));
+      return renumber([...cleared, nextRegion]);
+    });
+    flyRegionToChat(nextRegion);
+  };
+
+  const onSelectRegion = (id: string, _additive: boolean) => {
+    const hit = regions.find((r) => r.id === id);
+    setRegions((prev) => prev.map((r) => ({ ...r, selected: r.id === id })));
+    if (hit) flyRegionToChat(hit);
+  };
+
+  if (!active || !box || !node) return null;
+
+  return (
+    <>
+      <style>{`
+        @keyframes mark-chip-pop {
+          0% { transform: translate(-50%, -50%) scale(0.55); opacity: 0; }
+          100% { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+        }
+        @keyframes mark-chip-fly {
+          0% {
+            transform: translate(-50%, -50%) scale(1) rotate(0deg);
+            opacity: 1;
+            box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+          }
+          55% {
+            opacity: 1;
+            box-shadow: 0 12px 32px rgba(59, 130, 246, 0.28);
+          }
+          100% {
+            transform: translate(
+                calc(-50% + var(--mark-dx)),
+                calc(-50% + var(--mark-dy))
+              )
+              scale(0.72)
+              rotate(-6deg);
+            opacity: 0;
+            box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
+          }
+        }
+      `}</style>
+      <MarkRegionOverlay
+        imageBox={box}
+        regions={regions}
+        draft={draft}
+        detecting={detecting}
+        onDraftChange={setDraft}
+        onCommitDraft={onCommitDraft}
+        onSelectRegion={onSelectRegion}
+      />
+      {flies.length
+        ? createPortal(
+            <>
+              {flies.map((fly) => {
+                const dx = fly.endX - fly.startX;
+                const dy = fly.endY - fly.startY;
+                const style: CSSProperties = {
+                  position: 'fixed',
+                  left: fly.startX,
+                  top: fly.startY,
+                  width: CHIP_W,
+                  height: CHIP_H,
+                  zIndex: 9999,
+                  pointerEvents: 'none',
+                  ['--mark-dx' as string]: `${dx}px`,
+                  ['--mark-dy' as string]: `${dy}px`,
+                  animation:
+                    fly.phase === 'flying'
+                      ? `mark-chip-fly ${FLY_MS}ms cubic-bezier(0.22, 0.82, 0.2, 1) forwards`
+                      : `mark-chip-pop 160ms cubic-bezier(0.22, 1.2, 0.36, 1) forwards`,
+                  transform: 'translate(-50%, -50%)',
+                  willChange: 'transform, opacity',
+                };
+                return (
+                  <div
+                    key={fly.id}
+                    aria-hidden
+                    data-mark-fly-chip
+                    className={cn(
+                      CONTEXT_CHIP_PILL_CLASS,
+                      'pl-1 pr-2 shadow-[0_10px_28px_rgba(15,23,42,0.2)] ring-1 ring-sky-400/55'
+                    )}
+                    style={style}
+                  >
+                    {fly.thumbUrl ? (
+                      <img
+                        src={fly.thumbUrl}
+                        alt=""
+                        className="h-3.5 w-3.5 shrink-0 rounded-[3px] object-cover ring-1 ring-[var(--line)]"
+                        draggable={false}
+                      />
+                    ) : (
+                      <span className="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-[3px] bg-sky-100 text-[9px] font-semibold text-sky-700 ring-1 ring-sky-200">
+                        @
+                      </span>
+                    )}
+                    <span className="truncate font-medium">{fly.label}</span>
+                  </div>
+                );
+              })}
+            </>,
+            globalThis.document.body
+          )
+        : null}
+    </>
+  );
+}
+
+export default memo(MarkSessionHost);

--- a/apps/web/src/components/editor/nodes/ImageNode/mark/__tests__/markRegionDragPreview.test.ts
+++ b/apps/web/src/components/editor/nodes/ImageNode/mark/__tests__/markRegionDragPreview.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeDragBox,
+  previewDragBox,
+} from '../MarkRegionOverlay';
+
+describe('mark region drag boxes', () => {
+  it('preview shows sub-threshold rubber bands; commit rejects them', () => {
+    const preview = previewDragBox(10, 10, 16, 18, 400, 300);
+    expect(preview).toEqual({ x: 10, y: 10, w: 6, h: 8 });
+    expect(normalizeDragBox(10, 10, 16, 18, 400, 300)).toBeNull();
+  });
+
+  it('commit accepts boxes at least 12×12', () => {
+    const box = normalizeDragBox(0, 0, 20, 24, 400, 300);
+    expect(box).toEqual({ x: 0, y: 0, w: 20, h: 24 });
+    expect(previewDragBox(0, 0, 20, 24, 400, 300)).toEqual(box);
+  });
+
+  it('clamps to image bounds while dragging', () => {
+    const preview = previewDragBox(-10, -5, 50, 40, 100, 80);
+    expect(preview).toEqual({ x: 0, y: 0, w: 50, h: 40 });
+  });
+});

--- a/apps/web/src/components/editor/nodes/ImageNode/mockup/MockupSessionHost.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/mockup/MockupSessionHost.tsx
@@ -1,0 +1,25 @@
+import { lazy, Suspense, memo, type ReactNode } from 'react';
+import type { SceneDocument } from '@/components/rcb/sceneNode';
+
+const EmptyMockupHost = memo(function EmptyMockupHost(_props: { document: SceneDocument }) {
+  return null;
+});
+
+const PrivateMockupSessionHost = lazy(() =>
+  import(/* @vite-ignore */ '@/private/mockup/MockupSessionHost')
+    .then((m) => ({ default: m.default }))
+    .catch(() => ({ default: EmptyMockupHost }))
+);
+
+/**
+ * OSS entry: lazy-loads closed-source UI from src/private/mockup (not on GitHub).
+ */
+function MockupSessionHost({ document }: { document: SceneDocument }): ReactNode {
+  return (
+    <Suspense fallback={null}>
+      <PrivateMockupSessionHost document={document} />
+    </Suspense>
+  );
+}
+
+export default MockupSessionHost;

--- a/apps/web/src/components/editor/nodes/ImageNode/mockup/mockupUiLoader.ts
+++ b/apps/web/src/components/editor/nodes/ImageNode/mockup/mockupUiLoader.ts
@@ -1,0 +1,27 @@
+/**
+ * Detect closed-source mockup UI under src/private/mockup (gitignored).
+ * OSS clones without that folder keep the toolbar hidden.
+ */
+
+let cached: boolean | null = null;
+let pending: Promise<boolean> | null = null;
+
+export function getMockupUiInstalled(): boolean | null {
+  return cached;
+}
+
+export function probeMockupUiInstalled(): Promise<boolean> {
+  if (cached !== null) return Promise.resolve(cached);
+  if (!pending) {
+    pending = import(/* @vite-ignore */ '@/private/mockup')
+      .then(() => {
+        cached = true;
+        return true;
+      })
+      .catch(() => {
+        cached = false;
+        return false;
+      });
+  }
+  return pending;
+}

--- a/apps/web/src/components/editor/nodes/ImageNode/toolPanels/ImageToolPanelShell.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/toolPanels/ImageToolPanelShell.tsx
@@ -15,11 +15,17 @@ const panelBtn =
 
 /**
  * Image-tool 积分 costs — sync with apps/api `image_tools.py` `_KIND_CREDIT_COST`.
+ * No LLM (removeBg / editText / editElements / CSS adjust) → 0.
+ * Local desktop / BYOK also skip platform credits on the server.
  */
 export const IMAGE_TOOL_CREDIT_COST = {
   upscale: 20,
+  removeBg: 0,
   multiAngle: 30,
   expand: 30,
+  editText: 0,
+  editElements: 0,
+  detectRegions: 0,
   replaceText: 30,
   vector: 20,
   adjust: 0,

--- a/apps/web/src/components/editor/page/EditorStageWorld.tsx
+++ b/apps/web/src/components/editor/page/EditorStageWorld.tsx
@@ -22,6 +22,8 @@ import SvgCanvas from '@/components/editor/canvas/SvgCanvas';
 import ImageProcessWatcher from '@/components/editor/nodes/ImageNode/ImageProcessWatcher';
 import CropExpandSessionHost from '@/components/editor/nodes/ImageNode/cropExpand/CropExpandSessionHost';
 import UpscaleSessionHost from '@/components/editor/nodes/ImageNode/UpscaleSessionHost';
+import MarkSessionHost from '@/components/editor/nodes/ImageNode/mark/MarkSessionHost';
+import MockupSessionHost from '@/components/editor/nodes/ImageNode/mockup/MockupSessionHost';
 import ImageToolPanelHost from '@/components/editor/nodes/ImageNode/toolPanels/ImageToolPanelHost';
 import ShapeStylePanelHost from '@/components/editor/nodes/ShapeNode/ShapeStylePanelHost';
 import VideoTrimSessionHost from '@/components/editor/nodes/VideoNode/VideoTrimSessionHost';
@@ -783,6 +785,8 @@ function EditorStageWorld({
         <ShapeStylePanelHost document={document} />
         <CropExpandSessionHost document={document} />
         <UpscaleSessionHost document={document} />
+        <MarkSessionHost document={document} />
+        <MockupSessionHost document={document} />
         <VideoTrimSessionHost document={document} />
         <AudioTrimSessionHost document={document} />
         <AudioSpeedSessionHost document={document} />

--- a/apps/web/src/components/editor/panels/agent/designTools.ts
+++ b/apps/web/src/components/editor/panels/agent/designTools.ts
@@ -1,4 +1,8 @@
 import type { SceneDocument, SceneNode, SceneNodeInput } from '@/components/rcb/sceneNode';
+import {
+  INTELLIGENCE_VISION_KINDS,
+  isIntelligenceVisionEnabled,
+} from '@/service/imageTools';
 /**
  * Canvas design tools — schemas + local execution (tool loop).
  */
@@ -4196,7 +4200,10 @@ function execImageProcess(
     const kind = String(args.kind || '').trim();
     const allowed = new Set([
       'upscale',
+      'removeBg',
       'eraser',
+      'editText',
+      'editElements',
       'replaceText',
       'multiAngle',
       'expand',
@@ -4218,6 +4225,17 @@ function execImageProcess(
         status: 'error',
         summary: `image_process unknown kind=${kind || '(empty)'}`,
         next_actions: [`Use kind one of: ${[...allowed].join('|')}`],
+      };
+    }
+    if (
+      (INTELLIGENCE_VISION_KINDS as readonly string[]).includes(kind) &&
+      !isIntelligenceVisionEnabled()
+    ) {
+      return {
+        status: 'error',
+        summary:
+          'removeBg / editText / editElements require Recombyn Intelligence (configure RECOMBYN_INTELLIGENCE_URL on the API)',
+        next_actions: ['Use upscale, expand, or other LLM image tools instead'],
       };
     }
     const node = doc.deltaSetLike?.[nodeId];

--- a/apps/web/src/components/rcb/scene/document/mediaLifecycle.ts
+++ b/apps/web/src/components/rcb/scene/document/mediaLifecycle.ts
@@ -534,7 +534,10 @@ function looksLikeSvgSrc(src: string) {
 
 export type ImageProcessKind =
   | 'upscale'
+  | 'removeBg'
   | 'eraser'
+  | 'editText'
+  | 'editElements'
   | 'multiAngle'
   | 'moveObject'
   | 'expand'

--- a/apps/web/src/components/rcb/selection/chrome/SelectionContextToolbar.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/SelectionContextToolbar.tsx
@@ -72,6 +72,8 @@ import FontFamilyPicker from '@/components/editor/nodes/TextNode/FontFamilyPicke
 import TextEditDialog from '@/components/editor/nodes/TextNode/TextEditDialog';
 import IconAnnotateToolbar from '@/components/editor/nodes/ImageNode/IconAnnotateToolbar';
 import ImageToolbarEditTools from '@/components/editor/nodes/ImageNode/ImageToolbarEditTools';
+import { useImageToolCapabilities } from '@/service/imageTools';
+import { probeMockupUiInstalled } from '@/components/editor/nodes/ImageNode/mockup/mockupUiLoader';
 import ImageToolbarMoreDownload, {
   ToolbarMoreMenu,
   type ImageMoreAction,
@@ -343,6 +345,25 @@ function SelectionContextToolbar(props: Props): ReactNode {
   const imageToolPanel = useSelector(
     (s: any) => s.editor.imageToolPanel as null | { nodeId: string; kind: string }
   );
+  const { data: imageToolCaps } = useImageToolCapabilities();
+  const ilpEnabled = imageToolCaps?.ilp?.enabled === true;
+  const mockupIntelEnabled = imageToolCaps?.mockup?.enabled === true;
+  const [mockupUiInstalled, setMockupUiInstalled] = useState<boolean | null>(null);
+  const mockupEnabled = mockupIntelEnabled && mockupUiInstalled === true;
+
+  useEffect(() => {
+    if (!mockupIntelEnabled) {
+      setMockupUiInstalled(false);
+      return;
+    }
+    let cancelled = false;
+    void probeMockupUiInstalled().then((ok) => {
+      if (!cancelled) setMockupUiInstalled(ok);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [mockupIntelEnabled]);
   const node = document?.deltaSetLike?.[nodeId];
   const kind = node?.key || 'shape';
   const flipRotateOpen = isPanelKindOnNode(
@@ -567,10 +588,47 @@ function SelectionContextToolbar(props: Props): ReactNode {
           <ImageToolSep />
           <ImageToolbarEditTools
             onUpscale={() => dispatch(openImageToolPanel({ nodeId, kind: 'upscale' }))}
+            onRemoveBg={
+              ilpEnabled
+                ? () =>
+                    runImageProcess(
+                      'removeBg',
+                      t('editor.imageToolbar.processingRemoveBg'),
+                      undefined,
+                      { cutoutMode: 'ilp' }
+                    )
+                : undefined
+            }
             onEraser={() => dispatch(openImageToolPanel({ nodeId, kind: 'eraser' }))}
+            onMark={
+              ilpEnabled
+                ? () => dispatch(openImageToolPanel({ nodeId, kind: 'mark' }))
+                : undefined
+            }
             onReplaceText={
               String(node?.attrs?.letteringText || '').trim()
                 ? () => dispatch(openImageToolPanel({ nodeId, kind: 'replaceText' }))
+                : undefined
+            }
+            onEditText={
+              ilpEnabled
+                ? () => runImageProcess('editText', t('editor.imageToolbar.processingEditText'))
+                : undefined
+            }
+            onEditElements={
+              ilpEnabled
+                ? () =>
+                    runImageProcess(
+                      'editElements',
+                      t('editor.imageToolbar.processingEditElements'),
+                      undefined,
+                      { engine: 'ilp' }
+                    )
+                : undefined
+            }
+            onMockup={
+              mockupEnabled
+                ? () => dispatch(openImageToolPanel({ nodeId, kind: 'mockup' }))
                 : undefined
             }
             onMultiAngle={() =>

--- a/apps/web/src/service/imageTools.ts
+++ b/apps/web/src/service/imageTools.ts
@@ -1,5 +1,6 @@
 /**
- * Image toolbar AI tools — POST /api/v1/image/process (Seedream i2i).
+ * Image toolbar AI tools — POST /api/v1/image/process
+ * (Seedream i2i, or vision decompose for editText / editElements).
  */
 
 import { useQuery } from '@tanstack/react-query';
@@ -7,8 +8,12 @@ import { abortAfter, apiClient } from '@/service/client';
 
 export type ImageProcessKindApi =
   | 'upscale'
+  | 'removeBg'
   | 'multiAngle'
   | 'expand'
+  | 'editText'
+  | 'editElements'
+  | 'detectRegions'
   | 'replaceText'
   | 'vector'
   | 'adjust';
@@ -44,6 +49,7 @@ export type ImageProcessResult = {
   text?: string | null;
   kind: string;
   model?: string;
+  /** editText / editElements: split layers in source-pixel coords */
   layers?: ImageDecomposeLayer[];
   width?: number;
   height?: number;
@@ -54,13 +60,45 @@ export type ImageProcessResult = {
 };
 
 export type ImageToolCapabilities = {
-  kinds?: string[];
-  credits?: Record<string, number>;
+  ilp?: {
+    enabled?: boolean;
+    supports?: string[];
+  };
+  mockup?: {
+    enabled?: boolean;
+    templates?: Array<{
+      id: string;
+      name?: string;
+      kind?: string;
+      width?: number;
+      height?: number;
+    }>;
+  };
 };
 
-/** Server-reported image tool capabilities (credits, etc.). */
+/** Kinds that require Recombyn Intelligence (not available in OSS-only deploy). */
+export const INTELLIGENCE_VISION_KINDS = [
+  'removeBg',
+  'editText',
+  'editElements',
+] as const;
+
+let intelligenceVisionEnabled = false;
+
+/** Sync snapshot updated by ``useImageToolCapabilities`` / ``fetchImageToolCapabilities``. */
+export function isIntelligenceVisionEnabled(): boolean {
+  return intelligenceVisionEnabled;
+}
+
+function syncIntelligenceVisionEnabled(caps: ImageToolCapabilities | undefined): void {
+  intelligenceVisionEnabled = caps?.ilp?.enabled === true;
+}
+
+/** Server-reported image tool capabilities (ILP routing, credits, etc.). */
 export const fetchImageToolCapabilities = async () => {
-  return (await apiClient.imageToolsListImageTools({})) as ImageToolCapabilities;
+  const data = (await apiClient.imageToolsListImageTools({})) as ImageToolCapabilities;
+  syncIntelligenceVisionEnabled(data);
+  return data;
 };
 
 export function useImageToolCapabilities() {
@@ -71,7 +109,7 @@ export function useImageToolCapabilities() {
   });
 }
 
-/** Run an image toolbar tool on the API. */
+/** Run an image toolbar tool on the API (Seedream i2i or intelligence vision). */
 export const processImageTool = (
   data: ImageProcessBody,
   opts?: { signal?: AbortSignal }

--- a/apps/web/src/service/mockupTools.ts
+++ b/apps/web/src/service/mockupTools.ts
@@ -1,0 +1,36 @@
+/**
+ * Mockup capability helpers (OSS-safe).
+ * Render implementation lives in src/private/mockup — not committed to GitHub.
+ */
+
+import { getHttpErrorMessage } from '@/service/client';
+import type { ImageToolCapabilities } from '@/service/imageTools';
+
+export type MockupRenderResult = {
+  image: string;
+  kind: string;
+  template_id?: string;
+  width?: number;
+  height?: number;
+  engines?: string[];
+  warnings?: string[];
+};
+
+export function isMockupEnabled(caps?: ImageToolCapabilities | null): boolean {
+  return caps?.mockup?.enabled === true;
+}
+
+export async function renderMockup(
+  image: string,
+  templateId = 'demo-cylinder'
+): Promise<MockupRenderResult> {
+  const mod = await import(/* @vite-ignore */ '@/private/mockup/mockupTools').catch(() => null);
+  if (!mod?.renderMockup) {
+    throw new Error('Mockup UI package not installed (copy src/private.example/mockup → src/private/mockup)');
+  }
+  return mod.renderMockup(image, templateId);
+}
+
+export function mockupErrorMessage(err: unknown, fallback: string): string {
+  return getHttpErrorMessage(err, fallback);
+}

--- a/apps/web/src/store/modules/editor.ts
+++ b/apps/web/src/store/modules/editor.ts
@@ -84,6 +84,8 @@ export type ImageToolPanelKind =
   | 'quickEdit'
   | 'replaceText'
   | 'lottieEdit'
+  | 'mark'
+  | 'mockup'
   | 'upscale';
 
 const IMAGE_TOOL_SIDE_PANEL_KIND: Record<string, true> = {
@@ -94,6 +96,7 @@ const IMAGE_TOOL_SIDE_PANEL_KIND: Record<string, true> = {
   adjust: true,
   effects: true,
   blendMode: true,
+  mark: true,
 };
 
 /** Blend / effects dock beside any selected node (not image-only tools). */
@@ -115,6 +118,8 @@ const IMAGE_TOOL_EXTERNAL_SESSION_KIND: Record<string, true> = {
   flipRotate: true,
   quickEdit: true,
   lottieEdit: true,
+  mark: true,
+  mockup: true,
 };
 
 const TRANSIENT_NODE_ATTR_KEYS = new Set([


### PR DESCRIPTION
## Summary
- Restore ILP BFF (抠图/分层/标记/编辑文字) gated on \RECOMBYN_INTELLIGENCE_URL\
- Restore mockup BFF + OSS lazy loader; UI loads from gitignored \src/private/mockup\
- CI: typecheck-safe empty fallback when private mockup absent

## Local dev
1. \pps/api/.env\: \RECOMBYN_INTELLIGENCE_URL=http://127.0.0.1:8091\
2. Start intelligence + \
pm run dev:api\ + \
pm run dev:web\
3. Keep \pps/web/src/private/mockup/\ locally (gitignored)

## Test plan
- [x] \
pm run typecheck:web\
- [ ] CI api-unit + web-unit

Made with [Cursor](https://cursor.com)