### PR TITLE
fix(web): restore bumpSceneCanvasIdlePaint import and createSlice typo

### DIFF
--- a/apps/web/src/components/rcb/render/webgpuSceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/webgpuSceneRenderer.ts
@@ -13,7 +13,6 @@ import {
   shouldRunGpuDepthOfField,
 } from '@/components/rcb/render/gpuDepthOfField';
 import {
-  bumpSceneCanvasIdlePaint,
   getSharedSceneRenderBuffer,
   isSoaCanvasShapesEnabled,
   setSoaPaintDocument,
@@ -26,6 +25,7 @@ import {
 } from '@/components/rcb/render/webglInstanceAtlas';
 import { collectSoaWebglInstances } from '@/components/rcb/render/webglSceneRenderer';
 import {
+  bumpSceneCanvasIdlePaint,
   hitTestWithSpatialIndex,
   type CanvasSceneRendererDeps,
   type SceneRenderRequest,

--- a/apps/web/src/store/createSlice.ts
+++ b/apps/web/src/store/createSlice.ts
@@ -12,7 +12,7 @@ export type PayloadAction<P = void, T extends string = string> = {
 };
 
 export type Dispatch<A extends AnyAction = AnyAction> = (action: A) => A;
-a
+
 type CaseReducer<S, A extends AnyAction = AnyAction> = (
   state: S,
   action: A


### PR DESCRIPTION
fix(web): restore bumpSceneCanvasIdlePaint import and createSlice typo

- fix(web): restore bumpSceneCanvasIdlePaint import and createSlice typo
- feat(web): GPU DOF, canvas idle strokeAlign, and 10k mixed stress
- fix(web): SoA demotion single wake + dirty AABB lazy QT
- feat(web): SoA quadtree demotion bake, drop dual-path dead code, canvas docs
- fix(web,api): frame-local coords, workbench drag, text chrome, SoA hit
- fix(web,api): free chat UI after reply and harden canvas SoA
- feat(web): Zustand 直写 + 画布 SoA/手势/文本多项修复
- fix(web,api): canvas clip/flip/selectors, SoA render, dead vision cleanup
- fix(web): keep LOT preview after tab switch and persist precomp edits
- docs: point MCP canvas setup at Codex instead of Cursor
- fix(web): LOT tab materializes editable shapes and tighten workbench chrome
- chore: exclude pitch deck and private VPS scripts from OSS publish
- feat(web): unify animation workbench isolation policy and harden Lottie edit
- fix(web): tighten puppet animation UX, scope to workbench, restore minimap overview (#23)
- feat(web): add image puppet tool and harden animation workbench edit UX
- fix(web): hide preview guides in workbench edit and keep timeline open
- fix(web): gate animation workbench bind to open timeline and spawn on top
- fix(web): animation transport with empty boards and Redux play state (#20)
- feat: animation agent path and workbench timeline focus (#19)
- feat(web): add Lottie artboard timeline workbench
- checkpoint before checking out master
- checkpoint before checking out master
- fix(api): stop assets search matching meta_json base64 noise
- checkpoint before checking out master
- feat(web): blob upload previews and generator toolbar panel
- fix(web): stop SegmentTabs CJK labels wrapping inside chips
- ci(oss): mark no-cursor-coauthor status when merging zuoge PRs
- ci(oss): harden Publish OSS on Windows and keep zuoge merge gate
- fix(web): dock composers via SelectionToolbarShell and hide panels while transforming
- refactor(web): drop generator overlays and simplify composer chrome
- ci(oss): concrete public commit messages and no auto CI on zuoge
- ci: stop auto-running E2E, skill eval, and k6 on every push
- ci: scrub corrupted control chars from workflow YAML
- ci(e2e): honor E2E_PORT in Playwright webServer
- ci(e2e): use port 4173 on self-hosted so CI does not clash with :3000
- fix(web): keep generator composers mounted and wire Delete on empty prompts
- fix(web): scale text wrap width and keep selection chrome on-screen
- checkpoint before checking out master
- ci: run all workflows on self-hosted Windows runners
- fix(web): snap pasted nodes and artboards to the document grid
- fix(web): cap audio plate chrome like video playback bar
- feat: editor media chrome, asset search, and agent audio/lottie
- ci: align self-hosted runner setup with GitHub v2.336.0
- ci: run gate jobs on self-hosted Windows runner
- ci: retrigger workflows after lint and typecheck fixes
- fix(web): repair typecheck in mark and boolean union tests
- fix(api): remove unused imports after i18n refactor
- feat: soft-compress uploads, inline finish, agent harness seams
- docs: zh-CN README and api README nav
- docs: drop Cloud nav and deployment-modes from README index
- docs: remove cloud comparison from README and deployment guides
- fix(api): add apply_classified_model_route for memory graph node
- ci: retrigger workflows
- ci: retrigger workflows
- fix(api): remove unused import in memory graph node
- ci(api): allow F401 re-exports in graph state barrel
- fix(api): restore graph state protocol re-exports from main
- fix(api): import design protocol symbols from recombyn_protocol
- fix(api): re-export ReferenceIntelligenceTurnSchema from graph state
- fix(api): remove unused imports after auth cleanup
- refactor: unify cloud-only desktop and enable billing by default
- fix: correct stale paths after commercial and fixture cleanup
- chore: consolidate canvas stress E2E and fold k6 soak into smoke
- refactor: relocate closed-source tree from src/commercial into apps/
- chore: remove orphaned landing page SVG assets
- chore: round-2 dead code cleanup and dependency prune
- chore: remove dead code and unused imports across web and API
- feat(upload): chunked job uploads with refresh resume
- fix(ci): repair typecheck and web-unit failures on main
- fix: unify project/wallet cache and improve share/upload dev UX
- feat(editor): improve layer panel navigation and frame rename UX
- fix(ci): cast test harness dispatch to DesignToolContext
- fix(mcp): validate headless text nodes and harden canvas apply
- feat(mcp): align tool_ops apply with Agent flow and shared fixtures
- fix: include dev-api-port script in web Docker build
- docs: tidy README intro and move Star above MCP
- docs: remove MCP smoke test from user-facing docs
- feat: add MCP canvas control and remove desktop CLI mode
- refactor: unify ILP progress and env in deploy script
- fix: intelligence API key and improve ILP job progress
- fix(editor): clip smart guides to artboard overflow bounds
- fix: keep Intelligence vision responsive and stabilize ILP tooling
- fix: require intelligence API key in enable-ilp helper
- fix: theme mark chips and wire ILP env through compose
- feat: home copyright, JA Latin brand, generators and self-host polish
- chore: keep OSS commit messages free of publish-pipeline wording
- chore(): add one-shot rebuild script
- chore(): squash PRs to preserve commit titles
- chore(): use private commit messages on - fix: upload jobs, strict storage errors, and relocate OSS stubs
- fix(web): resolve runDesignAgent typecheck errors for CI
- fix(agent): vision Q&A for selection/mark chips and scoped publish glow
- fix: expand home rail by default and pad README wordmark
- fix: require strict media persistence and remove silent fallbacks
- fix(api): skip cover rebuild on rename-only PATCH (#7)
- fix: reposition home rail more menu when sidebar collapses
- fix: stop cover thumbnail flicker on home and publish dialog (#6)
- fix: project covers, list , editor nav, fonts and upload jobs (#5)
- fix(web): align share chrome with editor; show text typography in Inspect
- fix(web): drop local-only import scene test; fix mark targets fixture types
- fix(web,intel): brand 左格, mark media block, home rename , matting cache
- fix(web): add command_seq to transaction.chunk for DesignToolOpsEvent
- fix(editor): hide knobs while processing and restore chat bubble contrast
- fix(brand): use Latin zuoge wordmark across all locales
- docs(readme): enlarge brand wordmark ~2.5x
- fix(api): repair broken ILP decompose docstrings
- docs(readme): center brand header with a single div
- docs(brand): README logo, rename public repo to recombyn/zuoge
- docs(readme): rename product copy to 左格 / zuoge
- fix(vision): prefer local matting ONNX when BFF sends birefnet-general
- fix(vision): keep cutout canvas size, quiet mockup UX, drop dead BFF CV
- feat(home): brand wordmark, centered hero, admin Pro, mockup absorb
- fix(editor): include se-only in SelectionEdgeHandles plumbing
- fix(editor): polish text frames, video flip chrome, and wheel scroll ownership
- fix(ci): patch chat_job_sse get_job in image SSE unit test
- feat(editor): add fixed scrollable text frames and polish home composer
- feat(home): polish hero composer layout and dark-theme contrast
- fix(ci): resolve web typecheck and image job SSE unit test failures
- test(e2e): align home smoke with rail login and nav labels
- fix(editor): edge-anchor floating chrome and unify generator composers
- fix(editor): soft/full artboard chrome, flip/tidy selection, and README cleanup
- fix(ci): resolve web typecheck errors blocking main CI
- fix(editor): shift top title with left dock and refine color slider thumb
- fix(editor): overlay layout, mesh anchors, and canvas interaction polish
- fix: update ILP BFF smoke test for eraser and upscale kinds
- fix: vitest @commercial alias and API dev cv2 for OSS CI
- chore: untrack pub-bootstrap build artifact
- fix: OSS CI — commercial-oss stubs for @commercial/mockup alias
- chore: use recombyn author for OSS and add public repo bootstrap
- fix: repair CI failures and OSS publish flow
- fix: exclude build artifacts from OSS rsync
- chore: hard-delete commercial code on - chore: speed up OSS rsync (drop verbose)
- chore: vendor recombyn-intelligence into src/commercial
- chore: add private-to-public workflow and commercial tree
- chore: remove README hero image
- chore: remove unused readme hero image asset
- fix(canvas): refine mark UX and restore smart matting tools
- fix(canvas): mark quick-edit UX, process glow resize, and selection hover
- feat: restore intelligence vision and mockup BFF for local dev (#148)
- fix: remove remaining ILP and mark files missed in OSS purge (#147)
- chore: remove closed-source image vision tools from OSS (#146)
- fix: restore CI typecheck and web-unit on main
- fix: persist line/arrow angle when dragging endpoints
- feat: image fill controls and ILP depth layering
- fix: bind process SoftGlow to node paint and canvas idle cull
- chore: dedupe path translate/simplify and exit-edit i18n
- feat: prefer SAM soft masks and LaMa for image layer decompose
- fix: drop duplicate wallet.creditsLeft i18n keys
- fix: rename design intensity copy without changing lanes
- feat: filter skill inject by scope and required_context
- fix: pack Decide and Paint prompts by stage
- fix: Decide uses one structured LLM call with a single retry
- fix: build intelligence payload once and persist hop cache
- fix: gate Observe to paint or settle, one Review repair hop
- chore: rename wallet 积分 internals from tokens to credits
- chore: drop leftover aliases and docs to current contracts
- chore: read intelligence request fields from runtime attrs only
- chore: drop remaining dual-read aliases
- feat: use local model icons instead of lobehub
- chore: drop remaining aliases and unused image_credits
- fix: align overlay and rebase tests to current op ids
- fix: satisfy web typecheck in designTools path and frame fit
- chore: drop leftover aliases and stamp-era agent controller
- feat: snap artboard moves to peer smart guides
- test: keep api unit checks generic instead of pinning prompt copy
- test: align api unit asserts with lean paint and clarification
- feat: filled-ribbon vector pencils and drop stamp-era canvas paths
- ci: strip Cursor co-author locally and CONTRIBUTING to main
- chore: drop canvas scratch docs and ignore local e2e logs
- fix: expose get_design_task_for_update on design_tasks repository
- docs: refresh README product tagline and canvas description
- docs: refresh product tagline for open-source AI design workspace
- docs: clarify RCB canvas paint, LOD, and hit-testing in README
- fix: unblock CI without changing canvas radii behavior
- fix: unify canvas hit/chrome pipeline and design SSE progress
- fix: screen-space chrome via CameraTransform (ADR 0027)
- fix: keep pen outline fill visible and stop knob carpet
- fix: unblock web typecheck for auto-snap PR
- fix: restore canvas auto-snap and keep ink on the 1px grid
- fix: restore model chip labelSuffix and unblock CI research/pricing
- fix: unblock CI typecheck and task pricing floor assert
- feat: let LLM own design intent and free canvas tool ops
- docs: document OSS task pricing floors, locale, and design intensity
- feat: wire design intensity and locale through agent UI and runtime
- feat: open task-centric billing protocol 0.1.3
- fix: restore e2e encoding, typecheck fills, and remote apply hooks
- fix: land remaining agent memory, observe, and web contract renames
- fix: unblock CI for package rename, review gates, and skills paths
- feat: land billing protocol, pricing versions, and public skills catalog
- fix: CI installs for protocol SDKs and eval-framework lock
- feat: add intelligence provider boundary and protocol contract
- fix: restore canvas tool seed allowlist for empty DB
- docs: clarify product voice and drop PDF import
- fix: widen chat + design_global_rule text columns to LONGTEXT
- fix: widen chat session/message columns to LONGTEXT on MySQL
- fix: widen design_system_prompt.body to LONGTEXT on MySQL
- fix: locale detect, dark switch/preview, card-key ops, plaza seeds
- fix: store project/share documents as LONGTEXT in MySQL
- fix: stabilize project cloud and defer home-agent send during tour
- fix: store email OTP timestamps as BIGINT and bake Google client id in web image
- fix: harden cloud MySQL text columns and production web chrome
- fix: guest login modal, skills card UX, and deploy Docker builds (#112)
- feat: use PNG skill icons and marketplace-style tiles (#111)
- fix: stabilize media E2E and gate Send on model availability (#110)
- feat: off-request chat video and audio jobs (#109)
- feat: add .recombyn-plugin pack format and install API (#108)
- feat: Skill ops runner Phase C (handler.py → tool_ops) (#107)
- feat: Canvas plugins Phase B (toolbar registry) (#106)
- feat: Skill extensions Phase A (plugins/skills) (#105)
- fix: stabilize CI origin test and metrics scrape latency
- docs: drop core-feature dump and microservice framing
- feat: run editor image gen as async jobs
- refactor: share job DLQ paths and drop unused aliases
- docs: drop big-co framing and ignore local scratch files
- feat: admin export DLQ replay with depth gauge
- fix: draw scene text in server PDF/PNG export
- feat: editor menu for server PDF export
- feat: async artboard export jobs (PNG/PDF)
- docs: check admin Insights hydrate DLQ tab on Phase 6
- feat: ops stack for hydrate DLQ, Grafana, and ClamAV
- feat: send org invite emails via SES (best-effort)
- docs: check project org badge/move on Phase 6 roadmap
- feat: project org move/badge and org rename/kick
- feat: pending org invites with user search and accept/decline
- feat(web): account org tab, invite UI, and project org filter
- feat: project org_id, org invite API, and k8s PDB/NetworkPolicy
- feat: HPA/Ingress, admin write audit, org_members skeleton
- feat: Phase 6 follow-through (k8s, RBAC, OTel worker, 5k LOD)
- feat: ship deferred OTel, DLQ, ClamAV, dual Yjs merge
- test: mock image-gen promote + project revision conflict
- fix(web): clear tsc debt and gate typecheck:web in CI
- ci: desktop unsigned build + stress baselines docs
- docs: fix rollback step numbering in self-hosting
- ci: publish api/web/collab images to GHCR on tags
- ci: add unified CI gate + changelog rollback docs
- feat: upload magic sniff + RBAC security docs
- feat: Phase 3 correlation logs + dep audit CI
- feat: hydrate route coverage floor + Celery transient retry
- feat: ADR 0006 in-process LLM facade + alembic head gate
- feat: wire Design Agent hydrate through Celery jobs
- feat: Phase 2 async hydrate jobs + ADR 0005
- docs: map big-co AI canvas backend standards onto roadmap
- chore: phase-1 monorepo foundation (turbo, shared configs, husky, ADR)
- Disable rate limits in k6 CI and verify minted token before load.
- Add prometheus client deps for /metrics instrumentation.
- Fix CI: soft min_creates only for craft skills; install scene-builder in k6.
- Expand quality gates and harden canvas/agent stress paths.
- Rewrite design skills around intentional craft and medium choice.
- fix: assets are AI-only; LOD selection stays degraded
- fix: unify skeleton shimmer as solid card sweep
- fix: restore _derive_suggested_place_world to fix CI ImportError
- fix: chip fly-in no stutter; image tile hide on error; img_layers token warning
- fix: boolean result no longer re-fillets path; radius handles skip curve-only paths
- fix: remove stale _derive_suggested_place_world from support.py barrel
- fix: remove stale placement hints and improve LOD proxy rendering
- Harden observe scene feedback and document artboard vs viewport.
- Block Cursor Co-authored-by trailers via CI and require the check on main.
- Move GitHub Star CTA above the Canvas section in README locales.
- Scope canvas-to-chat fly-in to the right composer and refresh README Agent/canvas docs.
- Harden desktop export/tour UX and unify canvas-to-chat fly-in.
- chore: refresh GitHub contributors graph
- Skip category stress E2E in default CI when token is missing.
- chore: refresh GitHub contributors graph
- Switch to Apache-2.0 and harden XSS/CSP defenses.
- Fix e2e CI crash when .tmp-token.txt is missing.
- Add image Mark tool that flies region chips into Agent chat.
- Expand LobeHub model icons and cut home cold-path fetch noise.
- Harden design-agent paint timeouts, icon tools, and ref-UI stress.
- Thin the design-agent kernel and ship sparse review plus stress harness.
- Ship oRPC frontend stack and restore project cloud .
- Ship server-side project covers and oriented multi-select rotate chrome.
- Defer home/editor data loads to click paths and prefer async/await.
- Improve media editing UX and clear stale auth sessions on invalid tokens.
- chore: refresh GitHub contributors graph
- Fix permission-gate test for default-off wallet billing.
- Align free image model and empty desktop BYOK catalog.
- Consolidate license/docs and tighten agent content ownership.
- Publish built help site on this repo gh-pages; drop separate help URL.
- Clarify no white-label or impersonation in README license section.
- Move user docs out of the public monorepo.
- Expand docs for custom models, desktop packaging, and sponsor copy.
- Add audio generation nodes, media assets panel, and LLM provider updates.
- Add sponsor page and deploy docs via GitHub Pages.
- Move desktop editor home and title into the custom titlebar.
- Make local desktop BYOK-only and hide cloud billing UI.
- Add local/cloud desktop flavors with API sidecar and OS auto-login.
- Add Tauri v2 desktop shell with themed titlebar and docs.
- Fix CI unit failures for tip pencil fixture, _rev schema, and skill tests.
- Bind new-design paint to a host FOCUS artboard and tighten editor chrome.
- Add vector pencil brushes with hardness and sharper live tip preview.
- Ship tip-stamp pencil engine with dense live preview and sharp zoom bake.
- Fix Lottie snap stickiness and keep selection chrome on the host lattice.
- Keep pencil/pen freehand ink centered on the stored path.
- Restore pencil freehand pressure ink after Lottie merge regression.
- Mock lottie-web in Vitest so jsdom canvas stubs do not crash imports.
- Add Lottie generator plate and player on the canvas.
- Add self-host console login OTP and multi-artboard agent paint.
- Close account menu after language or theme pick.
- Flatten API seed data and harden Ask/canvas cold-start.
- Fix web snap/save/inspect: low-zoom guides, incremental collab persist, diagonal measure.
- Allow public plaza feed, canvas bg theme reset, and venv-aware dev:api.
- Fix half-pixel fill after hiding center stroke by expanding geom to outer ink.
- Let Ask typed confirm be judged by intent LLM via proposal_action.
- Fix selection chrome: HTML titles, live image radius, and undo fallback.
- Fix project cover tiles: multi-artboard collage and collab .
- Fix RCB selection chrome hit-testing so resize and toolbar no longer collide.
- Strengthen post-paint critique for craft and long canvases.
- Align RCB selection chrome to the shared world lattice and keep title/toolbar gaps screen-constant under canvas and browser zoom.
- Fix CI: expect create_image on lean create paint keys.
- Improve Design Agent quality: skills, paint kit, and critique.
- Fix Alembic xdist stamp races for API CI.
- Retire hand-written DDL for Alembic and trim LC/LG comment fluff.
- Allow run-lease claim before design_task insert when Redis is absent.
- Allow app.services paths in LangGraph checkpoint msgpack allowlist.
- Add minimal public knowledge seed so CI catalog tests pass without private overlay.
- Fix API pytest isolation after SQLITE_DB_PATH switches under xdist.
- Fix API tests and SQLite/auth helpers after the app package move.
- Fix SQLite path resolution after app/ package move.
- Add canvas smart guides and Agent pause/resume UX.
- Remove accidental app/storage runtime artifacts from the API refactor.
- Refactor API onto FastAPI app package with SQLModel data access.
- Improve canvas path edit, stroke outline, and editor chrome.
- Bust GitHub CDN cache for README hero image.
- Refine README hero chrome and add EN/zh/ja language pills.
- Refresh README hero with horizontal lockup and bottom language pills.
- Polish skill chips, multi-angle panel, and process overlay stacking.
- Fix README logo: use PNG mark after hero asset removal.
- Ship MIT design skill packs and English OSS seeds; improve editor canvas tooling.
- Harden public self-host defaults and document TLS checklist.
- Fix OSS docs to match Source Available license and seed wording.
- Fix small-screen canvas menu, share top chrome, and one-shot camera fit.
- Fix inspect/export for video nodes to match editor.
- Unify share boot UI and stabilize canvas camera fit.
- Fix share preview video playback and polish inspect/export UX.
- Polish canvas spacing/radius UX, collab share flow, and golden-path CI.
- Fix context menu click-through onto the bottom tool strip.
- Fix API unit tests against OSS prompt-pack cold start.
- Ship core Agent skills in public seed and document Yjs collab.
- Add Yjs canvas collaboration and flatten SvgCanvas modules.
- Keep view and download share links on the preview page.
- Persist share Can download ACL and dedupe StrictMode create.
- Fix Share dialog toggle stuck disabled under StrictMode.
- Use 3 columns for Me profile feed on iPad.
- Remove the README footer brand lockup.
- Suppress the browser context menu on the canvas stage.
- Fix canvas context menu on nodes and generator composers.
- Fix canvas pointer coords, context menu placement, and chrome clicks on small viewports.
- Wait for remote image decode before dropping local upload preview.
- Ship a minimal OSS prompt-pack baseline and Skills upload tile.
- Tune home grids per surface, shorten empty copy, and enable mobile video chat.
- Point commercial license contact to 702680355@qq.com.
- Adopt Recombyn Source Available License (ELv2-style terms).
- Remove Breatic references from README license blurbs.
- Add home Skills toolbox with zip import, prefs, and rail polish.
- Prefer English for engineering and docs-site defaults.
- Fix missing TOOL_OPS_SCHEMA_VERSION import in paint action node.
- Fix missing imports in LangGraph nodes after the host/graph split.
- Split Design Agent runtime into host/graph packages and add prompt-pack usedBy stages.
- Fix LangGraph checkpointer for async astream and MySQL 5.7.
- Accept parameters in tool_ops and surface validation failures in chat.
- Stop preloading skill bodies; demote short design asks to canvas_op.
- Ignore the whole data/private tree and document the local overlay.
- Stop tracking data/private so only local SaaS seeds stay on disk.
- Split API seeds into public stubs and a private overlay for OSS vs SaaS.
- Align docs with design packages; allow video from canvas context menu.
- Stop tracking local langgraph sqlite wal/shm sidecars.
- Drop design compatibility shims and cut over imports.
- Repackage design services into domain packages with compat shims.
- Tighten paint op envelope schema and unify op_error codes.
- Teach the agent via validation errors and gate OpenRouter on CN networks.
- Prefer local artboard snaps so distant guides stop stealing center align.
- Improve design-agent reliability and canvas attach UX.
- Ask readers to star the GitHub repo in the READMEs.
- Polish home rail/hero and clear plaza seed cases.
- Make eraser spawn a cutout node like remove-bg.
- Tighten README intro copy and remove repeated pitch lines.
- Fix text-toolbar align icons reading too light next to B/I/U.
- Improve canvas scale for multi-thousand nodes and reorganize rcb modules.
- Polish layer decompose UX and generator loading placement.
- Enable image layer decompose (editElements) with rembg subject fallback.
- Clarify Design Skill ownership and remove need_prompts legacy.
- Fix video layer hide, export scale guards, and route submenu positioning.
- Tighten multi-angle panel spacing and narrow the preview column.
- Lay out the multi-angle tool as left preview and right controls.
- Disable context-menu export for image/video generator plates.
- Apply video flip live on the canvas plate and slim the flip toolbar.
- Improve canvas video playback, trim keep-time, and MP3/MP4 export.
- Improve Ask clarify flow, project hydrate, and editor agent chrome.
- Polish agent route flyouts, landing/home UI, and editor chrome.
- Highlight LangGraph-native canvas control in the README.
- Remove unused frontend and API dependencies.
- Remove third-party product name references from comments.
- Add video extract-frame and make upload-placeholder deletes permanent.
- Mention PostgreSQL support on the README homepage.
- Document self-host skills, Postgres, backups, and BYOK.
- Harden skills ACL, DB concurrency, BYOK, and media paste UX.
- Improve canvas video playback and composer media attach UX.
- Memo web components and harden canvas video playback.
- Add canvas video nodes and polish home/video UX.
- Rebuild README hero from real product UI and brand mark.
- Refresh README hero: poster canvas mockup with matching agent chat.
- Refresh README hero to product UI; drop VitePress leftover wording.
- Harden knowledge seed when catalog-ready outlives DB path switches.
- Fix API integration CI: scene-builder install and LangGraph mocks.
- Fix CI unit failures for empty-DB tools and jsdom scroll.
- Polish OSS hygiene: docs, public assets, and self-host defaults.
- Clarify docker-compose header without Langfuse references.
- Drop Langfuse from the public OSS surface.
- Ignore the entire .cursor directory in git.
- Stop tracking .cursor; ignore the whole Cursor IDE folder.
- Widen dark lockup viewBox to match light wordmark.
- Widen recombyn lockup viewBox so the final n is not clipped.
- Polish README branding: visual editor wording and lockup footer.
- Ship open-source packaging, file-based design skills, and agent chat polish.
- Refine canvas align guides and continue agent/auth/editor updates.
- Add multilingual docs site for product guides and legal pages.
- Refine design agent flow prompts and resource loading.
- Ship marketing landing, locale URL prefixes, and editor/home polish.
- Wire Design Agent to LangGraph published flows with Ask mode and graph-hop replay logs.
- Ship infinite canvas rcb stack, unified SVG export, and main-site API surface.
- Move pipeline steps below reply and add retry/redesign choices.
- Add phased design agent modes, on-demand skills, and project listing rules.
- Ship design agent, plaza, wallet, and LighthouseDB/COS persistence.
- Fix design import response validation and reject bad suffixes.
- Rebuild Recombine as a monorepo canvas editor with import API.
- Initialize project using Create React App

[skip ci]