### PR TITLE
ci: disable automatic self-hosted workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,11 @@
 name: CI
 
-# Required check for branch protection: "CI / gate"
-# Lint + typecheck + unit + build only. E2E / skill / k6 are workflow_dispatch.
-# Self-hosted Windows — docs/self-hosted-ci-windows.md
+# Disabled for automatic PR/main runs — single self-hosted Windows runner is too
+# slow / contended. Re-enable triggers only when a dedicated runner pool exists.
+# Manual: Actions → CI → Run workflow
 
 on:
-  pull_request:
-  push:
-    branches: [main, master, develop]
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,15 +1,6 @@
 name: Dependency audit
 
 on:
-  pull_request:
-    paths:
-      - 'apps/api/pyproject.toml'
-      - 'apps/web/package.json'
-      - 'package-lock.json'
-      - 'package.json'
-      - '.github/workflows/dependency-audit.yml'
-  schedule:
-    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/nightly-quality.yml
+++ b/.github/workflows/nightly-quality.yml
@@ -1,10 +1,8 @@
 name: Nightly quality gates
 
-# Nightly soak — manual or scheduled only (not on every push).
+# Manual only — automatic schedule disabled (single self-hosted runner).
 
 on:
-  schedule:
-    - cron: '0 18 * * *' # 02:00 CST
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/protocol-contract-smoke.yml
+++ b/.github/workflows/protocol-contract-smoke.yml
@@ -1,18 +1,8 @@
 name: protocol-contract-smoke
 
-# Guard protocol + runtime contract helpers.
+# Guard protocol + runtime contract helpers. Manual only (self-hosted CI off).
 
 on:
-  push:
-    paths:
-      - "packages/protocol/**"
-      - "packages/runtime/**"
-      - ".github/workflows/protocol-contract-smoke.yml"
-  pull_request:
-    paths:
-      - "packages/protocol/**"
-      - "packages/runtime/**"
-      - ".github/workflows/protocol-contract-smoke.yml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Turn CI / audit / nightly / protocol-smoke into `workflow_dispatch` only
- Stops PR/push from queuing the single Windows runner
