### PR TITLE
fix: upload jobs, strict storage errors, and relocate OSS stubs

### DIFF
--- a/apps/api/app/api/main.py
+++ b/apps/api/app/api/main.py
@@ -20,7 +20,6 @@ from app.api.routes import (
     chat_audio_jobs,
     chat_lottie_jobs,
     image_process_jobs,
-    upload_jobs,
     me,
     mockup,
     notices,
@@ -48,7 +47,6 @@ api_router.include_router(collab.router)
 api_router.include_router(fonts.router)
 api_router.include_router(assets.router)
 api_router.include_router(uploads.router)
-api_router.include_router(upload_jobs.router)
 api_router.include_router(chat_sessions.router)
 api_router.include_router(import_image.router)
 api_router.include_router(import_jobs.router)

--- a/apps/api/app/api/routes/upload_jobs.py
+++ b/apps/api/app/api/routes/upload_jobs.py
@@ -16,7 +16,7 @@ from app.core.config import settings
 from app.services.job_store import get_job, save_job
 from worker.tasks import run_upload_job
 
-router = APIRouter(prefix="/uploads", tags=["upload-jobs"])
+router = APIRouter(tags=["upload-jobs"])
 _log = logging.getLogger(__name__)
 _KIND = "upload"
 
@@ -35,7 +35,11 @@ class UploadJobStatusResponse(BaseModel):
 
 
 def _upload_job_temp_dir() -> Path:
-    root = Path(getattr(settings, "workspace", Path.cwd()) or Path.cwd())
+    """Shared with Celery worker via compose volume ``storage/uploads``."""
+    root = Path(getattr(settings, "upload_dir", None) or "storage/uploads")
+    if not root.is_absolute():
+        # Match API cwd layout in Docker: /app/apps/api/storage/uploads
+        root = (Path.cwd() / root).resolve()
     dest = root / "upload_jobs"
     dest.mkdir(parents=True, exist_ok=True)
     return dest
@@ -123,7 +127,10 @@ def execute_upload_job(job: dict[str, Any]) -> dict[str, Any]:
     user_id = str(job.get("user_id") or "").strip()
     temp_path = Path(str(job.get("temp_path") or ""))
     if not user_id or not temp_path.is_file():
-        raise RuntimeError("upload job missing temp file")
+        raise RuntimeError(
+            "上传作业缺少临时文件（API 与 worker 未共享 storage/uploads；"
+            "或临时文件已过期被清理）"
+        )
 
     try:
         raw = temp_path.read_bytes()

--- a/apps/api/app/api/routes/uploads.py
+++ b/apps/api/app/api/routes/uploads.py
@@ -288,3 +288,8 @@ def delete_uploaded_file(
     if not ok:
         raise HTTPException(status_code=404, detail="Not found")
     return {"ok": True}
+
+
+from app.api.routes import upload_jobs
+
+router.include_router(upload_jobs.router)

--- a/apps/api/app/services/storage/__init__.py
+++ b/apps/api/app/services/storage/__init__.py
@@ -153,13 +153,32 @@ def get_storage() -> ObjectStorage:
     if _storage is not None:
         return _storage
     if settings.s3_enabled:
-        try:
-            _storage = S3Storage()
-        except Exception:
-            _storage = LocalStorage()
+        # Fail loud — do not silently degrade to local when S3 is configured.
+        _storage = S3Storage()
     else:
         _storage = LocalStorage()
     return _storage
+
+
+def _storage_put_error_message(exc: BaseException) -> str:
+    """Map object-storage failures to a clear, user-facing message."""
+    raw = str(exc) or type(exc).__name__
+    low = raw.lower()
+    if (
+        "arrears" in low
+        or "unavailableforlegalreasons" in low
+        or "account is arrears" in low
+        or "recharge" in low
+    ):
+        return (
+            "对象存储不可用：云存储账号已欠费，请充值后再试 "
+            f"(object storage arrears: {raw})"
+        )
+    if "accessdenied" in low or "invalidaccesskeyid" in low or "signature" in low:
+        return f"对象存储鉴权失败，请检查 S3/COS 密钥配置 ({raw})"
+    if "nosuchbucket" in low:
+        return f"对象存储桶不存在，请检查 S3_BUCKET 配置 ({raw})"
+    return f"对象存储写入失败: {raw}"
 
 
 def put_bytes(
@@ -168,9 +187,12 @@ def put_bytes(
     content_type: str | None = None,
     cache_control: str | None = None,
 ) -> str:
-    return get_storage().put_bytes(
-        key, data, content_type=content_type, cache_control=cache_control
-    )
+    try:
+        return get_storage().put_bytes(
+            key, data, content_type=content_type, cache_control=cache_control
+        )
+    except Exception as exc:
+        raise RuntimeError(_storage_put_error_message(exc)) from exc
 
 
 def get_bytes(key: str) -> bytes | None:
@@ -206,8 +228,7 @@ def upload_page_images(job_id: str | None, page_paths: list[Path]) -> tuple[list
             stored = storage.put_file(key, path, content_type=ctype)
             keys.append(stored)
             urls.append(storage.url_for(stored))
-        except Exception:
-            keys.append(rel)
-            urls.append(rel)
+        except Exception as exc:
+            raise RuntimeError(_storage_put_error_message(exc)) from exc
 
     return local_rels, keys, urls

--- a/apps/api/tests/unit_tests/test_storage_put_errors.py
+++ b/apps/api/tests/unit_tests/test_storage_put_errors.py
@@ -1,0 +1,35 @@
+"""Object-storage put failures must surface as clear RuntimeError messages."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.storage import _storage_put_error_message, put_bytes
+
+
+def test_arrears_message_is_explicit() -> None:
+    msg = _storage_put_error_message(
+        Exception(
+            "An error occurred (UnavailableForLegalReasons) when calling the "
+            "PutObject operation: Due to your account is arrears, it is "
+            "unavailable until you recharge."
+        )
+    )
+    assert "欠费" in msg
+    assert "对象存储" in msg
+
+
+def test_put_bytes_wraps_backend_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Boom:
+        def put_bytes(self, *args, **kwargs):  # noqa: ANN002, ANN003
+            raise Exception(
+                "An error occurred (UnavailableForLegalReasons) when calling "
+                "the PutObject operation: Due to your account is arrears"
+            )
+
+        def enabled_remote(self) -> bool:
+            return True
+
+    monkeypatch.setattr("app.services.storage.get_storage", lambda: Boom())
+    with pytest.raises(RuntimeError, match="欠费"):
+        put_bytes("assets/x.bin", b"hi", content_type="application/octet-stream")

--- a/apps/api/tests/unit_tests/test_upload_jobs.py
+++ b/apps/api/tests/unit_tests/test_upload_jobs.py
@@ -82,6 +82,31 @@ def test_get_upload_job_ok(monkeypatch: pytest.MonkeyPatch):
         assert body["result"]["item"]["url"] == "https://cdn.example/a.png"
 
 
+def test_upload_job_temp_dir_under_upload_dir(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    from app.api.routes import upload_jobs as route_mod
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "upload_dir", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    dest = route_mod._upload_job_temp_dir()
+    assert dest == (tmp_path / "upload_jobs").resolve()
+    assert dest.is_dir()
+
+
+def test_execute_upload_job_missing_temp_raises():
+    from app.api.routes.upload_jobs import execute_upload_job
+
+    with pytest.raises(RuntimeError, match="临时文件"):
+        execute_upload_job(
+            {
+                "user_id": "u1",
+                "temp_path": "/no/such/file",
+                "filename": "x.png",
+                "content_type": "image/png",
+            }
+        )
+
+
 def test_execute_upload_job_pushes_to_storage(monkeypatch: pytest.MonkeyPatch, tmp_path):
     from app.api.routes.upload_jobs import execute_upload_job
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -20,4 +20,6 @@ GOOGLE_CLIENT_ID=
 # VITE_DESKTOP_MODE=local          # sidecar SQLite API on 127.0.0.1:8000 (prod)
 # VITE_DESKTOP_MODE=cloud          # remote API only
 # VITE_API_BASE_URL=https://recombyn.com
+# Optional: change local API port when 8000 is occupied (Vite proxy + npm run dev:api).
+# VITE_DEV_API_PORT=8000
 

--- a/apps/web/src/service/upload.ts
+++ b/apps/web/src/service/upload.ts
@@ -1,7 +1,6 @@
 /**
- * Image upload → backend → Tencent COS (or local store).
- * Multipart + path-catch-all DELETE stay on ky `request`
- * (OpenAPI file schema is string[]; `{object_key:path}` is unsafe as a single oRPC param).
+ * Uploaded object metadata + DELETE helper.
+ * Canvas uploads use async jobs in `@/service/uploadJobs`.
  */
 
 import { request } from '@/utils/request';
@@ -15,23 +14,6 @@ export type UploadedFileItem = {
   width?: number | null;
   height?: number | null;
 };
-
-export type UploadFilesResult = {
-  items: UploadedFileItem[];
-};
-
-/** Upload one or more images/videos. Form field name: `files`. */
-export const uploadFiles = (
-  data: FormData,
-  opts?: { timeout?: number; signal?: AbortSignal }
-) =>
-  request<UploadFilesResult>({
-    url: '/api/v1/uploads',
-    method: 'post',
-    data,
-    timeout: opts?.timeout ?? 600000,
-    signal: opts?.signal,
-  });
 
 /** DELETE /api/v1/uploads/files/{encodedKeyPath} (`{object_key:path}`). */
 export const deleteUploadedFile = (encodedKeyPath: string) =>

--- a/apps/web/src/utils/uploadImage.ts
+++ b/apps/web/src/utils/uploadImage.ts
@@ -5,10 +5,9 @@
 
 import {
   deleteUploadedFile as deleteUploadedFileApi,
-  uploadFiles,
   type UploadedFileItem,
 } from '@/service/upload';
-import { uploadFileViaJob, dispatchUploadJobCreated, uploadTimeoutForMime } from '@/service/uploadJobs';
+import { uploadFileViaJob, dispatchUploadJobCreated } from '@/service/uploadJobs';
 import { resolveApiUrl } from '@/utils/apiBase';
 import { getToken } from '@/utils/token';
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import fs from 'fs';
 import path from 'path';
 import { createSvgIconsPlugin } from 'vite-plugin-svg-icons';
+import { resolveDevApiPort } from '../../scripts/dev-api-port.mjs';
 
 const isTauri = Boolean(process.env.TAURI_ENV_PLATFORM);
 
@@ -39,12 +40,13 @@ export default defineConfig(({ mode }) => {
   )
     .trim()
     .replace(/\/$/, '');
+  const devApiPort = resolveDevApiPort({ ...process.env, ...envWeb, ...envRoot });
 
   // Default proxy → local uvicorn. Only remote http(s) hosts override the target.
   const apiProxyTarget =
     apiBaseUrl && /^https?:\/\//i.test(apiBaseUrl) && !/127\.0\.0\.1|localhost/i.test(apiBaseUrl)
       ? apiBaseUrl
-      : 'http://127.0.0.1:8000';
+      : `http://127.0.0.1:${devApiPort}`;
   const apiProxySecure = /^https:\/\//i.test(apiProxyTarget);
 
   const commercialDevRoot = path.resolve(__dirname, '../../src/commercial/web');
@@ -127,7 +129,7 @@ export default defineConfig(({ mode }) => {
         'X-Frame-Options': 'SAMEORIGIN',
         'Referrer-Policy': 'strict-origin-when-cross-origin',
         'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=()',
-        'Content-Security-Policy': "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self' https://accounts.google.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: blob: https:; media-src 'self' data: blob: https:; connect-src 'self' https: wss: ws: blob: http://127.0.0.1:8000 http://localhost:8000 http://127.0.0.1:3000 http://localhost:3000; worker-src 'self' blob:; child-src 'self' blob:; frame-src 'self'",
+        'Content-Security-Policy': `default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self' https://accounts.google.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com https://cdn.jsdelivr.net; img-src 'self' data: blob: https:; media-src 'self' data: blob: https:; connect-src 'self' https: wss: ws: blob: http://127.0.0.1:${devApiPort} http://localhost:${devApiPort} http://127.0.0.1:3000 http://localhost:3000; worker-src 'self' blob:; child-src 'self' blob:; frame-src 'self'`,
       },
       fs: {
         allow: [path.resolve(__dirname), path.resolve(__dirname, '../..')],

--- a/deploy/caddy/Caddyfile.recombyn
+++ b/deploy/caddy/Caddyfile.recombyn
@@ -4,6 +4,12 @@ http://43.143.230.24 {
 	reverse_proxy 127.0.0.1:3000
 }
 
+# MinIO public object URLs (S3 path-style: /recombyn/<key>)
+files.recombyn.com {
+	encode gzip
+	reverse_proxy 127.0.0.1:9000
+}
+
 recombyn.com, www.recombyn.com {
 	encode gzip
 

--- a/deploy/vps/README.zh-CN.md
+++ b/deploy/vps/README.zh-CN.md
@@ -1,0 +1,133 @@
+# VPS 部署（MySQL + MinIO）
+
+目标机器：`43.143.230.24` · 域名 `recombyn.com` · 文件 CDN `files.recombyn.com`
+
+不再使用腾讯云 CynosDB / COS；数据库和对象存储都在本机 Docker 里。
+
+## 一、云上一键部署
+
+### 1. 登录 VPS
+
+```bash
+ssh root@43.143.230.24
+```
+
+### 2. 首次装 Docker + Caddy（只需一次）
+
+```bash
+cd /opt
+git clone <你的私有仓库地址> recombyn
+cd recombyn
+bash deploy/vps/bootstrap-server.sh
+```
+
+### 3. 配置密钥
+
+```bash
+cp deploy/vps/.env.production.example .env
+nano .env                    # MySQL / MinIO / COLLAB 等强密码
+
+cp apps/api/.env.selfhost.example apps/api/.env
+nano apps/api/.env           # 合并 Profile B + 你的 LLM API keys
+```
+
+`apps/api/.env` 里务必包含（容器内网络）：
+
+```env
+DATABASE_URL=mysql://recombyn:<密码>@mysql:3306/recombyn
+S3_ENABLED=true
+S3_ENDPOINT_URL=http://minio:9000
+S3_PUBLIC_BASE_URL=https://files.recombyn.com/recombyn
+S3_ACCESS_KEY=<与 .env 里 MINIO_ROOT_USER 一致>
+S3_SECRET_KEY=<与 .env 里 MINIO_ROOT_PASSWORD 一致>
+CORS_ORIGINS=["https://recombyn.com","https://www.recombyn.com"]
+COLLAB_PUBLIC_WS_URL=wss://recombyn.com/collab
+AUTH_CONSOLE_LOGIN_CODE=false
+```
+
+**不要**再设置 `*.tencentcdb.com` 或 `cos.*.myqcloud.com`。
+
+### 4. DNS
+
+| 记录 | 指向 |
+|------|------|
+| `recombyn.com` / `www` | `43.143.230.24` |
+| `files.recombyn.com` | `43.143.230.24` |
+
+### 5. Caddy + 启动
+
+```bash
+cp deploy/caddy/Caddyfile.recombyn /etc/caddy/Caddyfile
+systemctl enable caddy && systemctl reload caddy
+
+bash deploy/vps/deploy.sh
+```
+
+### 6. 验收
+
+```bash
+curl -s http://127.0.0.1:8000/api/v1/health
+# 期望: "db":"mysql", "s3": true
+
+curl -I https://recombyn.com
+curl -I https://files.recombyn.com/minio/health/live
+```
+
+---
+
+## 二、本地搭建（与线上同栈：MySQL + MinIO）
+
+Windows / macOS 开发机：
+
+### 1. 安装 Docker Desktop
+
+确保 `docker compose` 可用。
+
+### 2. 起基础设施
+
+```powershell
+cd E:\Tianmeng\resume-creation-web
+npm run dev:infra
+```
+
+会启动：`mysql` · `redis` · `minio` · 自动建桶 `recombyn`。
+
+### 3. API 环境
+
+`apps/api/.env` 已配置为：
+
+- `DATABASE_URL=mysql://recombyn:recombyn@127.0.0.1:3306/recombyn`
+- MinIO：`http://127.0.0.1:9000`，公开 URL 前缀 `http://127.0.0.1:9000/recombyn`
+
+### 4. 启动应用
+
+```powershell
+npm run dev:api
+npm run dev:worker
+npm run dev:web
+# 可选
+npm run dev:intelligence
+```
+
+或使用一键栈：
+
+```powershell
+npm run dev:stack
+```
+
+### 5. 本地验收
+
+| 服务 | 地址 |
+|------|------|
+| Web | http://localhost:3000 |
+| API | http://localhost:8000/docs |
+| MinIO 控制台 | http://127.0.0.1:9001 （minioadmin / minioadmin） |
+| Health | http://127.0.0.1:8000/api/v1/health → `"s3": true` |
+
+---
+
+## 从腾讯云迁出（已有数据时）
+
+1. 导出 CynosDB → `mysqldump`，导入 compose MySQL 卷。
+2. COS 对象可用 `mc mirror cos/... local/recombyn/` 迁到 MinIO。
+3. 确认 `S3_PUBLIC_BASE_URL` 指向新域名后再切流量。

--- a/deploy/vps/bootstrap-server.sh
+++ b/deploy/vps/bootstrap-server.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# First-time VPS prep (Ubuntu 22.04+). Run as root once.
+set -euo pipefail
+
+apt-get update
+apt-get install -y ca-certificates curl git ufw
+
+# Docker Engine + Compose plugin
+if ! command -v docker >/dev/null 2>&1; then
+  curl -fsSL https://get.docker.com | sh
+fi
+
+# Caddy (HTTPS)
+if ! command -v caddy >/dev/null 2>&1; then
+  apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
+  curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+  curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list
+  apt-get update
+  apt-get install -y caddy
+fi
+
+ufw allow OpenSSH
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw --force enable
+
+echo "[bootstrap] Docker: $(docker --version)"
+echo "[bootstrap] Next:"
+echo "  git clone <your-private-repo> /opt/recombyn && cd /opt/recombyn"
+echo "  cp deploy/vps/.env.production.example .env && nano .env"
+echo "  cp apps/api/.env.selfhost.example apps/api/.env && nano apps/api/.env"
+echo "  cp deploy/caddy/Caddyfile.recombyn /etc/caddy/Caddyfile && systemctl reload caddy"
+echo "  bash deploy/vps/deploy.sh"

--- a/deploy/vps/deploy.sh
+++ b/deploy/vps/deploy.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# One-shot (re)deploy on VPS — MySQL + MinIO + full stack.
+# Run on the server from repo root after .env and apps/api/.env are configured.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+if [[ ! -f .env ]]; then
+  echo "Missing .env — copy deploy/vps/.env.production.example to .env and edit secrets."
+  exit 1
+fi
+
+if [[ ! -f apps/api/.env ]]; then
+  echo "Missing apps/api/.env — copy apps/api/.env.selfhost.example Profile B and add LLM keys."
+  exit 1
+fi
+
+COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.prod.yml)
+
+if [[ -n "${RECOMBYN_TAG:-}" && -f docker-compose.ghcr.yml ]]; then
+  COMPOSE+=(-f docker-compose.ghcr.yml)
+  echo "[deploy] Using GHCR images tag=${RECOMBYN_TAG}"
+  "${COMPOSE[@]}" pull
+else
+  echo "[deploy] Building images locally..."
+fi
+
+"${COMPOSE[@]}" up -d --build mysql redis minio minio-init
+"${COMPOSE[@]}" up -d --build api worker collab web
+
+echo "[deploy] Waiting for API health..."
+for i in $(seq 1 60); do
+  if curl -fsS http://127.0.0.1:8000/api/v1/health >/dev/null 2>&1; then
+    curl -fsS http://127.0.0.1:8000/api/v1/health
+    echo
+    echo "[deploy] OK — reload Caddy if Caddyfile changed: systemctl reload caddy"
+    exit 0
+  fi
+  sleep 3
+done
+
+echo "[deploy] API did not become healthy in time — check: docker compose logs api --tail=100"
+exit 1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,25 @@
+# Production overrides — use with root .env (see deploy/vps/.env.production.example)
+#
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+#
+# Binds app ports to localhost only (Caddy on :443 → :3000; MinIO via files.* subdomain).
+
+services:
+  api:
+    ports:
+      - "127.0.0.1:8000:8000"
+    environment:
+      - AUTH_CONSOLE_LOGIN_CODE=${AUTH_CONSOLE_LOGIN_CODE:-false}
+      - CORS_ORIGINS=${CORS_ORIGINS:-["https://recombyn.com","https://www.recombyn.com"]}
+      - COLLAB_PUBLIC_WS_URL=${COLLAB_PUBLIC_WS_URL:-wss://recombyn.com/collab}
+      - PUBLIC_APP_BASE_URL=${PUBLIC_APP_BASE_URL:-https://recombyn.com}
+      - S3_PUBLIC_BASE_URL=${S3_PUBLIC_BASE_URL:-https://files.recombyn.com/recombyn}
+      - WALLET_BILLING_ENABLED=${WALLET_BILLING_ENABLED:-true}
+
+  web:
+    ports:
+      - "127.0.0.1:3000:80"
+
+  worker:
+    environment:
+      - WALLET_BILLING_ENABLED=${WALLET_BILLING_ENABLED:-true}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,37 @@ services:
       timeout: 3s
       retries: 10
 
+  minio:
+    image: minio/minio:RELEASE.2025-01-20T14-49-07Z
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+    ports:
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
+    volumes:
+      - minio_data:/data
+
+  minio-init:
+    image: minio/mc:RELEASE.2025-01-20T14-49-07Z
+    depends_on:
+      minio:
+        condition: service_started
+    restart: on-failure
+    entrypoint: >
+      /bin/sh -c "
+      until mc alias set local http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD}; do sleep 1; done;
+      mc mb local/$${MINIO_BUCKET} --ignore-existing;
+      mc anonymous set download local/$${MINIO_BUCKET};
+      exit 0;
+      "
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_BUCKET: ${MINIO_BUCKET:-recombyn}
+
   web:
     build:
       context: .
@@ -100,12 +131,23 @@ services:
       - RECOMBYN_INTELLIGENCE_API_KEY=${RECOMBYN_INTELLIGENCE_API_KEY:-}
       - RECOMBYN_INTELLIGENCE_TIMEOUT_SEC=${RECOMBYN_INTELLIGENCE_TIMEOUT_SEC:-30}
       - RECOMBYN_INTELLIGENCE_CIRCUIT_SEC=${RECOMBYN_INTELLIGENCE_CIRCUIT_SEC:-30}
+      - S3_ENABLED=${S3_ENABLED:-true}
+      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
+      - S3_ACCESS_KEY=${S3_ACCESS_KEY:-minioadmin}
+      - S3_SECRET_KEY=${S3_SECRET_KEY:-minioadmin}
+      - S3_BUCKET=${S3_BUCKET:-recombyn}
+      - S3_REGION=${S3_REGION:-us-east-1}
+      - S3_PUBLIC_BASE_URL=${S3_PUBLIC_BASE_URL:-http://127.0.0.1:9000/recombyn}
+      - S3_ADDRESSING_STYLE=${S3_ADDRESSING_STYLE:-path}
+      - S3_ACL_PUBLIC_READ=${S3_ACL_PUBLIC_READ:-true}
 
     depends_on:
       redis:
         condition: service_healthy
       mysql:
         condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
       collab:
         condition: service_started
 
@@ -187,11 +229,22 @@ services:
       - IMPORT_DPI=${IMPORT_DPI:-200}
       - DATABASE_URL=${DATABASE_URL:-mysql://recombyn:recombyn@mysql:3306/recombyn}
       - WALLET_BILLING_ENABLED=${WALLET_BILLING_ENABLED:-false}
+      - S3_ENABLED=${S3_ENABLED:-true}
+      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
+      - S3_ACCESS_KEY=${S3_ACCESS_KEY:-minioadmin}
+      - S3_SECRET_KEY=${S3_SECRET_KEY:-minioadmin}
+      - S3_BUCKET=${S3_BUCKET:-recombyn}
+      - S3_REGION=${S3_REGION:-us-east-1}
+      - S3_PUBLIC_BASE_URL=${S3_PUBLIC_BASE_URL:-http://127.0.0.1:9000/recombyn}
+      - S3_ADDRESSING_STYLE=${S3_ADDRESSING_STYLE:-path}
+      - S3_ACL_PUBLIC_READ=${S3_ACL_PUBLIC_READ:-true}
     depends_on:
       redis:
         condition: service_healthy
       mysql:
         condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
       api:
         condition: service_started
 
@@ -199,6 +252,7 @@ services:
 volumes:
   redis_data:
   mysql_data:
+  minio_data:
   clamav_data:
   prometheus_data:
   grafana_data:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -2,7 +2,7 @@
 
 You can run the full product on your own machine or server: web canvas, Design Agent, API, collab, and a database.
 
-Docker Compose is the default (**MySQL** + Redis + web + API + **Yjs**). Local npm + empty `DATABASE_URL` uses **SQLite**. Desktop (Tauri): **[desktop.md](./desktop.md)** — **Local** (sidecar + SQLite) / **Cloud** (same API as the browser).
+Docker Compose is the default (**MySQL** + **MinIO** + Redis + web + API + **Yjs**). Local npm dev uses the same **MySQL + MinIO** stack via `npm run dev:infra`. Empty `DATABASE_URL` (without MySQL in `.env`) falls back to **SQLite**. Desktop (Tauri): **[desktop.md](./desktop.md)** — **Local** (sidecar + SQLite) / **Cloud** (same API as the browser).
 
 ## What you get
 
@@ -17,6 +17,7 @@ Docker Compose is the default (**MySQL** + Redis + web + API + **Yjs**). Local n
 | ClamAV (optional) | `docker compose --profile av -f docker-compose.yml -f docker-compose.av.yml up -d --build` |
 | Agent seeds | prompt packs + skills + **AgentProfile** YAML from `apps/api/seeds/` |
 | **MySQL 8** | compose service + volume `mysql_data` |
+| **MinIO** (S3 API) | compose service + volume `minio_data` · console http://127.0.0.1:9001 |
 | Redis | Celery / queues |
 | Optional IntelligenceProvider | `docker compose -f docker-compose.yml -f docker-compose.intelligence.yml --profile intelligence up` · HTTP only · see [ADR 0017](./adr/0017-intelligence-provider-boundary.md) |
 
@@ -28,7 +29,10 @@ Host tools can reach MySQL at `127.0.0.1:3306` (same user/password). Change via 
 
 **Quality gates (Pytest / Playwright / k6 / Prometheus):** [quality-gates.md](./quality-gates.md).
 
-**Dev without Docker MySQL:** leave `DATABASE_URL` empty → SQLite at `storage/recombyn.db`.
+**Dev without Docker MySQL:** leave `DATABASE_URL` empty → SQLite at `storage/recombyn.db`.  
+**Recommended local dev:** `npm run dev:infra` then set `DATABASE_URL=mysql://recombyn:recombyn@127.0.0.1:3306/recombyn` and MinIO vars in `apps/api/.env` (see `apps/api/.env.selfhost.example`).
+
+Object storage defaults to **MinIO** (`S3_ENABLED=true`). Bucket `recombyn` is created on first boot; public read URLs use `S3_PUBLIC_BASE_URL` (local: `http://127.0.0.1:9000/recombyn`). Do not use Tencent COS unless you intentionally switch back.
 
 Default config loads from seed JSON under `apps/api/seeds/` on first API start.
 
@@ -330,23 +334,38 @@ Optional when billing is on:
 - Issue card keys (admin + `CARD_KEY_SALT` / `CARD_KEY_OPS_PASSWORD`)
 
 
-## Dev path (SQLite, no compose MySQL)
+## Dev path (MySQL + MinIO, npm on host)
+
+```bash
+npm run dev:infra   # mysql + redis + minio (+ bucket init)
+cp apps/api/.env.selfhost.example apps/api/.env   # merge LLM keys
+# Profile A in .env.selfhost.example: DATABASE_URL + S3_* → 127.0.0.1
+npm install
+npm run dev:api
+npm run dev:worker
+npm run dev:web
+```
+
+MinIO console: http://127.0.0.1:9001 (`minioadmin` / `minioadmin` by default).
+
+## Dev path (SQLite only, no MinIO)
 
 ```bash
 docker compose up -d redis
 cp apps/api/.env.example apps/api/.env
-# DATABASE_URL empty → SQLite
+# DATABASE_URL empty → SQLite; S3_ENABLED=false
 npm install
 npm run dev:api
 npm run dev:web
 ```
 
-To use compose MySQL from host uvicorn:
+To use compose MySQL from host uvicorn without MinIO (disk storage):
 
 ```bash
 docker compose up -d mysql redis
 # apps/api/.env:
 # DATABASE_URL=mysql://recombyn:recombyn@127.0.0.1:3306/recombyn
+# S3_ENABLED=false
 ```
 
 ## Canvas multiplayer (Yjs / WSS)

--- a/oss-stubs/apps/web/src/commercial/editorHosts.tsx
+++ b/oss-stubs/apps/web/src/commercial/editorHosts.tsx
@@ -1,9 +1,0 @@
-import type { SceneDocument } from '@/components/rcb/sceneNode';
-import type { ReactNode } from 'react';
-
-export function CommercialEditorHosts(_props: {
-  document: SceneDocument;
-  selectionTransforming?: boolean;
-}): ReactNode {
-  return null;
-}

--- a/oss-stubs/apps/web/src/commercial/imageToolbarTools.tsx
+++ b/oss-stubs/apps/web/src/commercial/imageToolbarTools.tsx
@@ -1,3 +1,0 @@
-export function CommercialImageToolbarTools(_props: { nodeId: string }): null {
-  return null;
-}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "build:desktop:sidecar": "node scripts/dev-desktop.mjs sidecar",
     "dev:api": "node scripts/dev-api.mjs",
     "dev:worker": "node scripts/dev-worker.mjs",
+    "dev:infra": "docker compose up -d mysql redis minio minio-init",
+    "setup:local": "powershell -ExecutionPolicy Bypass -File scripts/setup-local.ps1",
     "gen:contracts": "npm run gen --workspace=@recombyn/contracts",
     "build": "turbo run build --filter=@recombyn/web",
     "lint": "turbo run lint",

--- a/scripts/dev-api-port.mjs
+++ b/scripts/dev-api-port.mjs
@@ -1,0 +1,10 @@
+/** Shared local API port for Vite proxy and `npm run dev:api`. */
+export const DEFAULT_DEV_API_PORT = 8000;
+
+/** Read `VITE_DEV_API_PORT` from process env (supports merged Vite loadEnv objects). */
+export function resolveDevApiPort(env = process.env) {
+  const raw = String(env.VITE_DEV_API_PORT || '').trim();
+  if (!raw) return DEFAULT_DEV_API_PORT;
+  const port = Number.parseInt(raw, 10);
+  return Number.isFinite(port) && port > 0 ? port : DEFAULT_DEV_API_PORT;
+}

--- a/scripts/dev-api.mjs
+++ b/scripts/dev-api.mjs
@@ -1,7 +1,8 @@
-import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolveDevApiPort } from './dev-api-port.mjs';
 
 const apiRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../apps/api');
 const repoRoot = path.resolve(apiRoot, '../..');
@@ -13,13 +14,30 @@ const win = process.platform === 'win32';
 const venvPy = path.join(apiRoot, '.venv', win ? 'Scripts/python.exe' : 'bin/python');
 const py = existsSync(venvPy) ? venvPy : 'python';
 const sqliteRel = path.join('storage', 'recombyn.db').replace(/\\/g, '/');
+const devApiPort = resolveDevApiPort(process.env);
 
-/** Local web dev: avoid hanging on remote MySQL in apps/api/.env unless opted in. */
+function loadApiDotEnv() {
+  const envPath = path.join(apiRoot, '.env');
+  if (!existsSync(envPath)) return {};
+  const out = {};
+  for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq <= 0) continue;
+    out[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+  }
+  return out;
+}
+
+/** Local web dev: default SQLite unless apps/api/.env sets DATABASE_URL or USE_REMOTE_DB=1. */
 function devApiEnv() {
-  const env = { ...process.env, RECOMBYN_API_ROOT: apiRoot };
+  const fileEnv = loadApiDotEnv();
+  const env = { ...process.env, ...fileEnv, RECOMBYN_API_ROOT: apiRoot };
   const useRemote =
     String(env.USE_REMOTE_DB || '').trim() === '1' ||
-    String(env.USE_REMOTE_DB || '').toLowerCase() === 'true';
+    String(env.USE_REMOTE_DB || '').toLowerCase() === 'true' ||
+    Boolean(String(env.DATABASE_URL || '').trim());
   if (!useRemote) {
     env.DATABASE_URL = `sqlite:///${sqliteRel}`;
     env.SQLITE_DB_PATH = sqliteRel;
@@ -38,9 +56,21 @@ if (!existsSync(venvPy)) {
   );
 }
 
+// Drop stale listeners so Vite proxy and uvicorn stay on the same port.
+spawnSync('npx', ['--yes', 'kill-port', String(devApiPort)], { stdio: 'ignore', shell: win });
+
 const child = spawn(
   py,
-  ['-m', 'uvicorn', 'app.main:app', '--reload', '--host', '127.0.0.1', '--port', '8000'],
+  [
+    '-m',
+    'uvicorn',
+    'app.main:app',
+    '--reload',
+    '--host',
+    '127.0.0.1',
+    '--port',
+    String(devApiPort),
+  ],
   { cwd: apiRoot, stdio: 'inherit', env: devApiEnv() }
 );
 child.on('exit', (code, signal) => {

--- a/scripts/setup-local.ps1
+++ b/scripts/setup-local.ps1
@@ -1,0 +1,46 @@
+# Local dev stack: Docker MySQL + Redis + MinIO, then npm services.
+# Usage: powershell -ExecutionPolicy Bypass -File scripts/setup-local.ps1
+
+$ErrorActionPreference = "Stop"
+$Root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+Set-Location $Root
+
+function Test-Command($name) {
+  return [bool](Get-Command $name -ErrorAction SilentlyContinue)
+}
+
+Write-Host "==> Recombyn local setup (MySQL + MinIO)" -ForegroundColor Cyan
+
+if (-not (Test-Command docker)) {
+  Write-Host "Docker not found. Install Docker Desktop first:" -ForegroundColor Red
+  Write-Host "  https://www.docker.com/products/docker-desktop/"
+  exit 1
+}
+
+Write-Host "==> Starting mysql, redis, minio..."
+docker compose up -d mysql redis minio minio-init
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+Write-Host "==> Waiting for MySQL..."
+$ready = $false
+for ($i = 0; $i -lt 40; $i++) {
+  docker compose exec -T mysql mysqladmin ping -h 127.0.0.1 -urecombyn -precombyn 2>$null | Out-Null
+  if ($LASTEXITCODE -eq 0) { $ready = $true; break }
+  Start-Sleep -Seconds 2
+}
+if (-not $ready) {
+  Write-Host "MySQL not ready — check: docker compose logs mysql" -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "Infrastructure ready." -ForegroundColor Green
+Write-Host "  MinIO console : http://127.0.0.1:9001  (minioadmin / minioadmin)"
+Write-Host "  MySQL         : 127.0.0.1:3306         (recombyn / recombyn)"
+Write-Host ""
+Write-Host "Start app (separate terminals):"
+Write-Host "  npm run dev:api"
+Write-Host "  npm run dev:worker"
+Write-Host "  npm run dev:web"
+Write-Host ""
+Write-Host "Health check after API starts:"
+Write-Host "  curl http://127.0.0.1:8000/api/v1/health"


### PR DESCRIPTION
{
  "message": "fix: upload jobs, strict storage errors, and relocate OSS stubs\n\nMove oss-stubs under scripts/ and exclude sync tooling from the public mirror.\nSurface object-storage failures (including arrears) instead of silent local fallback.\nShare upload job temp dir with the worker volume and nest upload_jobs under uploads.\nUnify local dev API port config and add MinIO/VPS self-host helpers.\n\nSync-source: recombyn-dev@fb8496c",
  "tree": "38b1eea644a91a0adc0520e9854b0a74e060d0a2",
  "parents": ["1073c3290192e95cc20b042a87e270bfe5510c45"]
}
