### PR TITLE
fix(canvas): mark quick-edit, process glow resize, and selection hover

### DIFF
--- a/apps/api/scripts/test_mark_region_edit_local.py
+++ b/apps/api/scripts/test_mark_region_edit_local.py
@@ -1,0 +1,208 @@
+"""Mark region detect + i2i edit — saves artifacts for manual review.
+
+Output: apps/api/private-eval/mark-edit-test/
+  input.png          — synthetic upload
+  mark-crop.png      — cropped marked region
+  prompt.txt         — prompt sent to image model
+  output.png         — generated result (when API keys + provider work)
+  report.json        — detect + request metadata
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import sys
+from io import BytesIO
+from pathlib import Path
+
+_API_ROOT = Path(__file__).resolve().parents[1]
+if str(_API_ROOT) not in sys.path:
+    sys.path.insert(0, str(_API_ROOT))
+
+OUT = _API_ROOT / "private-eval" / "mark-edit-test"
+
+
+def _make_test_image() -> Path:
+    from PIL import Image, ImageDraw
+
+    OUT.mkdir(parents=True, exist_ok=True)
+    img = Image.new("RGB", (512, 512), (235, 235, 235))
+    draw = ImageDraw.Draw(img)
+    draw.ellipse([140, 160, 372, 392], fill=(180, 130, 70), outline=(120, 80, 40), width=3)
+    draw.rectangle([48, 48, 168, 96], fill=(60, 120, 220))
+    path = OUT / "input.png"
+    img.save(path)
+    return path
+
+
+def _to_data_url(path: Path) -> str:
+    raw = path.read_bytes()
+    b64 = base64.b64encode(raw).decode("ascii")
+    return f"data:image/png;base64,{b64}"
+
+
+def _crop_region(path: Path, rect: dict[str, float], node_w: float, node_h: float) -> bytes:
+    from PIL import Image
+
+    img = Image.open(path).convert("RGBA")
+    nw, nh = img.size
+    sx = nw / max(1, node_w)
+    sy = nh / max(1, node_h)
+    x = int(rect["x"] * sx)
+    y = int(rect["y"] * sy)
+    w = max(1, int(rect["w"] * sx))
+    h = max(1, int(rect["h"] * sy))
+    crop = img.crop((x, y, x + w, y + h))
+    buf = BytesIO()
+    crop.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _build_mark_payload(node_id: str, region: dict, node_w: float, node_h: float) -> str:
+    nx = f"{region['x'] / node_w:.3f}"
+    ny = f"{region['y'] / node_h:.3f}"
+    nw = f"{region['w'] / node_w:.3f}"
+    nh = f"{region['h'] / node_h:.3f}"
+    tag = "text" if region.get("kind") == "text" else "subject"
+    label = region.get("label") or f"区域 {region.get('index', 1)}"
+    return "\n".join(
+        [
+            "[Marked image region — edit this area on the referenced image]",
+            f"node_id: {node_id}",
+            f"region: #{region.get('index', 1)}({tag}@{nx},{ny},{nw}x{nh})",
+            f"label: {label}",
+        ]
+    )
+
+
+async def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="", help="image model id override")
+    args = parser.parse_args()
+
+    input_path = _make_test_image()
+    data_url = _to_data_url(input_path)
+    node_w = node_h = 512.0
+    node_id = "test-node-1"
+
+    report: dict = {"input": str(input_path), "detect": None, "generate": None}
+
+    from app.services.vision.ilp_client import ilp_enabled
+
+    if not ilp_enabled():
+        print("ILP disabled — set RECOMBYN_INTELLIGENCE_URL in apps/api/.env")
+        report["detect"] = {"error": "ilp_disabled"}
+    else:
+        from app.services.vision.ilp_detect_regions import detect_regions_via_ilp_adapter
+
+        detect = await detect_regions_via_ilp_adapter(image=data_url)
+        report["detect"] = {
+            "width": detect.get("width"),
+            "height": detect.get("height"),
+            "layer_count": len(detect.get("layers") or []),
+            "layers": detect.get("layers") or [],
+        }
+        print(f"detectRegions: {report['detect']['layer_count']} layers")
+
+    layers = (report.get("detect") or {}).get("layers") or []
+    # Prefer a mid-sized subject box — skip full-canvas OCR text layers.
+    pick = None
+    for layer in layers:
+        if layer.get("type") == "text":
+            w = float(layer.get("width") or 0)
+            h = float(layer.get("height") or 0)
+            if w >= node_w * 0.9 and h >= node_h * 0.9:
+                continue
+        w = float(layer.get("width") or 0)
+        h = float(layer.get("height") or 0)
+        if w < node_w * 0.15 or h < node_h * 0.15:
+            continue
+        if w > node_w * 0.85 and h > node_h * 0.85:
+            continue
+        pick = layer
+        break
+    if pick:
+        region = {
+            "index": 1,
+            "x": float(pick.get("x") or 0),
+            "y": float(pick.get("y") or 0),
+            "w": float(pick.get("width") or 1),
+            "h": float(pick.get("height") or 1),
+            "kind": pick.get("type") or "image",
+            "label": f"1 {pick.get('name') or '区域'}",
+        }
+    else:
+        region = {"index": 1, "x": 140, "y": 160, "w": 232, "h": 232, "kind": "image", "label": "1 区域"}
+
+    crop_bytes = _crop_region(input_path, region, node_w, node_h)
+    crop_path = OUT / "mark-crop.png"
+    crop_path.write_bytes(crop_bytes)
+    crop_data_url = f"data:image/png;base64,{base64.b64encode(crop_bytes).decode('ascii')}"
+
+    mark_payload = _build_mark_payload(node_id, region, node_w, node_h)
+    user_prompt = "把标记区域改成一只白色小狗，保持其余部分不变"
+    prompt = f"{mark_payload}\n\nUser request:\n{user_prompt}"
+    (OUT / "prompt.txt").write_text(prompt, encoding="utf-8")
+    print(f"prompt saved: {OUT / 'prompt.txt'}")
+
+    try:
+        from app.core.config import settings
+        from app.services.llm.image import generate_image, resolve_image_model
+
+        model_id = (
+            args.model.strip()
+            or str(getattr(settings, "image_default_model", "") or "").strip()
+            or resolve_image_model(None)
+        )
+        print(f"image model: {model_id}")
+
+        result = await generate_image(
+            prompt=prompt,
+            model=model_id,
+            images=[data_url, crop_data_url],
+            resolution="1K",
+            aspect_ratio="1:1",
+        )
+        urls = []
+        if isinstance(result, dict):
+            urls = list(result.get("images") or [])
+            if not urls and result.get("assets"):
+                urls = [
+                    str(a.get("url") or "").strip()
+                    for a in (result.get("assets") or [])
+                    if str(a.get("url") or "").strip()
+                ]
+        url = urls[0] if urls else ""
+        report["generate"] = {"url": url, "raw_keys": list(result.keys()) if isinstance(result, dict) else []}
+        if url.startswith("data:image"):
+            header, b64 = url.split(",", 1)
+            ext = "png" if "png" in header else "jpg"
+            out_path = OUT / f"output.{ext}"
+            out_path.write_bytes(base64.b64decode(b64))
+            print(f"output saved: {out_path}")
+        elif url.startswith("http"):
+            import httpx
+
+            async with httpx.AsyncClient(timeout=120.0) as client:
+                res = await client.get(url)
+                res.raise_for_status()
+                out_path = OUT / "output.png"
+                out_path.write_bytes(res.content)
+                print(f"output saved: {out_path}")
+        else:
+            print("generate returned no downloadable image — check API keys / model config")
+    except Exception as exc:
+        report["generate"] = {"error": str(exc)}
+        print(f"generate failed: {exc}")
+
+    (OUT / "report.json").write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"report: {OUT / 'report.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/apps/web/src/components/editor/nodes/AudioGeneratorNode/AudioGeneratorOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/AudioGeneratorNode/AudioGeneratorOverlay.tsx
@@ -1,7 +1,8 @@
 import { useMemo, type ReactNode, memo } from 'react';
 import { useSelector } from 'react-redux';
 import {
-  isAudioGeneratorNode
+  isAudioGeneratorNode,
+  shouldShowGeneratorComposer,
 } from '@/components/rcb/scene/document/nodeCapabilities';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import AudioGeneratorCard from '@/components/editor/nodes/AudioGeneratorNode/AudioGeneratorCard';
@@ -47,9 +48,11 @@ function AudioGeneratorOverlay({
             key={nodeId}
             nodeId={nodeId}
             sceneBox={{ x: left, y: top, width, height }}
-            showComposer={
-              !hidden && selectedNodeIds.length === 1 && selectedNodeIds[0] === nodeId
-            }
+            showComposer={shouldShowGeneratorComposer({
+              node,
+              hidden,
+              selected: selectedNodeIds.length === 1 && selectedNodeIds[0] === nodeId,
+            })}
             disabled={readOnly}
           />
         );

--- a/apps/web/src/components/editor/nodes/ImageGeneratorNode/ImageGeneratorOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/ImageGeneratorNode/ImageGeneratorOverlay.tsx
@@ -1,11 +1,12 @@
 import { useMemo, type ReactNode, memo } from 'react';
 import { useSelector } from 'react-redux';
 import {
-  isImageGeneratorNode
+  isImageGeneratorNode,
+  shouldShowGeneratorComposer,
 } from '@/components/rcb/scene/document/nodeCapabilities';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import ImageGeneratorCard from '@/components/editor/nodes/ImageGeneratorNode/ImageGeneratorCard';
-import { EMPTY_ID_LIST } from '@/store/modules/editor';
+import { EMPTY_ID_LIST, isCanvasAttachForNode } from '@/store/modules/editor';
 import type { SceneDocument } from '@/components/rcb/sceneNode';
 
 /**
@@ -56,13 +57,16 @@ function ImageGeneratorOverlay({
             key={nodeId}
             nodeId={nodeId}
             sceneBox={{ x: left, y: top, width, height }}
-            // Title comes from the shared selection label; composer follows it.
-            showComposer={
-              !hidden &&
-              ((selectedNodeIds.length === 1 && selectedNodeIds[0] === nodeId) ||
-                canvasAttachPick?.target === `node:${nodeId}` ||
-                pendingCanvasAttach?.target === `node:${nodeId}`)
-            }
+            showComposer={shouldShowGeneratorComposer({
+              node,
+              hidden,
+              selected: selectedNodeIds.length === 1 && selectedNodeIds[0] === nodeId,
+              attachPickActive: isCanvasAttachForNode(
+                nodeId,
+                canvasAttachPick,
+                pendingCanvasAttach
+              ),
+            })}
             disabled={readOnly}
           />
         );

--- a/apps/web/src/components/editor/nodes/ImageNode/ImageProcessOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageProcessOverlay.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { SoftGlowSurface } from '@/components/base';
 import { useRcbCamera, rcbCameraCssZoom } from '@/components/rcb';
 import { radiiFromAttrs } from '@/components/rcb/scene/document/sceneRadii';
+import { readScenePaintLocalSize } from '@/components/rcb/scene/paint/sceneToSvg';
 import type { SceneNodeInput } from '@/components/rcb/sceneNode';
 
 const PILL_BOTTOM_PAD_PX = 14;
@@ -22,8 +23,11 @@ export function NodeProcessGlow({
   node: SceneNodeInput;
   paintHost: SVGElement;
 }): ReactNode {
-  const width = Math.max(1, Number(node.width) || 1);
-  const height = Math.max(1, Number(node.height) || 1);
+  const fallback = {
+    width: Math.max(1, Number(node.width) || 1),
+    height: Math.max(1, Number(node.height) || 1),
+  };
+  const { width, height } = readScenePaintLocalSize(paintHost, fallback);
   const radii = radiiFromAttrs(node.attrs || {});
   const borderRadius = `${radii.tl}px ${radii.tr}px ${radii.br}px ${radii.bl}px`;
   const camera = useRcbCamera();

--- a/apps/web/src/components/editor/nodes/ImageNode/ImageQuickEditComposer.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageQuickEditComposer.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 import { HiOutlineBolt, HiOutlineChevronDown, HiOutlinePlus, HiOutlineViewfinderCircle } from 'react-icons/hi2';
+import { LuCrosshair } from 'react-icons/lu';
 import { generateImage, type ChatModelsResponse, type LlmModel } from '@/service/chat';
 import { apiQuery, getHttpErrorMessage } from '@/service/client';
 import { Dropdown, DropdownPanel, message, Tooltip } from '@/components/base';
@@ -26,6 +27,10 @@ import {
   buildImageGeneratorModelList,
   flyPickIntoImageComposer,
 } from '@/components/editor/nodes/ImageGeneratorNode/ImageGeneratorCard';
+import {
+  buildComposerChipPrompt,
+  collectComposerRefImages,
+} from '@/components/editor/panels/agent/agentSendPath';
 import ImageAspectRatioPicker, {
   DEFAULT_IMAGE_COUNT,
   DEFAULT_IMAGE_QUALITY,
@@ -45,11 +50,15 @@ import {
   clearCanvasAttachPick,
   closeImageToolPanel,
   consumePendingCanvasAttach,
+  consumePendingQuickEditMarkContexts,
   finishImageProcess,
+  openImageToolPanel,
   patchDocumentNode,
   pushEditorHistory,
   startCanvasAttachPick,
+  type PendingMarkContextChip,
 } from '@/store/modules/editor';
+import { useImageToolCapabilities } from '@/service/imageTools';
 import { noteCanvasFlyLand } from '@/components/editor/panels/agent/composer/flyToChat';
 import { FREE_IMAGE_MODEL_ID, planAllowsModelPick } from '@/utils/wallet';
 import { useWalletSnapshot } from '@/service/wallet';
@@ -60,6 +69,26 @@ import { readFileAsDataUrl } from '@/utils/uploadImage';
 import store from '@/store';
 
 type SceneBox = { left: number; top: number; width: number; height: number };
+
+function insertPendingMarkChips(
+  input: AgentComposerHandle | null,
+  list: PendingMarkContextChip[],
+  focus: boolean
+) {
+  for (const item of list) {
+    input?.insertContextAtCaret({
+      key: item.key,
+      label: item.label,
+      kind: item.kind,
+      payload: item.payload,
+      dataUrl: item.dataUrl,
+      thumbUrl: item.thumbUrl,
+    });
+    const tail = item.appendText?.trim();
+    if (tail) input?.insertPlainAtCaret(tail);
+  }
+  if (focus) input?.focus();
+}
 
 function nextQuickEditImageModelId(
   models: LlmModel[],
@@ -92,18 +121,19 @@ function ratioSummaryLabel(aspectRatio: string, t: (k: string) => string) {
 }
 
 /**
- * Floating quick-edit composer under a selected image (Chat on image toolbar).
- * Prefills `attrs.genPrompt` when the image was prompt-generated; sends the
- * current image as the primary reference for i2i edits.
+ * Floating quick-edit composer under a selected image.
+ * Prefills `attrs.genPrompt`; uses the image as the primary i2i reference.
  */
 function ImageQuickEditComposer({
   document,
   nodeId,
   box,
+  hidden = false,
 }: {
   document: SceneDocument;
   nodeId: string;
   box: SceneBox;
+  hidden?: boolean;
 }): ReactNode {
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -133,6 +163,11 @@ function ImageQuickEditComposer({
 
   const { planId } = useWalletSnapshot();
   const canPickModel = planAllowsModelPick(planId);
+  const { data: imageToolCaps } = useImageToolCapabilities();
+  const ilpEnabled = imageToolCaps?.ilp?.enabled === true;
+  const pendingQuickEditMarks = useSelector(
+    (s: any) => (s.editor.pendingQuickEditMarkContexts || []) as PendingMarkContextChip[]
+  );
   const canvasAttachPick = useSelector(
     (s: any) => s.editor?.canvasAttachPick as null | { target: string }
   );
@@ -172,13 +207,14 @@ function ImageQuickEditComposer({
     flyPendingAttach();
   }, [pendingCanvasAttach, pickTarget, document, dispatch]);
 
-  // Auto-focus prompt when the floating chat panel opens.
+  // Auto-focus prompt when the floating chat panel opens or mark session ends.
   useEffect(() => {
+    if (hidden) return;
     const id = requestAnimationFrame(() => {
       inputRef.current?.focus();
     });
     return () => cancelAnimationFrame(id);
-  }, [nodeId]);
+  }, [nodeId, hidden]);
 
   const modelsCatalogQuery = useQuery({
     ...apiQuery.chatGetModels.queryOptions(),
@@ -220,6 +256,13 @@ function ImageQuickEditComposer({
       abortRef.current?.abort();
     };
   }, []);
+
+  useEffect(() => {
+    if (!pendingQuickEditMarks.length) return;
+    const list = pendingQuickEditMarks.slice();
+    dispatch(consumePendingQuickEditMarkContexts());
+    insertPendingMarkChips(inputRef.current, list, !hidden);
+  }, [pendingQuickEditMarks, dispatch, hidden]);
 
   const attachments = contexts.filter((c) => c.kind === 'attachment');
   const inlineContexts = contexts.filter((c) => c.kind !== 'attachment');
@@ -285,17 +328,13 @@ function ImageQuickEditComposer({
       })
     );
     try {
+      const promptForApi = buildComposerChipPrompt(contexts, text);
       const body: Parameters<typeof generateImage>[0] = {
-        prompt: text,
+        prompt: promptForApi,
         model: canPickModel ? modelId : cloudImageFallbackId() || modelId,
         quality: DEFAULT_IMAGE_QUALITY,
         resolution,
-        images: [
-          src,
-          ...attachments
-            .map((c) => String(c.dataUrl || c.thumbUrl || '').trim())
-            .filter(Boolean),
-        ],
+        images: collectComposerRefImages(contexts, src),
       };
       if (aspectRatio !== 'smart') body.aspect_ratio = aspectRatio;
 
@@ -365,6 +404,14 @@ function ImageQuickEditComposer({
     [nodeId, src, t]
   );
 
+  const onMark = () => {
+    if (!ilpEnabled) {
+      message.warning(t('editor.imageToolbar.markNeedsIntelligence'));
+      return;
+    }
+    dispatch(openImageToolPanel({ nodeId, kind: 'mark', markSink: 'quickEdit' }));
+  };
+
   if (!node || !src) return null;
 
   return (
@@ -376,9 +423,11 @@ function ImageQuickEditComposer({
         className={cn(
           'pointer-events-auto absolute z-[32] flex h-[200px] w-[500px] flex-col overflow-visible',
           'rounded-2xl border border-[var(--line)] bg-[var(--surface)]',
-          'shadow-[0_8px_28px_rgba(15,23,42,0.12)]'
+          'shadow-[0_8px_28px_rgba(15,23,42,0.12)]',
+          hidden && 'invisible pointer-events-none'
         )}
         style={composerStyle}
+        aria-hidden={hidden || undefined}
         onPointerDown={(e) => {
           e.stopPropagation();
           e.nativeEvent.stopImmediatePropagation?.();
@@ -411,12 +460,21 @@ function ImageQuickEditComposer({
               <HiOutlinePlus className="h-4 w-4" strokeWidth={2} />
             </button>
           </Tooltip>
+          {ilpEnabled ? (
+            <Tooltip tip={t('editor.imageToolbar.mark')} placement="top">
+              <button
+                type="button"
+                disabled={sending}
+                aria-label={t('editor.imageToolbar.mark')}
+                onClick={onMark}
+                className={composerAttachActionClass()}
+              >
+                <LuCrosshair className="h-4 w-4" strokeWidth={2} />
+              </button>
+            </Tooltip>
+          ) : null}
           <Tooltip
-            tip={
-              pickingFromCanvas
-                ? t('agent.pickFromCanvasCancel')
-                : t('agent.pickFromCanvas')
-            }
+            tip={pickingFromCanvas ? t('agent.pickFromCanvasCancel') : t('agent.pickFromCanvas')}
             placement="top"
           >
             <button

--- a/apps/web/src/components/editor/nodes/ImageNode/mark/MarkSessionHost.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/mark/MarkSessionHost.tsx
@@ -3,21 +3,26 @@ import {
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
   type ReactNode,
   memo,
 } from 'react';
 import { createPortal } from 'react-dom';
 import { useDispatch, useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import { HiOutlinePlus } from 'react-icons/hi2';
 import { nanoid } from 'nanoid';
+import { message } from '@/components/base';
 import { rcbSceneToScreen, useRcbCamera } from '@/components/rcb';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import {
   closeImageToolPanel,
   enqueueAgentContexts,
+  enqueueQuickEditMarkContexts,
+  markPanelSink,
+  openImageToolPanel,
+  type ImageToolPanelState,
+  type PendingMarkContextChip,
 } from '@/store/modules/editor';
-import { CONTEXT_CHIP_PILL_CLASS } from '@/components/editor/panels/AgentComposerInput';
-import { resolveChatFlyTarget } from '@/components/editor/panels/agent/composer/flyToChat';
 import { getHttpErrorMessage } from '@/service/client';
 import {
   processImageTool,
@@ -25,7 +30,6 @@ import {
   type ImageDecomposeLayer,
 } from '@/service/imageTools';
 import { imageSrcToFile } from '@/utils/uploadImage';
-import { cn } from '@/utils/classnames';
 import MarkRegionOverlay, {
   type MarkRect,
   type MarkRegion,
@@ -33,23 +37,6 @@ import MarkRegionOverlay, {
 import type { SceneDocument, SceneNodeInput } from '@/components/rcb/sceneNode';
 
 type SceneBox = { left: number; top: number; width: number; height: number };
-
-type FlyAnim = {
-  id: string;
-  /** Fixed-viewport start (chip center). */
-  startX: number;
-  startY: number;
-  /** Fixed-viewport end (composer / dock). */
-  endX: number;
-  endY: number;
-  thumbUrl?: string;
-  label: string;
-  phase: 'ready' | 'flying' | 'done';
-};
-
-const FLY_MS = 640;
-const CHIP_W = 112;
-const CHIP_H = 28;
 
 function nodeBox(
   document: SceneDocument,
@@ -67,13 +54,25 @@ function nodeBox(
 
 function regionLabel(layer: ImageDecomposeLayer, index: number): string {
   const name = String(layer.name || '').trim();
-  if (name) return `${index} ${name}`;
   if (layer.type === 'text') {
     const text = String(layer.text || '').trim();
-    if (text) return `${index} ${text.slice(0, 12)}`;
+    if (text) return `${index} "${text.slice(0, 24)}"`;
     return `${index} 文字`;
   }
+  if (name && name !== '区域' && name !== '文字' && name !== '主体') {
+    return `${index} ${name}`;
+  }
   return `${index} 区域`;
+}
+
+/** Chip label in Agent composer — `[1] 区域` / `[1] 中秋团圆`. */
+function markComposerChipLabel(region: MarkRegion): string {
+  if (region.kind === 'text') {
+    const quoted = region.label?.match(/"([^"]+)"/)?.[1];
+    const text = quoted || region.label?.replace(/^\d+\s*/, '').trim();
+    if (text && text !== '文字') return `[${region.index}] ${text}`;
+  }
+  return `[${region.index}] 区域`;
 }
 
 /** Map API source-pixel layers → image-local mark regions. */
@@ -93,7 +92,16 @@ function layersToRegions(
     const y = Number(layer.y) || 0;
     const w = Math.max(1, Number(layer.width) || 1);
     const h = Math.max(1, Number(layer.height) || 1);
-    if (w * sx >= nodeW * 0.92 && h * sy >= nodeH * 0.92) continue;
+    const rw = w * sx;
+    const rh = h * sy;
+    // Skip full-canvas subject masks only — keep OCR text boxes even when large.
+    if (
+      layer.type !== 'text' &&
+      rw >= nodeW * 0.96 &&
+      rh >= nodeH * 0.96
+    ) {
+      continue;
+    }
     const index = out.length + 1;
     out.push({
       id: nanoid(8),
@@ -177,28 +185,21 @@ function buildMarkChipPayload(
   ].join('\n');
 }
 
-/** Landing point inside the right Agent composer (fallback: dock / viewport). */
-function resolveMarkChatFlyTarget(): { x: number; y: number } {
-  return resolveChatFlyTarget({ landId: 'agent' });
-}
-
 /**
- * Mark tool session: auto subject/text proposals + manual box select.
- * Selecting a region flies an @ chip into the right AgentDock chat.
+ * Mark session: region detect + manual box select.
+ * Toolbar mark → AgentDock; quick-edit mark → floating composer.
  */
 function MarkSessionHost({ document }: { document: SceneDocument }): ReactNode {
   const dispatch = useDispatch();
+  const { t } = useTranslation();
   const camera = useRcbCamera();
   const { data: imageToolCaps } = useImageToolCapabilities();
   const ilpEnabled = imageToolCaps?.ilp?.enabled === true;
   const panel = useSelector(
-    (s: any) =>
-      s.editor.imageToolPanel as null | { nodeId: string; kind: string }
-  );
-  const selectedNodeId = useSelector(
-    (s: any) => s.editor.selectedNodeId as string | null
+    (s: any) => s.editor.imageToolPanel as ImageToolPanelState | null
   );
   const active = panel?.kind === 'mark' ? panel.nodeId : null;
+  const markSink = markPanelSink(panel);
   const node = active ? document?.deltaSetLike?.[active] : null;
   const box = useMemo(
     () => (active && node ? nodeBox(document, node) : null),
@@ -211,18 +212,28 @@ function MarkSessionHost({ document }: { document: SceneDocument }): ReactNode {
   const [regions, setRegions] = useState<MarkRegion[]>([]);
   const [draft, setDraft] = useState<MarkRect | null>(null);
   const [detecting, setDetecting] = useState(false);
-  const [flies, setFlies] = useState<FlyAnim[]>([]);
+  const [promptText, setPromptText] = useState('');
+  const [activeRegionId, setActiveRegionId] = useState<string | null>(null);
+  const [hoverRegionId, setHoverRegionId] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const detectGenRef = useRef(0);
   const inflightRef = useRef<Set<string>>(new Set());
 
-  const close = () => dispatch(closeImageToolPanel());
+  const close = () => {
+    if (markSink === 'quickEdit' && active) {
+      dispatch(openImageToolPanel({ nodeId: active, kind: 'quickEdit' }));
+      return;
+    }
+    dispatch(closeImageToolPanel());
+  };
 
   useEffect(() => {
-    if (!active) return;
-    if (!selectedNodeId || selectedNodeId !== active) close();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedNodeId, active]);
+    if (!active) {
+      setPromptText('');
+      setHoverRegionId(null);
+      setActiveRegionId(null);
+    }
+  }, [active]);
 
   useEffect(() => {
     if (!active) return;
@@ -247,9 +258,9 @@ function MarkSessionHost({ document }: { document: SceneDocument }): ReactNode {
     if (!active || !src || !box) return;
     setRegions([]);
     setDraft(null);
-    setFlies([]);
     if (!ilpEnabled) {
       setDetecting(false);
+      message.warning(t('editor.imageToolbar.markNeedsIntelligence'));
       return;
     }
     const gen = ++detectGenRef.current;
@@ -276,14 +287,21 @@ function MarkSessionHost({ document }: { document: SceneDocument }): ReactNode {
         ).map((r, i) => ({
           ...r,
           index: i + 1,
-          selected: false,
+          selected: i === 0,
         }));
         setRegions(next);
+        if (next[0]) {
+          setActiveRegionId(next[0].id);
+        }
+        if (!next.length) {
+          message.info(t('editor.imageToolbar.markNoRegions'));
+        }
       } catch (err: unknown) {
         if (ac.signal.aborted || gen !== detectGenRef.current) return;
         const msg = getHttpErrorMessage(err, '');
         if (msg && !/unsupported kind|detectRegions/i.test(msg)) {
           console.warn('[mark] detect failed', msg);
+          message.error(t('editor.imageToolbar.markDetectFailed'));
         }
       } finally {
         if (gen === detectGenRef.current) setDetecting(false);
@@ -313,34 +331,16 @@ function MarkSessionHost({ document }: { document: SceneDocument }): ReactNode {
           : r.label?.replace(/^\d+\s*/, `${i + 1} `) || `${i + 1} 区域`,
     }));
 
-  const flyRegionToChat = async (region: MarkRegion) => {
+  const enqueueRegionMark = async (
+    region: MarkRegion,
+    opts?: { appendText?: string }
+  ) => {
     if (!active || !box || !src) return;
-    if (inflightRef.current.has(region.id)) return;
-    inflightRef.current.add(region.id);
+    if (!opts?.appendText && inflightRef.current.has(region.id)) return;
+    if (!opts?.appendText) inflightRef.current.add(region.id);
 
-    const center = rcbSceneToScreen(
-      camera,
-      box.left + region.x + region.w / 2,
-      box.top + region.y + region.h / 2
-    );
-    const target = resolveMarkChatFlyTarget();
-    const flyId = nanoid(6);
-    const label = region.label || `${region.index} 区域`;
-
-    setFlies((prev) => [
-      ...prev,
-      {
-        id: flyId,
-        startX: center.x,
-        startY: center.y,
-        endX: target.x,
-        endY: target.y,
-        label,
-        phase: 'ready',
-      },
-    ]);
-
-    const cropPromise = cropMarkRegionDataUrl(
+    const tail = String(opts?.appendText || '').trim();
+    const thumbEarly = await cropMarkRegionDataUrl(
       src,
       box.width,
       box.height,
@@ -348,46 +348,21 @@ function MarkSessionHost({ document }: { document: SceneDocument }): ReactNode {
       uploadKey
     ).catch(() => undefined);
 
-    // Pop-in, then fly — wait for thumb (capped) so the chip looks real mid-flight.
-    const [thumb] = await Promise.all([
-      cropPromise,
-      new Promise<void>((r) => window.setTimeout(r, 140)),
-    ]);
+    const chip: PendingMarkContextChip = {
+      key: `mark:${active}:${region.id}:${Date.now()}`,
+      label: markComposerChipLabel(region),
+      kind: 'image',
+      payload: buildMarkChipPayload(active, region, box.width, box.height),
+      ...(tail ? { appendText: ` ${tail}` } : {}),
+      ...(thumbEarly ? { dataUrl: thumbEarly, thumbUrl: thumbEarly } : {}),
+    };
 
-    const land = resolveMarkChatFlyTarget();
-    setFlies((prev) =>
-      prev.map((f) =>
-        f.id === flyId
-          ? {
-              ...f,
-              thumbUrl: thumb,
-              endX: land.x,
-              endY: land.y,
-              phase: 'flying',
-            }
-          : f
-      )
-    );
-
-    // Insert into chat as the tag arrives so it feels continuous.
-    window.setTimeout(() => {
-      dispatch(
-        enqueueAgentContexts([
-          {
-            key: `mark:${active}:${region.id}`,
-            label: region.label || `区域 ${region.index}`,
-            kind: 'image',
-            payload: buildMarkChipPayload(active, region, box.width, box.height),
-            ...(thumb ? { dataUrl: thumb, thumbUrl: thumb } : {}),
-          },
-        ])
-      );
-    }, Math.round(FLY_MS * 0.78));
-
-    window.setTimeout(() => {
-      setFlies((prev) => prev.filter((f) => f.id !== flyId));
-      inflightRef.current.delete(region.id);
-    }, FLY_MS + 100);
+    if (markSink === 'quickEdit') {
+      dispatch(enqueueQuickEditMarkContexts([chip]));
+    } else {
+      dispatch(enqueueAgentContexts([chip]));
+    }
+    if (!opts?.appendText) inflightRef.current.delete(region.id);
   };
 
   const onCommitDraft = (rect: MarkRect) => {
@@ -403,46 +378,39 @@ function MarkSessionHost({ document }: { document: SceneDocument }): ReactNode {
       const cleared = prev.map((r) => ({ ...r, selected: false }));
       return renumber([...cleared, nextRegion]);
     });
-    flyRegionToChat(nextRegion);
+    setActiveRegionId(nextRegion.id);
+    enqueueRegionMark(nextRegion);
   };
 
   const onSelectRegion = (id: string, _additive: boolean) => {
     const hit = regions.find((r) => r.id === id);
+    setActiveRegionId(id);
     setRegions((prev) => prev.map((r) => ({ ...r, selected: r.id === id })));
-    if (hit) flyRegionToChat(hit);
+    if (hit) enqueueRegionMark(hit);
   };
+
+  const promptRegion =
+    regions.find((r) => r.id === (hoverRegionId ?? activeRegionId)) || null;
+  const promptStyle = useMemo(() => {
+    if (!box || !promptRegion) return null;
+    const center = rcbSceneToScreen(
+      camera,
+      box.left + promptRegion.x + promptRegion.w / 2,
+      box.top + promptRegion.y
+    );
+    return {
+      position: 'fixed' as const,
+      left: center.x,
+      top: Math.max(72, center.y - 52),
+      transform: 'translate(-50%, -100%)',
+      zIndex: 9998,
+    };
+  }, [box, promptRegion, camera]);
 
   if (!active || !box || !node) return null;
 
   return (
     <>
-      <style>{`
-        @keyframes mark-chip-pop {
-          0% { transform: translate(-50%, -50%) scale(0.55); opacity: 0; }
-          100% { transform: translate(-50%, -50%) scale(1); opacity: 1; }
-        }
-        @keyframes mark-chip-fly {
-          0% {
-            transform: translate(-50%, -50%) scale(1) rotate(0deg);
-            opacity: 1;
-            box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
-          }
-          55% {
-            opacity: 1;
-            box-shadow: 0 12px 32px rgba(59, 130, 246, 0.28);
-          }
-          100% {
-            transform: translate(
-                calc(-50% + var(--mark-dx)),
-                calc(-50% + var(--mark-dy))
-              )
-              scale(0.72)
-              rotate(-6deg);
-            opacity: 0;
-            box-shadow: 0 2px 8px rgba(15, 23, 42, 0.08);
-          }
-        }
-      `}</style>
       <MarkRegionOverlay
         imageBox={box}
         regions={regions}
@@ -451,58 +419,43 @@ function MarkSessionHost({ document }: { document: SceneDocument }): ReactNode {
         onDraftChange={setDraft}
         onCommitDraft={onCommitDraft}
         onSelectRegion={onSelectRegion}
+        onHoverRegion={setHoverRegionId}
       />
-      {flies.length
+      {promptStyle && promptRegion
         ? createPortal(
-            <>
-              {flies.map((fly) => {
-                const dx = fly.endX - fly.startX;
-                const dy = fly.endY - fly.startY;
-                const style: CSSProperties = {
-                  position: 'fixed',
-                  left: fly.startX,
-                  top: fly.startY,
-                  width: CHIP_W,
-                  height: CHIP_H,
-                  zIndex: 9999,
-                  pointerEvents: 'none',
-                  ['--mark-dx' as string]: `${dx}px`,
-                  ['--mark-dy' as string]: `${dy}px`,
-                  animation:
-                    fly.phase === 'flying'
-                      ? `mark-chip-fly ${FLY_MS}ms cubic-bezier(0.22, 0.82, 0.2, 1) forwards`
-                      : `mark-chip-pop 160ms cubic-bezier(0.22, 1.2, 0.36, 1) forwards`,
-                  transform: 'translate(-50%, -50%)',
-                  willChange: 'transform, opacity',
-                };
-                return (
-                  <div
-                    key={fly.id}
-                    aria-hidden
-                    data-mark-fly-chip
-                    className={cn(
-                      CONTEXT_CHIP_PILL_CLASS,
-                      'pl-1 pr-2 shadow-[0_10px_28px_rgba(15,23,42,0.2)] ring-1 ring-sky-400/55'
-                    )}
-                    style={style}
-                  >
-                    {fly.thumbUrl ? (
-                      <img
-                        src={fly.thumbUrl}
-                        alt=""
-                        className="h-3.5 w-3.5 shrink-0 rounded-[3px] object-cover ring-1 ring-[var(--line)]"
-                        draggable={false}
-                      />
-                    ) : (
-                      <span className="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-[3px] bg-sky-100 text-[9px] font-semibold text-sky-700 ring-1 ring-sky-200">
-                        @
-                      </span>
-                    )}
-                    <span className="truncate font-medium">{fly.label}</span>
-                  </div>
-                );
-              })}
-            </>,
+            <div
+              data-mark-prompt
+              data-image-tool-panel
+              className="pointer-events-auto flex min-w-[min(92vw,360px)] max-w-[min(92vw,420px)] items-center gap-2 rounded-2xl border border-[var(--line)] bg-white/95 px-3 py-2 shadow-[0_12px_40px_rgba(15,23,42,0.16)] backdrop-blur-sm"
+              style={promptStyle}
+              onPointerDown={(e) => e.stopPropagation()}
+            >
+              <button
+                type="button"
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-[var(--muted)] hover:bg-[var(--surface-2)]"
+                aria-label={t('editor.imageToolbar.markAddRef')}
+              >
+                <HiOutlinePlus className="h-4 w-4" />
+              </button>
+              <span className="inline-flex h-6 shrink-0 items-center rounded-md bg-sky-50 px-1.5 text-[12px] font-semibold text-sky-700 ring-1 ring-sky-200">
+                {markComposerChipLabel(promptRegion)}
+              </span>
+              <input
+                type="text"
+                value={promptText}
+                onChange={(e) => setPromptText(e.target.value)}
+                placeholder={t('editor.imageToolbar.markPromptPh')}
+                className="min-w-0 flex-1 border-0 bg-transparent text-[13px] text-[var(--ink)] outline-none placeholder:text-[var(--muted)]"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                    e.preventDefault();
+                    const text = promptText.trim();
+                    void enqueueRegionMark(promptRegion, { appendText: text });
+                    if (text) setPromptText('');
+                  }
+                }}
+              />
+            </div>,
             globalThis.document.body
           )
         : null}

--- a/apps/web/src/components/editor/nodes/ImageNode/toolPanels/ImageToolPanelHost.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/toolPanels/ImageToolPanelHost.tsx
@@ -12,7 +12,9 @@ import {
   type ImageToolPanelKind,
   isImageToolExternalSessionKind,
   isNodeLayerToolPanelKind,
+  shouldClearImageToolPanelOnSelect,
 } from '@/store/modules/editor';
+import { isImageProcessRunning } from '@/components/rcb/scene/document/nodeCapabilities';
 import { buildNodeAdjustFilterCss } from '@/components/rcb/scene/document/sceneFill';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import { toolbarBoxForSelection } from '@/components/rcb/selection/selectionLogic';
@@ -30,6 +32,13 @@ import {
 } from '@/components/rcb/selection/chrome/BlendModeControl';
 import EraserMaskOverlay, { type EraserMaskOverlayHandle } from './EraserMaskOverlay';
 import EraserToolPanel from './EraserToolPanel';
+import MattingHintOverlay, {
+  type MattingBrushMode,
+  type MattingHintOverlayHandle,
+} from './MattingHintOverlay';
+import RemoveBgToolPanel from './RemoveBgToolPanel';
+import { defaultBrushSize } from './maskBrushUtils';
+import { startRemoveBgFromMasks } from './removeBgSession';
 import OpacityToolPanel from './OpacityToolPanel';
 import MultiAngleToolPanel from './MultiAngleToolPanel';
 import AdjustToolPanel, {
@@ -152,17 +161,23 @@ function ImageToolPanelHost({ document }: { document: SceneDocument }): ReactNod
   const [brushSize, setBrushSize] = useState(96);
   const [hasStrokes, setHasStrokes] = useState(false);
   const [eraseBusy, setEraseBusy] = useState(false);
+  const [mattingBrushMode, setMattingBrushMode] = useState<MattingBrushMode>('include');
+  const [mattingBusy, setMattingBusy] = useState(false);
   const maskRef = useRef<EraserMaskOverlayHandle>(null);
+  const mattingMaskRef = useRef<MattingHintOverlayHandle>(null);
   const adjustHistoryPushedRef = useRef(false);
   const adjustBaselineRef = useRef<{ cssFilter: string; adjustValues: unknown } | null>(null);
   const liveHistoryPushedRef = useRef(false);
 
   useEffect(() => {
     if (!panel) return;
-    if (!selectedNodeId || selectedNodeId !== panel.nodeId) {
+    if (shouldClearImageToolPanelOnSelect(panel, selectedNodeId)) {
       dispatch(closeImageToolPanel());
+      return;
     }
-  }, [selectedNodeId, panel, dispatch]);
+    const node = document?.deltaSetLike?.[panel.nodeId];
+    if (isImageProcessRunning(node)) dispatch(closeImageToolPanel());
+  }, [selectedNodeId, panel, document, dispatch]);
 
   useEffect(() => {
     if (!panel) return;
@@ -179,17 +194,25 @@ function ImageToolPanelHost({ document }: { document: SceneDocument }): ReactNod
   }, [document, panel, dispatch]);
 
   useEffect(() => {
-    if (panel?.kind !== 'eraser' || !panel.nodeId) return;
+    if (!panel?.nodeId) return;
+    if (panel.kind !== 'eraser' && panel.kind !== 'removeBg') return;
+
     const node = document?.deltaSetLike?.[panel.nodeId];
     const boxNow = nodeBox(document, node);
-    const shortSide = Math.min(boxNow?.width || 0, boxNow?.height || 0);
-    // ~12% of the short side — readable on large plates without maxing the slider.
-    const initial = Math.round(Math.min(280, Math.max(64, shortSide * 0.12 || 96)));
-    setBrushSize(initial);
+    if (!boxNow) return;
+
+    setBrushSize(defaultBrushSize(boxNow));
     setHasStrokes(false);
-    setEraseBusy(false);
-    maskRef.current?.clear();
-    // Only when opening / switching the eraser target.
+
+    if (panel.kind === 'eraser') {
+      setEraseBusy(false);
+      maskRef.current?.clear();
+      return;
+    }
+
+    setMattingBusy(false);
+    setMattingBrushMode('include');
+    mattingMaskRef.current?.clear();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [panel?.kind, panel?.nodeId]);
 
@@ -333,8 +356,7 @@ function ImageToolPanelHost({ document }: { document: SceneDocument }): ReactNod
           hasStrokes={hasStrokes}
           confirmBusy={eraseBusy}
           onReset={() => {
-            const shortSide = Math.min(box.width, box.height);
-            setBrushSize(Math.round(Math.min(280, Math.max(64, shortSide * 0.12 || 96))));
+            setBrushSize(defaultBrushSize(box));
             maskRef.current?.clear();
             setHasStrokes(false);
           }}
@@ -363,12 +385,55 @@ function ImageToolPanelHost({ document }: { document: SceneDocument }): ReactNod
                   (store.getState() as any).editor?.pendingImageProcessId || null,
                 onSpawned: close,
               });
-              message.success('擦除完成（透明 PNG）');
+              message.success('擦除完成');
             } catch (err: unknown) {
               const msg = err instanceof Error ? err.message : '';
               message.error(msg && msg !== '橡皮失败' ? msg : '橡皮失败');
             } finally {
               setEraseBusy(false);
+            }
+          }}
+        />
+      );
+      break;
+    case 'removeBg':
+      body = (
+        <RemoveBgToolPanel
+          brushSize={brushSize}
+          onBrushSizeChange={setBrushSize}
+          brushMode={mattingBrushMode}
+          onBrushModeChange={setMattingBrushMode}
+          hasStrokes={hasStrokes}
+          confirmBusy={mattingBusy}
+          onReset={() => {
+            setBrushSize(defaultBrushSize(box));
+            mattingMaskRef.current?.clear();
+            setHasStrokes(false);
+          }}
+          onCancel={close}
+          onConfirm={async () => {
+            if (mattingBusy) return;
+            const sourceId = panel.nodeId;
+            const node = document?.deltaSetLike?.[sourceId];
+            const src = String(node?.attrs?.src || '');
+            if (!src) {
+              message.error('未找到图片');
+              return;
+            }
+            setMattingBusy(true);
+            try {
+              await startRemoveBgFromMasks({
+                maskRef: mattingMaskRef.current,
+                sourceId,
+                label: t('editor.imageToolbar.processingRemoveBg'),
+                dispatch,
+                onSpawned: close,
+              });
+            } catch (err: unknown) {
+              const msg = err instanceof Error ? err.message : '';
+              message.error(msg || '抠图准备失败');
+            } finally {
+              setMattingBusy(false);
             }
           }}
         />
@@ -501,6 +566,15 @@ function ImageToolPanelHost({ document }: { document: SceneDocument }): ReactNod
           ref={maskRef}
           imageBox={box}
           brushSize={brushSize}
+          onDirtyChange={setHasStrokes}
+        />
+      ) : null}
+      {panel.kind === 'removeBg' ? (
+        <MattingHintOverlay
+          ref={mattingMaskRef}
+          imageBox={box}
+          brushSize={brushSize}
+          brushMode={mattingBrushMode}
           onDirtyChange={setHasStrokes}
         />
       ) : null}

--- a/apps/web/src/components/editor/nodes/LottieGeneratorNode/LottieGeneratorOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/LottieGeneratorNode/LottieGeneratorOverlay.tsx
@@ -1,7 +1,8 @@
 import { useMemo, type ReactNode, memo } from 'react';
 import { useSelector } from 'react-redux';
 import {
-  isLottieGeneratorNode
+  isLottieGeneratorNode,
+  shouldShowGeneratorComposer,
 } from '@/components/rcb/scene/document/nodeCapabilities';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import LottieGeneratorCard from '@/components/editor/nodes/LottieGeneratorNode/LottieGeneratorCard';
@@ -65,7 +66,11 @@ function LottieGeneratorOverlay({
               width,
               height,
             }}
-            showComposer={!hidden && selectedNodeIds.length === 1 && selectedNodeIds[0] === nodeId}
+            showComposer={shouldShowGeneratorComposer({
+              node,
+              hidden,
+              selected: selectedNodeIds.length === 1 && selectedNodeIds[0] === nodeId,
+            })}
             disabled={readOnly}
           />
         );

--- a/apps/web/src/components/editor/nodes/VideoGeneratorNode/VideoGeneratorOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/VideoGeneratorNode/VideoGeneratorOverlay.tsx
@@ -1,11 +1,12 @@
 import { useMemo, type ReactNode, memo } from 'react';
 import { useSelector } from 'react-redux';
 import {
-  isVideoGeneratorNode
+  isVideoGeneratorNode,
+  shouldShowGeneratorComposer,
 } from '@/components/rcb/scene/document/nodeCapabilities';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import VideoGeneratorCard from '@/components/editor/nodes/VideoGeneratorNode/VideoGeneratorCard';
-import { EMPTY_ID_LIST } from '@/store/modules/editor';
+import { EMPTY_ID_LIST, isCanvasAttachForNode } from '@/store/modules/editor';
 import type { SceneDocument } from '@/components/rcb/sceneNode';
 
 /**
@@ -56,13 +57,16 @@ function VideoGeneratorOverlay({
             key={nodeId}
             nodeId={nodeId}
             sceneBox={{ x: left, y: top, width, height }}
-            // Title comes from the shared selection label; composer follows it.
-            showComposer={
-              !hidden &&
-              ((selectedNodeIds.length === 1 && selectedNodeIds[0] === nodeId) ||
-                canvasAttachPick?.target === `node:${nodeId}` ||
-                pendingCanvasAttach?.target === `node:${nodeId}`)
-            }
+            showComposer={shouldShowGeneratorComposer({
+              node,
+              hidden,
+              selected: selectedNodeIds.length === 1 && selectedNodeIds[0] === nodeId,
+              attachPickActive: isCanvasAttachForNode(
+                nodeId,
+                canvasAttachPick,
+                pendingCanvasAttach
+              ),
+            })}
             disabled={readOnly}
           />
         );

--- a/apps/web/src/components/editor/page/EditorStageWorld.tsx
+++ b/apps/web/src/components/editor/page/EditorStageWorld.tsx
@@ -39,15 +39,20 @@ import {
   updateNodesInDocument,
 } from '@/components/rcb/scene/document/sceneDocument';
 import {
-  snapBoxToGrid,
-  smartGuideTargetPad,
   smartSnapThreshold,
-  snapTranslateToPeers,
   type SmartGuideLine,
 } from '@/components/rcb/selection/alignGuides';
-import { collectSmartGuideTargets } from '@/components/rcb/selection/selectionLogic';
+import {
+  computeMovedUnion,
+  smartGuideTargetsForDrag,
+} from '@/components/rcb/selection/selectionLogic';
+import { unionOfBoxes } from '@/components/rcb/selection/resizeGeometry';
 import { frameSelId } from '@/components/rcb/selection/frameSelectionIds';
 import SmartGuidesOverlay from '@/components/rcb/selection/chrome/SmartGuidesOverlay';
+import {
+  getNodeBoxFromDoc,
+  listNodeIdsFromDoc,
+} from '@/components/editor/canvas/canvasSession';
 import {
   parseFillGradient,
   serializeFillGradient,
@@ -192,6 +197,29 @@ function frameBox(frame: ArtboardFrame) {
     width: Math.max(1, Number(frame.width) || 1),
     height: Math.max(1, Number(frame.height) || 1),
   };
+}
+
+/** Nodes that visually sit inside moved frames — co-move + exclude from smart guides. */
+function nodeIdsOverlappingFrames(
+  doc: SceneDocument,
+  movedFrames: Array<{ id: string; startX: number; startY: number; width: number; height: number }>
+) {
+  const frameBoxes = movedFrames.map((frame) => ({
+    id: frame.id,
+    box: {
+      x: frame.startX,
+      y: frame.startY,
+      width: frame.width,
+      height: frame.height,
+    },
+  }));
+  const out: string[] = [];
+  for (const [nodeId, node] of Object.entries(doc.deltaSetLike || {})) {
+    if (!node || nodeId === 'ROOT') continue;
+    const box = nodeBox(node);
+    if (frameBoxes.some(({ box: fb }) => boxesIntersect(box, fb))) out.push(nodeId);
+  }
+  return out;
 }
 
 function bindUnownedNodesToFrames(doc: SceneDocument, frameIds: string[]): SceneDocument {
@@ -437,81 +465,89 @@ function EditorStageWorld({
       if (!frame && !dragged) return;
       const baseFrame = frame || frames.find((item) => item.id === dragged?.id);
       if (!baseFrame) return;
-      let moving = {
-        left: x,
-        top: y,
-        width: Math.max(1, Number(baseFrame.width) || 1),
-        height: Math.max(1, Number(baseFrame.height) || 1),
-      };
-      if (!opts?.skipGrid) {
-        if (gridSize > 0) {
-          moving = snapBoxToGrid(moving, gridSize);
-        }
-      }
-      const movedFrameIds = new Set(
-        (dragState?.frames || [{ id }]).map((item) => item.id)
-      );
+
+      const movedFrames =
+        dragState?.frames ||
+        [
+          {
+            id,
+            startX: Number(baseFrame.x) || 0,
+            startY: Number(baseFrame.y) || 0,
+            width: Math.max(1, Number(baseFrame.width) || 1),
+            height: Math.max(1, Number(baseFrame.height) || 1),
+          },
+        ];
+      const primary = dragged ?? movedFrames[0];
+      const baseX = primary.startX;
+      const baseY = primary.startY;
+      const rawDx = x - baseX;
+      const rawDy = y - baseY;
+
+      const movedFrameIds = new Set(movedFrames.map((item) => item.id));
       const threshold = smartSnapThreshold(camera.zoom);
-      const movedChildIds = nodeIdsBoundToFrames(document, [...movedFrameIds]);
+      const movedChildIds = new Set([
+        ...nodeIdsBoundToFrames(document, [...movedFrameIds]),
+        ...(dragState?.childOrigins.map((item) => item.nodeId) ?? []),
+      ]);
       const excludeIds = new Set<string>([
         ...movedChildIds,
         ...[...movedFrameIds, id].flatMap((frameId) => [frameId, frameSelId(frameId)]),
       ]);
-      const nodeIds = Object.keys(document.deltaSetLike || {}).filter(
-        (nodeId) => nodeId !== 'ROOT'
-      );
-      const guideTargets = collectSmartGuideTargets(
-        document,
-        () => nodeIds,
-        (nodeId) => {
-          const node = document.deltaSetLike?.[nodeId];
-          if (!node) return null;
-          const box = nodeBox(node);
-          return {
-            left: box.x,
-            top: box.y,
-            width: box.width,
-            height: box.height,
-          };
+
+      const origins = movedFrames.map((item) => ({
+        nodeId: frameSelId(item.id),
+        box: {
+          left: item.startX,
+          top: item.startY,
+          width: item.width,
+          height: item.height,
         },
-        excludeIds,
-        {
-          nearBox: moving,
-          pad: smartGuideTargetPad(threshold),
+      }));
+      const startUnion =
+        unionOfBoxes(origins.map((item) => item.box)) ?? origins[0].box;
+      const listNodeIds = () => listNodeIdsFromDoc(document);
+      const getNodeBox = (nodeId: string) => getNodeBoxFromDoc(document, nodeId);
+
+      const { sdx, sdy, guides } = computeMovedUnion({
+        union: startUnion,
+        origins,
+        document,
+        dx: rawDx,
+        dy: rawDy,
+        disableSnap: false,
+        gridSize: opts?.skipGrid ? 0 : gridSize,
+        targets: smartGuideTargetsForDrag({
+          document,
+          listNodeIds,
+          getNodeBox,
+          excludeIds,
+          nearBox: {
+            left: startUnion.left + rawDx,
+            top: startUnion.top + rawDy,
+            width: startUnion.width,
+            height: startUnion.height,
+          },
+          threshold,
           queryNodeIdsInRect: (area) =>
-            nodeIds.filter((nodeId) => {
-              const node = document.deltaSetLike?.[nodeId];
-              if (!node) return false;
-              const box = nodeBox(node);
+            listNodeIds().filter((nodeId) => {
+              const box = getNodeBox(nodeId);
+              if (!box) return false;
+              const right = box.left + box.width;
+              const bottom = box.top + box.height;
               return !(
-                box.x + box.width < area.left ||
-                box.x > area.left + area.width ||
-                box.y + box.height < area.top ||
-                box.y > area.top + area.height
+                right < area.left ||
+                box.left > area.left + area.width ||
+                bottom < area.top ||
+                box.top > area.top + area.height
               );
             }),
-        }
-      );
-      const snapped = snapTranslateToPeers(
-        moving,
-        guideTargets,
-        threshold
-      );
-      moving = snapped.box;
-      setFrameSmartGuides(snapped.guides);
-      const nextX = Math.round(moving.left);
-      const nextY = Math.round(moving.top);
-      const baseX = (dragged?.startX ?? Number(baseFrame.x)) || 0;
-      const baseY = (dragged?.startY ?? Number(baseFrame.y)) || 0;
-      const dx = nextX - baseX;
-      const dy = nextY - baseY;
-      const movedFrames = dragState?.frames || [{
-        id,
-        startX: Number(baseFrame.x) || 0,
-        startY: Number(baseFrame.y) || 0,
-        width: moving.width,
-        height: moving.height,
-      }];
+        }),
+        threshold,
+      });
+
+      setFrameSmartGuides(guides);
+      const dx = Math.round(sdx);
+      const dy = Math.round(sdy);
       let childPatches: Array<{
         nodeId: string;
         patch: { x: number; y: number };
@@ -608,7 +644,9 @@ function EditorStageWorld({
         frameMoveDocumentRef.current = document;
         setFrameSmartGuides([]);
         const boundNodeIds = nodeIdsBoundToFrames(document, frameIds);
-        const childOrigins = boundNodeIds
+        const interiorNodeIds = nodeIdsOverlappingFrames(document, movedFrames);
+        const coMoveIds = [...new Set([...boundNodeIds, ...interiorNodeIds])];
+        const childOrigins = coMoveIds
           .map((nodeId) => {
             const node = document.deltaSetLike?.[nodeId];
             if (!node) return null;

--- a/apps/web/src/components/editor/panels/AgentDock.tsx
+++ b/apps/web/src/components/editor/panels/AgentDock.tsx
@@ -184,6 +184,7 @@ import { useWalletSnapshot } from '@/service/wallet';
 import { FREE_IMAGE_MODEL_ID, planAllowsModelId, planAllowsModelPick } from '@/utils/wallet';
 import {
   buildDesignSceneSnapshot,
+  buildComposerChipPrompt,
   buildImageGenRequestBody,
   buildImageModeControls,
   buildStreamingAssistantSeed,
@@ -1859,26 +1860,7 @@ function AgentDock({
       : t('agent.pickFromCanvas'),
   };
 
-  const buildUserMessage = (text: string) => {
-    // Pass-through only: explicit composer chips + user text. No FE intent routing.
-    const parts: string[] = [];
-    if (contextChips.length) {
-      let attachIdx = 0;
-      parts.push(
-        ...contextChips.map((c) => {
-          if (c.kind === 'attachment') {
-            attachIdx += 1;
-            const payload = String(c.payload || '').trim();
-            if (payload) return `${payload}\nattachment_index: ${attachIdx}`;
-            return `[Attached image ${attachIdx}]\nname: ${c.label}`;
-          }
-          return c.payload;
-        })
-      );
-    }
-    parts.push(`User request:\n${text}`);
-    return parts.join('\n\n');
-  };
+  const buildUserMessage = (text: string) => buildComposerChipPrompt(contextChips, text);
 
   const finishAssistantPatch = (
     m: ChatUiMessage,
@@ -2602,14 +2584,15 @@ function AgentDock({
           Array.from({ length: count }, async (_, i) => {
             if (ac.signal.aborted) return;
             try {
+              const refImages = uniqueVisionUrls([...attachedImages, ...mentionImageSrcs]);
               const imageBody = buildImageGenRequestBody({
-                prompt: text,
+                prompt: contextChips.length ? userMessageForApi : text,
                 canPickModel,
                 model,
                 aspect,
                 resolution,
                 isImageInteraction,
-                attachedImages,
+                attachedImages: refImages,
               });
               const res = await generateImage(imageBody, { signal: ac.signal });
               const url = firstGeneratedImageUrl(res);

--- a/apps/web/src/components/editor/panels/agent/agentSendPath.ts
+++ b/apps/web/src/components/editor/panels/agent/agentSendPath.ts
@@ -369,6 +369,52 @@ export function buildImageGenRequestBody(opts: {
   return body;
 }
 
+/** Merge mark / mention / attachment refs for image-generation `images[]`. */
+export function collectComposerRefImages(
+  chips: ComposerContext[],
+  primarySrc?: string
+): string[] {
+  const out: string[] = [];
+  const primary = String(primarySrc || '').trim();
+  if (primary) out.push(primary);
+  for (const c of chips) {
+    if (c.kind === 'skill') continue;
+    const src = String(c.dataUrl || c.thumbUrl || '').trim();
+    if (!src) continue;
+    if (
+      c.kind === 'attachment' ||
+      c.kind === 'image' ||
+      src.startsWith('data:image/') ||
+      src.startsWith('http') ||
+      src.startsWith('/')
+    ) {
+      out.push(src);
+    }
+  }
+  return uniqueVisionUrls(out, 8);
+}
+
+/** Agent / quick-edit: inline chip payloads + user text → model prompt. */
+export function buildComposerChipPrompt(chips: ComposerContext[], userText: string): string {
+  const parts: string[] = [];
+  let attachIdx = 0;
+  for (const c of chips) {
+    if (c.kind === 'attachment') {
+      attachIdx += 1;
+      const payload = String(c.payload || '').trim();
+      if (payload) parts.push(`${payload}\nattachment_index: ${attachIdx}`);
+      else parts.push(`[Attached image ${attachIdx}]\nname: ${c.label}`);
+      continue;
+    }
+    if (c.kind === 'skill') continue;
+    const payload = String(c.payload || '').trim();
+    if (payload) parts.push(payload);
+  }
+  const text = String(userText || '').trim();
+  if (text) parts.push(`User request:\n${text}`);
+  return parts.join('\n\n');
+}
+
 export function uniqueVisionUrls(urls: Array<string | null | undefined>, max = 4): string[] {
   return urls
     .filter((u): u is string => Boolean(u))

--- a/apps/web/src/components/rcb/scene/document/nodeCapabilities.ts
+++ b/apps/web/src/components/rcb/scene/document/nodeCapabilities.ts
@@ -76,12 +76,20 @@ export function isExportableSceneNode(node: SceneNodeRef): boolean {
   return true;
 }
 
-/**
- * Share / public preview: drop generator plates and process-shimmer so viewers
- * only see finished scene content (same filter as export / cover).
- */
 export function isImageProcessRunning(node: SceneNodeRef): boolean {
   return Boolean(node) && String(node?.attrs?.processStatus || '') === 'running';
+}
+
+/** Generator bottom composer — hide while upload / generate / AI shimmer is active. */
+export function shouldShowGeneratorComposer(opts: {
+  node: SceneNodeRef;
+  hidden?: boolean;
+  selected?: boolean;
+  attachPickActive?: boolean;
+}): boolean {
+  if (opts.hidden) return false;
+  if (isImageProcessRunning(opts.node)) return false;
+  return Boolean(opts.selected || opts.attachPickActive);
 }
 
 /**

--- a/apps/web/src/components/rcb/scene/paint/sceneToSvg.ts
+++ b/apps/web/src/components/rcb/scene/paint/sceneToSvg.ts
@@ -1316,52 +1316,23 @@ export async function nodeToSvgElement(
 
     if (processing) {
       const g = appendChild(parent, svgEl('g'));
-      const kind = String(node.attrs?.processKind || '');
-      const previewSrc =
-        kind === 'upload' && src && String(src) !== TRANSPARENT_PIXEL_SRC ? String(src) : '';
-      if (previewSrc) {
-        const img = appendChild(
-          g,
-          svgEl('image', {
-            width: boxW,
-            height: boxH,
-            x: 0,
-            y: 0,
-            // Fill the node box (like rects) — default SVG `meet` letterboxes.
-            preserveAspectRatio: 'none',
-          })
-        );
-        setSvgImageHref(img, previewSrc);
-        if (cssFilter) setStyles(img, { filter: cssFilter });
-        const overlay = appendChild(g, svgEl('path', { d: clipD }));
-        setFill(overlay, 'rgba(185, 203, 218, 0.28)');
-        // Screen hairline — fixed scene 1.5 blows up under camera scale and
-        // reads as "selection larger than the photo" while uploading.
-        setStroke(overlay, { color: '#A8C5E4', width: editorChromeStrokeSceneWidth(1.5) });
-        setAttrs(overlay, {
-          'pointer-events': 'none',
-          'data-radius-body': '1',
-          'data-baseline': '1',
-        });
-      } else {
-        const gid = nextClipId('img-load');
-        const defs = ensureDefs(root);
-        const grad = svgEl('linearGradient', {
-          id: gid,
-          x1: '0%',
-          y1: '50%',
-          x2: '100%',
-          y2: '50%',
-        });
-        grad.appendChild(svgEl('stop', { offset: '0', 'stop-color': '#B9CBDA' }));
-        grad.appendChild(svgEl('stop', { offset: '0.55', 'stop-color': '#D5DEE6' }));
-        grad.appendChild(svgEl('stop', { offset: '1', 'stop-color': '#E8ECF0' }));
-        defs.appendChild(grad);
-        const plate = appendChild(g, svgEl('path', { d: clipD }));
-        setFill(plate, urlRef(gid));
-        setStroke(plate, { color: '#A8C5E4', width: editorChromeStrokeSceneWidth(1.5) });
-        setAttrs(plate, { 'data-radius-body': '1', 'data-baseline': '1' });
-      }
+      const gid = nextClipId('img-load');
+      const defs = ensureDefs(root);
+      const grad = svgEl('linearGradient', {
+        id: gid,
+        x1: '0%',
+        y1: '50%',
+        x2: '100%',
+        y2: '50%',
+      });
+      grad.appendChild(svgEl('stop', { offset: '0', 'stop-color': '#B9CBDA' }));
+      grad.appendChild(svgEl('stop', { offset: '0.55', 'stop-color': '#D5DEE6' }));
+      grad.appendChild(svgEl('stop', { offset: '1', 'stop-color': '#E8ECF0' }));
+      defs.appendChild(grad);
+      const plate = appendChild(g, svgEl('path', { d: clipD }));
+      setFill(plate, urlRef(gid));
+      setStroke(plate, { color: '#A8C5E4', width: editorChromeStrokeSceneWidth(1.5) });
+      setAttrs(plate, { 'data-radius-body': '1', 'data-baseline': '1' });
 
       tagNode(g, nodeId, 'image', undefined, left, top, boxW, boxH);
       // Process shimmer is editor chrome — never bake into export / cover clones.
@@ -2318,6 +2289,32 @@ function previewResizeText(
   });
   reapplySceneTransform(el, box.left, box.top, box.width, box.height);
   return true;
+}
+
+export function readScenePaintLocalSize(
+  el: SVGElement | null | undefined,
+  fallback: { width: number; height: number }
+): { width: number; height: number } {
+  if (!el) return fallback;
+  const anyEl = asHost(el);
+  if (anyEl.__sceneDidResize) {
+    const baseW = Number(anyEl.__sceneDragBaseW);
+    const baseH = Number(anyEl.__sceneDragBaseH);
+    if (baseW > 0 && baseH > 0) {
+      return { width: baseW, height: baseH };
+    }
+  }
+  const geom = readGeom(el);
+  if (geom) {
+    return {
+      width: Math.max(1, geom.width),
+      height: Math.max(1, geom.height),
+    };
+  }
+  return {
+    width: Math.max(1, fallback.width),
+    height: Math.max(1, fallback.height),
+  };
 }
 
 function previewResizeImage(

--- a/apps/web/src/components/rcb/selection/SelectionChrome.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionChrome.tsx
@@ -593,6 +593,20 @@ export function cursorForResize(handle: ResizeHandle, angleDeg: number): string 
   return dirs[idx];
 }
 
+/** Cursors set on the stage hit layer while hovering selection chrome handles. */
+export function isSelectionChromeCursor(cursor: string): boolean {
+  const c = String(cursor || '').trim();
+  if (!c) return false;
+  if (c.startsWith('url(')) return true;
+  if (c === 'default') return true;
+  return /resize|grab|alias|crosshair|pointer/.test(c);
+}
+
+export function clearSelectionChromeCursor(el: HTMLElement | null | undefined): void {
+  if (!el) return;
+  if (isSelectionChromeCursor(el.style.cursor)) el.style.cursor = '';
+}
+
 /**
  * Hit range around a painted control center (scene units).
  * Screen radius = half the painted size ? hitScale ??pointer near the point, not a DOM pad.

--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -20,8 +20,7 @@ import {
   type SmartGuideLine,
 } from './alignGuides';
 import SelectionChrome, {
-  cursorForResize,
-  pickChromeHandleAtClient,
+  clearSelectionChromeCursor,
   pickOverlayHandleAtClient,
   pickSelectionInkAtClient,
   syncOverlayHandleHoverAtClient,
@@ -29,7 +28,10 @@ import SelectionChrome, {
   tryStartOverlayHandleSeat,
   type ChromeHandlePick,
 } from './SelectionChrome';
-import { cursorForRotate } from './rotateCornerCursor';
+import {
+  applyPaintedChromeHover,
+  isSelectionHoverUiTarget,
+} from './selectionHoverChrome';
 import SelectionContextToolbar from './chrome/SelectionContextToolbar';
 import MultiSelectionToolbar from './chrome/MultiSelectionToolbar';
 import NodeTitleLabel from './chrome/NodeTitleLabel';
@@ -155,17 +157,6 @@ import {
 } from './selectionLogic';
 import { frameSelId, parseFrameSelId } from './frameSelectionIds';
 import type { SceneDocument } from '@/components/rcb/sceneNode';
-
-const ROTATE_CORNER_ICON_DEG = {
-  nw: 0,
-  ne: 90,
-  se: 180,
-  sw: 270,
-} as const;
-
-function rotateCornerIconDeg(corner: keyof typeof ROTATE_CORNER_ICON_DEG): number {
-  return ROTATE_CORNER_ICON_DEG[corner];
-}
 
 /** One frame of live transform chrome + paint (ADR 0027 — RAF preview). */
 export type TransformPreviewBatch = {
@@ -649,135 +640,64 @@ function SelectionFeature({
     let hoverRaf = 0;
     let pending: PointerEvent | null = null;
 
+    const clearChromeCursor = () => clearSelectionChromeCursor(hitEl);
+
+    const paintedChromeHover = (
+      e: PointerEvent,
+      scene: { x: number; y: number },
+      includeOverlayKnobs: boolean
+    ) =>
+      applyPaintedChromeHover({
+        hitEl,
+        clientX: e.clientX,
+        clientY: e.clientY,
+        target: e.target,
+        scene,
+        sceneDoc: documentRef.current,
+        liveUnion: liveUnionRef.current,
+        liveOrigins: liveOriginsRef.current,
+        liveAngle: liveAngleRef.current || 0,
+        pickOpts: chromePickOptsRef.current,
+        setEndpointHover,
+        includeOverlayKnobs,
+      });
+
     const runHoverHit = (e: PointerEvent) => {
       setEndpointHover(null);
       if (dragRef.current) {
         applyHover(null);
+        clearChromeCursor();
         return;
       }
       const hoverScene = toScene(e.clientX, e.clientY);
       syncOverlayHandleHoverAtClient(e.clientX, e.clientY, e.target, hoverScene);
       const target = e.target as HTMLElement | null;
+
       const variantsHost = target?.closest?.(
         '[data-image-variants-bar]'
       ) as HTMLElement | null;
       if (variantsHost) {
         const pinned = variantsHost.getAttribute('data-image-node-id');
         if (pinned) {
+          clearChromeCursor();
           applyHover(pinned);
           return;
         }
       }
-      if (
-        target?.closest?.(
-          '[data-ctx-menu],[data-sel-toolbar],[data-export-panel],[data-frame-toolbar],[data-image-tool-panel],[data-image-variants],[data-image-quick-edit],[data-lottie-edit-composer],[data-video-quick-edit],[data-audio-quick-edit],[data-shape-style-panel],[data-gradient-handles],[data-mesh-handles],[data-fill-image-handles],[data-dev-props],[data-video-playback-bar],[data-video-trim-toolbar],[data-audio-playback-bar],[data-audio-trim-toolbar],[data-audio-speed-toolbar],[data-radius-handle],[data-star-handle],[data-poly-handle],[data-circle-handle],[data-rcb-hit-zone]'
-        )
-      ) {
-        // Selection pill often overlaps knobs at high zoom — still show chrome cursor.
-        const pickOptsEarly = chromePickOptsRef.current;
-        if (
-          hitEl &&
-          !pickOptsEarly.suppressChrome &&
-          pickOptsEarly.showHandles &&
-          liveUnionRef.current &&
-          liveOriginsRef.current?.length
-        ) {
-          const painted = resolvePaintedControlChrome(
-            documentRef.current,
-            liveOriginsRef.current,
-            liveUnionRef.current,
-            liveAngleRef.current || 0
-          );
-          const paint = pickChromeHandleAtClient(
-            e.clientX,
-            e.clientY,
-            e.target,
-            {
-              ...pickOptsEarly,
-              box: painted.box,
-              angle: painted.angle,
-              scene: toScene(e.clientX, e.clientY),
-            }
-          );
-          if (paint?.kind === 'endpoint') {
-            setEndpointHover(paint.handle);
-            hitEl.style.cursor = 'default';
-            applyHover(null);
-            return;
-          }
-          if (paint?.kind === 'resize') {
-            hitEl.style.cursor = cursorForResize(paint.handle, painted.angle);
-            applyHover(null);
-            return;
-          }
-          if (paint?.kind === 'rotate') {
-            hitEl.style.cursor = cursorForRotate(
-              rotateCornerIconDeg(paint.corner),
-              painted.angle
-            );
-            applyHover(null);
-            return;
-          }
+
+      if (isSelectionHoverUiTarget(target)) {
+        if (paintedChromeHover(e, hoverScene, false)) {
+          applyHover(null);
+          return;
         }
         applyHover(null);
         return;
       }
 
       const p = toScene(e.clientX, e.clientY);
-      const pickOpts = chromePickOptsRef.current;
-      const liveUnionNow = liveUnionRef.current;
-      const liveOriginsNow = liveOriginsRef.current;
-      const liveAngleNow = liveAngleRef.current;
-      if (
-        hitEl &&
-        !pickOpts.suppressChrome &&
-        pickOpts.showHandles &&
-        liveUnionNow &&
-        liveOriginsNow?.length
-      ) {
-        const painted = resolvePaintedControlChrome(
-          documentRef.current,
-          liveOriginsNow,
-          liveUnionNow,
-          liveAngleNow || 0
-        );
-        const pick = pickChromeHandleAtClient(e.clientX, e.clientY, e.target, {
-          ...pickOpts,
-          box: painted.box,
-          angle: painted.angle,
-          scene: p,
-        });
-        if (pick?.kind === 'endpoint') {
-          setEndpointHover(pick.handle);
-          hitEl.style.cursor = 'default';
-          applyHover(null);
-          return;
-        }
-        if (pick?.kind === 'resize') {
-          hitEl.style.cursor = cursorForResize(pick.handle, painted.angle);
-          applyHover(null);
-          return;
-        }
-        if (pick?.kind === 'rotate') {
-          hitEl.style.cursor = cursorForRotate(
-            rotateCornerIconDeg(pick.corner),
-            painted.angle
-          );
-          applyHover(null);
-          return;
-        }
-        const knob = pickOverlayHandleAtClient(e.clientX, e.clientY, e.target, p);
-        if (knob?.kind === 'radius' || knob?.kind === 'shape') {
-          hitEl.style.cursor = 'pointer';
-          applyHover(null);
-          return;
-        }
-        if (
-          hitEl.style.cursor &&
-          /resize|grab|alias|crosshair|pointer/.test(hitEl.style.cursor)
-        ) {
-          hitEl.style.cursor = '';
-        }
+      if (paintedChromeHover(e, p, true)) {
+        applyHover(null);
+        return;
       }
 
       // Only hit-test when the pointer is over the stage / paper / selection chrome.
@@ -821,6 +741,7 @@ function SelectionFeature({
         cancelAnimationFrame(hoverRaf);
         hoverRaf = 0;
       }
+      clearSelectionChromeCursor(hitEl);
       applyHover(null);
     };
 
@@ -831,6 +752,7 @@ function SelectionFeature({
       if (hoverRaf) cancelAnimationFrame(hoverRaf);
       window.removeEventListener('pointermove', onHoverMove);
       window.removeEventListener('blur', onLeave);
+      clearSelectionChromeCursor(hitEl);
     };
   }, [enabled, hitEl, paperEl, overlayRoot, artboard, hitTest, dispatch, toScene, workspaceMode, readOnly]);
 
@@ -1066,7 +988,7 @@ function SelectionFeature({
       if (target.closest('[data-sel-toolbar],[data-frame-toolbar]')) return;
       if (
         target.closest(
-          '[data-ctx-menu],[data-export-panel],[data-image-label],[data-frame-label],[data-crop-expand-overlay],[data-crop-expand-toolbar],[data-image-tool-panel],[data-image-variants],[data-image-quick-edit],[data-lottie-edit-composer],[data-video-quick-edit],[data-audio-quick-edit],[data-shape-style-panel],[data-gradient-handles],[data-mesh-handles],[data-fill-image-handles],[data-fill-image-preview],[data-color-panel],[data-text-inline-editor],[data-frame-handle],[data-image-generator],[data-video-generator],[data-video-playback-bar],[data-video-trim-toolbar],[data-audio-playback-bar],[data-audio-trim-toolbar],[data-audio-speed-toolbar]'
+          '[data-ctx-menu],[data-export-panel],[data-image-label],[data-frame-label],[data-crop-expand-overlay],[data-crop-expand-toolbar],[data-image-tool-panel],[data-image-variants],[data-image-quick-edit],[data-lottie-edit-composer],[data-video-quick-edit],[data-audio-quick-edit],[data-shape-style-panel],[data-gradient-handles],[data-mesh-handles],[data-fill-image-handles],[data-fill-image-preview],[data-color-panel],[data-text-inline-editor],[data-frame-handle],[data-image-generator],[data-video-generator],[data-video-playback-bar],[data-video-trim-toolbar],[data-audio-playback-bar],[data-audio-trim-toolbar],[data-audio-speed-toolbar],[data-mockup-session],[data-mockup-toolbar],[data-upscale-toolbar],[data-mark-overlay],[data-mark-prompt]'
         )
       )
         return;
@@ -1482,6 +1404,7 @@ function SelectionFeature({
       setMarquee(null);
       if (!drag) return;
       dragRef.current = null;
+      clearSelectionChromeCursor(hitEl);
       const {
         sceneDoc,
         toScene,
@@ -2303,7 +2226,8 @@ function SelectionFeature({
         />
       ) : null}
 
-      {!inspectDev && chromeUnion && singleNode && !transforming && !suppressToolbars ? (
+      {!inspectDev && chromeUnion && singleNode && !transforming && !suppressToolbars &&
+      String(singleNodeData?.attrs?.processStatus || '') !== 'running' ? (
         <SelectionContextToolbar
           document={document}
           nodeId={selectedNodeIds[0]}

--- a/apps/web/src/components/rcb/selection/__tests__/selectionChromeCursor.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/selectionChromeCursor.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clearSelectionChromeCursor,
+  isSelectionChromeCursor,
+} from '../SelectionChrome';
+import { cursorForRotate } from '../rotateCornerCursor';
+
+describe('selection chrome cursor reset', () => {
+  it('detects rotate data-url cursors', () => {
+    const rotate = cursorForRotate(0, 0);
+    expect(rotate.startsWith('url(')).toBe(true);
+    expect(isSelectionChromeCursor(rotate)).toBe(true);
+  });
+
+  it('detects resize and endpoint cursors', () => {
+    expect(isSelectionChromeCursor('nw-resize')).toBe(true);
+    expect(isSelectionChromeCursor('default')).toBe(true);
+    expect(isSelectionChromeCursor('pointer')).toBe(true);
+    expect(isSelectionChromeCursor('')).toBe(false);
+    expect(isSelectionChromeCursor('text')).toBe(false);
+  });
+
+  it('clears chrome cursors from the hit layer element', () => {
+    const el = document.createElement('div');
+    el.style.cursor = cursorForRotate(90, 45);
+    clearSelectionChromeCursor(el);
+    expect(el.style.cursor).toBe('');
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/selectionHoverChrome.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/selectionHoverChrome.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SELECTION_HOVER_UI_SELECTOR,
+  isSelectionHoverUiTarget,
+} from '../selectionHoverChrome';
+
+describe('selectionHoverChrome', () => {
+  it('matches floating toolbar hosts', () => {
+    const el = document.createElement('div');
+    el.setAttribute('data-sel-toolbar', '');
+    document.body.appendChild(el);
+    expect(isSelectionHoverUiTarget(el)).toBe(true);
+    document.body.removeChild(el);
+  });
+
+  it('exports a stable overlap selector list', () => {
+    expect(SELECTION_HOVER_UI_SELECTOR).toContain('[data-mark-overlay]');
+    expect(SELECTION_HOVER_UI_SELECTOR).toContain('[data-sel-toolbar]');
+  });
+});

--- a/apps/web/src/components/rcb/selection/__tests__/videoImageLayerParity.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/videoImageLayerParity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   nodeToSvgElement,
   previewSvgNodeGeometry,
+  readScenePaintLocalSize,
   videoSvgOwnsPixels,
 } from '../../scene/paint/sceneToSvg';
 
@@ -191,5 +192,35 @@ describe('video move preview geom == HTML plate override', () => {
       width: Number(anyEl.sceneWidth),
       height: Number(anyEl.sceneHeight),
     }).toEqual(moved);
+  });
+});
+
+describe('process glow local size during resize preview', () => {
+  it('readScenePaintLocalSize keeps drag-base dims while preview scales the group', async () => {
+    const { root, layer } = svgRoot({
+      'data-rcb-infinite': '1',
+      'data-rcb-shared-scene-surface': '1',
+    });
+    const node = {
+      key: 'image',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      attrs: {
+        processStatus: 'running',
+        processKind: 'upload',
+        processLabel: 'Uploading',
+      },
+    };
+    const el = await nodeToSvgElement(root, layer, doc, node, 'img-upload');
+    expect(el).toBeTruthy();
+    const nodeEls = new Map<string, SVGElement>([['img-upload', el!]]);
+    expect(previewSvgNodeGeometry(nodeEls, 'img-upload', { left: 0, top: 0, width: 160, height: 160 })).toBe(
+      true
+    );
+    const local = readScenePaintLocalSize(el, { width: 160, height: 160 });
+    expect(local).toEqual({ width: 100, height: 100 });
+    expect(el!.querySelector('image')).toBeNull();
   });
 });

--- a/apps/web/src/components/rcb/selection/chrome/SelectionContextToolbar.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/SelectionContextToolbar.tsx
@@ -29,6 +29,7 @@ import {
   openVideoToolPanel,
   openAudioToolPanel,
   isImageToolSidePanelKind,
+  isQuickEditMarkPanel,
 } from '@/store/modules/editor';
 import FlipRotateToolbar from '@/components/editor/nodes/ImageNode/FlipRotateToolbar';
 import ImageQuickEditComposer from '@/components/editor/nodes/ImageNode/ImageQuickEditComposer';
@@ -56,6 +57,7 @@ import {
   isAudioGeneratorNode,
   isIconImageNode,
   isImageGeneratorNode,
+  isImageProcessRunning,
   isLottieGeneratorNode,
   isVideoGeneratorNode,
   supportsCornerRadius,
@@ -373,6 +375,7 @@ function SelectionContextToolbar(props: Props): ReactNode {
     kind,
     ['image', 'video']
   );
+  const quickEditMarkPaused = isQuickEditMarkPanel(imageToolPanel, nodeId, kind);
   const quickEditOpen = isPanelKindOnNode(
     imageToolPanel,
     nodeId,
@@ -380,6 +383,7 @@ function SelectionContextToolbar(props: Props): ReactNode {
     kind,
     ['image', 'video', 'audio', 'lottie']
   );
+  const quickEditComposerOpen = quickEditOpen || quickEditMarkPaused;
   const lottieEditOpen = isPanelKindOnNode(
     imageToolPanel,
     nodeId,
@@ -421,7 +425,7 @@ function SelectionContextToolbar(props: Props): ReactNode {
   }, [decorationOpen, alignOpen]);
 
   if (!node || !box) return null;
-  // Generator plate uses its own composer overlay — hide photo AI selection chrome.
+  if (isImageProcessRunning(node)) return null;
   if (
     isImageGeneratorNode(node) ||
     isVideoGeneratorNode(node) ||
@@ -537,7 +541,7 @@ function SelectionContextToolbar(props: Props): ReactNode {
       </>
     ) : null;
 
-  if (quickEditOpen || lottieEditOpen) {
+  if (quickEditComposerOpen || lottieEditOpen) {
     if (kind === 'video') {
       return <VideoQuickEditComposer document={document} nodeId={nodeId} box={box} />;
     }
@@ -547,7 +551,14 @@ function SelectionContextToolbar(props: Props): ReactNode {
     if (kind === 'lottie') {
       return <LottieQuickEditComposer document={document} nodeId={nodeId} box={box} />;
     }
-    return <ImageQuickEditComposer document={document} nodeId={nodeId} box={box} />;
+    return (
+      <ImageQuickEditComposer
+        document={document}
+        nodeId={nodeId}
+        box={box}
+        hidden={quickEditMarkPaused}
+      />
+    );
   }
 
   const flipRotateToolbar = (

--- a/apps/web/src/components/rcb/selection/selectionHoverChrome.ts
+++ b/apps/web/src/components/rcb/selection/selectionHoverChrome.ts
@@ -1,0 +1,148 @@
+import type { SceneDocument } from '@/components/rcb/sceneNode';
+import type { SceneBox } from './alignGuides';
+import {
+  clearSelectionChromeCursor,
+  cursorForResize,
+  pickChromeHandleAtClient,
+  pickOverlayHandleAtClient,
+  type ChromeHandlePick,
+  type ChromeHandlePickOpts,
+} from './SelectionChrome';
+import { cursorForRotate } from './rotateCornerCursor';
+import { resolvePaintedControlChrome } from './selectionLogic';
+
+const ROTATE_CORNER_ICON_DEG = {
+  nw: 0,
+  ne: 90,
+  se: 180,
+  sw: 270,
+} as const;
+
+/** Floating UI that may overlap selection chrome — still allow handle cursors. */
+export const SELECTION_HOVER_UI_SELECTOR = [
+  '[data-ctx-menu]',
+  '[data-sel-toolbar]',
+  '[data-export-panel]',
+  '[data-frame-toolbar]',
+  '[data-image-tool-panel]',
+  '[data-image-variants]',
+  '[data-image-quick-edit]',
+  '[data-lottie-edit-composer]',
+  '[data-video-quick-edit]',
+  '[data-audio-quick-edit]',
+  '[data-shape-style-panel]',
+  '[data-gradient-handles]',
+  '[data-mesh-handles]',
+  '[data-fill-image-handles]',
+  '[data-dev-props]',
+  '[data-video-playback-bar]',
+  '[data-video-trim-toolbar]',
+  '[data-audio-playback-bar]',
+  '[data-audio-trim-toolbar]',
+  '[data-audio-speed-toolbar]',
+  '[data-radius-handle]',
+  '[data-star-handle]',
+  '[data-poly-handle]',
+  '[data-circle-handle]',
+  '[data-rcb-hit-zone]',
+  '[data-mockup-session]',
+  '[data-mockup-toolbar]',
+  '[data-upscale-toolbar]',
+  '[data-mark-overlay]',
+  '[data-mark-prompt]',
+].join(',');
+
+export function isSelectionHoverUiTarget(target: EventTarget | null): boolean {
+  return Boolean(
+    target instanceof HTMLElement && target.closest(SELECTION_HOVER_UI_SELECTOR)
+  );
+}
+
+export type PaintedChromeHoverInput = {
+  hitEl: HTMLElement;
+  clientX: number;
+  clientY: number;
+  target: EventTarget | null;
+  scene: { x: number; y: number };
+  sceneDoc: SceneDocument | null;
+  liveUnion: SceneBox | null;
+  liveOrigins: Array<{ nodeId: string; box: SceneBox }> | null;
+  liveAngle: number;
+  pickOpts: ChromeHandlePickOpts & { suppressChrome?: boolean; showHandles?: boolean };
+  setEndpointHover: (handle: 'w' | 'e' | null) => void;
+  includeOverlayKnobs?: boolean;
+};
+
+function cursorForChromePick(pick: ChromeHandlePick, angle: number): string {
+  if (pick.kind === 'endpoint') return 'default';
+  if (pick.kind === 'resize') return cursorForResize(pick.handle, angle);
+  return cursorForRotate(ROTATE_CORNER_ICON_DEG[pick.corner], angle);
+}
+
+/**
+ * Paint + pick selection chrome under the pointer; apply cursor / endpoint hover.
+ * Returns true when a chrome or overlay-knob cursor was applied.
+ */
+export function applyPaintedChromeHover(input: PaintedChromeHoverInput): boolean {
+  const {
+    hitEl,
+    clientX,
+    clientY,
+    target,
+    scene,
+    sceneDoc,
+    liveUnion,
+    liveOrigins,
+    liveAngle,
+    pickOpts,
+    setEndpointHover,
+    includeOverlayKnobs = true,
+  } = input;
+
+  if (
+    pickOpts.suppressChrome ||
+    !pickOpts.showHandles ||
+    !liveUnion ||
+    !liveOrigins?.length
+  ) {
+    clearSelectionChromeCursor(hitEl);
+    return false;
+  }
+
+  const painted = resolvePaintedControlChrome(
+    sceneDoc,
+    liveOrigins,
+    liveUnion,
+    liveAngle || 0
+  );
+  const pick = pickChromeHandleAtClient(clientX, clientY, target, {
+    ...pickOpts,
+    box: painted.box,
+    angle: painted.angle,
+    scene,
+  });
+
+  if (pick?.kind === 'endpoint') {
+    setEndpointHover(pick.handle);
+    hitEl.style.cursor = 'default';
+    return true;
+  }
+
+  if (pick?.kind === 'resize' || pick?.kind === 'rotate') {
+    setEndpointHover(null);
+    hitEl.style.cursor = cursorForChromePick(pick, painted.angle);
+    return true;
+  }
+
+  if (includeOverlayKnobs) {
+    const knob = pickOverlayHandleAtClient(clientX, clientY, target, scene);
+    if (knob?.kind === 'radius' || knob?.kind === 'shape') {
+      setEndpointHover(null);
+      hitEl.style.cursor = 'pointer';
+      return true;
+    }
+  }
+
+  clearSelectionChromeCursor(hitEl);
+  return false;
+}

--- a/apps/web/src/components/rcb/shapes/RcbShapeHost.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapeHost.tsx
@@ -43,6 +43,15 @@ type Props = {
   revealOverflow?: boolean;
 };
 
+function sameProcessingPaintNode(prev: unknown, next: unknown): boolean {
+  if (!prev || !next || typeof prev !== 'object' || typeof next !== 'object') return false;
+  const a = prev as { key?: string; attrs?: { processStatus?: string } };
+  const b = next as { key?: string; attrs?: { processStatus?: string } };
+  if (a.attrs !== b.attrs) return false;
+  if (String(a.attrs?.processStatus || '') !== 'running') return false;
+  return a.key === b.key;
+}
+
 /**
  * A geometry commit creates a new document shell, while every untouched node
  * keeps its object identity. Comparing the whole document here made every
@@ -52,6 +61,9 @@ type Props = {
 export function shapeHostPropsEqual(previous: Props, next: Props): boolean {
   const prevNode = previous.document?.deltaSetLike?.[previous.nodeId];
   const nextNode = next.document?.deltaSetLike?.[next.nodeId];
+  const sameNode =
+    prevNode === nextNode ||
+    (prevNode && nextNode && sameProcessingPaintNode(prevNode, nextNode));
   return (
     previous.nodeId === next.nodeId &&
     previous.zIndex === next.zIndex &&
@@ -59,9 +71,9 @@ export function shapeHostPropsEqual(previous: Props, next: Props): boolean {
     previous.frameClipToken === next.frameClipToken &&
     previous.forceHidden === next.forceHidden &&
     previous.revealOverflow === next.revealOverflow &&
-    prevNode === nextNode &&
-  // clearImageProcessAttrs replaces attrs on the same node record — compare attrs
-  // so upload/AI shimmer unmounts even when geometry commits skip sceneReloadToken.
+    sameNode &&
+    // clearImageProcessAttrs replaces attrs on the same node record — compare attrs
+    // so upload/AI shimmer unmounts even when geometry commits skip sceneReloadToken.
     prevNode?.attrs === nextNode?.attrs
   );
 }

--- a/apps/web/src/components/rcb/shapes/__tests__/shapeHostProps.test.ts
+++ b/apps/web/src/components/rcb/shapes/__tests__/shapeHostProps.test.ts
@@ -46,4 +46,20 @@ describe('shapeHostPropsEqual', () => {
 
     expect(shapeHostPropsEqual(props(before), props(after))).toBe(false);
   });
+
+  it('ignores geometry-only preview updates while process shimmer is running', () => {
+    const attrs = { processStatus: 'running', processLabel: 'Uploading' };
+    const before = {
+      deltaSetLike: {
+        'brush-a': { id: 'brush-a', key: 'image', x: 0, y: 0, width: 100, height: 100, attrs },
+      },
+    };
+    const after = {
+      deltaSetLike: {
+        'brush-a': { id: 'brush-a', key: 'image', x: 0, y: 0, width: 180, height: 180, attrs },
+      },
+    };
+
+    expect(shapeHostPropsEqual(props(before), props(after))).toBe(true);
+  });
 });

--- a/apps/web/src/store/modules/editor.ts
+++ b/apps/web/src/store/modules/editor.ts
@@ -73,6 +73,7 @@ function documentFromExternalPayload(raw: unknown): SceneDocument {
 /** Side panel / toolbar kinds for image tools. */
 export type ImageToolPanelKind =
   | 'eraser'
+  | 'removeBg'
   | 'opacity'
   | 'multiAngle'
   | 'expand'
@@ -88,8 +89,60 @@ export type ImageToolPanelKind =
   | 'mockup'
   | 'upscale';
 
+export type ImageToolPanelState = {
+  nodeId: string;
+  kind: ImageToolPanelKind;
+  /** `quickEdit` — mark regions land in the floating composer; default is agent chat. */
+  markSink?: 'agent' | 'quickEdit';
+};
+
+export type PendingMarkContextChip = {
+  key: string;
+  label: string;
+  kind: string;
+  payload: string;
+  dataUrl?: string;
+  thumbUrl?: string;
+  appendText?: string;
+};
+
+export function canvasAttachTargetForNode(nodeId: string): string {
+  return `node:${nodeId}`;
+}
+
+export function isCanvasAttachForNode(
+  nodeId: string,
+  canvasAttachPick: { target: string } | null | undefined,
+  pendingCanvasAttach: { target: string } | null | undefined
+): boolean {
+  const target = canvasAttachTargetForNode(nodeId);
+  return (
+    canvasAttachPick?.target === target || pendingCanvasAttach?.target === target
+  );
+}
+
+export function isQuickEditMarkPanel(
+  panel: ImageToolPanelState | null | undefined,
+  nodeId: string,
+  nodeKey = 'image'
+): boolean {
+  return (
+    nodeKey === 'image' &&
+    panel?.nodeId === nodeId &&
+    panel?.kind === 'mark' &&
+    panel?.markSink === 'quickEdit'
+  );
+}
+
+export function markPanelSink(
+  panel: ImageToolPanelState | null | undefined
+): 'agent' | 'quickEdit' {
+  return panel?.markSink === 'quickEdit' ? 'quickEdit' : 'agent';
+}
+
 const IMAGE_TOOL_SIDE_PANEL_KIND: Record<string, true> = {
   eraser: true,
+  removeBg: true,
   opacity: true,
   replaceText: true,
   multiAngle: true,
@@ -97,6 +150,7 @@ const IMAGE_TOOL_SIDE_PANEL_KIND: Record<string, true> = {
   effects: true,
   blendMode: true,
   mark: true,
+  mockup: true,
 };
 
 /** Blend / effects dock beside any selected node (not image-only tools). */
@@ -144,10 +198,14 @@ function isTransientNodePatch(patch: unknown): boolean {
   return keys.length > 0 && keys.every((key) => TRANSIENT_NODE_ATTR_KEYS.has(key));
 }
 
-function isTransientFramePatch(patch: unknown): boolean {
-  if (!patch || typeof patch !== 'object') return false;
-  const keys = Object.keys(patch as Record<string, unknown>);
-  return keys.length > 0 && keys.every((key) => TRANSIENT_FRAME_KEYS.has(key));
+export function shouldClearImageToolPanelOnSelect(
+  panel: { nodeId: string; kind: string } | null | undefined,
+  nextNodeId: string | null
+): boolean {
+  if (!panel) return false;
+  // Mockup / mark stay open while picking another image or clicking empty canvas.
+  if (panel.kind === 'mockup' || panel.kind === 'mark') return false;
+  return !nextNodeId || panel.nodeId !== nextNodeId;
 }
 
 export function isImageToolSidePanelKind(kind: string | undefined | null): boolean {
@@ -261,7 +319,7 @@ const initialState = {
   /** Blank loading node while image import runs. */
   pendingImportPlaceholderId: null as string | null,
   /** Interactive image tool panel docked to the right of the source image (figs 2-5). */
-  imageToolPanel: null as null | { nodeId: string; kind: ImageToolPanelKind },
+  imageToolPanel: null as null | ImageToolPanelState,
   videoToolPanel: null as null | {
     nodeId: string;
     kind: VideoToolPanelKind;
@@ -321,14 +379,8 @@ const initialState = {
    * Mark / programmatic chips for the right AgentDock (@ mentions).
    * EditorPage opens the panel when `agentOpenNonce` bumps; dock inserts then clears.
    */
-  pendingAgentContexts: [] as Array<{
-    key: string;
-    label: string;
-    kind: string;
-    payload: string;
-    dataUrl?: string;
-    thumbUrl?: string;
-  }>,
+  pendingAgentContexts: [] as PendingMarkContextChip[],
+  pendingQuickEditMarkContexts: [] as PendingMarkContextChip[],
   agentOpenNonce: 0,
 };
 
@@ -653,7 +705,7 @@ const editorSlice = createSlice({
       state.selectedNodeIds = action.payload ? [action.payload] : [];
       // Selecting a node clears artboard multi-select (single-target click).
       if (action.payload) state.selectedFrameIds = [];
-      if (!action.payload || state.imageToolPanel?.nodeId !== action.payload) {
+      if (shouldClearImageToolPanelOnSelect(state.imageToolPanel, action.payload)) {
         state.imageToolPanel = null;
       }
       if (!action.payload || state.videoToolPanel?.nodeId !== action.payload) {
@@ -677,7 +729,7 @@ const editorSlice = createSlice({
       state.selectedNodeId = ids[0] || null;
       // Do not clear selectedFrameIds here — marquee may select frames + nodes together.
       // Callers that want nodes-only should also dispatch setSelectedFrameIds([]).
-      if (!ids[0] || state.imageToolPanel?.nodeId !== ids[0]) {
+      if (shouldClearImageToolPanelOnSelect(state.imageToolPanel, ids[0] || null)) {
         state.imageToolPanel = null;
       }
       if (!ids[0] || state.videoToolPanel?.nodeId !== ids[0]) {
@@ -779,7 +831,7 @@ const editorSlice = createSlice({
       state.selectedNodeIds = nodeIds;
       state.selectedNodeId = nodeIds[0] || null;
       state.selectedFrameIds = frameIds;
-      if (!nodeIds[0] || state.imageToolPanel?.nodeId !== nodeIds[0]) {
+      if (shouldClearImageToolPanelOnSelect(state.imageToolPanel, nodeIds[0] || null)) {
         state.imageToolPanel = null;
       }
       if (!nodeIds[0] || state.videoToolPanel?.nodeId !== nodeIds[0]) {
@@ -2052,9 +2104,13 @@ const editorSlice = createSlice({
       syncLibraryOnEdit(state);
     },
     openImageToolPanel(state, action) {
-      const { nodeId, kind } = action.payload || {};
+      const { nodeId, kind, markSink } = action.payload || {};
       if (!nodeId || !kind) return;
-      state.imageToolPanel = { nodeId, kind };
+      state.imageToolPanel = {
+        nodeId,
+        kind,
+        ...(markSink === 'quickEdit' && { markSink: 'quickEdit' as const }),
+      };
       state.videoToolPanel = null;
       state.audioToolPanel = null;
       state.shapeStylePanel = null;
@@ -2202,16 +2258,7 @@ const editorSlice = createSlice({
     },
     enqueueAgentContexts(
       state,
-      action: PayloadAction<
-        Array<{
-          key: string;
-          label: string;
-          kind: string;
-          payload: string;
-          dataUrl?: string;
-          thumbUrl?: string;
-        }>
-      >
+      action: PayloadAction<PendingMarkContextChip[]>
     ) {
       const list = Array.isArray(action.payload) ? action.payload : [];
       if (!list.length) return;
@@ -2220,6 +2267,17 @@ const editorSlice = createSlice({
     },
     consumePendingAgentContexts(state) {
       state.pendingAgentContexts = [];
+    },
+    enqueueQuickEditMarkContexts(
+      state,
+      action: PayloadAction<PendingMarkContextChip[]>
+    ) {
+      const list = Array.isArray(action.payload) ? action.payload : [];
+      if (!list.length) return;
+      state.pendingQuickEditMarkContexts = [...state.pendingQuickEditMarkContexts, ...list];
+    },
+    consumePendingQuickEditMarkContexts(state) {
+      state.pendingQuickEditMarkContexts = [];
     },
   },
 });
@@ -2314,6 +2372,8 @@ export const {
   consumePendingCanvasAttach,
   enqueueAgentContexts,
   consumePendingAgentContexts,
+  enqueueQuickEditMarkContexts,
+  consumePendingQuickEditMarkContexts,
 } = editorSlice.actions;
 
 export default editorSlice.reducer;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -110,9 +110,8 @@ export default defineConfig(({ mode }) => {
     },
     assetsInclude: ['**/*.wasm'],
     server: {
-      // Bind IPv4 explicitly so Playwright / k6 / curl on 127.0.0.1 work on Windows
-      // (Vite default `localhost` often resolves to ::1 only).
-      host: '127.0.0.1',
+      // Listen on all local interfaces so both localhost and 127.0.0.1 work on Windows.
+      host: true,
       port: 3000,
       strictPort: true,
       // Browser auto-open only for plain `npm run dev`, not under Tauri.

--- a/scripts/dev-stack.mjs
+++ b/scripts/dev-stack.mjs
@@ -1,9 +1,7 @@
 /**
- * Local stack: Vite web (3000) + collab WS (1234).
+ * Local stack: API (8000) + Vite web (3000) + collab WS (1234).
  *
  *   npm run dev:stack
- *
- * Optional API (separate terminal): npm run dev:api
  */
 import { spawn } from 'node:child_process';
 import path from 'node:path';
@@ -33,6 +31,7 @@ function run(name, args) {
   console.log(`[dev:stack] started ${name}`);
 }
 
+run('api', ['run', 'dev:api']);
 run('web', ['run', 'dev', '--workspace=apps/web']);
 run('collab', ['run', 'dev', '--workspace=apps/collab']);
 


### PR DESCRIPTION
## Summary
- Add quick-edit Mark flow: chips route to the floating composer, dialog pauses during marking, and mark payloads are sent to image generation APIs.
- Hide generator toolbars/composers while image/video/audio/Lottie nodes are processing or uploading.
- Fix upload/process shimmer flicker during resize by syncing SoftGlow to SVG drag-base geometry and using a single gradient process plate.
- Consolidate selection chrome hover/cursor handling (`selectionHoverChrome`) and fix rotate cursor stuck after leaving handles.
- Improve local dev: `dev:stack` starts API + web + collab; Vite binds all local interfaces.

## Test plan
- [x] `vitest` selection chrome/hover + shape host + video parity tests (19 passed)
- [ ] Upload an image, resize while Uploading — no image/shimmer flicker
- [ ] Quick-edit Mark → generate with region chip
- [ ] Rotate handle cursor resets when leaving the handle zone
- [ ] `npm run dev:stack` — http://localhost:3000 loads with API on :8000