### PR TITLE
fix(web): update animation transport with empty boards and Redux play state

### DIFF
--- a/apps/web/src/components/editor/nodes/AnimationNode/AnimationNodeOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/AnimationNode/AnimationNodeOverlay.tsx
@@ -14,6 +14,7 @@ import {
   memo,
 } from 'react';
 import { createPortal } from 'react-dom';
+import { useSelector } from 'react-redux';
 import lottie, { type AnimationItem } from 'lottie-web';
 import { useRcbCamera } from '@/components/rcb';
 import {
@@ -112,6 +113,10 @@ function LottiePlate({
   const camera = useRcbCamera();
   const z = Math.max(0.05, camera.zoom || 1);
   const fill = resolveLottiePlateFill(plateFill, frameHost);
+  const reduxPlaying = useSelector((s: any) => Boolean(s.editor.lottiePlaying));
+  const playingHostId = useSelector((s: any) =>
+    String(s.editor.lottiePlayingHostId || '').trim()
+  );
 
   useEffect(() => {
     const host = hostEl;
@@ -124,6 +129,8 @@ function LottiePlate({
       | {
           lottieTimelinePanel?: { nodeId?: string } | null;
           lottiePlayheadSec?: number;
+          lottiePlaying?: boolean;
+          lottiePlayingHostId?: string | null;
         }
       | undefined;
     const timelineOwns =
@@ -136,9 +143,9 @@ function LottiePlate({
         // FO + CSS zoom scale still works for path ink; dock/lightbox also use SVG.
         renderer: 'svg',
         loop,
-        // When the timeline dock owns this node, stay paused at the playhead
-        // so JSON patches don't jump back to t=0 with autoplay.
-        autoplay: !timelineOwns,
+        // Never autoplay — Redux transport owns play/pause. Leftover autoplay
+        // kept the ink moving while the toolbar still showed the play icon.
+        autoplay: false,
         animationData: structuredClone
           ? structuredClone(data)
           : JSON.parse(JSON.stringify(data)),
@@ -188,8 +195,14 @@ function LottiePlate({
       getDurationSec: durationSec,
     };
     lottieHosts.set(nodeId, api);
-    if (timelineOwns) {
-      api.seek(Math.min(restoreSec, durationSec()));
+    const at = Math.min(restoreSec, durationSec());
+    const hostMatches =
+      !String(editorState?.lottiePlayingHostId || '').trim() ||
+      String(editorState?.lottiePlayingHostId) === String(nodeId);
+    if (Boolean(editorState?.lottiePlaying) && hostMatches && !timelineOwns) {
+      api.playFrom(at);
+    } else {
+      api.seek(at);
     }
     return () => {
       anim.destroy();
@@ -212,6 +225,18 @@ function LottiePlate({
     if (!anim) return;
     anim.setSpeed(speed);
   }, [speed]);
+
+  // Keep host ink in lockstep with Redux play/pause (icon ↔ visual).
+  useEffect(() => {
+    const api = lottieHosts.get(nodeId);
+    if (!api) return;
+    const mine = !playingHostId || playingHostId === String(nodeId);
+    if (reduxPlaying && mine) {
+      if (api.isPaused()) api.play();
+    } else if (!api.isPaused()) {
+      api.pause();
+    }
+  }, [reduxPlaying, playingHostId, nodeId, hostEl, animationJson]);
 
   return createPortal(
     <div

--- a/apps/web/src/components/editor/nodes/AnimationNode/AnimationTimelineDock.tsx
+++ b/apps/web/src/components/editor/nodes/AnimationNode/AnimationTimelineDock.tsx
@@ -72,6 +72,7 @@ import {
   resolveAnimationLayerLink,
 } from '@/components/editor/nodes/AnimationNode/animationAutoKey';
 import { buildScenePosePatchesFromAnimation } from '@/components/editor/nodes/AnimationNode/animationScenePoseSync';
+import { animationHasPlayableContent } from '@/components/editor/nodes/AnimationNode/animationFrameSync';
 import { isAnimationFrameHostNode } from '@/components/rcb/scene/document/nodeCapabilities';
 import { nodeIdsBoundToFrames } from '@/components/rcb/scene/document/sceneClipboard';
 import {
@@ -1992,7 +1993,7 @@ function AnimationTimelineDock({
             <AnimationTransportControls
               playing={playing}
               loop={loop}
-              ready={Boolean(animationData)}
+              ready={animationHasPlayableContent(animationData)}
               onPlayPause={togglePlay}
               onStepFrame={(dir) => seekTo(playhead + dir / fps, { pause: true })}
               onSeekEdge={(toEnd) =>

--- a/apps/web/src/components/editor/nodes/AnimationNode/AnimationToolbarEditTools.tsx
+++ b/apps/web/src/components/editor/nodes/AnimationNode/AnimationToolbarEditTools.tsx
@@ -18,6 +18,7 @@ import {
   frameToSec,
   snapSecToFrame,
 } from '@/components/editor/nodes/AnimationNode/animationTimelineModel';
+import { animationHasPlayableContent } from '@/components/editor/nodes/AnimationNode/animationFrameSync';
 import { isAnimationArtboardKind } from '@/components/rcb/frames/types';
 import {
   openLottieTimelinePanel,
@@ -95,6 +96,10 @@ function AnimationToolbarEditTools({
     const fr = frames.find((f: any) => String(f?.id) === animationFrameId);
     return fr && isAnimationArtboardKind(fr.kind) ? fr : null;
   }, [animationFrameId, document]);
+  const hasPlayableContent = useMemo(
+    () => animationHasPlayableContent(node?.attrs?.animationData),
+    [node?.attrs?.animationData]
+  );
   const animationIntent = Boolean(animationFrameId);
 
   const bounds = useMemo(() => {
@@ -117,14 +122,19 @@ function AnimationToolbarEditTools({
 
   useEffect(() => {
     const sync = () => {
-      setPlaybackReady(
-        Boolean(getLottieHost(nodeId)) || timelineOpen || Boolean(workbenchFrame)
-      );
+      // Empty 动画工作台 still has a plate + host — only enable when layers exist.
+      setPlaybackReady(hasPlayableContent && Boolean(getLottieHost(nodeId)));
     };
     sync();
     const id = window.setInterval(sync, 400);
     return () => window.clearInterval(id);
-  }, [nodeId, timelineOpen, workbenchFrame]);
+  }, [nodeId, hasPlayableContent]);
+
+  useEffect(() => {
+    if (hasPlayableContent || !lottiePlaying) return;
+    dispatch(setLottiePlaying(false));
+    getLottieHost(nodeId)?.pause();
+  }, [dispatch, hasPlayableContent, lottiePlaying, nodeId]);
 
   const speedItems: MenuItemType[] = [
     { key: '0.5', label: '0.5×' },
@@ -156,6 +166,7 @@ function AnimationToolbarEditTools({
   };
 
   const onTogglePlay = () => {
+    if (!hasPlayableContent) return;
     const { workInSec, workOutSec } = bounds;
     if (workbenchFrame || animationIntent) {
       if (lottiePlaying) {
@@ -226,7 +237,7 @@ function AnimationToolbarEditTools({
       >
         <span
           aria-hidden
-          className="block h-3 w-3 shrink-0 rotate-45 border-[1.5px] border-current bg-transparent"
+          className="block h-2.5 w-2.5 shrink-0 rotate-45 border-[1.5px] border-current bg-transparent"
         />
       </Tool>
       <ImageToolSep />

--- a/apps/web/src/components/editor/nodes/AnimationNode/AnimationTransportControls.tsx
+++ b/apps/web/src/components/editor/nodes/AnimationNode/AnimationTransportControls.tsx
@@ -135,6 +135,7 @@ function AnimationTransportControls({
         onClick={onToggleLoop}
         active={loop}
         muted={!loop}
+        disabled={!ready}
       >
         {loop ? (
           <TbRepeat className="h-3.5 w-3.5" strokeWidth={1.75} />

--- a/apps/web/src/components/editor/nodes/AnimationNode/__tests__/animationFrameSync.test.ts
+++ b/apps/web/src/components/editor/nodes/AnimationNode/__tests__/animationFrameSync.test.ts
@@ -1,11 +1,43 @@
 import { describe, expect, it } from 'vitest';
 import {
   animationHostHasUnlinkedInk,
+  animationHasPlayableContent,
   syncArtboardChildrenIntoAnimation,
 } from '../animationFrameSync';
 import { buildLottieTimelineScenes } from '../animationTimelineModel';
 import { parseLottieAnimationData } from '@/components/rcb/scene/document/nodeFactories';
 import type { SceneDocument } from '@/components/rcb/sceneNode';
+
+describe('animationHasPlayableContent', () => {
+  it('is false for missing or empty-layer animation', () => {
+    expect(animationHasPlayableContent(null)).toBe(false);
+    expect(
+      animationHasPlayableContent({
+        v: '5.7.0',
+        fr: 30,
+        ip: 0,
+        op: 30,
+        w: 100,
+        h: 100,
+        layers: [],
+      })
+    ).toBe(false);
+  });
+
+  it('is true when at least one layer exists', () => {
+    expect(
+      animationHasPlayableContent({
+        v: '5.7.0',
+        fr: 30,
+        ip: 0,
+        op: 30,
+        w: 100,
+        h: 100,
+        layers: [{ ind: 1, ty: 4, ip: 0, op: 30 }],
+      })
+    ).toBe(true);
+  });
+});
 
 function makeDoc(): SceneDocument {
   const frameId = 'frame_lottie';

--- a/apps/web/src/components/editor/nodes/AnimationNode/animationFrameSync.ts
+++ b/apps/web/src/components/editor/nodes/AnimationNode/animationFrameSync.ts
@@ -32,6 +32,14 @@ export function animationHostHasUnlinkedInk(
   });
 }
 
+/** Empty workbench / blank seed — nothing meaningful to play or scrub. */
+export function animationHasPlayableContent(animationData: unknown): boolean {
+  const anim = parseLottieAnimationData(animationData);
+  if (!anim) return false;
+  const layers = Array.isArray(anim.layers) ? anim.layers : [];
+  return layers.length > 0;
+}
+
 /** Prefer clipboard helper; fall back to scanning deltaSetLike (partial docs / tests). */
 function listNodesBoundToFrame(document: SceneDocument, frameId: string): string[] {
   const wanted = String(frameId || '').trim();


### PR DESCRIPTION
fix(web): update animation transport with empty boards and Redux play state

- Disable play, seek, and loop when the animation workbench has no layers
- Stop Lottie host autoplay so the toolbar play/pause icon matches the ink
- Shrink the keyframe diamond icon by 2px

[skip ci]