### PR TITLE
fix(web): crisp idle rounded edges and clear frame-plate ghost chrome

### DIFF
--- a/apps/web/src/components/home/ProjectCoverCollage.tsx
+++ b/apps/web/src/components/home/ProjectCoverCollage.tsx
@@ -193,13 +193,7 @@ function ProjectCoverCollage({
     <div className={projectThumbFrameClass(className)}>
       {collage ? (
         <div className={cn('absolute inset-0', projectThumbZoomLayerClass)}>{collage}</div>
-      ) : (
-        <SoftGlowSurface
-          className="absolute inset-0 h-full w-full !rounded-none"
-          seed="cover-empty"
-          aria-hidden
-        />
-      )}
+      ) : null}
       {children}
     </div>
   );

--- a/apps/web/src/components/rcb/render/__tests__/webglInstances.test.ts
+++ b/apps/web/src/components/rcb/render/__tests__/webglInstances.test.ts
@@ -57,9 +57,71 @@ describe('collectSoaWebglInstances', () => {
     const angles: number[] = [];
     collectSoaWebglInstances(buf, { x: 0, y: 0, width: 100, height: 100 }, rects, colors, kinds, angles);
     expect(kinds.length).toBe(2);
-    expect(kinds).toContain(0);
+    // Default shape stroke uses SDF rounded path (kind 4), not sharp instanced quad.
+    expect(kinds).toContain(4);
     expect(kinds).toContain(1);
     expect(angles.every((a) => a === 0)).toBe(true);
+  });
+
+  it('packs stroke-disabled sharp rect as kind 0', () => {
+    let doc = createEmptyDocument({ width: 800, height: 600, emptyWorld: true });
+    doc = addNodeToDocument(doc, 'r', {
+      id: 'r',
+      key: 'shape',
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+      attrs: {
+        shapeType: 'rect',
+        fill: '#ff0000',
+        'stroke-enabled': false,
+      },
+      children: [],
+    });
+    const buf = createSceneRenderBuffer();
+    syncSceneRenderBufferFromDocument(buf, doc);
+    buf.flags[0] = (buf.flags[0] | SOA_FLAG_CANVAS_IDLE) >>> 0;
+    const rects: number[] = [];
+    const colors: number[] = [];
+    const kinds: number[] = [];
+    const angles: number[] = [];
+    collectSoaWebglInstances(buf, { x: 0, y: 0, width: 100, height: 100 }, rects, colors, kinds, angles);
+    expect(kinds).toEqual([0]);
+  });
+
+  it('packs rounded rect as shader SDF kind 4 with radii in uvs', () => {
+    let doc = createEmptyDocument({ width: 800, height: 600, emptyWorld: true });
+    doc = addNodeToDocument(doc, 'r', {
+      id: 'r',
+      key: 'shape',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 80,
+      attrs: {
+        shapeType: 'rect',
+        fill: '#ffffff',
+        cornerRadius: 20,
+        'stroke-enabled': false,
+      },
+      children: [],
+    });
+    const buf = createSceneRenderBuffer();
+    syncSceneRenderBufferFromDocument(buf, doc);
+    buf.flags[0] = (buf.flags[0] | SOA_FLAG_CANVAS_IDLE) >>> 0;
+    const rects: number[] = [];
+    const colors: number[] = [];
+    const kinds: number[] = [];
+    const angles: number[] = [];
+    const uvs: number[] = [];
+    const strokes: number[] = [];
+    collectSoaWebglInstances(buf, { x: 0, y: 0, width: 200, height: 200 }, rects, colors, kinds, angles, uvs, {
+      strokes,
+    });
+    expect(kinds).toEqual([4]);
+    expect(uvs[0]).toBeGreaterThan(0);
+    expect(strokes).toEqual([0, 0, 0, 0]);
   });
 
   it('packs line as oriented thin quad from world path polyline', () => {

--- a/apps/web/src/components/rcb/render/sceneRenderBuffer.ts
+++ b/apps/web/src/components/rcb/render/sceneRenderBuffer.ts
@@ -13,7 +13,6 @@ import {
 import { isNodeOverlayHidden } from '@/components/rcb/scene/document/nodeCapabilities';
 import {
   clampCornerRadii,
-  getLiveCornerRadiusPreviewNodeId,
   getLiveCornerRadiusPreviewRadii,
   mergeLiveCornerRadiiIntoAttrs,
   radiiFromAttrs,
@@ -2287,10 +2286,11 @@ export function paintSoaBufferBasic(
         return true;
       }
     }
-    const liveGeoPreview =
-      getLiveCornerRadiusPreviewNodeId() === id ||
-      getLiveShapeParamsPreviewNodeId() === id;
-    if (getShapeHost(id)?.el && !liveGeoPreview) {
+    // Host owns fill/stroke. Live corner-radius is applied on the host SVG —
+    // do not also paint SoA (WebGL used stale sharp radii → white AABB corners).
+    // Poly/star side live-geo still needs SoA rebuild under the host.
+    const liveShapeParams = getLiveShapeParamsPreviewNodeId() === id;
+    if (getShapeHost(id)?.el && !liveShapeParams) {
       clearSoaDirtyFlag(buf, i);
       return true;
     }

--- a/apps/web/src/components/rcb/render/webglDepthOfFieldPass.ts
+++ b/apps/web/src/components/rcb/render/webglDepthOfFieldPass.ts
@@ -20,6 +20,7 @@ layout(location = 4) in float aAngle;
 layout(location = 5) in vec4 aUv;
 layout(location = 6) in float aDepth;
 layout(location = 7) in vec4 aClip;
+layout(location = 8) in vec4 aStroke;
 out vec2 vUv;
 out vec2 vAtlasUv;
 out vec4 vColor;
@@ -27,10 +28,17 @@ out float vKind;
 out float vDepth;
 out vec2 vWorld;
 out vec4 vClip;
+out vec2 vHalf;
+out vec4 vRadii;
+out vec4 vStroke;
 void main() {
   vec2 local;
   if (aKind > 1.5 && aKind < 2.5) {
     local = vec2(aCorner.x * aRect.z, (aCorner.y - 0.5) * aRect.w);
+  } else if (aKind > 3.5) {
+    float pad = aStroke.w * 0.5;
+    vec2 size = aRect.zw + vec2(pad * 2.0);
+    local = aCorner * size - vec2(pad);
   } else {
     local = aCorner * aRect.zw;
   }
@@ -50,6 +58,9 @@ void main() {
   vDepth = aDepth;
   vWorld = pos;
   vClip = aClip;
+  vHalf = aRect.zw * 0.5;
+  vRadii = aUv;
+  vStroke = aStroke;
 }`;
 
 const SCENE_FS = `#version 300 es
@@ -62,16 +73,44 @@ in float vKind;
 in float vDepth;
 in vec2 vWorld;
 in vec4 vClip;
+in vec2 vHalf;
+in vec4 vRadii;
+in vec4 vStroke;
 layout(location = 0) out vec4 outColor;
 layout(location = 1) out vec4 outDepth;
+float sdRoundBox(vec2 p, vec2 b, vec4 r) {
+  r.xy = (p.x > 0.0) ? r.xy : r.zw;
+  r.x = (p.y > 0.0) ? r.x : r.y;
+  vec2 q = abs(p) - b + r.x;
+  return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r.x;
+}
 void main() {
   if (vWorld.x < vClip.x || vWorld.y < vClip.y || vWorld.x > vClip.z || vWorld.y > vClip.w) {
     discard;
   }
-  if (vKind > 2.5) {
+  if (vKind > 2.5 && vKind < 3.5) {
     vec4 tex = texture(uAtlas, vAtlasUv);
     if (tex.a < 0.01) discard;
     outColor = tex;
+    outDepth = vec4(vDepth, 0.0, 0.0, 1.0);
+    return;
+  }
+  if (vKind > 3.5) {
+    vec2 p = vUv * vHalf;
+    vec4 r = vec4(vRadii.y, vRadii.z, vRadii.x, vRadii.w);
+    float d = sdRoundBox(p, vHalf, r);
+    float sw = max(0.0, vStroke.w);
+    float aa = max(fwidth(d), 0.001);
+    float outer = d - sw * 0.5;
+    float cover = 1.0 - smoothstep(-aa, aa, outer);
+    if (cover < 0.01) discard;
+    vec3 rgb = vColor.rgb;
+    if (sw > 0.001) {
+      float inner = d + sw * 0.5;
+      float inFill = 1.0 - smoothstep(-aa, aa, inner);
+      rgb = mix(vStroke.rgb, vColor.rgb, inFill);
+    }
+    outColor = vec4(rgb, vColor.a * cover);
     outDepth = vec4(vDepth, 0.0, 0.0, 1.0);
     return;
   }
@@ -317,7 +356,7 @@ export function createWebglDepthOfFieldPass(gl: WebGL2RenderingContext): WebglDe
   };
 }
 
-/** Scene program attribute locations for depth (6) + clipContent LTRB (7). */
+/** Scene program: depth (6) + clip LTRB (7) + stroke rgba+width (8). */
 export function bindWebglDofSceneAttributes(
   gl: WebGL2RenderingContext,
   cornerBuf: WebGLBuffer,
@@ -327,7 +366,8 @@ export function bindWebglDofSceneAttributes(
   angleBuf: WebGLBuffer,
   uvBuf: WebGLBuffer,
   depthBuf: WebGLBuffer,
-  clipBuf: WebGLBuffer
+  clipBuf: WebGLBuffer,
+  strokeBuf: WebGLBuffer
 ) {
   const inst = 1;
   gl.bindBuffer(gl.ARRAY_BUFFER, cornerBuf);
@@ -369,6 +409,11 @@ export function bindWebglDofSceneAttributes(
   gl.enableVertexAttribArray(7);
   gl.vertexAttribPointer(7, 4, gl.FLOAT, false, 0, 0);
   gl.vertexAttribDivisor(7, inst);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, strokeBuf);
+  gl.enableVertexAttribArray(8);
+  gl.vertexAttribPointer(8, 4, gl.FLOAT, false, 0, 0);
+  gl.vertexAttribDivisor(8, inst);
 }
 
 export function createWebglDepthInstanceBuffer(gl: WebGL2RenderingContext) {

--- a/apps/web/src/components/rcb/render/webglSceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/webglSceneRenderer.ts
@@ -23,6 +23,7 @@ import {
   unpackCssColor,
   type SceneRenderBuffer,
 } from '@/components/rcb/render/sceneRenderBuffer';
+import { getLiveCornerRadiusPreviewRadii } from '@/components/rcb/scene/document/sceneRadii';
 import type { SceneDocument } from '@/components/rcb/sceneNode';
 import {
   collectSoaBakeTilesIntoAtlas,
@@ -33,7 +34,6 @@ import {
   releaseSoaAtlasPrefix,
   releaseSoaAtlasRegion,
   stampSoaPathToAtlas,
-  stampSoaRoundedRectToAtlas,
   stampSoaEllipseToAtlas,
   type SoaAtlasRegion,
   type SoaWebglAtlas,
@@ -85,16 +85,25 @@ layout(location = 3) in float aKind;
 layout(location = 4) in float aAngle;
 layout(location = 5) in vec4 aUv;
 layout(location = 6) in vec4 aClip;
+layout(location = 7) in vec4 aStroke;
 out vec2 vUv;
 out vec2 vAtlasUv;
 out vec4 vColor;
 out float vKind;
 out vec2 vWorld;
 out vec4 vClip;
+out vec2 vHalf;
+out vec4 vRadii;
+out vec4 vStroke;
 void main() {
   vec2 local;
   if (aKind > 1.5 && aKind < 2.5) {
     local = vec2(aCorner.x * aRect.z, (aCorner.y - 0.5) * aRect.w);
+  } else if (aKind > 3.5) {
+    // Grow the quad so center-aligned stroke is not clipped by the fill AABB.
+    float pad = aStroke.w * 0.5;
+    vec2 size = aRect.zw + vec2(pad * 2.0);
+    local = aCorner * size - vec2(pad);
   } else {
     local = aCorner * aRect.zw;
   }
@@ -113,7 +122,20 @@ void main() {
   vKind = aKind;
   vWorld = pos;
   vClip = aClip;
+  vHalf = aRect.zw * 0.5;
+  vRadii = aUv;
+  vStroke = aStroke;
 }`;
+
+/** IQ rounded-box SDF; r = (tr, br, tl, bl). */
+const FS_ROUND_SDF = `
+float sdRoundBox(vec2 p, vec2 b, vec4 r) {
+  r.xy = (p.x > 0.0) ? r.xy : r.zw;
+  r.x = (p.y > 0.0) ? r.x : r.y;
+  vec2 q = abs(p) - b + r.x;
+  return min(max(q.x, q.y), 0.0) + length(max(q, 0.0)) - r.x;
+}
+`;
 
 const FS = `#version 300 es
 precision mediump float;
@@ -124,15 +146,40 @@ in vec4 vColor;
 in float vKind;
 in vec2 vWorld;
 in vec4 vClip;
+in vec2 vHalf;
+in vec4 vRadii;
+in vec4 vStroke;
 out vec4 outColor;
+${FS_ROUND_SDF}
 void main() {
   if (vWorld.x < vClip.x || vWorld.y < vClip.y || vWorld.x > vClip.z || vWorld.y > vClip.w) {
     discard;
   }
-  if (vKind > 2.5) {
+  // Atlas stamp (paths / bake tiles).
+  if (vKind > 2.5 && vKind < 3.5) {
     vec4 tex = texture(uAtlas, vAtlasUv);
     if (tex.a < 0.01) discard;
     outColor = tex;
+    return;
+  }
+  // Shader rounded rect — avoids 256px atlas downsample soft edges when idle.
+  if (vKind > 3.5) {
+    vec2 p = vUv * vHalf;
+    // aUv/vRadii stored as tl,tr,br,bl → IQ order tr,br,tl,bl
+    vec4 r = vec4(vRadii.y, vRadii.z, vRadii.x, vRadii.w);
+    float d = sdRoundBox(p, vHalf, r);
+    float sw = max(0.0, vStroke.w);
+    float aa = max(fwidth(d), 0.001);
+    float outer = d - sw * 0.5;
+    float cover = 1.0 - smoothstep(-aa, aa, outer);
+    if (cover < 0.01) discard;
+    vec3 rgb = vColor.rgb;
+    if (sw > 0.001) {
+      float inner = d + sw * 0.5;
+      float inFill = 1.0 - smoothstep(-aa, aa, inner);
+      rgb = mix(vStroke.rgb, vColor.rgb, inFill);
+    }
+    outColor = vec4(rgb, vColor.a * cover);
     return;
   }
   if (vKind > 0.5 && vKind < 1.5) {
@@ -142,6 +189,8 @@ void main() {
 }`;
 
 const UNIT_QUAD = new Float32Array([0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1]);
+/** Instanced kind: shader SDF rounded rect (fill ± center stroke). */
+export const SOA_WEBGL_KIND_ROUNDED = 4;
 /** Default line thickness in scene units (used when SoA stroke width is unset). */
 export const SOA_WEBGL_LINE_THICKNESS = 2;
 /** Cap segments emitted per path so one dense stroke cannot explode the instance batch. */
@@ -219,6 +268,19 @@ export function resolveSoaWebglSlotClip(
   return [left, top, right, bottom];
 }
 
+function pushInstanceStroke(
+  strokes: number[] | undefined,
+  rgba: [number, number, number, number] | null,
+  width: number
+) {
+  if (!strokes) return;
+  if (!rgba || width <= 0) {
+    strokes.push(0, 0, 0, 0);
+    return;
+  }
+  strokes.push(rgba[0], rgba[1], rgba[2], width);
+}
+
 function pushLineInstance(
   x0: number,
   y0: number,
@@ -234,7 +296,8 @@ function pushLineInstance(
   depths: number[] | undefined,
   depth: number,
   clips: number[] | undefined,
-  clip: readonly [number, number, number, number]
+  clip: readonly [number, number, number, number],
+  strokes?: number[]
 ) {
   const dx = x1 - x0;
   const dy = y1 - y0;
@@ -247,6 +310,7 @@ function pushLineInstance(
   uvs.push(0, 0, 1, 1);
   if (depths) depths.push(depth);
   pushInstanceClip(clips, clip);
+  pushInstanceStroke(strokes, null, 0);
 }
 
 function countPathSegments(buf: SceneRenderBuffer, index: number): number {
@@ -330,12 +394,14 @@ function commitAtlasRegionInstance(
   slotDepth: number,
   clips: number[] | undefined,
   clip: readonly [number, number, number, number],
+  strokes: number[] | undefined,
   offsetX = 0,
   offsetY = 0
 ) {
   pushAtlasRegionInstance(atlas, region, rects, colors, kinds, angles, uvs, rotRad, offsetX, offsetY);
   if (depthOut) depthOut.push(slotDepth);
   pushInstanceClip(clips, clip);
+  pushInstanceStroke(strokes, null, 0);
 }
 
 export type CollectSoaWebglOpts = {
@@ -346,13 +412,15 @@ export type CollectSoaWebglOpts = {
   depthForId?: (id: string) => number;
   /** Parallel scene-space LTRB clip per instance (clipContent artboards). */
   clips?: number[];
+  /** Parallel stroke rgba+width for rounded SDF (kind 4); zeros for other kinds. */
+  strokes?: number[];
   /** Document for clip resolve; defaults to {@link getSoaPaintDocument}. */
   document?: SceneDocument | null;
 };
 
 /**
  * Pack visible rect / ellipse / line / path instances intersecting the view.
- * kinds: 0=rect, 1=ellipse, 2=line-or-path-segment, 3=atlas path stamp.
+ * kinds: 0=rect, 1=ellipse, 2=line-or-path-segment, 3=atlas path stamp, 4=rounded SDF.
  */
 export function collectSoaWebglInstances(
   buf: SceneRenderBuffer,
@@ -368,6 +436,7 @@ export function collectSoaWebglInstances(
   const depthOut = opts?.depths;
   const depthForId = opts?.depthForId;
   const clips = opts?.clips;
+  const strokes = opts?.strokes;
   const paintDoc = opts?.document ?? getSoaPaintDocument();
   const vl = view.left ?? view.x ?? 0;
   const vt = view.top ?? view.y ?? 0;
@@ -394,6 +463,7 @@ export function collectSoaWebglInstances(
     const lineW = soaStrokeWidth(buf, i);
     const forceStamp = (flags & SOA_FLAG_DIRTY) !== 0;
     const nodeId = buf.ids[i] || '';
+    const id = nodeId;
     const slotDepth = depthForId ? depthForId(nodeId) : 0.5;
     const slotClip = resolveSoaWebglSlotClip(buf, i, paintDoc);
 
@@ -435,6 +505,7 @@ export function collectSoaWebglInstances(
           pushAtlasRegionInstance(atlas, region, rects, colors, kinds, angles, uvs, 0, 0, 0);
           if (depthOut) depthOut.push(slotDepth);
           pushInstanceClip(clips, slotClip);
+          pushInstanceStroke(strokes, null, 0);
           if (forceStamp) buf.flags[i] = (flags & ~SOA_FLAG_DIRTY) >>> 0;
           continue;
         }
@@ -464,7 +535,8 @@ export function collectSoaWebglInstances(
           depthOut,
           slotDepth,
           clips,
-          slotClip
+          slotClip,
+          strokes
         );
         emitted += 1;
       };
@@ -511,7 +583,8 @@ export function collectSoaWebglInstances(
             depthOut,
             slotDepth,
             clips,
-            slotClip
+            slotClip,
+            strokes
           );
           emitted += 1;
         };
@@ -555,13 +628,13 @@ export function collectSoaWebglInstances(
         depthOut,
         slotDepth,
         clips,
-        slotClip
+        slotClip,
+        strokes
       );
       if (forceStamp) buf.flags[i] = (flags & ~SOA_FLAG_DIRTY) >>> 0;
       continue;
     }
 
-    const id = buf.ids[i];
     const liveAngle = id ? getNodeTransformPreview(id)?.angle : undefined;
     let rotDeg = 0;
     if (Number.isFinite(liveAngle) && Math.abs(Number(liveAngle)) > 0.5) {
@@ -576,45 +649,27 @@ export function collectSoaWebglInstances(
     const fillCss = unpackCssColor(buf.colors[i]);
     const worldBox = { left: x, top: y, width: w, height: h };
 
-    // Rounded / stroked rects → atlas (instanced quads are fill-only sharp).
-    if (kind === SOA_KIND_RECT && atlas && odx === 0 && ody === 0) {
+    // Rounded rects → shader SDF (atlas 256px cell softens large/zoomed idle ink).
+    if (kind === SOA_KIND_RECT) {
       const ro = i * 4;
-      const tl = buf.radii[ro] || 0;
-      const tr = buf.radii[ro + 1] || 0;
-      const br = buf.radii[ro + 2] || 0;
-      const bl = buf.radii[ro + 3] || 0;
+      const liveR = id ? getLiveCornerRadiusPreviewRadii(id) : null;
+      const tl = liveR ? liveR.tl : buf.radii[ro] || 0;
+      const tr = liveR ? liveR.tr : buf.radii[ro + 1] || 0;
+      const br = liveR ? liveR.br : buf.radii[ro + 2] || 0;
+      const bl = liveR ? liveR.bl : buf.radii[ro + 3] || 0;
       const rounded = tl > 0.5 || tr > 0.5 || br > 0.5 || bl > 0.5;
       if (rounded || hasOutline) {
-        const region = stampSoaRoundedRectToAtlas(
-          atlas,
-          `round:${id || i}`,
-          worldBox,
-          fillCss,
-          { tl, tr, br, bl },
-          {
-            force: forceStamp,
-            strokeCss: hasOutline ? outlineCss : undefined,
-            strokeWidth: hasOutline ? outlineW : 0,
-          }
-        );
-        if (region) {
-          commitAtlasRegionInstance(
-            atlas,
-            region,
-            rects,
-            colors,
-            kinds,
-            angles,
-            uvs,
-            rotRad,
-            depthOut,
-            slotDepth,
-            clips,
-            slotClip
-          );
-          clearSoaDirtyFlag(buf, i, flags, forceStamp);
-          continue;
-        }
+        const outlineRgba = hasOutline ? argbToRgba(outlineArgb) : null;
+        rects.push(x, y, w, h);
+        colors.push(rgba[0], rgba[1], rgba[2], rgba[3]);
+        kinds.push(SOA_WEBGL_KIND_ROUNDED);
+        angles.push(rotRad);
+        uvs.push(tl, tr, br, bl);
+        if (depthOut) depthOut.push(slotDepth);
+        pushInstanceClip(clips, slotClip);
+        pushInstanceStroke(strokes, outlineRgba, hasOutline ? outlineW : 0);
+        clearSoaDirtyFlag(buf, i, flags, forceStamp);
+        continue;
       }
     }
 
@@ -644,7 +699,8 @@ export function collectSoaWebglInstances(
           depthOut,
           slotDepth,
           clips,
-          slotClip
+          slotClip,
+          strokes
         );
         clearSoaDirtyFlag(buf, i, flags, forceStamp);
         continue;
@@ -658,6 +714,7 @@ export function collectSoaWebglInstances(
     uvs.push(0, 0, 1, 1);
     if (depthOut) depthOut.push(slotDepth);
     pushInstanceClip(clips, slotClip);
+    pushInstanceStroke(strokes, null, 0);
     clearSoaDirtyFlag(buf, i, flags, forceStamp);
   }
 }
@@ -687,6 +744,7 @@ export function createWebglSceneRenderer(
   const angleBuf = gl.createBuffer();
   const uvBuf = gl.createBuffer();
   const clipBuf = gl.createBuffer();
+  const strokeBuf = gl.createBuffer();
   const depthBuf = gl.createBuffer();
   const atlasTex = gl.createTexture();
   let disposed = false;
@@ -711,7 +769,8 @@ export function createWebglSceneRenderer(
       angleBuf,
       uvBuf,
       depthBuf,
-      clipBuf
+      clipBuf,
+      strokeBuf
     );
     gl.bindVertexArray(null);
     return dofPass;
@@ -753,6 +812,11 @@ export function createWebglSceneRenderer(
   gl.enableVertexAttribArray(6);
   gl.vertexAttribPointer(6, 4, gl.FLOAT, false, 0, 0);
   gl.vertexAttribDivisor(6, 1);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, strokeBuf);
+  gl.enableVertexAttribArray(7);
+  gl.vertexAttribPointer(7, 4, gl.FLOAT, false, 0, 0);
+  gl.vertexAttribDivisor(7, 1);
   gl.bindVertexArray(null);
 
   gl.bindTexture(gl.TEXTURE_2D, atlasTex);
@@ -777,6 +841,8 @@ export function createWebglSceneRenderer(
     gl.bindBuffer(gl.ARRAY_BUFFER, uvBuf);
     gl.bufferData(gl.ARRAY_BUFFER, instanceCap * 4 * 4, gl.DYNAMIC_DRAW);
     gl.bindBuffer(gl.ARRAY_BUFFER, clipBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, instanceCap * 4 * 4, gl.DYNAMIC_DRAW);
+    gl.bindBuffer(gl.ARRAY_BUFFER, strokeBuf);
     gl.bufferData(gl.ARRAY_BUFFER, instanceCap * 4 * 4, gl.DYNAMIC_DRAW);
     gl.bindBuffer(gl.ARRAY_BUFFER, depthBuf);
     gl.bufferData(gl.ARRAY_BUFFER, instanceCap * 4, gl.DYNAMIC_DRAW);
@@ -834,6 +900,7 @@ export function createWebglSceneRenderer(
       const angles: number[] = [];
       const uvs: number[] = [];
       const clips: number[] = [];
+      const strokes: number[] = [];
       const depths: number[] = [];
 
       let depthLookup: ReturnType<typeof buildNormalizedDepthLookup> | null = null;
@@ -906,6 +973,7 @@ export function createWebglSceneRenderer(
               SOA_WEBGL_NO_CLIP[2],
               SOA_WEBGL_NO_CLIP[3]
             );
+            strokes.push(0, 0, 0, 0);
           }
         }
         if (import.meta.env.DEV && atlas.stats.misses + atlas.stats.hits > 0) {
@@ -924,6 +992,7 @@ export function createWebglSceneRenderer(
           depths: useDof ? depths : undefined,
           depthForId: depthLookup ? (id) => depthLookup!.depthForId(id) : undefined,
           clips,
+          strokes,
           document: req.document,
         });
       }
@@ -956,6 +1025,12 @@ export function createWebglSceneRenderer(
           : Array.from({ length: count * 4 }, (_, i) => SOA_WEBGL_NO_CLIP[i % 4]);
       gl.bindBuffer(gl.ARRAY_BUFFER, clipBuf);
       gl.bufferSubData(gl.ARRAY_BUFFER, 0, new Float32Array(clipFill));
+      const strokeFill =
+        strokes.length === count * 4
+          ? strokes
+          : Array.from({ length: count * 4 }, () => 0);
+      gl.bindBuffer(gl.ARRAY_BUFFER, strokeBuf);
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, new Float32Array(strokeFill));
       if (useDof) {
         const depthFill =
           depths.length === count
@@ -1008,6 +1083,7 @@ export function createWebglSceneRenderer(
       gl.deleteBuffer(angleBuf);
       gl.deleteBuffer(uvBuf);
       gl.deleteBuffer(clipBuf);
+      gl.deleteBuffer(strokeBuf);
       gl.deleteBuffer(depthBuf);
       gl.deleteTexture(atlasTex);
       gl.deleteVertexArray(vao);

--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -314,6 +314,31 @@ function selectionOriginsClose(
   return true;
 }
 
+/**
+ * Soft plate focus: plate edge only — clear node/frame handle chrome.
+ * Full chrome: one frame origin. Applied on pointerdown because the store→live
+ * sync effect skips while dragRef is set; if selection already matches on up,
+ * deps won't fire and stale liveOrigins would keep ghost handles.
+ */
+function framePlateLiveChrome(
+  frameId: string,
+  box: SceneBox | null,
+  chrome: 'soft' | 'full'
+): {
+  origins: Array<{ nodeId: string; box: SceneBox }>;
+  union: SceneBox | null;
+  angle: number;
+} {
+  if (chrome === 'full' && box) {
+    return {
+      origins: [{ nodeId: frameSelId(frameId), box }],
+      union: box,
+      angle: 0,
+    };
+  }
+  return { origins: [], union: null, angle: 0 };
+}
+
 /** One frame of live transform chrome + paint (ADR 0027 — RAF preview). */
 export type TransformPreviewBatch = {
   union?: SceneBox | null;
@@ -1408,6 +1433,12 @@ function SelectionFeature({
         // border band still get full chrome. First-click must not force full.
         const chrome: 'soft' | 'full' = empty || onEdge ? 'full' : 'soft';
         onSelectFrame?.(frameId, { chrome });
+        // Store clears nodes immediately; live chrome must follow on down —
+        // dragRef blocks the store sync effect until pointerup.
+        const live = framePlateLiveChrome(frameId, box, chrome);
+        setLiveOrigins(live.origins);
+        setLiveUnion(live.union);
+        setLiveAngle(live.angle);
 
         if (!box || !empty) {
           dragRef.current = seed('pointing_canvas', e, p, {
@@ -1419,12 +1450,8 @@ function SelectionFeature({
           return;
         }
 
-        const origins = [{ nodeId: frameSelId(frameId), box }];
-        setLiveOrigins(origins);
-        setLiveUnion(box);
-        setLiveAngle(0);
         dragRef.current = seed('frame_move', e, p, {
-          origins,
+          origins: live.origins,
           union: box,
           frameId,
           frameStartX: box.left,
@@ -2098,14 +2125,26 @@ function SelectionFeature({
             additive: shiftKey,
           });
         } else if (platePick && drag.frameId) {
-          onSelectFrame?.(drag.frameId, {
-            chrome: drag.framePlateChrome === 'full' ? 'full' : 'soft',
-          });
+          const chrome = drag.framePlateChrome === 'full' ? 'full' : 'soft';
+          onSelectFrame?.(drag.frameId, { chrome });
+          // Same as pointerdown: re-apply live chrome when store deps are unchanged
+          // (selection already applied on down → effect would not re-run).
+          const box = getFrameBox(sceneDoc, drag.frameId);
+          const live = framePlateLiveChrome(drag.frameId, box, chrome);
+          setLiveOrigins(live.origins);
+          setLiveUnion(live.union);
+          setLiveAngle(live.angle);
         } else if (frameHit) {
           onSelectFrame?.(frameHit, { chrome: 'soft' });
+          setLiveOrigins([]);
+          setLiveUnion(null);
+          setLiveAngle(0);
         } else {
           onSelectFrame?.(null);
           onSelect([]);
+          setLiveOrigins([]);
+          setLiveUnion(null);
+          setLiveAngle(0);
         }
         endTransform();
         return;

--- a/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
@@ -759,20 +759,30 @@ function RcbShapesLayer({
   // Corner-radius drag stays on SoA canvas (transparent SVG corners).
   useLayoutEffect(() => {
     if (!isSoaCanvasShapesEnabled() || aiMutationLock > 0) return;
-    const flipHostInk = (previewNodeId: string | null) => {
+    const flipHostInk = (
+      previewNodeId: string | null,
+      mode: 'host' | 'canvas'
+    ) => {
       const buf = getSharedSceneRenderBuffer();
       if (buf.count === 0) return;
       const hostIds = new Set(fullHostsRef.current);
       for (const id of forceFullSetRef.current) hostIds.add(id);
-      if (previewNodeId) hostIds.delete(previewNodeId);
+      if (previewNodeId) {
+        if (mode === 'host') hostIds.add(previewNodeId);
+        else hostIds.delete(previewNodeId);
+      }
       const flipped = applySoaHostInkFlags(buf, hostIds);
       if (flipped > 0) flushDemotionPaintWake();
     };
     const unsubRadius = subscribeLiveCornerRadiusPreview(() => {
-      flipHostInk(getLiveCornerRadiusPreviewNodeId());
+      // Corner radius live ink is applied on the DOM host SVG. Forcing the
+      // slot onto SoA canvas idle left WebGL painting a stale sharp AABB under
+      // the rounded host (white corners while dragging R).
+      flipHostInk(getLiveCornerRadiusPreviewNodeId(), 'host');
     });
     const unsubShapeParams = subscribeLiveShapeParamsPreview(() => {
-      flipHostInk(getLiveShapeParamsPreviewNodeId());
+      // Poly/star sides need SoA live-geo rebuild — demote host for that node.
+      flipHostInk(getLiveShapeParamsPreviewNodeId(), 'canvas');
     });
     return () => {
       unsubRadius();

--- a/docs/assets/lang-en.svg
+++ b/docs/assets/lang-en.svg
@@ -1,12 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="74" height="20" role="img" aria-label="English">
-  <title>English</title>
-  <rect width="74" height="20" rx="3" fill="#d9d9d9"/>
-  <text
-    x="37"
-    y="14.5"
-    text-anchor="middle"
-    font-family="Verdana, Geneva, DejaVu Sans, sans-serif"
-    font-size="11"
-    fill="#333"
-  >English</text>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="49" height="20" role="img" aria-label="English"><title>English</title><filter id="blur"><feGaussianBlur stdDeviation="16"/></filter><linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="r"><rect width="49" height="20" rx="3"/></clipPath><g clip-path="url(#r)"><rect width="0" height="20" fill="#d9d9d9"/><rect x="0" width="49" height="20" fill="#d9d9d9"/><rect width="49" height="20" fill="url(#s)"/></g><g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110"><g transform="scale(.1)"><g aria-hidden="true" fill="#ccc"><text x="245" y="150" fill-opacity=".8" filter="url(#blur)" textLength="390">English</text><text x="245" y="150" fill-opacity=".3" textLength="390">English</text></g><text x="245" y="140" textLength="390" fill="#333">English</text></g></g></svg>

--- a/docs/assets/lang-ja.svg
+++ b/docs/assets/lang-ja.svg
@@ -1,12 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="72" height="20" role="img" aria-label="å,ž">
-  <title>å,ž</title>
-  <rect width="72" height="20" rx="3" fill="#d9d9d9"/>
-  <text
-    x="36"
-    y="14.5"
-    text-anchor="middle"
-    font-family="Verdana, Geneva, DejaVu Sans, sans-serif"
-    font-size="11"
-    fill="#333"
-  >å,ž</text>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="43" height="20" role="img" aria-label="&#26085;&#26412;&#35486;"><title>&#26085;&#26412;&#35486;</title><filter id="blur"><feGaussianBlur stdDeviation="16"/></filter><linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="r"><rect width="43" height="20" rx="3"/></clipPath><g clip-path="url(#r)"><rect width="0" height="20" fill="#d9d9d9"/><rect x="0" width="43" height="20" fill="#d9d9d9"/><rect width="43" height="20" fill="url(#s)"/></g><g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110"><g transform="scale(.1)"><g aria-hidden="true" fill="#ccc"><text x="215" y="150" fill-opacity=".8" filter="url(#blur)" textLength="330">&#26085;&#26412;&#35486;</text><text x="215" y="150" fill-opacity=".3" textLength="330">&#26085;&#26412;&#35486;</text></g><text x="215" y="140" textLength="330" fill="#333">&#26085;&#26412;&#35486;</text></g></g></svg>

--- a/docs/assets/lang-zh-CN.svg
+++ b/docs/assets/lang-zh-CN.svg
@@ -1,12 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="88" height="20" role="img" aria-label="€S-‡">
-  <title>€S-‡</title>
-  <rect width="88" height="20" rx="3" fill="#d9d9d9"/>
-  <text
-    x="44"
-    y="14.5"
-    text-anchor="middle"
-    font-family="Verdana, Geneva, DejaVu Sans, sans-serif"
-    font-size="11"
-    fill="#333"
-  >€S-‡</text>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="55" height="20" role="img" aria-label="&#31616;&#20307;&#20013;&#25991;"><title>&#31616;&#20307;&#20013;&#25991;</title><filter id="blur"><feGaussianBlur stdDeviation="16"/></filter><linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="r"><rect width="55" height="20" rx="3"/></clipPath><g clip-path="url(#r)"><rect width="0" height="20" fill="#d9d9d9"/><rect x="0" width="55" height="20" fill="#d9d9d9"/><rect width="55" height="20" fill="url(#s)"/></g><g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110"><g transform="scale(.1)"><g aria-hidden="true" fill="#ccc"><text x="275" y="150" fill-opacity=".8" filter="url(#blur)" textLength="450">&#31616;&#20307;&#20013;&#25991;</text><text x="275" y="150" fill-opacity=".3" textLength="450">&#31616;&#20307;&#20013;&#25991;</text></g><text x="275" y="140" textLength="450" fill="#333">&#31616;&#20307;&#20013;&#25991;</text></g></g></svg>


### PR DESCRIPTION
fix(web): crisp idle rounded edges and clear frame-plate ghost chrome

- fix(web): crisp idle rounded edges and clear frame-plate ghost chrome
- fix(web): pen fill in artboards, stuck selection chrome, and mark gesture yield (#33)
- fix(web): SoA WebGL single-path ink, Worker bake, stroked atlas stamps
- chore: ignore and strip local vitest/e2e scratch from - docs(web): shorten SoA README blurb and expand mixed 10k browser stress
- chore: ignore e2e logs and local _remote deploy helpers
- fix(web): precise SoA path hit, frame reveal split, and SoA README
- fix(web): restore bumpSceneCanvasIdlePaint import and createSlice typo
- feat(web): GPU DOF, canvas idle strokeAlign, and 10k mixed stress
- fix(web): SoA demotion single wake + dirty AABB lazy QT
- feat(web): SoA quadtree demotion bake, drop dual-path dead code, canvas docs
- fix(web,api): frame-local coords, workbench drag, text chrome, SoA hit
- fix(web,api): free chat UI after reply and harden canvas SoA
- feat(web): Zustand 直写 + 画布 SoA/手势/文本多项修复
- fix(web,api): canvas clip/flip/selectors, SoA render, dead vision cleanup
- fix(web): keep LOT preview after tab switch and persist precomp edits
- docs: point MCP canvas setup at Codex instead of Cursor
- fix(web): LOT tab materializes editable shapes and tighten workbench chrome
- chore: exclude pitch deck and private VPS scripts from OSS publish
- feat(web): unify animation workbench isolation policy and harden Lottie edit
- fix(web): tighten puppet animation UX, scope to workbench, restore minimap overview (#23)
- feat(web): add image puppet tool and harden animation workbench edit UX
- fix(web): hide preview guides in workbench edit and keep timeline open
- fix(web): gate animation workbench bind to open timeline and spawn on top
- fix(web): animation transport with empty boards and Redux play state (#20)
- feat: animation agent path and workbench timeline focus (#19)
- feat(web): add Lottie artboard timeline workbench
- checkpoint before checking out master
- checkpoint before checking out master
- fix(api): stop assets search matching meta_json base64 noise
- checkpoint before checking out master
- feat(web): blob upload previews and generator toolbar panel
- fix(web): stop SegmentTabs CJK labels wrapping inside chips
- ci(oss): mark no-cursor-coauthor status when merging zuoge PRs
- ci(oss): harden Publish OSS on Windows and keep zuoge merge gate
- fix(web): dock composers via SelectionToolbarShell and hide panels while transforming
- refactor(web): drop generator overlays and simplify composer chrome
- ci(oss): concrete public commit messages and no auto CI on zuoge
- ci: stop auto-running E2E, skill eval, and k6 on every push
- ci: scrub corrupted control chars from workflow YAML
- ci(e2e): honor E2E_PORT in Playwright webServer
- ci(e2e): use port 4173 on self-hosted so CI does not clash with :3000
- fix(web): keep generator composers mounted and wire Delete on empty prompts
- fix(web): scale text wrap width and keep selection chrome on-screen
- checkpoint before checking out master
- ci: run all workflows on self-hosted Windows runners
- fix(web): snap pasted nodes and artboards to the document grid
- fix(web): cap audio plate chrome like video playback bar
- feat: editor media chrome, asset search, and agent audio/lottie
- ci: align self-hosted runner setup with GitHub v2.336.0
- ci: run gate jobs on self-hosted Windows runner
- ci: retrigger workflows after lint and typecheck fixes
- fix(web): repair typecheck in mark and boolean union tests
- fix(api): remove unused imports after i18n refactor
- feat: soft-compress uploads, inline finish, agent harness seams
- docs: zh-CN README and api README nav
- docs: drop Cloud nav and deployment-modes from README index
- docs: remove cloud comparison from README and deployment guides
- fix(api): add apply_classified_model_route for memory graph node
- ci: retrigger workflows
- ci: retrigger workflows
- fix(api): remove unused import in memory graph node
- ci(api): allow F401 re-exports in graph state barrel
- fix(api): restore graph state protocol re-exports from main
- fix(api): import design protocol symbols from recombyn_protocol
- fix(api): re-export ReferenceIntelligenceTurnSchema from graph state
- fix(api): remove unused imports after auth cleanup
- refactor: unify cloud-only desktop and enable billing by default
- fix: correct stale paths after commercial and fixture cleanup
- chore: consolidate canvas stress E2E and fold k6 soak into smoke
- refactor: relocate closed-source tree from src/commercial into apps/
- chore: remove orphaned landing page SVG assets
- chore: round-2 dead code cleanup and dependency prune
- chore: remove dead code and unused imports across web and API
- feat(upload): chunked job uploads with refresh resume
- fix(ci): repair typecheck and web-unit failures on main
- fix: unify project/wallet cache and improve share/upload dev UX
- feat(editor): improve layer panel navigation and frame rename UX
- fix(ci): cast test harness dispatch to DesignToolContext
- fix(mcp): validate headless text nodes and harden canvas apply
- feat(mcp): align tool_ops apply with Agent flow and shared fixtures
- fix: include dev-api-port script in web Docker build
- docs: tidy README intro and move Star above MCP
- docs: remove MCP smoke test from user-facing docs
- feat: add MCP canvas control and remove desktop CLI mode
- refactor: unify ILP progress and env in deploy script
- fix: intelligence API key and improve ILP job progress
- fix(editor): clip smart guides to artboard overflow bounds
- fix: keep Intelligence vision responsive and stabilize ILP tooling
- fix: require intelligence API key in enable-ilp helper
- fix: theme mark chips and wire ILP env through compose
- feat: home copyright, JA Latin brand, generators and self-host polish
- chore: keep OSS commit messages free of publish-pipeline wording
- chore(): add one-shot rebuild script
- chore(): squash PRs to preserve commit titles
- chore(): use private commit messages on - fix: upload jobs, strict storage errors, and relocate OSS stubs
- fix(web): resolve runDesignAgent typecheck errors for CI
- fix(agent): vision Q&A for selection/mark chips and scoped publish glow
- fix: expand home rail by default and pad README wordmark
- fix: require strict media persistence and remove silent fallbacks
- fix(api): skip cover rebuild on rename-only PATCH (#7)
- fix: reposition home rail more menu when sidebar collapses
- fix: stop cover thumbnail flicker on home and publish dialog (#6)
- fix: project covers, list , editor nav, fonts and upload jobs (#5)
- fix(web): align share chrome with editor; show text typography in Inspect
- fix(web): drop local-only import scene test; fix mark targets fixture types
- fix(web,intel): brand 左格, mark media block, home rename , matting cache
- fix(web): add command_seq to transaction.chunk for DesignToolOpsEvent
- fix(editor): hide knobs while processing and restore chat bubble contrast
- fix(brand): use Latin zuoge wordmark across all locales
- docs(readme): enlarge brand wordmark ~2.5x
- fix(api): repair broken ILP decompose docstrings
- docs(readme): center brand header with a single div
- docs(brand): README logo, rename public repo to recombyn/zuoge
- docs(readme): rename product copy to 左格 / zuoge
- fix(vision): prefer local matting ONNX when BFF sends birefnet-general
- fix(vision): keep cutout canvas size, quiet mockup UX, drop dead BFF CV
- feat(home): brand wordmark, centered hero, admin Pro, mockup absorb
- fix(editor): include se-only in SelectionEdgeHandles plumbing
- fix(editor): polish text frames, video flip chrome, and wheel scroll ownership
- fix(ci): patch chat_job_sse get_job in image SSE unit test
- feat(editor): add fixed scrollable text frames and polish home composer
- feat(home): polish hero composer layout and dark-theme contrast
- fix(ci): resolve web typecheck and image job SSE unit test failures
- test(e2e): align home smoke with rail login and nav labels
- fix(editor): edge-anchor floating chrome and unify generator composers
- fix(editor): soft/full artboard chrome, flip/tidy selection, and README cleanup
- fix(ci): resolve web typecheck errors blocking main CI
- fix(editor): shift top title with left dock and refine color slider thumb
- fix(editor): overlay layout, mesh anchors, and canvas interaction polish
- fix: update ILP BFF smoke test for eraser and upscale kinds
- fix: vitest @commercial alias and API dev cv2 for OSS CI
- chore: untrack pub-bootstrap build artifact
- fix: OSS CI — commercial-oss stubs for @commercial/mockup alias
- chore: use recombyn author for OSS and add public repo bootstrap
- fix: repair CI failures and OSS publish flow
- fix: exclude build artifacts from OSS rsync
- chore: hard-delete commercial code on - chore: speed up OSS rsync (drop verbose)
- chore: vendor recombyn-intelligence into src/commercial
- chore: add private-to-public workflow and commercial tree
- chore: remove README hero image
- chore: remove unused readme hero image asset
- fix(canvas): refine mark UX and restore smart matting tools
- fix(canvas): mark quick-edit UX, process glow resize, and selection hover
- feat: restore intelligence vision and mockup BFF for local dev (#148)
- fix: remove remaining ILP and mark files missed in OSS purge (#147)
- chore: remove closed-source image vision tools from OSS (#146)
- fix: restore CI typecheck and web-unit on main
- fix: persist line/arrow angle when dragging endpoints
- feat: image fill controls and ILP depth layering
- fix: bind process SoftGlow to node paint and canvas idle cull
- chore: dedupe path translate/simplify and exit-edit i18n
- feat: prefer SAM soft masks and LaMa for image layer decompose
- fix: drop duplicate wallet.creditsLeft i18n keys
- fix: rename design intensity copy without changing lanes
- feat: filter skill inject by scope and required_context
- fix: pack Decide and Paint prompts by stage
- fix: Decide uses one structured LLM call with a single retry
- fix: build intelligence payload once and persist hop cache
- fix: gate Observe to paint or settle, one Review repair hop
- chore: rename wallet 积分 internals from tokens to credits
- chore: drop leftover aliases and docs to current contracts
- chore: read intelligence request fields from runtime attrs only
- chore: drop remaining dual-read aliases
- feat: use local model icons instead of lobehub
- chore: drop remaining aliases and unused image_credits
- fix: align overlay and rebase tests to current op ids
- fix: satisfy web typecheck in designTools path and frame fit
- chore: drop leftover aliases and stamp-era agent controller
- feat: snap artboard moves to peer smart guides
- test: keep api unit checks generic instead of pinning prompt copy
- test: align api unit asserts with lean paint and clarification
- feat: filled-ribbon vector pencils and drop stamp-era canvas paths
- ci: strip Cursor co-author locally and CONTRIBUTING to main
- chore: drop canvas scratch docs and ignore local e2e logs
- fix: expose get_design_task_for_update on design_tasks repository
- docs: refresh README product tagline and canvas description
- docs: refresh product tagline for open-source AI design workspace
- docs: clarify RCB canvas paint, LOD, and hit-testing in README
- fix: unblock CI without changing canvas radii behavior
- fix: unify canvas hit/chrome pipeline and design SSE progress
- fix: screen-space chrome via CameraTransform (ADR 0027)
- fix: keep pen outline fill visible and stop knob carpet
- fix: unblock web typecheck for auto-snap PR
- fix: restore canvas auto-snap and keep ink on the 1px grid
- fix: restore model chip labelSuffix and unblock CI research/pricing
- fix: unblock CI typecheck and task pricing floor assert
- feat: let LLM own design intent and free canvas tool ops
- docs: document OSS task pricing floors, locale, and design intensity
- feat: wire design intensity and locale through agent UI and runtime
- feat: open task-centric billing protocol 0.1.3
- fix: restore e2e encoding, typecheck fills, and remote apply hooks
- fix: land remaining agent memory, observe, and web contract renames
- fix: unblock CI for package rename, review gates, and skills paths
- feat: land billing protocol, pricing versions, and public skills catalog
- fix: CI installs for protocol SDKs and eval-framework lock
- feat: add intelligence provider boundary and protocol contract
- fix: restore canvas tool seed allowlist for empty DB
- docs: clarify product voice and drop PDF import
- fix: widen chat + design_global_rule text columns to LONGTEXT
- fix: widen chat session/message columns to LONGTEXT on MySQL
- fix: widen design_system_prompt.body to LONGTEXT on MySQL
- fix: locale detect, dark switch/preview, card-key ops, plaza seeds
- fix: store project/share documents as LONGTEXT in MySQL
- fix: stabilize project cloud and defer home-agent send during tour
- fix: store email OTP timestamps as BIGINT and bake Google client id in web image
- fix: harden cloud MySQL text columns and production web chrome
- fix: guest login modal, skills card UX, and deploy Docker builds (#112)
- feat: use PNG skill icons and marketplace-style tiles (#111)
- fix: stabilize media E2E and gate Send on model availability (#110)
- feat: off-request chat video and audio jobs (#109)
- feat: add .recombyn-plugin pack format and install API (#108)
- feat: Skill ops runner Phase C (handler.py → tool_ops) (#107)
- feat: Canvas plugins Phase B (toolbar registry) (#106)
- feat: Skill extensions Phase A (plugins/skills) (#105)
- fix: stabilize CI origin test and metrics scrape latency
- docs: drop core-feature dump and microservice framing
- feat: run editor image gen as async jobs
- refactor: share job DLQ paths and drop unused aliases
- docs: drop big-co framing and ignore local scratch files
- feat: admin export DLQ replay with depth gauge
- fix: draw scene text in server PDF/PNG export
- feat: editor menu for server PDF export
- feat: async artboard export jobs (PNG/PDF)
- docs: check admin Insights hydrate DLQ tab on Phase 6
- feat: ops stack for hydrate DLQ, Grafana, and ClamAV
- feat: send org invite emails via SES (best-effort)
- docs: check project org badge/move on Phase 6 roadmap
- feat: project org move/badge and org rename/kick
- feat: pending org invites with user search and accept/decline
- feat(web): account org tab, invite UI, and project org filter
- feat: project org_id, org invite API, and k8s PDB/NetworkPolicy
- feat: HPA/Ingress, admin write audit, org_members skeleton
- feat: Phase 6 follow-through (k8s, RBAC, OTel worker, 5k LOD)
- feat: ship deferred OTel, DLQ, ClamAV, dual Yjs merge
- test: mock image-gen promote + project revision conflict
- fix(web): clear tsc debt and gate typecheck:web in CI
- ci: desktop unsigned build + stress baselines docs
- docs: fix rollback step numbering in self-hosting
- ci: publish api/web/collab images to GHCR on tags
- ci: add unified CI gate + changelog rollback docs
- feat: upload magic sniff + RBAC security docs
- feat: Phase 3 correlation logs + dep audit CI
- feat: hydrate route coverage floor + Celery transient retry
- feat: ADR 0006 in-process LLM facade + alembic head gate
- feat: wire Design Agent hydrate through Celery jobs
- feat: Phase 2 async hydrate jobs + ADR 0005
- docs: map big-co AI canvas backend standards onto roadmap
- chore: phase-1 monorepo foundation (turbo, shared configs, husky, ADR)
- Disable rate limits in k6 CI and verify minted token before load.
- Add prometheus client deps for /metrics instrumentation.
- Fix CI: soft min_creates only for craft skills; install scene-builder in k6.
- Expand quality gates and harden canvas/agent stress paths.
- Rewrite design skills around intentional craft and medium choice.
- fix: assets are AI-only; LOD selection stays degraded
- fix: unify skeleton shimmer as solid card sweep
- fix: restore _derive_suggested_place_world to fix CI ImportError
- fix: chip fly-in no stutter; image tile hide on error; img_layers token warning
- fix: boolean result no longer re-fillets path; radius handles skip curve-only paths
- fix: remove stale _derive_suggested_place_world from support.py barrel
- fix: remove stale placement hints and improve LOD proxy rendering
- Harden observe scene feedback and document artboard vs viewport.
- Block Cursor Co-authored-by trailers via CI and require the check on main.
- Move GitHub Star CTA above the Canvas section in README locales.
- Scope canvas-to-chat fly-in to the right composer and refresh README Agent/canvas docs.
- Harden desktop export/tour UX and unify canvas-to-chat fly-in.
- chore: refresh GitHub contributors graph
- Skip category stress E2E in default CI when token is missing.
- chore: refresh GitHub contributors graph
- Switch to Apache-2.0 and harden XSS/CSP defenses.
- Fix e2e CI crash when .tmp-token.txt is missing.
- Add image Mark tool that flies region chips into Agent chat.
- Expand LobeHub model icons and cut home cold-path fetch noise.
- Harden design-agent paint timeouts, icon tools, and ref-UI stress.
- Thin the design-agent kernel and ship sparse review plus stress harness.
- Ship oRPC frontend stack and restore project cloud .
- Ship server-side project covers and oriented multi-select rotate chrome.
- Defer home/editor data loads to click paths and prefer async/await.
- Improve media editing UX and clear stale auth sessions on invalid tokens.
- chore: refresh GitHub contributors graph
- Fix permission-gate test for default-off wallet billing.
- Align free image model and empty desktop BYOK catalog.
- Consolidate license/docs and tighten agent content ownership.
- Publish built help site on this repo gh-pages; drop separate help URL.
- Clarify no white-label or impersonation in README license section.
- Move user docs out of the public monorepo.
- Expand docs for custom models, desktop packaging, and sponsor copy.
- Add audio generation nodes, media assets panel, and LLM provider updates.
- Add sponsor page and deploy docs via GitHub Pages.
- Move desktop editor home and title into the custom titlebar.
- Make local desktop BYOK-only and hide cloud billing UI.
- Add local/cloud desktop flavors with API sidecar and OS auto-login.
- Add Tauri v2 desktop shell with themed titlebar and docs.
- Fix CI unit failures for tip pencil fixture, _rev schema, and skill tests.
- Bind new-design paint to a host FOCUS artboard and tighten editor chrome.
- Add vector pencil brushes with hardness and sharper live tip preview.
- Ship tip-stamp pencil engine with dense live preview and sharp zoom bake.
- Fix Lottie snap stickiness and keep selection chrome on the host lattice.
- Keep pencil/pen freehand ink centered on the stored path.
- Restore pencil freehand pressure ink after Lottie merge regression.
- Mock lottie-web in Vitest so jsdom canvas stubs do not crash imports.
- Add Lottie generator plate and player on the canvas.
- Add self-host console login OTP and multi-artboard agent paint.
- Close account menu after language or theme pick.
- Flatten API seed data and harden Ask/canvas cold-start.
- Fix web snap/save/inspect: low-zoom guides, incremental collab persist, diagonal measure.
- Allow public plaza feed, canvas bg theme reset, and venv-aware dev:api.
- Fix half-pixel fill after hiding center stroke by expanding geom to outer ink.
- Let Ask typed confirm be judged by intent LLM via proposal_action.
- Fix selection chrome: HTML titles, live image radius, and undo fallback.
- Fix project cover tiles: multi-artboard collage and collab .
- Fix RCB selection chrome hit-testing so resize and toolbar no longer collide.
- Strengthen post-paint critique for craft and long canvases.
- Align RCB selection chrome to the shared world lattice and keep title/toolbar gaps screen-constant under canvas and browser zoom.
- Fix CI: expect create_image on lean create paint keys.
- Improve Design Agent quality: skills, paint kit, and critique.
- Fix Alembic xdist stamp races for API CI.
- Retire hand-written DDL for Alembic and trim LC/LG comment fluff.
- Allow run-lease claim before design_task insert when Redis is absent.
- Allow app.services paths in LangGraph checkpoint msgpack allowlist.
- Add minimal public knowledge seed so CI catalog tests pass without private overlay.
- Fix API pytest isolation after SQLITE_DB_PATH switches under xdist.
- Fix API tests and SQLite/auth helpers after the app package move.
- Fix SQLite path resolution after app/ package move.
- Add canvas smart guides and Agent pause/resume UX.
- Remove accidental app/storage runtime artifacts from the API refactor.
- Refactor API onto FastAPI app package with SQLModel data access.
- Improve canvas path edit, stroke outline, and editor chrome.
- Bust GitHub CDN cache for README hero image.
- Refine README hero chrome and add EN/zh/ja language pills.
- Refresh README hero with horizontal lockup and bottom language pills.
- Polish skill chips, multi-angle panel, and process overlay stacking.
- Fix README logo: use PNG mark after hero asset removal.
- Ship MIT design skill packs and English OSS seeds; improve editor canvas tooling.
- Harden public self-host defaults and document TLS checklist.
- Fix OSS docs to match Source Available license and seed wording.
- Fix small-screen canvas menu, share top chrome, and one-shot camera fit.
- Fix inspect/export for video nodes to match editor.
- Unify share boot UI and stabilize canvas camera fit.
- Fix share preview video playback and polish inspect/export UX.
- Polish canvas spacing/radius UX, collab share flow, and golden-path CI.
- Fix context menu click-through onto the bottom tool strip.
- Fix API unit tests against OSS prompt-pack cold start.
- Ship core Agent skills in public seed and document Yjs collab.
- Add Yjs canvas collaboration and flatten SvgCanvas modules.
- Keep view and download share links on the preview page.
- Persist share Can download ACL and dedupe StrictMode create.
- Fix Share dialog toggle stuck disabled under StrictMode.
- Use 3 columns for Me profile feed on iPad.
- Remove the README footer brand lockup.
- Suppress the browser context menu on the canvas stage.
- Fix canvas context menu on nodes and generator composers.
- Fix canvas pointer coords, context menu placement, and chrome clicks on small viewports.
- Wait for remote image decode before dropping local upload preview.
- Ship a minimal OSS prompt-pack baseline and Skills upload tile.
- Tune home grids per surface, shorten empty copy, and enable mobile video chat.
- Point commercial license contact to 702680355@qq.com.
- Adopt Recombyn Source Available License (ELv2-style terms).
- Remove Breatic references from README license blurbs.
- Add home Skills toolbox with zip import, prefs, and rail polish.
- Prefer English for engineering and docs-site defaults.
- Fix missing TOOL_OPS_SCHEMA_VERSION import in paint action node.
- Fix missing imports in LangGraph nodes after the host/graph split.
- Split Design Agent runtime into host/graph packages and add prompt-pack usedBy stages.
- Fix LangGraph checkpointer for async astream and MySQL 5.7.
- Accept parameters in tool_ops and surface validation failures in chat.
- Stop preloading skill bodies; demote short design asks to canvas_op.
- Ignore the whole data/private tree and document the local overlay.
- Stop tracking data/private so only local SaaS seeds stay on disk.
- Split API seeds into public stubs and a private overlay for OSS vs SaaS.
- Align docs with design packages; allow video from canvas context menu.
- Stop tracking local langgraph sqlite wal/shm sidecars.
- Drop design compatibility shims and cut over imports.
- Repackage design services into domain packages with compat shims.
- Tighten paint op envelope schema and unify op_error codes.
- Teach the agent via validation errors and gate OpenRouter on CN networks.
- Prefer local artboard snaps so distant guides stop stealing center align.
- Improve design-agent reliability and canvas attach UX.
- Ask readers to star the GitHub repo in the READMEs.
- Polish home rail/hero and clear plaza seed cases.
- Make eraser spawn a cutout node like remove-bg.
- Tighten README intro copy and remove repeated pitch lines.
- Fix text-toolbar align icons reading too light next to B/I/U.
- Improve canvas scale for multi-thousand nodes and reorganize rcb modules.
- Polish layer decompose UX and generator loading placement.
- Enable image layer decompose (editElements) with rembg subject fallback.
- Clarify Design Skill ownership and remove need_prompts legacy.
- Fix video layer hide, export scale guards, and route submenu positioning.
- Tighten multi-angle panel spacing and narrow the preview column.
- Lay out the multi-angle tool as left preview and right controls.
- Disable context-menu export for image/video generator plates.
- Apply video flip live on the canvas plate and slim the flip toolbar.
- Improve canvas video playback, trim keep-time, and MP3/MP4 export.
- Improve Ask clarify flow, project hydrate, and editor agent chrome.
- Polish agent route flyouts, landing/home UI, and editor chrome.
- Highlight LangGraph-native canvas control in the README.
- Remove unused frontend and API dependencies.
- Remove third-party product name references from comments.
- Add video extract-frame and make upload-placeholder deletes permanent.
- Mention PostgreSQL support on the README homepage.
- Document self-host skills, Postgres, backups, and BYOK.
- Harden skills ACL, DB concurrency, BYOK, and media paste UX.
- Improve canvas video playback and composer media attach UX.
- Memo web components and harden canvas video playback.
- Add canvas video nodes and polish home/video UX.
- Rebuild README hero from real product UI and brand mark.
- Refresh README hero: poster canvas mockup with matching agent chat.
- Refresh README hero to product UI; drop VitePress leftover wording.
- Harden knowledge seed when catalog-ready outlives DB path switches.
- Fix API integration CI: scene-builder install and LangGraph mocks.
- Fix CI unit failures for empty-DB tools and jsdom scroll.
- Polish OSS hygiene: docs, public assets, and self-host defaults.
- Clarify docker-compose header without Langfuse references.
- Drop Langfuse from the public OSS surface.
- Ignore the entire .cursor directory in git.
- Stop tracking .cursor; ignore the whole Cursor IDE folder.
- Widen dark lockup viewBox to match light wordmark.
- Widen recombyn lockup viewBox so the final n is not clipped.
- Polish README branding: visual editor wording and lockup footer.
- Ship open-source packaging, file-based design skills, and agent chat polish.
- Refine canvas align guides and continue agent/auth/editor updates.
- Add multilingual docs site for product guides and legal pages.
- Refine design agent flow prompts and resource loading.
- Ship marketing landing, locale URL prefixes, and editor/home polish.
- Wire Design Agent to LangGraph published flows with Ask mode and graph-hop replay logs.
- Ship infinite canvas rcb stack, unified SVG export, and main-site API surface.
- Move pipeline steps below reply and add retry/redesign choices.
- Add phased design agent modes, on-demand skills, and project listing rules.
- Ship design agent, plaza, wallet, and LighthouseDB/COS persistence.
- Fix design import response validation and reject bad suffixes.
- Rebuild Recombine as a monorepo canvas editor with import API.
- Initialize project using Create React App

[skip ci]