### PR TITLE
fix(web): unify RCB paint stack and ideal hit by stackOrder

### DIFF
--- a/apps/web/src/components/editor/canvas/SvgCanvas.tsx
+++ b/apps/web/src/components/editor/canvas/SvgCanvas.tsx
@@ -2000,6 +2000,12 @@ function SvgCanvas({
     [document, ids, selectedFrameIds]
   );
 
+  /** Single-selected artboard — temporary front over world SoA ink (plate under ink CSS). */
+  const paintRaiseFrameIds = useMemo(() => {
+    if (selectedFrameIds.length !== 1 || ids.length > 0) return [] as string[];
+    return [String(selectedFrameIds[0] || '')].filter(Boolean);
+  }, [ids.length, selectedFrameIds]);
+
   /** DOM hosts: SoftGlow process + pen path-edit + active video/audio FO (≤1 each).
    * Text edit → TextInlineEditor overlay. Idle image/video/audio → canvas ink / plate. */
   const forceFullIds = useMemo(() => {
@@ -2115,6 +2121,7 @@ function SvgCanvas({
             keepVisibleIds={keepVisibleIds}
             revealOverflowIds={revealOverflowIds}
             paintRaiseIds={paintRaiseIds}
+            paintRaiseFrameIds={paintRaiseFrameIds}
             forceFullIds={forceFullIds}
             spatialIndex={nodeSpatialIndex}
           />

--- a/apps/web/src/components/rcb/canvas/RcbCanvas.tsx
+++ b/apps/web/src/components/rcb/canvas/RcbCanvas.tsx
@@ -202,11 +202,10 @@ export type RcbCanvasProps = {
 /**
  * Layers:
  *   1. Grid canvas
- *   2. Frame plate SVG (below shape ink)
- *   3. SoA / canvas shape ink (single vector surface)
- *   4. DOM shape hosts (text / media FO / editors)
- *   5. Chrome SVG (preview, guides, selection)
- *   6. Overlay HTML UI
+ *   2. SoA / canvas shape ink (under stack SVG)
+ *   3. Stack SVG — artboard plates + DOM hosts interleaved by stackOrder data-z
+ *   4. Chrome SVG (preview, guides, selection)
+ *   5. Overlay HTML UI
  */
 function RcbCanvas({
   artboard,
@@ -522,26 +521,18 @@ function RcbCanvas({
     });
   }, [camera, devicePixelRatio, viewportEl?.clientWidth, viewportEl?.clientHeight]);
 
-  // z-order: grid → frame plates → SoA canvas ink → DOM hosts → chrome.
-  const sceneFramesSvgRef = useRef<SVGSVGElement | null>(null);
+  // z-order: grid → SoA canvas ink → stack SVG (plates+hosts) → chrome.
   const sceneInkSvgRef = useRef<SVGSVGElement | null>(null);
   const sceneChromeSvgRef = useRef<SVGSVGElement | null>(null);
 
   const publishSceneWorldMounts = useCallback(() => {
-    const framesInk = sceneFramesSvgRef.current;
     const ink = sceneInkSvgRef.current;
     const chrome = sceneChromeSvgRef.current;
-    const framesCamera = framesInk
-      ? (framesInk.querySelector(':scope > g[data-rcb-scene-camera]') as SVGGElement | null)
-      : null;
     const inkCamera = ink
       ? (ink.querySelector(':scope > g[data-rcb-scene-camera]') as SVGGElement | null)
       : null;
     const chromeCamera = chrome
       ? (chrome.querySelector(':scope > g[data-rcb-scene-camera]') as SVGGElement | null)
-      : null;
-    const framesMount = framesCamera
-      ? (framesCamera.querySelector(':scope > g[data-rcb-frames-mount]') as SVGGElement | null)
       : null;
     const mount = inkCamera
       ? (inkCamera.querySelector(':scope > g[data-rcb-shapes-mount]') as SVGGElement | null)
@@ -559,24 +550,9 @@ function RcbCanvas({
           ':scope > g[data-rcb-selection-chrome-mount]'
         ) as SVGGElement | null)
       : null;
-    setSceneWorldRoot(
-      ink,
-      mount,
-      previewMount,
-      guidesMount,
-      selectionChromeMount,
-      framesInk,
-      framesMount
-    );
+    // Plates alias onto the shapes mount inside setSceneWorldRoot.
+    setSceneWorldRoot(ink, mount, previewMount, guidesMount, selectionChromeMount);
   }, []);
-
-  const setSceneFramesRootNode = useCallback(
-    (node: SVGSVGElement | null) => {
-      sceneFramesSvgRef.current = node;
-      publishSceneWorldMounts();
-    },
-    [publishSceneWorldMounts]
-  );
 
   const setSceneInkRootNode = useCallback(
     (node: SVGSVGElement | null) => {
@@ -594,7 +570,7 @@ function RcbCanvas({
     [publishSceneWorldMounts]
   );
   useEffect(() => {
-    return () => setSceneWorldRoot(null, null, null, null, null, null, null);
+    return () => setSceneWorldRoot(null, null, null, null, null);
   }, []);
 
   const paintCameraKeyRef = useRef('');
@@ -605,7 +581,7 @@ function RcbCanvas({
   /** Backend recreate / idle-list identity still forces one full ink pass. */
   const transformPreviewFullPaintRef = useRef(false);
 
-  // Stage: grid → frame plates → SoA canvas ink → DOM hosts (ADR 0027).
+  // Stage: grid → SoA ink → shared stack SVG (plates+hosts by stackOrder) → chrome.
   // Hit uses the product SceneSpatialRuntime published by SvgCanvas (one path).
   // Recreate ink backend when GPU DOF toggles webgl ↔ webgpu.
   const [inkBackendKey, setInkBackendKey] = useState(() => resolveIdleInkBackend());
@@ -881,7 +857,7 @@ function RcbCanvas({
                 [data-rcb-canvas] [data-rcb-video-svg-underlay="1"] { opacity: 0; }
               `}</style>
               {defs}
-              {/* Grid under frame plates. */}
+              {/* Grid under stack ink. */}
               <canvas
                 ref={paintCanvasRef}
                 aria-hidden
@@ -892,43 +868,14 @@ function RcbCanvas({
                 data-rcb-grid-top={String(Math.floor(sceneTop / g) * g)}
                 className="pointer-events-none absolute inset-0 z-0"
               />
-              {/* Frame plates below SoA canvas ink. */}
-              {stageW > 0 && stageH > 0 ? (
-                <svg
-                  ref={setSceneFramesRootNode}
-                  aria-hidden
-                  data-rcb-scene-frames-root="1"
-                  data-rcb-screen-surface="1"
-                  data-rcb-infinite="1"
-                  data-rcb-shared-scene-surface="1"
-                  className="pointer-events-none absolute inset-0 z-[1] overflow-visible"
-                  width={stageW}
-                  height={stageH}
-                  viewBox={`0 0 ${stageW} ${stageH}`}
-                  preserveAspectRatio="none"
-                  style={{
-                    width: stageW,
-                    height: stageH,
-                    display: 'block',
-                    overflow: 'visible',
-                    shapeRendering: 'geometricPrecision',
-                    pointerEvents: 'none',
-                    isolation: 'isolate',
-                  }}
-                >
-                  <g data-rcb-scene-camera="1" transform={sceneCameraTransform}>
-                    <g data-rcb-frames-mount="1" />
-                  </g>
-                </svg>
-              ) : null}
               <canvas
                 ref={inkCanvasRef}
                 aria-hidden
                 data-rcb-idle-ink-canvas="1"
                 data-rcb-canvas-idle-count={String(listSceneCanvasIdlePaintIds().length)}
-                className="pointer-events-none absolute inset-0 z-[2]"
+                className="pointer-events-none absolute inset-0 z-[1]"
               />
-              {/* DOM hosts (text/media/editors) above SoA canvas ink. */}
+              {/* Plates + DOM hosts — one mount, stackOrder data-z. */}
               {stageW > 0 && stageH > 0 ? (
                 <svg
                   ref={setSceneInkRootNode}
@@ -939,7 +886,7 @@ function RcbCanvas({
                   data-rcb-shared-scene-surface="1"
                   data-rcb-scene-surface="1"
                   data-rcb-grid-size={String(g)}
-                  className="pointer-events-none absolute inset-0 z-[3] overflow-visible"
+                  className="pointer-events-none absolute inset-0 z-[2] overflow-visible"
                   width={stageW}
                   height={stageH}
                   viewBox={`0 0 ${stageW} ${stageH}`}
@@ -951,8 +898,6 @@ function RcbCanvas({
                     overflow: 'visible',
                     shapeRendering: 'geometricPrecision',
                     pointerEvents: 'none',
-                    // Keep mix-blend-mode layers compositing in SVG paint order
-                    // (above artboard plates) instead of against the page backdrop.
                     isolation: 'isolate',
                   }}
                 >
@@ -961,7 +906,7 @@ function RcbCanvas({
                   </g>
                 </svg>
               ) : null}
-              {/* Draw preview / guides / selection above shape ink — same CameraTransform. */}
+              {/* Draw preview / guides / selection above stack paint. */}
               {stageW > 0 && stageH > 0 ? (
                 <svg
                   ref={setSceneChromeRootNode}
@@ -969,7 +914,7 @@ function RcbCanvas({
                   data-rcb-scene-chrome-root="1"
                   data-rcb-screen-surface="1"
                   data-rcb-infinite="1"
-                  className="pointer-events-none absolute inset-0 z-[4] overflow-visible"
+                  className="pointer-events-none absolute inset-0 z-[3] overflow-visible"
                   width={stageW}
                   height={stageH}
                   viewBox={`0 0 ${stageW} ${stageH}`}

--- a/apps/web/src/components/rcb/core/spatialIndex.ts
+++ b/apps/web/src/components/rcb/core/spatialIndex.ts
@@ -2,11 +2,17 @@ import type { SceneDocument } from '@/components/rcb/sceneNode';
 /**
  * Spatial index for scene AABBs (culling + hit candidate filter).
  * Backed by {@link SoaQuadtree} (world units; pan/zoom only transforms queries).
+ *
+ * Product hit indexes **nodes** (bare id) and **artboard plates** (`frame:id`)
+ * in one QT. Paint box = hit box. Marquee (`queryIdsInRect`) returns nodes only.
  */
 
 import { SoaQuadtree, type SoaQuadItem } from './soaQuadtree';
-import { nodeLeftTop } from '../scene/paint/sceneToSvg';
+import { nodeLeftTop, frameSceneBounds } from '../scene/paint/sceneToSvg';
 import { effectivePaintBox } from './transformPreview';
+import { stackFrameKey, parseStackKey } from '@/components/rcb/scene/document/sceneDocument';
+import { getLiveArtboardFrameGeometry } from '@/components/rcb/frames/HtmlArtboardFrame';
+import { isArtboardVisibleInDocument } from '@/components/rcb/scene/document/nodeCapabilities';
 
 export type RcbSpatialItem = SoaQuadItem;
 
@@ -236,6 +242,29 @@ export function nodeSceneAabb(
   };
 }
 
+/** Artboard plate AABB in the same world space as nodeSceneAabb (key = `frame:id`). */
+export function frameSceneAabb(
+  document: SceneDocument,
+  frameId: string,
+  pad = 0
+): { minX: number; minY: number; maxX: number; maxY: number } | null {
+  const fid = String(frameId || '').trim();
+  if (!fid || !document) return null;
+  const frame = (Array.isArray(document.frames) ? document.frames : []).find(
+    (f) => String(f?.id || '') === fid
+  );
+  if (!frame || frame.locked || !isArtboardVisibleInDocument(frame)) return null;
+  const live = getLiveArtboardFrameGeometry(fid);
+  const box = frameSceneBounds(document, frame, live);
+  const expand = Math.max(0, pad);
+  return {
+    minX: box.left - expand,
+    minY: box.top - expand,
+    maxX: box.left + box.width + expand,
+    maxY: box.top + box.height + expand,
+  };
+}
+
 /** Prefer spatial candidates once the scene reaches this many root ids. */
 export const SCENE_SPATIAL_LARGE_THRESHOLD = 48;
 
@@ -247,6 +276,8 @@ export type SceneSpatialSyncInput = {
   patchedNodeIds?: readonly string[];
   /** Extra AABB pad in scene units (stroke handled inside nodeSceneAabb). */
   aabbPad?: number;
+  /** When true (default), keep `frame:id` plate AABBs in the same QT. */
+  indexFrames?: boolean;
 };
 
 /**
@@ -259,9 +290,11 @@ export class SceneSpatialRuntime {
   private reloadToken: number | string | null = null;
   /** Length-only membership fingerprint — page.children is a new array every paste. */
   private childrenLen = -1;
+  private framesLen = -1;
   private rank = new Map<string, number>();
   /** Skip StrictMode double-invoke with the same membership + patch set. */
   private lastSyncKey = '';
+  private indexFrames = true;
 
   constructor(cellSize = 256) {
     this.index = new RcbSpatialIndex(cellSize);
@@ -279,8 +312,58 @@ export class SceneSpatialRuntime {
     this.index.clear();
     this.reloadToken = null;
     this.childrenLen = -1;
+    this.framesLen = -1;
     this.rank = new Map();
     this.lastSyncKey = '';
+  }
+
+  /** Collect node + optional frame plate items for a full replaceAll. */
+  private collectSyncItems(
+    doc: SceneDocument,
+    childrenSrc: readonly string[],
+    pad: number,
+    withFrames: boolean
+  ): RcbSpatialItem[] {
+    const items: RcbSpatialItem[] = [];
+    for (const id of childrenSrc) {
+      const box = nodeSceneAabb(doc, id, pad);
+      if (!box) continue;
+      items.push({ id, ...box });
+    }
+    if (withFrames) {
+      for (const frame of Array.isArray(doc.frames) ? doc.frames : []) {
+        const fid = String(frame?.id || '').trim();
+        if (!fid) continue;
+        const box = frameSceneAabb(doc, fid, pad);
+        if (!box) continue;
+        items.push({ id: stackFrameKey(fid), ...box });
+      }
+    }
+    return items;
+  }
+
+  /** Reconcile `frame:*` plate keys after node sync (membership + live geom). */
+  private syncFramePlates(doc: SceneDocument, pad: number): void {
+    if (!this.indexFrames) return;
+    const want = new Set<string>();
+    for (const frame of Array.isArray(doc.frames) ? doc.frames : []) {
+      const fid = String(frame?.id || '').trim();
+      if (!fid) continue;
+      const key = stackFrameKey(fid);
+      const box = frameSceneAabb(doc, fid, pad);
+      if (!box) {
+        this.index.remove(key);
+        continue;
+      }
+      want.add(key);
+      this.index.upsert({ id: key, ...box });
+    }
+    for (const id of [...this.index.ids()]) {
+      const parsed = parseStackKey(id);
+      if (!parsed || parsed.kind !== 'frame') continue;
+      if (!want.has(id)) this.index.remove(id);
+    }
+    this.framesLen = Array.isArray(doc.frames) ? doc.frames.length : 0;
   }
 
   sync(input: SceneSpatialSyncInput): RcbSpatialIndex {
@@ -292,14 +375,19 @@ export class SceneSpatialRuntime {
     const childrenSrc = input.childrenIds;
     const pad = input.aabbPad ?? 32;
     const patched = input.patchedNodeIds || [];
-    const syncKey = `${input.reloadToken}:${childrenSrc.length}:${patched.length}:${patched[0] || ''}:${patched[patched.length - 1] || ''}`;
+    this.indexFrames = input.indexFrames !== false;
+    const framesLen = Array.isArray(doc.frames) ? doc.frames.length : 0;
+    const syncKey = `${input.reloadToken}:${childrenSrc.length}:${framesLen}:${patched.length}:${patched[0] || ''}:${patched[patched.length - 1] || ''}:${this.indexFrames ? 1 : 0}`;
     if (syncKey === this.lastSyncKey && this.index.size > 0) {
+      // Live plate drag: still refresh frame AABBs from live geom.
+      if (this.indexFrames) this.syncFramePlates(doc, pad);
       return this.index;
     }
     this.lastSyncKey = syncKey;
 
     const tokenChanged = this.reloadToken !== input.reloadToken;
     const lenChanged = this.childrenLen !== childrenSrc.length;
+    const framesChanged = this.framesLen !== framesLen;
     if (tokenChanged || lenChanged || this.index.size === 0) {
       this.rank = buildIdRankMap(childrenSrc);
       this.childrenLen = childrenSrc.length;
@@ -308,14 +396,10 @@ export class SceneSpatialRuntime {
     if (tokenChanged || this.index.size === 0) {
       // One replaceAll — sequential upsert rebuilds the tree on every out-of-root
       // paste offset and went O(n²) once the scene grew past a few dozen nodes.
-      const items: RcbSpatialItem[] = [];
-      for (const id of childrenSrc) {
-        const box = nodeSceneAabb(doc, id, pad);
-        if (!box) continue;
-        items.push({ id, ...box });
-      }
+      const items = this.collectSyncItems(doc, childrenSrc, pad, this.indexFrames);
       this.index.replaceAll(items);
       this.reloadToken = input.reloadToken;
+      this.framesLen = framesLen;
       return this.index;
     }
 
@@ -327,6 +411,7 @@ export class SceneSpatialRuntime {
       const idSet = grewOnly ? null : new Set(childrenSrc);
       if (idSet) {
         for (const id of [...this.index.ids()]) {
+          if (parseStackKey(id)?.kind === 'frame') continue;
           if (!idSet.has(id)) this.index.remove(id);
         }
       }
@@ -362,10 +447,12 @@ export class SceneSpatialRuntime {
         return key && !addedIds.has(key);
       });
       if (geomOnly.length) this.patchNodes(doc, geomOnly, pad);
+      this.syncFramePlates(doc, pad);
       return this.index;
     }
 
     this.patchNodes(doc, patched, pad);
+    if (framesChanged || this.indexFrames) this.syncFramePlates(doc, pad);
     return this.index;
   }
 
@@ -379,6 +466,13 @@ export class SceneSpatialRuntime {
     if (patchedNodeIds.length === 1) {
       const id = String(patchedNodeIds[0] || '').trim();
       if (!id) return;
+      if (parseStackKey(id)?.kind === 'frame') {
+        const fid = parseStackKey(id)!.id;
+        const box = frameSceneAabb(document, fid, aabbPad);
+        if (!box) this.index.remove(id);
+        else this.index.upsert({ id, ...box });
+        return;
+      }
       if (!document.deltaSetLike?.[id]) {
         this.index.remove(id);
         return;
@@ -392,6 +486,13 @@ export class SceneSpatialRuntime {
     for (const raw of patchedNodeIds) {
       const id = String(raw || '').trim();
       if (!id) continue;
+      if (parseStackKey(id)?.kind === 'frame') {
+        const fid = parseStackKey(id)!.id;
+        const box = frameSceneAabb(document, fid, aabbPad);
+        if (!box) this.index.remove(id);
+        else upserts.push({ id, ...box });
+        continue;
+      }
       if (!document.deltaSetLike?.[id]) {
         this.index.remove(id);
         continue;
@@ -404,10 +505,10 @@ export class SceneSpatialRuntime {
     else if (upserts.length > 1) this.index.bulkUpsert(upserts);
   }
 
-  /** Bottom→top ids intersecting rect (rank-sorted hits only). */
+  /** Bottom→top ids intersecting rect (rank-sorted). Nodes only — frames excluded. */
   queryIdsInRect(
     box: { left: number; top: number; width: number; height: number },
-    opts?: { ascending?: boolean }
+    opts?: { ascending?: boolean; includeFrames?: boolean }
   ): string[] {
     const hits = this.index.search(
       box.left,
@@ -416,14 +517,16 @@ export class SceneSpatialRuntime {
       box.top + box.height
     );
     if (!hits.length) return [];
-    return sortIdsByRank(
-      hits.map((h) => h.id),
-      this.rank,
-      { ascending: opts?.ascending !== false }
-    );
+    const ids = hits
+      .map((h) => h.id)
+      .filter((id) => opts?.includeFrames || parseStackKey(id)?.kind !== 'frame');
+    return sortIdsByRank(ids, this.rank, { ascending: opts?.ascending !== false });
   }
 
-  /** Top→bottom hit-test order — always spatial broad-phase (no full-scene scan). */
+  /**
+   * Top→bottom hit-test order — spatial broad-phase for nodes + `frame:*` plates.
+   * Caller must re-sort by permanent stackOrder (ideal hit contract).
+   */
   hitCandidateIds(opts: { x: number; y: number; pad: number }): string[] {
     const nearby = this.index.searchPoint(opts.x, opts.y, opts.pad);
     return sortIdsByRank(

--- a/apps/web/src/components/rcb/frames/HtmlArtboardFrame.tsx
+++ b/apps/web/src/components/rcb/frames/HtmlArtboardFrame.tsx
@@ -14,8 +14,8 @@ import { createSvgBoard } from '@/components/rcb/scene/paint/sceneToSvg';
 import { append, setAttrs, setFill, setStroke, svgEl } from '@/components/rcb/scene/paint/svgDom';
 import {
   getShapeHost,
-  getSceneFramesMount,
-  getSceneFramesRoot,
+  getSceneShapesMount,
+  getSceneWorldRoot,
   getSceneSelectionChromeMount,
   getSceneWorldEpoch,
   registerShapeHost,
@@ -300,16 +300,15 @@ function HtmlArtboardFrame({
     const host = hostRef.current;
     if (!host) return undefined;
 
-    // Plates sit on the frames SVG (below SoA ink). Opaque white on the shapes
-    // mount would cover WebGL ink inside the artboard while unclipped overflow
-    // still painted outside — looks like inverted clip.
-    const framesRoot = getSceneFramesRoot();
-    const framesMount = getSceneFramesMount();
-    if (!framesRoot || !framesMount) return undefined;
+    // Plates + node hosts share the shapes mount; data-z = stackOrder so a
+    // newer 画板 covers boolean / media hosts without type-specific clips.
+    const sharedRoot = getSceneWorldRoot();
+    const sharedMount = getSceneShapesMount();
+    if (!sharedRoot || !sharedMount) return undefined;
     const { root, layer: sceneLayer, shared } = createSvgBoard(host, 1, 1, {
       infinite: true,
-      sharedRoot: framesRoot,
-      sharedMount: framesMount,
+      sharedRoot,
+      sharedMount,
     });
     layerRef.current = sceneLayer;
     // createSvgBoard tags shared layers as shape; frames must not share that attr
@@ -322,8 +321,8 @@ function HtmlArtboardFrame({
     registerShapeHost({ nodeId: frame.id, root, layer: sceneLayer, el, kind: 'svg' });
     updateShapeHostElement(frame.id, el);
 
-    if (shared && framesMount && sceneLayer.parentNode === framesMount) {
-      syncSharedMountPaintOrder(framesMount);
+    if (shared && sharedMount && sceneLayer.parentNode === sharedMount) {
+      syncSharedMountPaintOrder(sharedMount);
     }
 
     return () => {
@@ -395,10 +394,10 @@ function HtmlArtboardFrame({
   useLayoutEffect(() => {
     if (layer !== 'body') return;
     const sceneLayer = layerRef.current;
-    const framesMount = getSceneFramesMount();
-    if (!sceneLayer || !framesMount || sceneLayer.parentNode !== framesMount) return;
+    const sharedMount = getSceneShapesMount();
+    if (!sceneLayer || !sharedMount || sceneLayer.parentNode !== sharedMount) return;
     sceneLayer.setAttribute('data-z', String(zIndex));
-    syncSharedMountPaintOrder(framesMount);
+    syncSharedMountPaintOrder(sharedMount);
   }, [layer, zIndex]);
   if (layer === 'label') {
     const live = resolvePaintFrameGeometry(frame);
@@ -465,7 +464,7 @@ function HtmlArtboardFrame({
     <>
       <div
         className="pointer-events-none absolute left-0 top-0 overflow-visible"
-        // Plate paints on the frames SVG (below SoA ink) via data-z. Do not mirror
+        // Plate paints on the shared stack SVG via data-z. Do not mirror
         // stack z on this HTML anchor — a private-SVG fallback with high CSS z
         // covers shapes while still letting clicks through (SVG is none).
         style={{ zIndex: 0 }}

--- a/apps/web/src/components/rcb/frames/__tests__/framePlatePointer.test.ts
+++ b/apps/web/src/components/rcb/frames/__tests__/framePlatePointer.test.ts
@@ -6,7 +6,6 @@ import {
   isPointOnFrameEdge,
   listContentNodeIds,
   resolveFramePlateDragMode,
-  resolveFramePlateTarget,
 } from '../framePlatePointer';
 import type { SceneDocument } from '@/components/rcb/sceneNode';
 
@@ -18,99 +17,6 @@ describe('framePlatePointer', () => {
       activePageId: 'p1',
     } as unknown as SceneDocument;
     expect(listContentNodeIds(doc)).toEqual(['a', 'b']);
-  });
-
-  it('resolveFramePlateTarget accepts empty interior hits', () => {
-    const doc = {
-      frames: [{ id: 'f1', x: 0, y: 0, width: 300, height: 300 }],
-      deltaSetLike: { ROOT: { children: [] } },
-    } as unknown as SceneDocument;
-    const hitTestFrame = (x: number, y: number) =>
-      x >= 0 && x <= 300 && y >= 0 && y <= 300 ? 'f1' : null;
-    expect(resolveFramePlateTarget(doc, { x: 100, y: 100 }, null, hitTestFrame)).toBe('f1');
-  });
-
-  it('resolveFramePlateTarget accepts full-bleed plate hits', () => {
-    const doc = {
-      frames: [{ id: 'f1', x: 0, y: 0, width: 300, height: 300 }],
-      deltaSetLike: {
-        ROOT: { children: ['bg'] },
-        bg: {
-          id: 'bg',
-          key: 'shape',
-          x: 0,
-          y: 0,
-          width: 300,
-          height: 300,
-          attrs: { shapeType: 'rect' },
-        },
-      },
-    } as unknown as SceneDocument;
-    const hitTestFrame = () => 'f1';
-    expect(resolveFramePlateTarget(doc, { x: 50, y: 50 }, 'bg', hitTestFrame)).toBe('f1');
-  });
-
-  it('resolveFramePlateTarget keeps bound frame children as node hits', () => {
-    const doc = {
-      frames: [{ id: 'f1', x: 0, y: 0, width: 300, height: 300 }],
-      stackOrder: ['frame:f1'],
-      deltaSetLike: {
-        ROOT: { children: ['shape'] },
-        shape: {
-          id: 'shape',
-          key: 'shape',
-          x: 40,
-          y: 40,
-          width: 80,
-          height: 80,
-          attrs: { shapeType: 'rect', frameId: 'f1', frameOrder: 0 },
-        },
-      },
-    } as unknown as SceneDocument;
-    const hitTestFrame = () => 'f1';
-    expect(resolveFramePlateTarget(doc, { x: 50, y: 50 }, 'shape', hitTestFrame)).toBeNull();
-  });
-
-  it('resolveFramePlateTarget prefers higher plate over world nodes underneath', () => {
-    const doc = {
-      frames: [{ id: 'anim', x: 0, y: 0, width: 400, height: 300, kind: 'animation' }],
-      stackOrder: ['node:under', 'frame:anim'],
-      deltaSetLike: {
-        ROOT: { children: ['under'] },
-        under: {
-          id: 'under',
-          key: 'shape',
-          x: 20,
-          y: 20,
-          width: 200,
-          height: 200,
-          attrs: { shapeType: 'rect' },
-        },
-      },
-    } as unknown as SceneDocument;
-    const hitTestFrame = () => 'anim';
-    expect(resolveFramePlateTarget(doc, { x: 100, y: 100 }, 'under', hitTestFrame)).toBe('anim');
-  });
-
-  it('resolveFramePlateTarget rejects real shape hits', () => {
-    const doc = {
-      frames: [{ id: 'f1', x: 0, y: 0, width: 300, height: 300 }],
-      deltaSetLike: {
-        ROOT: { children: ['shape'] },
-        shape: {
-          id: 'shape',
-          key: 'shape',
-          x: 40,
-          y: 40,
-          width: 80,
-          height: 80,
-          attrs: { shapeType: 'rect' },
-        },
-      },
-    } as unknown as SceneDocument;
-    const hitTestFrame = () => 'f1';
-    // No stackOrder → equal z; unbound shape is not treated as under-plate.
-    expect(resolveFramePlateTarget(doc, { x: 50, y: 50 }, 'shape', hitTestFrame)).toBeNull();
   });
 
   it('frameIsEmpty uses bound children (attrs.frameId), not geometry', () => {
@@ -212,26 +118,6 @@ describe('framePlatePointer', () => {
     expect(frameIsEmpty(doc, 'f1')).toBe(true);
   });
 
-  it('resolveFramePlateTarget treats Lottie frame host as plate', () => {
-    const doc = {
-      frames: [{ id: 'lot', x: 0, y: 0, width: 300, height: 300, kind: 'animation' }],
-      deltaSetLike: {
-        ROOT: { children: ['host'] },
-        host: {
-          id: 'host',
-          key: 'lottie',
-          x: 0,
-          y: 0,
-          width: 300,
-          height: 300,
-          attrs: { frameId: 'lot', animationFrameHost: true },
-        },
-      },
-    } as unknown as SceneDocument;
-    const hitTestFrame = () => 'lot';
-    expect(resolveFramePlateTarget(doc, { x: 50, y: 50 }, 'host', hitTestFrame)).toBe('lot');
-  });
-
   it('frameIsEmpty ignores Lottie frame host (host-only plate is empty)', () => {
     const doc = {
       frames: [{ id: 'lot', x: 0, y: 0, width: 300, height: 300, kind: 'animation' }],
@@ -251,44 +137,10 @@ describe('framePlatePointer', () => {
     expect(frameIsEmpty(doc, 'lot')).toBe(true);
   });
 
-  it('isPointOnFrameEdge detects border band', () => {
-    const box = { left: 0, top: 0, width: 300, height: 300 };
-    const band = framePlateEdgeBandScene(1);
-    expect(isPointOnFrameEdge({ x: band / 2, y: 150 }, box, 1)).toBe(true);
-    expect(isPointOnFrameEdge({ x: 150, y: 150 }, box, 1)).toBe(false);
-  });
-
-  it('resolveFramePlateDragMode: empty → frame_move, occupied → pointing_canvas', () => {
-    const emptyDoc = {
-      frames: [{ id: 'f1', x: 0, y: 0, width: 300, height: 300 }],
-      deltaSetLike: { ROOT: { children: [] } },
-    } as unknown as SceneDocument;
-    expect(
-      resolveFramePlateDragMode(emptyDoc, 'f1', { readOnly: false, canMove: true })
-    ).toBe('frame_move');
-    expect(
-      resolveFramePlateDragMode(emptyDoc, 'f1', { readOnly: true, canMove: true })
-    ).toBe('pointing_canvas');
-
-    const occupied = {
-      pages: [{ id: 'p1', children: ['inner'] }],
-      activePageId: 'p1',
-      frames: [{ id: 'f1', x: 0, y: 0, width: 300, height: 300 }],
-      deltaSetLike: {
-        ROOT: { children: [] },
-        inner: {
-          id: 'inner',
-          key: 'shape',
-          x: 40,
-          y: 40,
-          width: 80,
-          height: 80,
-          attrs: { frameId: 'f1' },
-        },
-      },
-    } as unknown as SceneDocument;
-    expect(
-      resolveFramePlateDragMode(occupied, 'f1', { readOnly: false, canMove: true })
-    ).toBe('pointing_canvas');
+  it('edge band scales with zoom and detects border hits', () => {
+    const box = { left: 0, top: 0, width: 200, height: 100 };
+    expect(framePlateEdgeBandScene(1)).toBeGreaterThan(0);
+    expect(isPointOnFrameEdge({ x: 2, y: 50 }, box, 1)).toBe(true);
+    expect(isPointOnFrameEdge({ x: 100, y: 50 }, box, 1)).toBe(false);
   });
 });

--- a/apps/web/src/components/rcb/frames/frameContentClip.ts
+++ b/apps/web/src/components/rcb/frames/frameContentClip.ts
@@ -18,6 +18,7 @@ let revealOverflowNodeIds: ReadonlySet<string> = EMPTY_REVEAL_OVERFLOW;
 
 const EMPTY_PAINT_RAISE = new Set<string>();
 let paintRaiseNodeIds: ReadonlySet<string> = EMPTY_PAINT_RAISE;
+let paintRaiseFrameIds: ReadonlySet<string> = EMPTY_PAINT_RAISE;
 
 /**
  * Optional registry for hosts that temporarily paint past clipContent.
@@ -60,14 +61,38 @@ export function selectionPaintRaises(nodeId: string | null | undefined): boolean
   return paintRaiseNodeIds.has(nodeId);
 }
 
+/** Single-selected artboard / 动画工作台 — temporary paint front over world ink. */
+export function setSelectionPaintRaiseFrameIds(ids: Iterable<string> | null | undefined): void {
+  if (!ids) {
+    paintRaiseFrameIds = EMPTY_PAINT_RAISE;
+    return;
+  }
+  const next = new Set<string>();
+  for (const id of ids) {
+    const s = String(id || '').trim();
+    if (s) next.add(s);
+  }
+  paintRaiseFrameIds = next.size ? next : EMPTY_PAINT_RAISE;
+}
+
+export function selectionPaintRaisesFrame(frameId: string | null | undefined): boolean {
+  if (!frameId) return false;
+  return paintRaiseFrameIds.has(frameId);
+}
+
 export function hasSelectionPaintRaise(): boolean {
-  return paintRaiseNodeIds.size > 0;
+  return paintRaiseNodeIds.size > 0 || paintRaiseFrameIds.size > 0;
 }
 
 /** Ids currently raised above stack max for paint (selection). */
 export function listSelectionPaintRaiseIds(): string[] {
   if (!paintRaiseNodeIds.size) return [];
   return [...paintRaiseNodeIds];
+}
+
+export function listSelectionPaintRaiseFrameIds(): string[] {
+  if (!paintRaiseFrameIds.size) return [];
+  return [...paintRaiseFrameIds];
 }
 
 export function hasFrameClipRevealOverflow(): boolean {

--- a/apps/web/src/components/rcb/frames/framePlatePointer.ts
+++ b/apps/web/src/components/rcb/frames/framePlatePointer.ts
@@ -4,9 +4,7 @@ import {
   isAnimationFrameHostNode,
   isNodeHiddenInDocument,
 } from '@/components/rcb/scene/document/nodeCapabilities';
-import { isAnimationWorkbenchPreviewChild } from '@/components/editor/nodes/AnimationNode/animationWorkbenchFocus';
 import { getLiveArtboardFrameGeometry } from '@/components/rcb/frames/HtmlArtboardFrame';
-import { stackZIndex } from '@/components/rcb/scene/document/sceneDocument';
 import type { SceneDocument } from '@/components/rcb/sceneNode';
 
 export type FrameSceneBox = {
@@ -103,37 +101,4 @@ export function resolveFramePlateDragMode(
   if (opts.readOnly || !opts.canMove) return 'pointing_canvas';
   if (frameIsEmpty(doc, frameId)) return 'frame_move';
   return 'pointing_canvas';
-}
-
-/**
- * Frame plate pick: pointer inside artboard, no real shape ink under cursor.
- * Full-bleed background rects count as plate, not content.
- * Preview-mode workbench children also count as plate (select workbench, not child).
- */
-export function resolveFramePlateTarget(
-  doc: SceneDocument,
-  p: { x: number; y: number },
-  hitId: string | null,
-  hitTestFrame?: (x: number, y: number) => string | null
-): string | null {
-  const frameId = hitTestFrame?.(p.x, p.y) ?? null;
-  if (!frameId) return null;
-  if (!hitId) return frameId;
-  if (frameForFullBleedPlate(doc, hitId) === frameId) return frameId;
-
-  const hitNode = doc.deltaSetLike?.[hitId];
-  const ownedByFrame = Boolean(
-    hitNode && String(hitNode.attrs?.frameId || '').trim() === frameId
-  );
-  if (ownedByFrame && hitNode && isAnimationWorkbenchPreviewChild(doc, hitNode)) {
-    return frameId;
-  }
-  // Real content owned by this frame keeps the node hit (not the plate).
-  if (ownedByFrame) return null;
-
-  // World / lower-frame node under a higher plate — plate wins (matches paint).
-  if (stackZIndex(doc, 'frame', frameId) > stackZIndex(doc, 'node', hitId)) {
-    return frameId;
-  }
-  return null;
 }

--- a/apps/web/src/components/rcb/index.ts
+++ b/apps/web/src/components/rcb/index.ts
@@ -42,6 +42,8 @@ export {
   createCanvasSceneRenderer,
   resolveIdleInkBackend,
   hitTestWithSpatialIndex,
+  hitTestSceneTargetWithSpatialIndex,
+  collectUnifiedHitCandidates,
   isFullDirty,
   isNoopSoaDirtyRegion,
   dirtyTouchesNode,
@@ -71,6 +73,8 @@ export {
   getFillImageReady,
   setFillImageCacheEntry,
   clearFillImageCache,
+  canvasPixelsReadable,
+  isFillImageWebglUnsafe,
   setSceneCanvasIdlePaint,
   getSceneCanvasIdlePaint,
   clearSceneCanvasIdlePaint,
@@ -97,6 +101,7 @@ export {
   setSoaCanvasShapesEnabledForTests,
   isSoaCanvasEligible,
   isSoaBasicGeomSufficient,
+  isSoaRichFillAtlasStampable,
   soaStrokeWidth,
   SOA_DEFAULT_STROKE_WIDTH,
   hitTestSoaBuffer,
@@ -122,6 +127,7 @@ export {
   SOA_FLAG_VISIBLE,
   SOA_FLAG_CANVAS_IDLE,
   SOA_FLAG_BASIC_GEOM,
+  SOA_FLAG_ATLAS_STAMP,
   SOA_FLAG_FREE,
   SOA_KIND_RECT,
   SOA_KIND_ELLIPSE,
@@ -345,3 +351,9 @@ export {
   coerceSceneDocumentInput,
 } from './sceneNode';
 export type { SceneNodeRef } from './scene/document/nodeCapabilities';
+export {
+  stackPaintZ,
+  stackPaintMaxZ,
+  stackPaintNaturalZ,
+  syncStackPaintOrder,
+} from './scene/document/sceneStackPainter';

--- a/apps/web/src/components/rcb/render/__tests__/sceneRenderer.test.ts
+++ b/apps/web/src/components/rcb/render/__tests__/sceneRenderer.test.ts
@@ -1727,6 +1727,158 @@ describe('hitTestWithSpatialIndex', () => {
     ]);
   });
 
+  it('partial-stale rescue: QT returns a neighbor while the moved node is absent', () => {
+    const doc = {
+      stackOrder: ['node:neighbor', 'node:moved'],
+      deltaSetLike: {
+        ROOT: { children: ['neighbor', 'moved'] },
+        neighbor: {
+          id: 'neighbor',
+          key: 'shape',
+          x: 0,
+          y: 0,
+          width: 40,
+          height: 40,
+          attrs: { shapeType: 'rect', 'fill-color': '#eee' },
+        },
+        moved: {
+          id: 'moved',
+          key: 'shape',
+          x: 500,
+          y: 500,
+          width: 80,
+          height: 80,
+          attrs: { shapeType: 'rect', 'fill-color': '#fff' },
+        },
+      },
+    } as unknown as SceneDocument;
+    const spatial = new SceneSpatialRuntime(64);
+    // Neighbor still indexed near origin; moved still at stale (0,0) AABB — click at 520.
+    spatial.index.upsert({ id: 'neighbor', minX: 0, minY: 0, maxX: 40, maxY: 40 });
+    spatial.index.upsert({ id: 'moved', minX: 0, minY: 0, maxX: 80, maxY: 80 });
+    // Coarse at 520 returns [] with small pad — use large pad so neighbor isn't required;
+    // simulate non-empty order by also indexing a decoy at the click that misses precise.
+    spatial.index.upsert({ id: 'decoy', minX: 510, minY: 510, maxX: 530, maxY: 530 });
+    expect(
+      hitTestWithSpatialIndex(
+        {
+          getDocument: () => doc,
+          getSpatial: () => spatial,
+          getZoom: () => 1,
+          listNodeIds: () => ['neighbor', 'moved'],
+          getNodeBox: (id) => {
+            const node = doc.deltaSetLike[id];
+            if (!node) return null;
+            return { left: node.x, top: node.y, width: node.width, height: node.height };
+          },
+        },
+        { x: 520, y: 520 }
+      )
+    ).toBe('moved');
+  });
+
+  it('unified walk: higher plate wins over world node under it (returns __frame__:id)', () => {
+    const doc = {
+      stackOrder: ['node:under', 'frame:board'],
+      frames: [
+        {
+          id: 'board',
+          name: 'A',
+          backgroundColor: '#fff',
+          x: 0,
+          y: 0,
+          width: 200,
+          height: 200,
+        },
+      ],
+      deltaSetLike: {
+        ROOT: { children: ['under'] },
+        under: {
+          id: 'under',
+          key: 'shape',
+          x: 20,
+          y: 20,
+          width: 80,
+          height: 80,
+          attrs: { shapeType: 'rect', 'fill-color': '#0af' },
+        },
+      },
+    } as unknown as SceneDocument;
+    const spatial = new SceneSpatialRuntime(64);
+    spatial.sync({
+      document: doc,
+      childrenIds: ['under'],
+      reloadToken: 1,
+      aabbPad: 0,
+    });
+    expect(
+      hitTestWithSpatialIndex(
+        {
+          getDocument: () => doc,
+          getSpatial: () => spatial,
+          getZoom: () => 1,
+          listNodeIds: () => ['under'],
+          getNodeBox: (id) => {
+            const node = doc.deltaSetLike[id];
+            return { left: node.x, top: node.y, width: node.width, height: node.height };
+          },
+        },
+        { x: 40, y: 40 }
+      )
+    ).toBe('__frame__:board');
+  });
+
+  it('unified walk: bound child above its plate keeps the node hit', () => {
+    const doc = {
+      stackOrder: ['frame:board'],
+      frames: [
+        {
+          id: 'board',
+          name: 'A',
+          backgroundColor: '#fff',
+          x: 0,
+          y: 0,
+          width: 200,
+          height: 200,
+        },
+      ],
+      deltaSetLike: {
+        ROOT: { children: ['child'] },
+        child: {
+          id: 'child',
+          key: 'shape',
+          x: 20,
+          y: 20,
+          width: 80,
+          height: 80,
+          attrs: { shapeType: 'rect', 'fill-color': '#0af', frameId: 'board', frameOrder: 0 },
+        },
+      },
+    } as unknown as SceneDocument;
+    const spatial = new SceneSpatialRuntime(64);
+    spatial.sync({
+      document: doc,
+      childrenIds: ['child'],
+      reloadToken: 1,
+      aabbPad: 0,
+    });
+    expect(
+      hitTestWithSpatialIndex(
+        {
+          getDocument: () => doc,
+          getSpatial: () => spatial,
+          getZoom: () => 1,
+          listNodeIds: () => ['child'],
+          getNodeBox: (id) => {
+            const node = doc.deltaSetLike[id];
+            return { left: node.x, top: node.y, width: node.width, height: node.height };
+          },
+        },
+        { x: 40, y: 40 }
+      )
+    ).toBe('child');
+  });
+
   it('uses stackOrder instead of root child order for overlapping nodes', () => {
     const doc = {
       stackOrder: ['node:back', 'node:front'],

--- a/apps/web/src/components/rcb/render/__tests__/soaRoundedIdle.test.ts
+++ b/apps/web/src/components/rcb/render/__tests__/soaRoundedIdle.test.ts
@@ -186,7 +186,7 @@ describe('SoA basic geom vs rounded / poly', () => {
     expect(buf.flags[0] & SOA_FLAG_CANVAS_IDLE).toBeFalsy();
   });
 
-  it('boolean evenodd / outlined stay off SoA basic but can idle on canvas Path2D', () => {
+  it('boolean evenodd / outlined idle on SoA basic (atlas stamp)', () => {
     let doc = createEmptyDocument({ width: 400, height: 400, emptyWorld: true });
     doc = addNodeToDocument(doc, 'b', {
       id: 'b',
@@ -207,14 +207,14 @@ describe('SoA basic geom vs rounded / poly', () => {
       children: [],
     });
     expect(canIdlePaintOnCanvas(doc.deltaSetLike.b)).toBe(true);
-    expect(isSoaBasicGeomSufficient(doc.deltaSetLike.b)).toBe(false);
+    expect(isSoaBasicGeomSufficient(doc.deltaSetLike.b)).toBe(true);
     const buf = createSceneRenderBuffer();
     syncSceneRenderBufferFromDocument(buf, doc);
-    expect(buf.flags[0] & SOA_FLAG_BASIC_GEOM).toBeFalsy();
-    expect(buf.flags[0] & SOA_FLAG_CANVAS_IDLE).toBeFalsy();
+    expect(buf.flags[0] & SOA_FLAG_BASIC_GEOM).toBeTruthy();
+    expect(buf.flags[0] & SOA_FLAG_CANVAS_IDLE).toBeTruthy();
   });
 
-  it('gradient / text / media stay off SoA basic; outside-stroke enters basic idle', () => {
+  it('gradient / text stay off SoA basic; image+gradient idle via atlas; outside-stroke enters basic idle', () => {
     let doc = createEmptyDocument({ width: 800, height: 600, emptyWorld: true });
     const cases: Array<{ id: string; node: Parameters<typeof addNodeToDocument>[2] }> = [
       {
@@ -292,21 +292,57 @@ describe('SoA basic geom vs rounded / poly', () => {
     expect(buf.flags[buf.indexById.get('outside')!] & SOA_FLAG_BASIC_GEOM).toBeTruthy();
     expect(buf.flags[buf.indexById.get('outside')!] & SOA_FLAG_CANVAS_IDLE).toBeTruthy();
     expect(buf.strokeWidths[buf.indexById.get('outside')!]).toBe(2);
-    for (const id of ['grad', 'txt', 'img'] as const) {
+    for (const id of ['grad'] as const) {
       const node = doc.deltaSetLike[id];
       expect(isSoaBasicGeomSufficient(node), id).toBe(false);
       const i = buf.indexById.get(id);
       expect(i).toBeDefined();
       expect(buf.flags[i!] & SOA_FLAG_BASIC_GEOM, id).toBeFalsy();
-      expect(buf.flags[i!] & SOA_FLAG_CANVAS_IDLE, id).toBeFalsy();
+      // Rich fills idle via atlas stamp (CANVAS_IDLE), not BASIC_GEOM.
+      expect(buf.flags[i!] & SOA_FLAG_CANVAS_IDLE, id).toBeTruthy();
     }
+    // Static image/text: atlas-stamp idle (CANVAS_IDLE) without BASIC_GEOM.
+    expect(isSoaBasicGeomSufficient(doc.deltaSetLike.img)).toBe(false);
+    const imgIdx = buf.indexById.get('img')!;
+    expect(buf.flags[imgIdx] & SOA_FLAG_BASIC_GEOM).toBeFalsy();
+    expect(buf.flags[imgIdx] & SOA_FLAG_CANVAS_IDLE).toBeTruthy();
+    expect(isSoaBasicGeomSufficient(doc.deltaSetLike.txt)).toBe(false);
+    const txtIdx = buf.indexById.get('txt')!;
+    expect(buf.flags[txtIdx] & SOA_FLAG_BASIC_GEOM).toBeFalsy();
+    expect(buf.flags[txtIdx] & SOA_FLAG_CANVAS_IDLE).toBeTruthy();
     expect(isSoaCanvasEligible(doc.deltaSetLike.outside)).toBe(true);
     expect(isSoaCanvasEligible(doc.deltaSetLike.grad)).toBe(true);
-    expect(isSoaCanvasEligible(doc.deltaSetLike.txt)).toBe(false);
-    expect(isSoaCanvasEligible(doc.deltaSetLike.img)).toBe(false);
+    expect(isSoaCanvasEligible(doc.deltaSetLike.txt)).toBe(true);
+    expect(isSoaCanvasEligible(doc.deltaSetLike.img)).toBe(true);
     expect(canIdlePaintOnCanvas(doc.deltaSetLike.outside)).toBe(true);
     expect(canIdlePaintOnCanvas(doc.deltaSetLike.grad)).toBe(true);
-    // Text idle paints via rich canvas (not SoA BASIC_GEOM); still no ShapeHost.
     expect(canIdlePaintOnCanvas(doc.deltaSetLike.txt)).toBe(true);
+    expect(canIdlePaintOnCanvas(doc.deltaSetLike.img)).toBe(true);
+  });
+
+  it('donut ellipse idles via atlas stamp (not BASIC_GEOM)', () => {
+    let doc = createEmptyDocument({ width: 800, height: 600, emptyWorld: true });
+    doc = addNodeToDocument(doc, 'donut', {
+      id: 'donut',
+      key: 'shape',
+      x: 0,
+      y: 0,
+      width: 80,
+      height: 80,
+      attrs: {
+        shapeType: 'ellipse',
+        'fill-color': '#0cf',
+        ellipseInnerRatio: 0.4,
+        'stroke-enabled': false,
+      },
+      children: [],
+    });
+    const buf = createSceneRenderBuffer();
+    syncSceneRenderBufferFromDocument(buf, doc);
+    expect(isSoaBasicGeomSufficient(doc.deltaSetLike.donut)).toBe(false);
+    const i = buf.indexById.get('donut')!;
+    expect(buf.flags[i] & SOA_FLAG_BASIC_GEOM).toBeFalsy();
+    expect(buf.flags[i] & SOA_FLAG_CANVAS_IDLE).toBeTruthy();
+    expect(canIdlePaintOnCanvas(doc.deltaSetLike.donut)).toBe(true);
   });
 });

--- a/apps/web/src/components/rcb/render/sceneRenderBuffer.ts
+++ b/apps/web/src/components/rcb/render/sceneRenderBuffer.ts
@@ -54,6 +54,9 @@ import {
   selectionPaintRaises,
 } from '@/components/rcb/frames/frameContentClip';
 import { buildNodeStackZMap, maxDocumentStackZ } from '@/components/rcb/scene/document/sceneDocument';
+import {
+  isNodeAabbFullyOccludedByHigherArtboard,
+} from '@/components/rcb/scene/document/sceneHitBridge';
 
 export const SOA_FLAG_VISIBLE = 1 << 0;
 export const SOA_FLAG_LOCKED = 1 << 1;
@@ -64,6 +67,11 @@ export const SOA_FLAG_CANVAS_IDLE = 1 << 3;
 export const SOA_FLAG_BASIC_GEOM = 1 << 4;
 /** Tombstone slot awaiting reuse via freeSlots (skipped by paint/hit). */
 export const SOA_FLAG_FREE = 1 << 5;
+/**
+ * Idle ink via Canvas→atlas stamp (gradient / rotated solid / rich fill).
+ * Not BASIC_GEOM — collectSoaWebglInstances bakes `rich:` cells.
+ */
+export const SOA_FLAG_ATLAS_STAMP = 1 << 6;
 
 export const SOA_KIND_RECT = 0;
 export const SOA_KIND_ELLIPSE = 1;
@@ -71,6 +79,8 @@ export const SOA_KIND_LINE = 2;
 export const SOA_KIND_PATH = 3;
 export const SOA_KIND_IMAGE = 4;
 export const SOA_KIND_POLY = 5;
+/** Static text glyphs — atlas-stamped idle (not BASIC_GEOM). */
+export const SOA_KIND_TEXT = 6;
 export const SOA_KIND_OTHER = 15;
 /** Fallback line/path width when attrs omit border-width (matches prior Canvas/WebGL default). */
 export const SOA_DEFAULT_STROKE_WIDTH = 2;
@@ -101,13 +111,13 @@ function shapeTypeToken(node: SceneNodeInput): string {
   return String(raw).toLowerCase();
 }
 
-/** Lightweight SoA BASIC_GEOM eligibility — not rich idle text/media (those use canvasIds). */
+/** Lightweight SoA slot eligibility — vectors + static image/video/audio/text. */
 export function isSoaCanvasEligible(node: SceneNodeInput | null | undefined): boolean {
   if (!node) return false;
   const key = String(node.key || '');
-  // Text/image/video/audio idle on canvas via paintCanvasIdleNode — not BASIC_GEOM slots.
-  if (key === 'lottie' || key === 'audio' || key === 'group' || key === 'text') return false;
-  if (key === 'image' || key === 'video') return false;
+  // Lottie/group stay DOM. Static image/video/audio/text can atlas-stamp.
+  if (key === 'lottie' || key === 'group') return false;
+  if (key === 'text' || key === 'image' || key === 'video' || key === 'audio') return true;
   const t = shapeTypeToken(node);
   if (t === 'rect' || t === 'roundrect' || t === '' || key === 'shape') return true;
   if (t === 'circle' || t === 'ellipse' || t === 'oval') return true;
@@ -164,8 +174,66 @@ function hasVisibleOutlineStroke(node: SceneNodeInput): boolean {
 }
 
 /**
+ * True when gradient / image / diffuse / rotated-solid / poly / donut-arc
+ * fills can idle via atlas stamp (shared stackOrder: ink under plates; host when above).
+ */
+export function isSoaRichFillAtlasStampable(node: SceneNodeInput | null | undefined): boolean {
+  if (!node || !isSoaCanvasEligible(node)) return false;
+  if (isSoaBasicGeomSufficient(node)) return false;
+  const key = String(node.key || '');
+  if (key === 'text' || key === 'image' || key === 'video' || key === 'audio') return false;
+  const attrs = node.attrs || {};
+  if (attrs.flipX === true || attrs.flipX === 'true') return false;
+  if (attrs.flipY === true || attrs.flipY === 'true') return false;
+
+  const fillType = String(attrs['fill-type'] || 'solid').toLowerCase();
+  const richFill =
+    fillType === 'linear' ||
+    fillType === 'radial' ||
+    fillType === 'angular' ||
+    fillType === 'image' ||
+    fillType === 'diffuse';
+  const solidish = !fillType || fillType === 'solid';
+  if (!richFill && !solidish) return false;
+
+  const rotated = Math.abs(Number(attrs.angle) || 0) > 0.5;
+  const t = shapeTypeToken(node);
+  const customPath = String(attrs.path || '').trim();
+  const pathLike =
+    t === 'pen' || t === 'pencil' || t === 'path' || key === 'path' || Boolean(customPath);
+
+  // WebGL has no POLY instancing — Canvas-bake → atlas for all eligible fills.
+  if (t === 'triangle' || t === 'polygon' || t === 'star') return true;
+
+  if (pathLike) {
+    if (!customPath || customPath.length >= HEAVY_PATH_D_CHARS) return false;
+  } else if (
+    t !== 'rect' &&
+    t !== 'roundrect' &&
+    t !== '' &&
+    t !== 'circle' &&
+    t !== 'ellipse' &&
+    t !== 'oval'
+  ) {
+    return false;
+  }
+
+  // Donut / pie / annular sector — paintCanvasShapeInk evenodd bake.
+  if (t === 'circle' || t === 'ellipse' || t === 'oval') {
+    if (ellipseInnerRatioFromAttrs(attrs) > 1e-6) return true;
+    const arc = ellipseArcPercentFromAttrs(attrs);
+    if (arc > 0 && arc < 100 - 1e-6) return true;
+  }
+
+  if (richFill) return true;
+  // Rotated solid rect/ellipse/path — bake instead of forcing a DOM host.
+  if (rotated && solidish) return true;
+  return false;
+}
+
+/**
  * True when SoA BASIC_GEOM can draw the node on the product WebGL path
- * (or Canvas2D helpers in Vitest). Non-basic → DOM host.
+ * (or Canvas2D helpers in Vitest). Non-basic → DOM host or atlas stamp.
  */
 export function isSoaBasicGeomSufficient(node: SceneNodeInput | null | undefined): boolean {
   if (!node || !isSoaCanvasEligible(node)) return false;
@@ -192,15 +260,15 @@ export function isSoaBasicGeomSufficient(node: SceneNodeInput | null | undefined
 
   if (t === 'line' || t === 'arrow') return true;
   if (t === 'triangle' || t === 'polygon' || t === 'star') {
-    // WebGL skips SOA_KIND_POLY — Vitest Canvas2D SoA only.
+    // Product WebGL stamps POLY via rich atlas; Vitest Canvas2D uses basic SoA.
     return !webgl;
   }
   if (t === 'pen' || t === 'pencil' || t === 'path' || key === 'path' || customPath) {
     const d = customPath;
     if (!d || d.length >= HEAVY_PATH_D_CHARS) return false;
-    const fillRule = String(attrs['fill-rule'] || '').toLowerCase();
-    if (fillRule === 'evenodd') return false;
-    if (attrs.outlined === true || attrs.outlined === 'true') return false;
+    // evenodd / outlined (boolean results) stamp via the WebGL atlas like
+    // other closed paths — stackOrder is enforced by the shared plate+host mount,
+    // not by forcing a DOM host.
     return true;
   }
   if (t === 'rect' || t === 'roundrect' || t === '') return true;
@@ -562,6 +630,7 @@ export function unpackCssColor(argb: number): string {
 
 function shapeKindOf(node: SceneNodeInput): number {
   const key = String(node.key || '');
+  if (key === 'text') return SOA_KIND_TEXT;
   if (key === 'image' || key === 'video' || key === 'audio') return SOA_KIND_IMAGE;
   const t = shapeTypeToken(node);
   // Boolean / outline silhouettes keep a stored `path` — never solid RECT ink/hit.
@@ -639,9 +708,14 @@ function writeSlot(
   let flags = SOA_FLAG_DIRTY;
   if (!isNodeOverlayHidden(document, node)) flags |= SOA_FLAG_VISIBLE;
   if (node.attrs?.locked) flags |= SOA_FLAG_LOCKED;
-  // BASIC_GEOM → SoA canvas ink. Text / media / non-basic stay off this flag.
+  // BASIC_GEOM → SoA / WebGL vector ink. Image/video/text + rich fills get
+  // CANVAS_IDLE without BASIC_GEOM so collectSoaWebglInstances can atlas-stamp.
   if (isSoaBasicGeomSufficient(node)) {
     flags |= SOA_FLAG_BASIC_GEOM | SOA_FLAG_CANVAS_IDLE;
+  } else if (kind === SOA_KIND_IMAGE || kind === SOA_KIND_TEXT) {
+    flags |= SOA_FLAG_CANVAS_IDLE;
+  } else if (isSoaRichFillAtlasStampable(node)) {
+    flags |= SOA_FLAG_CANVAS_IDLE | SOA_FLAG_ATLAS_STAMP;
   }
   buf.flags[index] = flags >>> 0;
   buf.ids[index] = id;
@@ -1942,6 +2016,17 @@ export function paintSoaIdleSlot(
   if (doc && id) {
     const node = doc.deltaSetLike?.[id] as SceneNodeInput | undefined;
     if (node) {
+      if (
+        isNodeAabbFullyOccludedByHigherArtboard(doc, { ...node, id }, {
+          left: x,
+          top: y,
+          width: w,
+          height: h,
+        })
+      ) {
+        buf.flags[i] = (flags & ~SOA_FLAG_DIRTY) >>> 0;
+        return;
+      }
       clipped = clipSoaIdleSlotToFrame(ctx, doc, id, node, { x, y, w, h });
     }
   }
@@ -2476,10 +2561,17 @@ export function applySoaHostInkFlags(
       kind === SOA_KIND_ELLIPSE ||
       kind === SOA_KIND_LINE ||
       kind === SOA_KIND_PATH ||
-      kind === SOA_KIND_POLY;
+      kind === SOA_KIND_POLY ||
+      kind === SOA_KIND_IMAGE ||
+      kind === SOA_KIND_TEXT;
     if (!shapeEligible) return false;
     let flags = buf.flags[i];
-    const wantInk = !hosts.has(id) && (flags & SOA_FLAG_BASIC_GEOM) !== 0;
+    const wantInk =
+      !hosts.has(id) &&
+      ((flags & SOA_FLAG_BASIC_GEOM) !== 0 ||
+        (flags & SOA_FLAG_ATLAS_STAMP) !== 0 ||
+        kind === SOA_KIND_IMAGE ||
+        kind === SOA_KIND_TEXT);
     const isInk = (flags & SOA_FLAG_CANVAS_IDLE) !== 0;
     if (wantInk === isInk) return false;
     if (wantInk) flags = (flags | SOA_FLAG_CANVAS_IDLE) >>> 0;

--- a/apps/web/src/components/rcb/render/sceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/sceneRenderer.ts
@@ -21,9 +21,18 @@ import { isImageProcessRunning } from '@/components/rcb/scene/document/nodeCapab
 import { PROCESS_PLATE_STROKE } from '@/components/rcb/process/processGlow';
 import { paintProcessPlateCanvas } from '@/components/rcb/process/processPlateSvg';
 import {
-  hitTestSceneAtPoint,
+  hitTestUnifiedStackAtPoint,
   type SceneHitBox,
+  type SceneStackHit,
 } from '@/components/rcb/scene/document/sceneHitBridge';
+import {
+  buildNodeStackZMap,
+  buildUnifiedHitZMap,
+  maxDocumentStackZ,
+  stackFrameKey,
+} from '@/components/rcb/scene/document/sceneDocument';
+import { frameSelId } from '@/components/rcb/selection/frameSelectionIds';
+import { frameSceneAabb } from '@/components/rcb/core/spatialIndex';
 import {
   effectiveEllipseArcPercentFromAttrs,
   effectiveEllipseInnerRatioFromAttrs,
@@ -54,10 +63,6 @@ import {
   type InnerShadowSpec,
 } from '@/components/rcb/scene/document/sceneEffects';
 import { resolveTextFramePlateFill } from '@/components/rcb/scene/document/nodeFactories';
-import {
-  buildNodeStackZMap,
-  maxDocumentStackZ,
-} from '@/components/rcb/scene/document/sceneDocument';
 import {
   findClippingFrameForNode,
   frameClipRevealsOverflow,
@@ -104,6 +109,7 @@ import {
   getSharedSceneRenderBuffer,
   isSoaCanvasShapesEnabled,
   isSoaBasicGeomSufficient,
+  isSoaRichFillAtlasStampable,
   isSoaWebglEnvEnabled,
   paintSoaBufferBasic,
   paintSoaIdleSlot,
@@ -117,7 +123,7 @@ import {
   SOA_KIND_RECT,
 } from '@/components/rcb/render/sceneRenderBuffer';
 
-export { isSoaBasicGeomSufficient } from '@/components/rcb/render/sceneRenderBuffer';
+export { isSoaBasicGeomSufficient, isSoaRichFillAtlasStampable } from '@/components/rcb/render/sceneRenderBuffer';
 import {
   getSharedSoaBakeCache,
   getSoaBakeCountThreshold,
@@ -184,87 +190,52 @@ export type SceneRendererHitDeps = {
   allowSvgDomHit?: boolean;
 };
 
-/** Spatial coarse → precise geometry (shared by svg + canvas backends). */
+/**
+ * Ideal product hit (ADR 0027):
+ *   SceneSpatialRuntime QT (nodes + `frame:id` plates, paint box = hit box)
+ *   → permanent stackOrder top-first
+ *   → first precise geometry / plate AABB wins
+ *
+ * Returns bare node id, or `__frame__:id` for artboard plates (see frameSelId).
+ * Selection paint raise is ignored (paint-only).
+ */
 export function hitTestWithSpatialIndex(
   deps: SceneRendererHitDeps,
   point: RcbVec,
   screen?: { clientX: number; clientY: number }
 ): SceneNodeId | null {
-  const doc = deps.getDocument();
-  const zoom = Math.max(0.05, deps.getZoom() || 1);
-  const pad = sceneHitSlop(zoom);
-  const searchPad = pad + 64 / zoom;
-  const spatial = deps.getSpatial();
-  let order = doc
-    ? spatial.hitCandidateIds({
-        x: point.x,
-        y: point.y,
-        pad: searchPad,
-      })
-    : [];
+  const target = hitTestSceneTargetWithSpatialIndex(deps, point, screen);
+  if (!target) return null;
+  return target.kind === 'frame' ? frameSelId(target.id) : target.id;
+}
 
-  // frameLocal plate moves (and some commits) leave shared spatial AABBs at the
-  // old world box while getNodeBox / paint already use the new origin — coarse
-  // returns [] even though ink is under the cursor. Rescue + heal the index.
-  if (doc && order.length === 0) {
-    const allIds = deps.listNodeIds();
-    const rescued: string[] = [];
-    for (const id of allIds) {
-      const box = deps.getNodeBox(id);
-      if (!box) continue;
-      if (
-        point.x < box.left - searchPad ||
-        point.x > box.left + box.width + searchPad ||
-        point.y < box.top - searchPad ||
-        point.y > box.top + box.height + searchPad
-      ) {
-        continue;
-      }
-      rescued.push(id);
-    }
-    if (rescued.length) {
-      spatial.patchNodes(doc, rescued, 32);
-      order = rescued;
-    }
-  }
-
-  const hitOrder = doc
-    ? (() => {
-        const zMap = buildNodeStackZMap(doc, order);
-        const rank = new Map(order.map((id, i) => [id, i]));
-        return order.slice().sort((a, b) => {
-          // Hit uses permanent stackOrder only. Selection paint raise (max+1) is
-          // paint-only — otherwise a raised empty/back node steals clicks from
-          // visible strokes (pen / line / pencil) drawn above it.
-          const za = zMap.get(a) || 0;
-          const zb = zMap.get(b) || 0;
-          return zb - za || (rank.get(b) || 0) - (rank.get(a) || 0);
-        });
-      })()
-    : order;
+/** Typed ideal hit — prefer this over string encoding when wiring new callers. */
+export function hitTestSceneTargetWithSpatialIndex(
+  deps: SceneRendererHitDeps,
+  point: RcbVec,
+  screen?: { clientX: number; clientY: number }
+): SceneStackHit | null {
+  const collected = collectUnifiedHitCandidates(deps, point);
+  if (!collected) return null;
+  const { doc, hitOrder, pad, searchPad, spatial, rescuedIds, order } = collected;
   const allowSvgDomHit = deps.allowSvgDomHit === true;
   const buf =
-    doc && isSoaCanvasShapesEnabled() && hitOrder.length ? getSharedSceneRenderBuffer() : null;
-  const hit = doc
-    ? hitTestSceneAtPoint({
-        document: doc,
-        order: hitOrder,
-        x: point.x,
-        y: point.y,
-        zoom,
-        screen,
-        getNodeBox: deps.getNodeBox,
-        nodeEls: allowSvgDomHit ? (deps.getNodeEls?.() ?? null) : null,
-        allowSvgDomHit,
-        soaBuf: buf && buf.count > 0 ? buf : null,
-        // Broad-phase keeps searchPad (stale index / edge candidates). Fine hit
-        // uses screen-constant stroke slop only — filled AABB must not inherit
-        // the +64 CSS px halo or empty clicks above a plate steal selection.
-        pad,
-      })
-    : null;
+    isSoaCanvasShapesEnabled() && hitOrder.length ? getSharedSceneRenderBuffer() : null;
+  const hit = hitTestUnifiedStackAtPoint({
+    document: doc,
+    order: hitOrder,
+    x: point.x,
+    y: point.y,
+    zoom: collected.zoom,
+    screen,
+    getNodeBox: deps.getNodeBox,
+    nodeEls: allowSvgDomHit ? (deps.getNodeEls?.() ?? null) : null,
+    allowSvgDomHit,
+    soaBuf: buf && buf.count > 0 ? buf : null,
+    pad,
+  });
   if (typeof window !== 'undefined' && import.meta.env.DEV) {
-    const allIds = doc ? deps.listNodeIds() : [];
+    const allIds = deps.listNodeIds();
     const pointInBox = (
       box: { left: number; top: number; width: number; height: number } | null | undefined
     ) => {
@@ -276,30 +247,115 @@ export function hitTestWithSpatialIndex(
         point.y <= box.top + box.height + searchPad
       );
     };
-    // When order is empty, dump every listed id box so we can tell "click in
-    // empty world" vs "spatial index empty/stale" without Redux spelunking.
     const idSource = order.length ? order.slice(0, 12) : allIds.slice(0, 24);
     const boxes = idSource.map((id) => {
+      if (String(id).startsWith('frame:')) {
+        return { id, box: null, containsPoint: false };
+      }
       const box = deps.getNodeBox(id);
       return { id, box, containsPoint: pointInBox(box) };
     });
     (window as unknown as { __rcbHitTrace?: unknown }).__rcbHitTrace = {
       point,
-      zoom,
+      zoom: collected.zoom,
       pad,
       searchPad,
-      doc: Boolean(doc),
+      doc: true,
       disposed: false,
       spatialSize: spatial?.size ?? -1,
       allIdsLen: allIds.length,
       orderLen: order.length,
       orderHead: order.slice(0, 8),
+      rescuedIds,
+      hitOrderHead: hitOrder.slice(0, 8),
       boxes,
       anyBoxContainsPoint: boxes.some((b) => b.containsPoint),
       hit,
     };
   }
   return hit;
+}
+
+/** Coarse QT + point-in-box rescue (nodes + frames) + permanent stackOrder sort. */
+export function collectUnifiedHitCandidates(
+  deps: SceneRendererHitDeps,
+  point: RcbVec
+): {
+  doc: NonNullable<ReturnType<SceneRendererHitDeps['getDocument']>>;
+  zoom: number;
+  pad: number;
+  searchPad: number;
+  spatial: ReturnType<SceneRendererHitDeps['getSpatial']>;
+  order: string[];
+  rescuedIds: string[];
+  hitOrder: string[];
+} | null {
+  const doc = deps.getDocument();
+  if (!doc) return null;
+  const zoom = Math.max(0.05, deps.getZoom() || 1);
+  const pad = sceneHitSlop(zoom);
+  const searchPad = pad + 64 / zoom;
+  const spatial = deps.getSpatial();
+  let order = spatial.hitCandidateIds({
+    x: point.x,
+    y: point.y,
+    pad: searchPad,
+  });
+
+  const seen = new Set(order);
+  const rescuedIds: string[] = [];
+  const pointHitsBox = (box: {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  }) =>
+    point.x >= box.left - searchPad &&
+    point.x <= box.left + box.width + searchPad &&
+    point.y >= box.top - searchPad &&
+    point.y <= box.top + box.height + searchPad;
+
+  // Partial stale rescue: QT may still return neighbors while the moved
+  // node's indexed AABB lags getNodeBox / live plate geom.
+  for (const id of deps.listNodeIds()) {
+    if (seen.has(id)) continue;
+    const box = deps.getNodeBox(id);
+    if (!box || !pointHitsBox(box)) continue;
+    rescuedIds.push(id);
+    seen.add(id);
+  }
+  for (const frame of Array.isArray(doc.frames) ? doc.frames : []) {
+    const fid = String(frame?.id || '').trim();
+    if (!fid) continue;
+    const key = stackFrameKey(fid);
+    if (seen.has(key)) continue;
+    const aabb = frameSceneAabb(doc, fid, searchPad);
+    if (!aabb) continue;
+    if (
+      point.x < aabb.minX ||
+      point.x > aabb.maxX ||
+      point.y < aabb.minY ||
+      point.y > aabb.maxY
+    ) {
+      continue;
+    }
+    rescuedIds.push(key);
+    seen.add(key);
+  }
+  if (rescuedIds.length) {
+    spatial.patchNodes(doc, rescuedIds, 32);
+    order = [...order, ...rescuedIds];
+  }
+
+  const zMap = buildUnifiedHitZMap(doc, order);
+  const rank = new Map(order.map((id, i) => [id, i]));
+  const hitOrder = order.slice().sort((a, b) => {
+    const za = zMap.get(a) || 0;
+    const zb = zMap.get(b) || 0;
+    return zb - za || (rank.get(b) || 0) - (rank.get(a) || 0);
+  });
+
+  return { doc, zoom, pad, searchPad, spatial, order, rescuedIds, hitOrder };
 }
 
 export function isFullDirty(dirty: DirtyRegion): boolean {
@@ -883,8 +939,9 @@ function isTransparentCssColor(c: string): boolean {
 /**
  * Vectors that paint on the SoA / canvas ink surface (ADR 0027).
  *
- * Product WebGL only draws BASIC_GEOM instances (+ atlas stamps). Anything it
- * cannot paint keeps a DOM host — not a second ink backend.
+ * Product WebGL draws BASIC_GEOM (+ atlas stamps for paths / boolean). Nodes that
+ * must interleave above artboard plates still promote to DOM hosts on the shared
+ * stack mount (`worldNodeStacksAboveAnyFrame`).
  *
  * Vitest (WebGL off): broader rich idle for Canvas2D paint helpers.
  *
@@ -893,9 +950,6 @@ function isTransparentCssColor(c: string): boolean {
 export function canIdlePaintOnCanvas(node: SceneNodeInput | null | undefined): boolean {
   if (!node) return false;
   if (isImageProcessRunning(node)) return false;
-  // Frame membership does NOT force a DOM host — artboard children demote to
-  // canvas idle / SoA like world nodes. Clip + stackOrder stay on the shared
-  // frame plate / SVG mount; ink paints under it (ADR 0027).
   const key = String(node.key || '');
   if (key === 'lottie' || key === 'group') {
     return false;
@@ -907,13 +961,23 @@ export function canIdlePaintOnCanvas(node: SceneNodeInput | null | undefined): b
     return false;
   }
 
-  // Product ink = WebGL instances only. Text/media stay FO/DOM until stamped.
-  // Vectors demote only when SoA-basic (what collectSoaWebglInstances draws).
+  // Product WebGL: basic + atlas-stamped paths/boolean/image/video/audio/text/gradients.
+  // Lottie stays DOM. Puppet-warp images stay DOM hosts.
+  // StackOrder above plates still promotes to hosts (shared mount data-z).
   if (isSoaWebglEnvEnabled()) {
-    if (key === 'text' || key === 'image' || key === 'video' || key === 'audio') {
+    if (key === 'lottie' || key === 'group') {
       return false;
     }
-    return isSoaBasicGeomSufficient(node);
+    if (key === 'text' || key === 'audio') return true;
+    if (key === 'image' || key === 'video') {
+      if (nodeNeedsPuppetWarp(node)) return false;
+      // Cross-origin without CORS cannot stamp into WebGL — keep a DOM host.
+      const src = mediaPaintSrc(node);
+      if (src && isFillImageWebglUnsafe(src)) return false;
+      return true;
+    }
+    if (isSoaBasicGeomSufficient(node)) return true;
+    return isSoaRichFillAtlasStampable(node);
   }
 
   if (key === 'text') return true;
@@ -1229,8 +1293,44 @@ const FILL_IMAGE_CACHE_MAX = 64;
 const DIFFUSE_BAKE_CACHE_MAX = 24;
 
 const fillImageCache = new Map<string, CanvasImageSource>();
+/** Srcs that painted a non-readable canvas (CORS) — never stamp into WebGL atlas. */
+const fillImageWebglUnsafe = new Set<string>();
 const diffuseBakeCache = new Map<string, HTMLCanvasElement>();
 
+/** True when canvas pixels can be read (safe to upload to WebGL). */
+export function canvasPixelsReadable(
+  canvas: HTMLCanvasElement | OffscreenCanvas | null | undefined
+): boolean {
+  if (!canvas) return false;
+  try {
+    const ctx = canvas.getContext('2d') as
+      | CanvasRenderingContext2D
+      | OffscreenCanvasRenderingContext2D
+      | null;
+    if (!ctx) return false;
+    ctx.getImageData(0, 0, 1, 1);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Remote http(s) need CORS for WebGL atlas; blob/data are same-document. */
+function fillImageShouldUseCors(url: string): boolean {
+  const u = String(url || '').trim();
+  if (!u) return false;
+  if (u.startsWith('blob:') || u.startsWith('data:') || u.startsWith('file:')) return false;
+  return /^https?:\/\//i.test(u) || u.startsWith('//');
+}
+
+export function isFillImageWebglUnsafe(src: string): boolean {
+  return fillImageWebglUnsafe.has(String(src || '').trim());
+}
+
+export function markFillImageWebglUnsafe(src: string): void {
+  const url = String(src || '').trim();
+  if (url) fillImageWebglUnsafe.add(url);
+}
 export function imageSourceSize(img: CanvasImageSource): { iw: number; ih: number } {
   if (typeof HTMLImageElement !== 'undefined' && img instanceof HTMLImageElement) {
     return { iw: img.naturalWidth || img.width || 1, ih: img.naturalHeight || img.height || 1 };
@@ -1252,10 +1352,17 @@ export function getFillImageReady(src: string): CanvasImageSource | null {
   const cached = fillImageCache.get(url);
   if (cached) {
     if (typeof HTMLImageElement !== 'undefined' && cached instanceof HTMLImageElement) {
-      if (cached.complete && (cached.naturalWidth || cached.width)) return cached;
-      return null;
+      // Legacy cache entries loaded without CORS would taint the WebGL atlas.
+      if (fillImageShouldUseCors(url) && cached.crossOrigin !== 'anonymous') {
+        fillImageCache.delete(url);
+      } else if (cached.complete && (cached.naturalWidth || cached.width)) {
+        return cached;
+      } else {
+        return null;
+      }
+    } else {
+      return cached;
     }
-    return cached;
   }
   if (typeof Image === 'undefined') return null;
   if (fillImageCache.size >= FILL_IMAGE_CACHE_MAX) {
@@ -1264,6 +1371,10 @@ export function getFillImageReady(src: string): CanvasImageSource | null {
   }
   const img = new Image();
   img.decoding = 'async';
+  // Required so bake → atlas → texImage2D is not tainted by cross-origin bitmaps.
+  if (fillImageShouldUseCors(url)) {
+    img.crossOrigin = 'anonymous';
+  }
   img.src = url;
   fillImageCache.set(url, img);
   if (img.complete && (img.naturalWidth || img.width)) return img;
@@ -1273,6 +1384,15 @@ export function getFillImageReady(src: string): CanvasImageSource | null {
       'load',
       () => {
         bumpSceneCanvasIdlePaint();
+      },
+      { once: true }
+    );
+    img.addEventListener(
+      'error',
+      () => {
+        // CORS failure with crossOrigin=anonymous — do not keep stamping/bumping.
+        markFillImageWebglUnsafe(url);
+        fillImageCache.delete(url);
       },
       { once: true }
     );
@@ -1290,6 +1410,7 @@ export function setFillImageCacheEntry(src: string, img: CanvasImageSource): voi
 /** Test / dispose helper. */
 export function clearFillImageCache(): void {
   fillImageCache.clear();
+  fillImageWebglUnsafe.clear();
   diffuseBakeCache.clear();
 }
 
@@ -2321,6 +2442,217 @@ export function paintCanvasMediaInk(
   ctx.restore();
 }
 
+/**
+ * Bake static image / video poster for WebGL atlas stamp (crop + corners).
+ * Returns null while decode is pending (caller should skip; load bumps idle).
+ */
+export function bakeMediaInkForAtlas(
+  node: SceneNodeInput,
+  width: number,
+  height: number
+): HTMLCanvasElement | OffscreenCanvas | null {
+  if (nodeNeedsPuppetWarp(node)) return null;
+  const src = mediaPaintSrc(node);
+  if (!src || isFillImageWebglUnsafe(src) || !getFillImageReady(src)) return null;
+  const w = Math.max(1, Math.round(width));
+  const h = Math.max(1, Math.round(height));
+  // Cap bake resolution so atlas cells stay sharp without huge canvases.
+  const maxEdge = 512;
+  const scale = Math.min(1, maxEdge / Math.max(w, h));
+  const bw = Math.max(1, Math.round(w * scale));
+  const bh = Math.max(1, Math.round(h * scale));
+  let canvas: HTMLCanvasElement | OffscreenCanvas;
+  if (typeof OffscreenCanvas !== 'undefined') {
+    canvas = new OffscreenCanvas(bw, bh);
+  } else if (typeof document !== 'undefined') {
+    const c = document.createElement('canvas');
+    c.width = bw;
+    c.height = bh;
+    canvas = c;
+  } else {
+    return null;
+  }
+  const ctx = canvas.getContext('2d') as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null;
+  if (!ctx) return null;
+  ctx.setTransform(scale, 0, 0, scale, 0, 0);
+  paintCanvasMediaInk(ctx as CanvasRenderingContext2D, {
+    node,
+    width: w,
+    height: h,
+    opacity: 1,
+  });
+  // Never return a tainted bake — stamping it would poison the shared WebGL atlas.
+  if (!canvasPixelsReadable(canvas)) {
+    markFillImageWebglUnsafe(src);
+    return null;
+  }
+  return canvas;
+}
+
+/**
+ * Bake idle audio plate for WebGL atlas stamp (wash + waveform bars).
+ */
+export function bakeAudioInkForAtlas(
+  node: SceneNodeInput,
+  width: number,
+  height: number,
+  zoom = 1
+): HTMLCanvasElement | OffscreenCanvas | null {
+  if (String(node.key || '') !== 'audio') return null;
+  const w = Math.max(1, Math.round(width));
+  const h = Math.max(1, Math.round(height));
+  const maxEdge = 512;
+  const scale = Math.min(1, maxEdge / Math.max(w, h));
+  const bw = Math.max(1, Math.round(w * scale));
+  const bh = Math.max(1, Math.round(h * scale));
+  let canvas: HTMLCanvasElement | OffscreenCanvas;
+  if (typeof OffscreenCanvas !== 'undefined') {
+    canvas = new OffscreenCanvas(bw, bh);
+  } else if (typeof document !== 'undefined') {
+    const c = document.createElement('canvas');
+    c.width = bw;
+    c.height = bh;
+    canvas = c;
+  } else {
+    return null;
+  }
+  const ctx = canvas.getContext('2d') as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null;
+  if (!ctx) return null;
+  ctx.setTransform(scale, 0, 0, scale, 0, 0);
+  const opacity = Math.min(1, Math.max(0.05, Number(node.attrs?.opacity) || 1));
+  const screenH = h * Math.max(0.05, zoom || 1);
+  if (screenH < 18) {
+    const c2 = ctx as CanvasRenderingContext2D;
+    c2.save();
+    c2.globalAlpha = opacity;
+    c2.fillStyle = '#e9eaee';
+    c2.fillRect(0, 0, w, h);
+    c2.restore();
+  } else {
+    paintCanvasAudioInk(ctx as CanvasRenderingContext2D, {
+      node,
+      width: w,
+      height: h,
+      opacity,
+    });
+  }
+  return canvas;
+}
+
+/**
+ * Bake rich shape ink for WebGL atlas (`rich:`): gradients, rotated solids,
+ * triangle/polygon/star, donut/arc ellipses.
+ */
+export function bakeShapeInkForAtlas(
+  node: SceneNodeInput,
+  width: number,
+  height: number
+): HTMLCanvasElement | OffscreenCanvas | null {
+  if (!isSoaRichFillAtlasStampable(node)) return null;
+  const w = Math.max(1, Math.round(width));
+  const h = Math.max(1, Math.round(height));
+  const maxEdge = 512;
+  const scale = Math.min(1, maxEdge / Math.max(w, h));
+  const bw = Math.max(1, Math.round(w * scale));
+  const bh = Math.max(1, Math.round(h * scale));
+  let canvas: HTMLCanvasElement | OffscreenCanvas;
+  if (typeof OffscreenCanvas !== 'undefined') {
+    canvas = new OffscreenCanvas(bw, bh);
+  } else if (typeof document !== 'undefined') {
+    const c = document.createElement('canvas');
+    c.width = bw;
+    c.height = bh;
+    canvas = c;
+  } else {
+    return null;
+  }
+  const ctx = canvas.getContext('2d') as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null;
+  if (!ctx) return null;
+  ctx.setTransform(scale, 0, 0, scale, 0, 0);
+  const opacity = Math.min(1, Math.max(0.05, Number(node.attrs?.opacity) || 1));
+  const key = String(node.key || '');
+  const t = String(node.attrs?.shapeType || (key === 'shape' ? 'rect' : key) || '').toLowerCase();
+  const customPath = String(node.attrs?.path || '').trim();
+  const pathLike =
+    t === 'pen' || t === 'pencil' || t === 'path' || key === 'path' || Boolean(customPath);
+  const angle = Number(node.attrs?.angle) || 0;
+  const c2 = ctx as CanvasRenderingContext2D;
+  c2.save();
+  if (Math.abs(angle) > 0.5) {
+    c2.translate(w / 2, h / 2);
+    c2.rotate((angle * Math.PI) / 180);
+    c2.translate(-w / 2, -h / 2);
+  }
+  if (pathLike) {
+    paintCanvasPathInk(c2, { node, width: w, height: h, opacity });
+  } else {
+    paintCanvasShapeInk(c2, { node, width: w, height: h, opacity });
+  }
+  c2.restore();
+  if (!canvasPixelsReadable(canvas)) {
+    const fillSrc = String(node.attrs?.['fill-image-src'] || '').trim();
+    if (fillSrc) markFillImageWebglUnsafe(fillSrc);
+    return null;
+  }
+  return canvas;
+}
+
+/**
+ * Bake static text for WebGL atlas stamp (glyphs or greeking by zoom).
+ */
+export function bakeTextInkForAtlas(
+  node: SceneNodeInput,
+  width: number,
+  height: number,
+  zoom = 1
+): HTMLCanvasElement | OffscreenCanvas | null {
+  if (String(node.key || '') !== 'text') return null;
+  const w = Math.max(1, Math.round(width));
+  const h = Math.max(1, Math.round(height));
+  const maxEdge = 512;
+  const scale = Math.min(1, maxEdge / Math.max(w, h));
+  const bw = Math.max(1, Math.round(w * scale));
+  const bh = Math.max(1, Math.round(h * scale));
+  let canvas: HTMLCanvasElement | OffscreenCanvas;
+  if (typeof OffscreenCanvas !== 'undefined') {
+    canvas = new OffscreenCanvas(bw, bh);
+  } else if (typeof document !== 'undefined') {
+    const c = document.createElement('canvas');
+    c.width = bw;
+    c.height = bh;
+    canvas = c;
+  } else {
+    return null;
+  }
+  const ctx = canvas.getContext('2d') as CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D | null;
+  if (!ctx) return null;
+  ctx.setTransform(scale, 0, 0, scale, 0, 0);
+  const opacity = Math.min(1, Math.max(0.15, Number(node.attrs?.opacity) || 1));
+  const fontPx = Math.max(1, Number(node.attrs?.fontSize) || 14);
+  const screenFont = fontPx * Math.max(0.05, zoom || 1);
+  if (screenFont < 7) {
+    const fill = resolveNodeProxyFill(node);
+    (ctx as CanvasRenderingContext2D).save();
+    (ctx as CanvasRenderingContext2D).globalAlpha = opacity;
+    paintTextProxyLines(ctx as CanvasRenderingContext2D, {
+      node,
+      width: w,
+      height: h,
+      fill,
+      opacity,
+    });
+    (ctx as CanvasRenderingContext2D).restore();
+  } else {
+    paintCanvasTextInk(ctx as CanvasRenderingContext2D, {
+      node,
+      width: w,
+      height: h,
+      opacity,
+    });
+  }
+  return canvas;
+}
+
 export type CanvasIdleNodePaintOpts = {
   left: number;
   top: number;
@@ -2335,7 +2667,6 @@ export type CanvasIdleNodePaintOpts = {
 
 /**
  * Clip Canvas ink to the node's owning clipContent frame (scene space).
- * Needed when idle ink paints above artboard plates.
  */
 export function clipCanvasIdleToOwningFrame(
   ctx: CanvasRenderingContext2D,

--- a/apps/web/src/components/rcb/render/webglInstanceAtlas.ts
+++ b/apps/web/src/components/rcb/render/webglInstanceAtlas.ts
@@ -3,8 +3,12 @@
  * (ADR 0027). One textured quad replaces many line segments.
  */
 import {
+  SOA_KIND_ELLIPSE,
+  SOA_KIND_IMAGE,
   SOA_KIND_PATH,
+  SOA_KIND_POLY,
   SOA_KIND_RECT,
+  SOA_KIND_TEXT,
   type SceneRenderBuffer,
 } from '@/components/rcb/render/sceneRenderBuffer';
 
@@ -186,11 +190,32 @@ export function pruneSoaAtlasForBuffer(atlas: SoaWebglAtlas, buf: SceneRenderBuf
     if (!id) continue;
     const kind = buf.kinds[i];
     if (kind === SOA_KIND_PATH) keep.add(`path:${id}`);
-    if (kind === SOA_KIND_RECT) keep.add(`round:${id}`);
+    if (kind === SOA_KIND_RECT) {
+      keep.add(`round:${id}`);
+      keep.add(`rich:${id}`);
+    }
+    if (kind === SOA_KIND_ELLIPSE || kind === SOA_KIND_POLY || kind === SOA_KIND_PATH) {
+      keep.add(`rich:${id}`);
+    }
+    if (kind === SOA_KIND_IMAGE) {
+      // image/video share IMAGE kind; audio stamps use aud: prefix.
+      keep.add(`img:${id}`);
+      keep.add(`aud:${id}`);
+    }
+    if (kind === SOA_KIND_TEXT) keep.add(`txt:${id}`);
   }
   let n = 0;
   for (const key of [...atlas.regions.keys()]) {
-    if (!key.startsWith('path:') && !key.startsWith('round:')) continue;
+    if (
+      !key.startsWith('path:') &&
+      !key.startsWith('round:') &&
+      !key.startsWith('img:') &&
+      !key.startsWith('aud:') &&
+      !key.startsWith('txt:') &&
+      !key.startsWith('rich:')
+    ) {
+      continue;
+    }
     if (keep.has(key)) continue;
     if (releaseSoaAtlasRegion(atlas, key)) n += 1;
   }
@@ -386,7 +411,7 @@ export function stampSoaPathToAtlas(
   fillCss: string,
   closed: boolean,
   lineWidth = 2,
-  opts?: { force?: boolean; strokeCss?: string }
+  opts?: { force?: boolean; strokeCss?: string; fillRule?: 'nonzero' | 'evenodd' }
 ): SoaAtlasRegion | null {
   const polyWorld = computePolylineWorldBounds(xy, startPoint * 2, pointCount);
   if (!polyWorld) return null;
@@ -402,6 +427,7 @@ export function stampSoaPathToAtlas(
   if (!region) return null;
 
   const strokeCss = opts?.strokeCss ?? fillCss;
+  const fillRule = opts?.fillRule === 'evenodd' ? 'evenodd' : 'nonzero';
   const hasFill = closed && atlasCssIsOpaque(fillCss);
   const strokeOk = atlasCssIsOpaque(strokeCss);
   const inner = atlas.cell - SOA_ATLAS_PAD * 2;
@@ -417,23 +443,14 @@ export function stampSoaPathToAtlas(
     ctx.lineJoin = closed ? 'round' : 'miter';
     ctx.beginPath();
     let pending = false;
-    const finishContour = () => {
-      if (!pending) return;
-      if (closed) {
-        ctx.closePath();
-        if (hasFill) ctx.fill();
-      }
-      if (strokeOk) ctx.stroke();
-      pending = false;
-      ctx.beginPath();
-    };
     const base = startPoint * 2;
     for (let i = 0; i < pointCount; i += 1) {
       const o = base + i * 2;
       const x = xy[o];
       const y = xy[o + 1];
       if (!Number.isFinite(x) || !Number.isFinite(y)) {
-        finishContour();
+        if (pending && closed) ctx.closePath();
+        pending = false;
         continue;
       }
       if (!pending) {
@@ -443,7 +460,12 @@ export function stampSoaPathToAtlas(
         ctx.lineTo(x, y);
       }
     }
-    finishContour();
+    if (pending && closed) ctx.closePath();
+    if (hasFill && closed) {
+      if (fillRule === 'evenodd') ctx.fill('evenodd');
+      else ctx.fill();
+    }
+    if (strokeOk) ctx.stroke();
   });
   return region;
 }
@@ -534,6 +556,7 @@ export function stampImageToAtlas(
   world: { left: number; top: number; width: number; height: number },
   opts?: { force?: boolean }
 ): SoaAtlasRegion | null {
+  if (!atlasStampSourceIsSafe(source)) return null;
   const existing = atlas.regions.get(key);
   if (existing && !opts?.force) {
     touchLru(atlas, key);
@@ -652,4 +675,37 @@ let sharedAtlas: SoaWebglAtlas | null = null;
 export function ensureSharedSoaWebglAtlas(): SoaWebglAtlas | null {
   if (!sharedAtlas) sharedAtlas = createSoaWebglAtlas();
   return sharedAtlas;
+}
+
+/** Drop a tainted atlas surface and allocate a fresh one (WebGL texImage2D recovery). */
+export function recreateSharedSoaWebglAtlas(): SoaWebglAtlas | null {
+  sharedAtlas = createSoaWebglAtlas();
+  return sharedAtlas;
+}
+
+/** True when a stamp source will not taint the atlas canvas. */
+export function atlasStampSourceIsSafe(source: CanvasImageSource): boolean {
+  if (typeof HTMLCanvasElement !== 'undefined' && source instanceof HTMLCanvasElement) {
+    try {
+      const ctx = source.getContext('2d');
+      if (!ctx) return false;
+      ctx.getImageData(0, 0, 1, 1);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  if (typeof OffscreenCanvas !== 'undefined' && source instanceof OffscreenCanvas) {
+    try {
+      const ctx = source.getContext('2d');
+      if (!ctx) return false;
+      ctx.getImageData(0, 0, 1, 1);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  // HTMLImageElement / ImageBitmap / Video — trust caller CORS; drawImage of
+  // cross-origin without CORS taints. Prefer baking through a readable canvas.
+  return true;
 }

--- a/apps/web/src/components/rcb/render/webglSceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/webglSceneRenderer.ts
@@ -15,29 +15,47 @@ import {
   SOA_FLAG_CANVAS_IDLE,
   SOA_FLAG_DIRTY,
   SOA_FLAG_VISIBLE,
+  SOA_FLAG_BASIC_GEOM,
   SOA_KIND_ELLIPSE,
+  SOA_KIND_IMAGE,
   SOA_KIND_LINE,
   SOA_KIND_PATH,
+  SOA_KIND_POLY,
   SOA_KIND_RECT,
+  SOA_KIND_TEXT,
   soaStrokeWidth,
   unpackCssColor,
   type SceneRenderBuffer,
 } from '@/components/rcb/render/sceneRenderBuffer';
 import { getLiveCornerRadiusPreviewRadii } from '@/components/rcb/scene/document/sceneRadii';
-import type { SceneDocument } from '@/components/rcb/sceneNode';
+import type { SceneDocument, SceneNodeInput } from '@/components/rcb/sceneNode';
 import {
   collectSoaBakeTilesIntoAtlas,
   ensureSharedSoaWebglAtlas,
+  recreateSharedSoaWebglAtlas,
   getSoaAtlasStats,
   pruneSoaAtlasForBuffer,
   pushAtlasRegionInstance,
   releaseSoaAtlasPrefix,
   releaseSoaAtlasRegion,
+  stampImageToAtlas,
   stampSoaPathToAtlas,
   stampSoaEllipseToAtlas,
   type SoaAtlasRegion,
   type SoaWebglAtlas,
 } from '@/components/rcb/render/webglInstanceAtlas';
+import {
+  bakeAudioInkForAtlas,
+  bakeMediaInkForAtlas,
+  bakeShapeInkForAtlas,
+  bakeTextInkForAtlas,
+  bumpSceneCanvasIdlePaint,
+  isFillImageWebglUnsafe,
+  hitTestWithSpatialIndex,
+  type CanvasSceneRendererDeps,
+  type SceneRenderRequest,
+  type SceneRenderer,
+} from '@/components/rcb/render/sceneRenderer';
 import {
   collectReadySoaBakeTilesForView,
   createSoaBakeCache,
@@ -48,13 +66,6 @@ import {
   shouldUseSoaBake,
   unionSoaDirtyAabb,
 } from '@/components/rcb/render/soaBakeLayer';
-import {
-  bumpSceneCanvasIdlePaint,
-  hitTestWithSpatialIndex,
-  type CanvasSceneRendererDeps,
-  type SceneRenderRequest,
-  type SceneRenderer,
-} from '@/components/rcb/render/sceneRenderer';
 import {
   findClippingFrameForNode,
   frameClipRevealsOverflow,
@@ -416,6 +427,8 @@ export type CollectSoaWebglOpts = {
   strokes?: number[];
   /** Document for clip resolve; defaults to {@link getSoaPaintDocument}. */
   document?: SceneDocument | null;
+  /** Camera zoom — text atlas greeking threshold. */
+  zoom?: number;
 };
 
 /**
@@ -438,6 +451,7 @@ export function collectSoaWebglInstances(
   const clips = opts?.clips;
   const strokes = opts?.strokes;
   const paintDoc = opts?.document ?? getSoaPaintDocument();
+  const zoom = Math.max(0.05, Number(opts?.zoom) || 1);
   const vl = view.left ?? view.x ?? 0;
   const vt = view.top ?? view.y ?? 0;
   const vr = vl + view.width;
@@ -452,7 +466,10 @@ export function collectSoaWebglInstances(
       kind !== SOA_KIND_RECT &&
       kind !== SOA_KIND_ELLIPSE &&
       kind !== SOA_KIND_LINE &&
-      kind !== SOA_KIND_PATH
+      kind !== SOA_KIND_PATH &&
+      kind !== SOA_KIND_POLY &&
+      kind !== SOA_KIND_IMAGE &&
+      kind !== SOA_KIND_TEXT
     ) {
       continue;
     }
@@ -466,6 +483,119 @@ export function collectSoaWebglInstances(
     const id = nodeId;
     const slotDepth = depthForId ? depthForId(nodeId) : 0.5;
     const slotClip = resolveSoaWebglSlotClip(buf, i, paintDoc);
+    const paintClips: Array<[number, number, number, number]> = [
+      [slotClip[0], slotClip[1], slotClip[2], slotClip[3]],
+    ];
+
+    if (kind === SOA_KIND_IMAGE) {
+      const node = paintDoc?.deltaSetLike?.[id];
+      if (!node || !atlas) {
+        clearSoaDirtyFlag(buf, i, flags, forceStamp);
+        continue;
+      }
+      const isAudio = String(node.key || '') === 'audio';
+      const baked = isAudio
+        ? bakeAudioInkForAtlas(node, w, h, zoom)
+        : bakeMediaInkForAtlas(node, w, h);
+      if (!baked) {
+        if (!isAudio) {
+          const src = String(
+            (node.key === 'video' ? node.attrs?.poster : null) || node.attrs?.src || ''
+          ).trim();
+          // Pending decode → bump. CORS/tainted → stop retrying; host will paint.
+          if (src && isFillImageWebglUnsafe(src)) {
+            clearSoaDirtyFlag(buf, i, flags, forceStamp);
+          } else {
+            bumpSceneCanvasIdlePaint();
+          }
+        } else clearSoaDirtyFlag(buf, i, flags, forceStamp);
+        continue;
+      }
+      const region = stampImageToAtlas(
+        atlas,
+        isAudio ? `aud:${id}` : `img:${id}`,
+        baked as CanvasImageSource,
+        { left: x, top: y, width: w, height: h },
+        { force: forceStamp }
+      );
+      if (region) {
+        for (const activeClip of paintClips) {
+          pushAtlasRegionInstance(atlas, region, rects, colors, kinds, angles, uvs, 0, odx, ody);
+          if (depthOut) depthOut.push(slotDepth);
+          pushInstanceClip(clips, activeClip);
+          pushInstanceStroke(strokes, null, 0);
+        }
+        if (forceStamp) buf.flags[i] = (flags & ~SOA_FLAG_DIRTY) >>> 0;
+      }
+      continue;
+    }
+
+    if (kind === SOA_KIND_TEXT) {
+      const node = paintDoc?.deltaSetLike?.[id];
+      if (!node || !atlas) {
+        clearSoaDirtyFlag(buf, i, flags, forceStamp);
+        continue;
+      }
+      const baked = bakeTextInkForAtlas(node, w, h, zoom);
+      if (!baked) {
+        clearSoaDirtyFlag(buf, i, flags, forceStamp);
+        continue;
+      }
+      const region = stampImageToAtlas(
+        atlas,
+        `txt:${id}`,
+        baked as CanvasImageSource,
+        { left: x, top: y, width: w, height: h },
+        { force: forceStamp }
+      );
+      if (region) {
+        for (const activeClip of paintClips) {
+          pushAtlasRegionInstance(atlas, region, rects, colors, kinds, angles, uvs, 0, odx, ody);
+          if (depthOut) depthOut.push(slotDepth);
+          pushInstanceClip(clips, activeClip);
+          pushInstanceStroke(strokes, null, 0);
+        }
+        if (forceStamp) buf.flags[i] = (flags & ~SOA_FLAG_DIRTY) >>> 0;
+      }
+      continue;
+    }
+
+    // Gradient / rotated / poly / donut — Canvas bake → atlas (not BASIC_GEOM).
+    if (
+      (flags & SOA_FLAG_BASIC_GEOM) === 0 &&
+      (kind === SOA_KIND_RECT ||
+        kind === SOA_KIND_ELLIPSE ||
+        kind === SOA_KIND_PATH ||
+        kind === SOA_KIND_POLY)
+    ) {
+      const node = paintDoc?.deltaSetLike?.[id];
+      if (!node || !atlas) {
+        clearSoaDirtyFlag(buf, i, flags, forceStamp);
+        continue;
+      }
+      const baked = bakeShapeInkForAtlas(node, w, h);
+      if (!baked) {
+        clearSoaDirtyFlag(buf, i, flags, forceStamp);
+        continue;
+      }
+      const region = stampImageToAtlas(
+        atlas,
+        `rich:${id}`,
+        baked as CanvasImageSource,
+        { left: x, top: y, width: w, height: h },
+        { force: forceStamp }
+      );
+      if (region) {
+        for (const activeClip of paintClips) {
+          pushAtlasRegionInstance(atlas, region, rects, colors, kinds, angles, uvs, 0, odx, ody);
+          if (depthOut) depthOut.push(slotDepth);
+          pushInstanceClip(clips, activeClip);
+          pushInstanceStroke(strokes, null, 0);
+        }
+        if (forceStamp) buf.flags[i] = (flags & ~SOA_FLAG_DIRTY) >>> 0;
+      }
+      continue;
+    }
 
     if (kind === SOA_KIND_PATH) {
       const start = buf.pathStart[i];
@@ -487,6 +617,9 @@ export function collectSoaWebglInstances(
           continue;
         }
         const fillCss = unpackCssColor(buf.colors[i]);
+        const fillRuleAttr = String(
+          paintDoc?.deltaSetLike?.[id]?.attrs?.['fill-rule'] || ''
+        ).toLowerCase();
         const region = stampSoaPathToAtlas(
           atlas,
           `path:${id}`,
@@ -499,13 +632,16 @@ export function collectSoaWebglInstances(
           {
             force: forceStamp,
             strokeCss: unpackCssColor(buf.strokeColors[i] || 0xff333333),
+            fillRule: fillRuleAttr === 'evenodd' ? 'evenodd' : 'nonzero',
           }
         );
         if (region) {
-          pushAtlasRegionInstance(atlas, region, rects, colors, kinds, angles, uvs, 0, 0, 0);
-          if (depthOut) depthOut.push(slotDepth);
-          pushInstanceClip(clips, slotClip);
-          pushInstanceStroke(strokes, null, 0);
+          for (const activeClip of paintClips) {
+            pushAtlasRegionInstance(atlas, region, rects, colors, kinds, angles, uvs, 0, 0, 0);
+            if (depthOut) depthOut.push(slotDepth);
+            pushInstanceClip(clips, activeClip);
+            pushInstanceStroke(strokes, null, 0);
+          }
           if (forceStamp) buf.flags[i] = (flags & ~SOA_FLAG_DIRTY) >>> 0;
           continue;
         }
@@ -520,24 +656,26 @@ export function collectSoaWebglInstances(
       let emitted = 0;
       const emitSeg = (a: number, b: number) => {
         if (emitted >= SOA_WEBGL_PATH_MAX_SEGS) return;
-        pushLineInstance(
-          buf.pathXY[a] + odx,
-          buf.pathXY[a + 1] + ody,
-          buf.pathXY[b] + odx,
-          buf.pathXY[b + 1] + ody,
-          strokeRgba,
-          lineW,
-          rects,
-          colors,
-          kinds,
-          angles,
-          uvs,
-          depthOut,
-          slotDepth,
-          clips,
-          slotClip,
-          strokes
-        );
+        for (const activeClip of paintClips) {
+          pushLineInstance(
+            buf.pathXY[a] + odx,
+            buf.pathXY[a + 1] + ody,
+            buf.pathXY[b] + odx,
+            buf.pathXY[b + 1] + ody,
+            strokeRgba,
+            lineW,
+            rects,
+            colors,
+            kinds,
+            angles,
+            uvs,
+            depthOut,
+            slotDepth,
+            clips,
+            activeClip,
+            strokes
+          );
+        }
         emitted += 1;
       };
       for (let p = 0; p < len; p += 1) {
@@ -568,24 +706,26 @@ export function collectSoaWebglInstances(
         let emitted = 0;
         const emitSeg = (a: number, b: number) => {
           if (emitted >= SOA_WEBGL_PATH_MAX_SEGS) return;
-          pushLineInstance(
-            buf.pathXY[a] + odx,
-            buf.pathXY[a + 1] + ody,
-            buf.pathXY[b] + odx,
-            buf.pathXY[b + 1] + ody,
-            strokeRgba,
-            lineW,
-            rects,
-            colors,
-            kinds,
-            angles,
-            uvs,
-            depthOut,
-            slotDepth,
-            clips,
-            slotClip,
-            strokes
-          );
+          for (const activeClip of paintClips) {
+            pushLineInstance(
+              buf.pathXY[a] + odx,
+              buf.pathXY[a + 1] + ody,
+              buf.pathXY[b] + odx,
+              buf.pathXY[b + 1] + ody,
+              strokeRgba,
+              lineW,
+              rects,
+              colors,
+              kinds,
+              angles,
+              uvs,
+              depthOut,
+              slotDepth,
+              clips,
+              activeClip,
+              strokes
+            );
+          }
           emitted += 1;
         };
         for (let p = 0; p < len; p += 1) {
@@ -613,24 +753,26 @@ export function collectSoaWebglInstances(
       const maxX = Math.max(x, x1) + lineW;
       const maxY = Math.max(y, y1) + lineW;
       if (maxX < vl || maxY < vt || minX > vr || minY > vb) continue;
-      pushLineInstance(
-        x,
-        y,
-        x1,
-        y1,
-        strokeRgba,
-        lineW,
-        rects,
-        colors,
-        kinds,
-        angles,
-        uvs,
-        depthOut,
-        slotDepth,
-        clips,
-        slotClip,
-        strokes
-      );
+      for (const activeClip of paintClips) {
+        pushLineInstance(
+          x,
+          y,
+          x1,
+          y1,
+          strokeRgba,
+          lineW,
+          rects,
+          colors,
+          kinds,
+          angles,
+          uvs,
+          depthOut,
+          slotDepth,
+          clips,
+          activeClip,
+          strokes
+        );
+      }
       if (forceStamp) buf.flags[i] = (flags & ~SOA_FLAG_DIRTY) >>> 0;
       continue;
     }
@@ -660,14 +802,16 @@ export function collectSoaWebglInstances(
       const rounded = tl > 0.5 || tr > 0.5 || br > 0.5 || bl > 0.5;
       if (rounded || hasOutline) {
         const outlineRgba = hasOutline ? argbToRgba(outlineArgb) : null;
-        rects.push(x, y, w, h);
-        colors.push(rgba[0], rgba[1], rgba[2], rgba[3]);
-        kinds.push(SOA_WEBGL_KIND_ROUNDED);
-        angles.push(rotRad);
-        uvs.push(tl, tr, br, bl);
-        if (depthOut) depthOut.push(slotDepth);
-        pushInstanceClip(clips, slotClip);
-        pushInstanceStroke(strokes, outlineRgba, hasOutline ? outlineW : 0);
+        for (const activeClip of paintClips) {
+          rects.push(x, y, w, h);
+          colors.push(rgba[0], rgba[1], rgba[2], rgba[3]);
+          kinds.push(SOA_WEBGL_KIND_ROUNDED);
+          angles.push(rotRad);
+          uvs.push(tl, tr, br, bl);
+          if (depthOut) depthOut.push(slotDepth);
+          pushInstanceClip(clips, activeClip);
+          pushInstanceStroke(strokes, outlineRgba, hasOutline ? outlineW : 0);
+        }
         clearSoaDirtyFlag(buf, i, flags, forceStamp);
         continue;
       }
@@ -687,34 +831,38 @@ export function collectSoaWebglInstances(
         }
       );
       if (region) {
-        commitAtlasRegionInstance(
-          atlas,
-          region,
-          rects,
-          colors,
-          kinds,
-          angles,
-          uvs,
-          rotRad,
-          depthOut,
-          slotDepth,
-          clips,
-          slotClip,
-          strokes
-        );
+        for (const activeClip of paintClips) {
+          commitAtlasRegionInstance(
+            atlas,
+            region,
+            rects,
+            colors,
+            kinds,
+            angles,
+            uvs,
+            rotRad,
+            depthOut,
+            slotDepth,
+            clips,
+            activeClip,
+            strokes
+          );
+        }
         clearSoaDirtyFlag(buf, i, flags, forceStamp);
         continue;
       }
     }
 
-    rects.push(x, y, w, h);
-    colors.push(rgba[0], rgba[1], rgba[2], rgba[3]);
-    kinds.push(kind === SOA_KIND_ELLIPSE ? 1 : 0);
-    angles.push(rotRad);
-    uvs.push(0, 0, 1, 1);
-    if (depthOut) depthOut.push(slotDepth);
-    pushInstanceClip(clips, slotClip);
-    pushInstanceStroke(strokes, null, 0);
+    for (const activeClip of paintClips) {
+      rects.push(x, y, w, h);
+      colors.push(rgba[0], rgba[1], rgba[2], rgba[3]);
+      kinds.push(kind === SOA_KIND_ELLIPSE ? 1 : 0);
+      angles.push(rotRad);
+      uvs.push(0, 0, 1, 1);
+      if (depthOut) depthOut.push(slotDepth);
+      pushInstanceClip(clips, activeClip);
+      pushInstanceStroke(strokes, null, 0);
+    }
     clearSoaDirtyFlag(buf, i, flags, forceStamp);
   }
 }
@@ -994,6 +1142,7 @@ export function createWebglSceneRenderer(
           clips,
           strokes,
           document: req.document,
+          zoom: z,
         });
       }
       const count = kinds.length;
@@ -1043,8 +1192,22 @@ export function createWebglSceneRenderer(
       if (atlas.revision !== atlasUploadedRevision) {
         gl.bindTexture(gl.TEXTURE_2D, atlasTex);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 1);
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, atlas.canvas as TexImageSource);
-        atlasUploadedRevision = atlas.revision;
+        try {
+          gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.RGBA,
+            gl.RGBA,
+            gl.UNSIGNED_BYTE,
+            atlas.canvas as TexImageSource
+          );
+          atlasUploadedRevision = atlas.revision;
+        } catch {
+          // Tainted atlas (cross-origin draw without CORS). Replace surface so
+          // later stamps can recover; this frame draws with the last good tex.
+          recreateSharedSoaWebglAtlas();
+          atlasUploadedRevision = -1;
+        }
       }
 
       const drawProg = dof ? dof.sceneProgram : prog;

--- a/apps/web/src/components/rcb/scene/document/__tests__/higherArtboardPaintOcclusion.test.ts
+++ b/apps/web/src/components/rcb/scene/document/__tests__/higherArtboardPaintOcclusion.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+import {
+  listHigherArtboardOccluderBoxes,
+  isNodeAabbFullyOccludedByHigherArtboard,
+} from '../sceneHitBridge';
+import {
+  addNodeToDocument,
+  createBareDocument,
+} from '../sceneDocument';
+import { setSelectionPaintRaiseFrameIds } from '@/components/rcb/frames/frameContentClip';
+
+describe('higher artboard paint occlusion', () => {
+  it('lists plates above an unbound world node', () => {
+    let doc = createBareDocument();
+    doc = addNodeToDocument(doc, 'rect', {
+      id: 'rect',
+      key: 'rect',
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 200,
+      attrs: {},
+      children: [],
+    });
+    doc.frames = [
+      {
+        id: 'board',
+        name: '动画工作台',
+        backgroundColor: '#fff',
+        x: 50,
+        y: 50,
+        width: 100,
+        height: 100,
+        kind: 'animation',
+      },
+    ];
+    doc.stackOrder = ['node:rect', 'frame:board'];
+    const holes = listHigherArtboardOccluderBoxes(doc, doc.deltaSetLike.rect);
+    expect(holes).toHaveLength(1);
+    expect(holes[0]).toEqual({ left: 50, top: 50, right: 150, bottom: 150 });
+    expect(
+      isNodeAabbFullyOccludedByHigherArtboard(doc, doc.deltaSetLike.rect, {
+        left: 60,
+        top: 60,
+        width: 20,
+        height: 20,
+      })
+    ).toBe(true);
+    expect(
+      isNodeAabbFullyOccludedByHigherArtboard(doc, doc.deltaSetLike.rect, {
+        left: 0,
+        top: 0,
+        width: 200,
+        height: 200,
+      })
+    ).toBe(false);
+  });
+
+  it('does not occlude frame-bound children (they paint above their plate)', () => {
+    let doc = createBareDocument();
+    doc.frames = [
+      {
+        id: 'board',
+        name: 'A',
+        backgroundColor: '#fff',
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+      },
+    ];
+    doc.stackOrder = ['frame:board'];
+    doc = addNodeToDocument(doc, 'child', {
+      id: 'child',
+      key: 'rect',
+      x: 10,
+      y: 10,
+      width: 20,
+      height: 20,
+      attrs: { frameId: 'board' },
+      children: [],
+    });
+    expect(listHigherArtboardOccluderBoxes(doc, doc.deltaSetLike.child)).toEqual([]);
+  });
+
+  it('frame-bound child is still occluded by a later artboard', () => {
+    let doc = createBareDocument();
+    doc.frames = [
+      {
+        id: 'a',
+        name: 'A',
+        backgroundColor: '#fff',
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+      },
+      {
+        id: 'b',
+        name: '动画',
+        backgroundColor: '#eee',
+        x: 20,
+        y: 20,
+        width: 80,
+        height: 80,
+        kind: 'animation',
+      },
+    ];
+    doc.stackOrder = ['frame:a', 'node:child', 'frame:b'];
+    doc = addNodeToDocument(doc, 'child', {
+      id: 'child',
+      key: 'rect',
+      x: 30,
+      y: 30,
+      width: 40,
+      height: 40,
+      attrs: { frameId: 'a' },
+      children: [],
+    });
+    const holes = listHigherArtboardOccluderBoxes(doc, doc.deltaSetLike.child);
+    expect(holes).toHaveLength(1);
+    expect(holes[0]).toEqual({ left: 20, top: 20, right: 100, bottom: 100 });
+  });
+
+  it('selection-raised frame occludes world nodes even when they stack above', () => {
+    let doc = createBareDocument();
+    doc = addNodeToDocument(doc, 'rect', {
+      id: 'rect',
+      key: 'rect',
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 200,
+      attrs: {},
+      children: [],
+    });
+    doc.frames = [
+      {
+        id: 'board',
+        name: '动画工作台',
+        backgroundColor: '#fff',
+        x: 50,
+        y: 50,
+        width: 100,
+        height: 100,
+        kind: 'animation',
+      },
+    ];
+    // World node above the plate in stackOrder (would cover without select raise).
+    doc.stackOrder = ['frame:board', 'node:rect'];
+    expect(listHigherArtboardOccluderBoxes(doc, doc.deltaSetLike.rect)).toEqual([]);
+
+    setSelectionPaintRaiseFrameIds(['board']);
+    try {
+      const holes = listHigherArtboardOccluderBoxes(doc, doc.deltaSetLike.rect);
+      expect(holes).toHaveLength(1);
+      expect(
+        isNodeAabbFullyOccludedByHigherArtboard(doc, doc.deltaSetLike.rect, {
+          left: 60,
+          top: 60,
+          width: 20,
+          height: 20,
+        })
+      ).toBe(true);
+    } finally {
+      setSelectionPaintRaiseFrameIds(null);
+    }
+  });
+
+  it('outlined boolean under a later artboard is fully occluded for host clip', () => {
+    let doc = createBareDocument();
+    doc = addNodeToDocument(doc, 'bool', {
+      id: 'bool',
+      key: 'shape',
+      x: 40,
+      y: 40,
+      width: 200,
+      height: 200,
+      attrs: {
+        shapeType: 'path',
+        path: 'M0 0 H200 V200 H0 Z M40 40 H160 V160 H40 Z',
+        closed: 'true',
+        outlined: 'true',
+        'fill-rule': 'evenodd',
+        'fill-color': '#ffffff',
+      },
+      children: [],
+    });
+    doc.frames = [
+      {
+        id: 'board',
+        name: '动画工作台',
+        backgroundColor: '#fff',
+        x: 0,
+        y: 0,
+        width: 364,
+        height: 364,
+        kind: 'animation',
+      },
+    ];
+    doc.stackOrder = ['node:bool', 'frame:board'];
+    expect(
+      isNodeAabbFullyOccludedByHigherArtboard(doc, doc.deltaSetLike.bool, {
+        left: 40,
+        top: 40,
+        width: 200,
+        height: 200,
+      })
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/components/rcb/scene/document/__tests__/unifiedStackOrderPaint.test.ts
+++ b/apps/web/src/components/rcb/scene/document/__tests__/unifiedStackOrderPaint.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addNodeToDocument,
+  createBareDocument,
+  selectionPaintZIndex,
+  stackZIndex,
+  worldNodeStacksAboveAnyFrame,
+} from '../sceneDocument';
+import { pickFullAndCanvasIds, nodeNeedsDomShapeHost } from '@/components/rcb/shapes/RcbShapesLayer';
+import { syncSharedMountPaintOrder } from '@/components/rcb/shapes/shapeHostRegistry';
+import { isSoaBasicGeomSufficient } from '@/components/rcb/render/sceneRenderBuffer';
+import { stackPaintZ, syncStackPaintOrder } from '../sceneStackPainter';
+
+/**
+ * Unified stackOrder contract: rect / boolean / image / video / artboard share
+ * one paint-order field. Physical hosts + plates interleave by data-z.
+ */
+describe('unified stackOrder paint', () => {
+  function layer(z: number, kind: 'shape' | 'frame', id: string) {
+    const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    g.setAttribute(kind === 'frame' ? 'data-rcb-frame-layer' : 'data-rcb-shape-layer', '1');
+    g.setAttribute('data-z', String(z));
+    g.setAttribute('data-id', id);
+    return g;
+  }
+
+  it('interleaves artboard plate above boolean / image / video hosts by stackOrder', () => {
+    const mount = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    // stackOrder: bool → image → video → board (board on top)
+    mount.append(
+      layer(400000, 'frame', 'board'),
+      layer(100001, 'shape', 'bool'),
+      layer(200001, 'shape', 'image'),
+      layer(300001, 'shape', 'video')
+    );
+    syncStackPaintOrder(mount as SVGGElement);
+    expect([...mount.children].map((el) => el.getAttribute('data-id'))).toEqual([
+      'bool',
+      'image',
+      'video',
+      'board',
+    ]);
+  });
+
+  it('only stackOrder z decides plate vs host cover (same mount)', () => {
+    let doc = createBareDocument();
+    doc = addNodeToDocument(doc, 'bool', {
+      id: 'bool',
+      key: 'shape',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      attrs: {
+        shapeType: 'path',
+        path: 'M0 0 H100 V100 H0 Z M20 20 H80 V80 H20 Z',
+        outlined: 'true',
+        'fill-rule': 'evenodd',
+      },
+      children: [],
+    });
+    doc = addNodeToDocument(doc, 'img', {
+      id: 'img',
+      key: 'image',
+      x: 10,
+      y: 10,
+      width: 80,
+      height: 80,
+      attrs: { src: 'https://example.com/a.png' },
+      children: [],
+    });
+    doc.frames = [
+      {
+        id: 'board',
+        name: '动画',
+        backgroundColor: '#fff',
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 200,
+        kind: 'animation',
+      },
+    ];
+    doc.stackOrder = ['node:bool', 'node:img', 'frame:board'];
+    expect(stackZIndex(doc, 'node', 'bool')).toBeLessThan(stackZIndex(doc, 'frame', 'board'));
+    expect(stackZIndex(doc, 'node', 'img')).toBeLessThan(stackZIndex(doc, 'frame', 'board'));
+    expect(stackPaintZ(doc, 'frame', 'board')).toBe(stackZIndex(doc, 'frame', 'board'));
+    expect(selectionPaintZIndex(doc, 'frame', 'board', true)).toBeGreaterThan(
+      stackZIndex(doc, 'node', 'img')
+    );
+  });
+
+  it('boolean evenodd is SoA-basic; still hosts when stacked above a plate', () => {
+    let doc = createBareDocument();
+    doc = addNodeToDocument(doc, 'bool', {
+      id: 'bool',
+      key: 'shape',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      attrs: {
+        shapeType: 'path',
+        path: 'M0 0 H100 V100 H0 Z M20 20 H80 V80 H20 Z',
+        outlined: 'true',
+        'fill-rule': 'evenodd',
+        'fill-color': '#fff',
+      },
+      children: [],
+    });
+    expect(isSoaBasicGeomSufficient(doc.deltaSetLike.bool)).toBe(true);
+
+    doc.frames = [
+      {
+        id: 'board',
+        name: 'A',
+        backgroundColor: '#fff',
+        x: 0,
+        y: 0,
+        width: 50,
+        height: 50,
+      },
+    ];
+    doc.stackOrder = ['frame:board', 'node:bool'];
+    expect(worldNodeStacksAboveAnyFrame(doc, 'bool')).toBe(true);
+    const { fullIds, canvasIds } = pickFullAndCanvasIds({
+      document: doc,
+      visibleIds: ['bool'],
+      zoom: 1,
+    });
+    expect(fullIds).toEqual(['bool']);
+    expect(canvasIds).toEqual([]);
+  });
+
+  it('frame-bound children always take a DOM host (plate shares stack SVG above ink)', () => {
+    const node = {
+      id: 'child',
+      key: 'shape',
+      x: 0,
+      y: 0,
+      width: 40,
+      height: 40,
+      attrs: { shapeType: 'rect', frameId: 'board', 'fill-color': '#abc' },
+    };
+    expect(nodeNeedsDomShapeHost(node as never)).toBe(true);
+    let doc = createBareDocument();
+    doc.frames = [
+      { id: 'board', name: 'A', backgroundColor: '#fff', x: 0, y: 0, width: 100, height: 100 },
+    ];
+    doc.stackOrder = ['frame:board'];
+    doc = addNodeToDocument(doc, 'child', { ...node, children: [] } as never);
+    const { fullIds } = pickFullAndCanvasIds({
+      document: doc,
+      visibleIds: ['child'],
+      zoom: 1,
+    });
+    expect(fullIds).toContain('child');
+  });
+
+  it('static text idles on ink when below plates; hosts when stacked above', () => {
+    let doc = createBareDocument();
+    doc = addNodeToDocument(doc, 'txt', {
+      id: 'txt',
+      key: 'text',
+      x: 0,
+      y: 0,
+      width: 120,
+      height: 32,
+      attrs: { fontSize: 16, markdown: 'Hello' },
+      children: [],
+    });
+    doc.frames = [
+      {
+        id: 'board',
+        name: 'A',
+        backgroundColor: '#fff',
+        x: 0,
+        y: 0,
+        width: 50,
+        height: 50,
+      },
+    ];
+    doc.stackOrder = ['node:txt', 'frame:board'];
+    let pick = pickFullAndCanvasIds({ document: doc, visibleIds: ['txt'], zoom: 1 });
+    expect(pick.canvasIds).toContain('txt');
+    expect(pick.fullIds).not.toContain('txt');
+
+    doc.stackOrder = ['frame:board', 'node:txt'];
+    pick = pickFullAndCanvasIds({ document: doc, visibleIds: ['txt'], zoom: 1 });
+    expect(pick.fullIds).toContain('txt');
+    expect(pick.canvasIds).not.toContain('txt');
+  });
+
+  it('static image idles on ink when below plates; hosts when stacked above', () => {
+    let doc = createBareDocument();
+    doc = addNodeToDocument(doc, 'img', {
+      id: 'img',
+      key: 'image',
+      x: 0,
+      y: 0,
+      width: 80,
+      height: 80,
+      attrs: { src: 'https://example.com/a.png' },
+      children: [],
+    });
+    doc.frames = [
+      {
+        id: 'board',
+        name: 'A',
+        backgroundColor: '#fff',
+        x: 0,
+        y: 0,
+        width: 50,
+        height: 50,
+      },
+    ];
+    doc.stackOrder = ['node:img', 'frame:board'];
+    let pick = pickFullAndCanvasIds({ document: doc, visibleIds: ['img'], zoom: 1 });
+    expect(pick.canvasIds).toContain('img');
+    expect(pick.fullIds).not.toContain('img');
+
+    doc.stackOrder = ['frame:board', 'node:img'];
+    pick = pickFullAndCanvasIds({ document: doc, visibleIds: ['img'], zoom: 1 });
+    expect(pick.fullIds).toContain('img');
+    expect(pick.canvasIds).not.toContain('img');
+  });
+
+  it('idle audio plate idles on ink when below plates; hosts when stacked above', () => {
+    let doc = createBareDocument();
+    doc = addNodeToDocument(doc, 'aud', {
+      id: 'aud',
+      key: 'audio',
+      x: 0,
+      y: 0,
+      width: 160,
+      height: 48,
+      attrs: { src: 'https://example.com/a.mp3', audioGenerator: true },
+      children: [],
+    });
+    doc.frames = [
+      {
+        id: 'board',
+        name: 'A',
+        backgroundColor: '#fff',
+        x: 0,
+        y: 0,
+        width: 50,
+        height: 50,
+      },
+    ];
+    doc.stackOrder = ['node:aud', 'frame:board'];
+    let pick = pickFullAndCanvasIds({ document: doc, visibleIds: ['aud'], zoom: 1 });
+    expect(pick.canvasIds).toContain('aud');
+    expect(pick.fullIds).not.toContain('aud');
+
+    doc.stackOrder = ['frame:board', 'node:aud'];
+    pick = pickFullAndCanvasIds({ document: doc, visibleIds: ['aud'], zoom: 1 });
+    expect(pick.fullIds).toContain('aud');
+    expect(pick.canvasIds).not.toContain('aud');
+  });
+
+  it('gradient fill idles on ink when below plates; hosts when stacked above', () => {
+    let doc = createBareDocument();
+    doc = addNodeToDocument(doc, 'grad', {
+      id: 'grad',
+      key: 'shape',
+      x: 0,
+      y: 0,
+      width: 80,
+      height: 80,
+      attrs: {
+        shapeType: 'rect',
+        'fill-type': 'linear',
+        'fill-gradient': '{"type":"linear","colorStops":[{"offset":0,"color":"#f00"},{"offset":1,"color":"#00f"}]}',
+      },
+      children: [],
+    });
+    doc.frames = [
+      {
+        id: 'board',
+        name: 'A',
+        backgroundColor: '#fff',
+        x: 0,
+        y: 0,
+        width: 50,
+        height: 50,
+      },
+    ];
+    doc.stackOrder = ['node:grad', 'frame:board'];
+    let pick = pickFullAndCanvasIds({ document: doc, visibleIds: ['grad'], zoom: 1 });
+    expect(pick.canvasIds).toContain('grad');
+    expect(pick.fullIds).not.toContain('grad');
+
+    doc.stackOrder = ['frame:board', 'node:grad'];
+    pick = pickFullAndCanvasIds({ document: doc, visibleIds: ['grad'], zoom: 1 });
+    expect(pick.fullIds).toContain('grad');
+    expect(pick.canvasIds).not.toContain('grad');
+  });
+
+  it('star / donut ellipse idle below plates; host when stacked above', () => {
+    let doc = createBareDocument();
+    doc = addNodeToDocument(doc, 'star', {
+      id: 'star',
+      key: 'shape',
+      x: 0,
+      y: 0,
+      width: 80,
+      height: 80,
+      attrs: { shapeType: 'star', 'fill-color': '#fc0', sides: 5 },
+      children: [],
+    });
+    doc = addNodeToDocument(doc, 'donut', {
+      id: 'donut',
+      key: 'shape',
+      x: 100,
+      y: 0,
+      width: 80,
+      height: 80,
+      attrs: { shapeType: 'ellipse', 'fill-color': '#0cf', ellipseInnerRatio: 0.4 },
+      children: [],
+    });
+    doc.frames = [
+      {
+        id: 'board',
+        name: 'A',
+        backgroundColor: '#fff',
+        x: 0,
+        y: 0,
+        width: 50,
+        height: 50,
+      },
+    ];
+    doc.stackOrder = ['node:star', 'node:donut', 'frame:board'];
+    let pick = pickFullAndCanvasIds({
+      document: doc,
+      visibleIds: ['star', 'donut'],
+      zoom: 1,
+    });
+    expect(pick.canvasIds).toEqual(expect.arrayContaining(['star', 'donut']));
+    expect(pick.fullIds).not.toContain('star');
+    expect(pick.fullIds).not.toContain('donut');
+
+    doc.stackOrder = ['frame:board', 'node:star', 'node:donut'];
+    pick = pickFullAndCanvasIds({
+      document: doc,
+      visibleIds: ['star', 'donut'],
+      zoom: 1,
+    });
+    expect(pick.fullIds).toEqual(expect.arrayContaining(['star', 'donut']));
+    expect(pick.canvasIds).not.toContain('star');
+    expect(pick.canvasIds).not.toContain('donut');
+  });
+
+  it('syncSharedMountPaintOrder matches syncStackPaintOrder', () => {
+    const mount = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    const a = layer(3, 'shape', 'a');
+    const b = layer(1, 'frame', 'b');
+    mount.append(a, b);
+    syncSharedMountPaintOrder(mount as SVGGElement);
+    expect([...mount.children].map((el) => el.getAttribute('data-id'))).toEqual(['b', 'a']);
+  });
+});

--- a/apps/web/src/components/rcb/scene/document/sceneDocument.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneDocument.ts
@@ -205,6 +205,12 @@ export function buildNodeStackZMap(
   for (const id of ids) {
     const key = String(id || '');
     if (!key || out.has(key)) continue;
+    const parsed = parseStackKey(key);
+    if (parsed?.kind === 'frame') {
+      const frameIndex = order.indexOf(stackFrameKey(parsed.id));
+      out.set(key, frameIndex < 0 ? 0 : (frameIndex + 1) * STACK_GROUP_STRIDE);
+      continue;
+    }
     const node = doc.deltaSetLike?.[key];
     const frameId = String(node?.attrs?.frameId || '').trim();
     if (!frameId) {
@@ -247,6 +253,17 @@ export function buildNodeStackZMap(
     out.set(key, (frameIndex + 1) * STACK_GROUP_STRIDE + localSlot);
   }
   return out;
+}
+
+/**
+ * Unified hit z-map: bare node ids + `frame:id` plate keys share one permanent
+ * stackOrder scale (selection paint raise is ignored).
+ */
+export function buildUnifiedHitZMap(
+  doc: SceneDocument | null | undefined,
+  candidateKeys: readonly string[]
+): Map<string, number> {
+  return buildNodeStackZMap(doc, candidateKeys);
 }
 
 export function stackZIndex(doc: SceneDocument, kind: 'frame' | 'node', id: string): number {
@@ -324,8 +341,8 @@ export function selectionPaintZIndex(
 
 /**
  * World (unbound) node whose stack z is above at least one artboard plate.
- * Those must paint as SVG hosts on the shared shapes mount — SoA canvas sits
- * under that SVG, so idle ink can never cover 动画工作台 / artboard plates.
+ * Those must paint as SVG hosts on the shared stack mount — SoA ink sits under
+ * that SVG, so only hosts can cover 画板 / 动画工作台 plates via data-z.
  */
 export function worldNodeStacksAboveAnyFrame(
   doc: SceneDocument | null | undefined,

--- a/apps/web/src/components/rcb/scene/document/sceneHitBridge.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneHitBridge.ts
@@ -26,8 +26,13 @@ import { getLiveArtboardFrameGeometry } from '@/components/rcb/frames/HtmlArtboa
 import { frameSceneBounds, nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import {
   parseStackKey,
+  selectionPaintZIndex,
   stackZIndex,
 } from '@/components/rcb/scene/document/sceneDocument';
+import {
+  selectionPaintRaises,
+  selectionPaintRaisesFrame,
+} from '@/components/rcb/frames/frameContentClip';
 import {
   HEAVY_PATH_D_CHARS,
   distPointToPathD,
@@ -41,7 +46,6 @@ import {
 } from '@/components/rcb/scene/document/sceneShapes';
 import {
   hitTestSoaSlot,
-  SOA_FLAG_CANVAS_IDLE,
   SOA_KIND_LINE,
   SOA_KIND_PATH,
   SOA_KIND_POLY,
@@ -269,10 +273,6 @@ export function hitTestSceneAtPoint(opts: HitTestSceneAtPointOpts): string | nul
     const kind = soaIndex != null && soaIndex >= 0 ? soaBuf!.kinds[soaIndex] : -1;
     const strokeSoa =
       kind === SOA_KIND_PATH || kind === SOA_KIND_LINE || kind === SOA_KIND_POLY;
-    const isSoaIdle =
-      soaIndex != null &&
-      soaIndex >= 0 &&
-      (soaBuf!.flags[soaIndex] & SOA_FLAG_CANVAS_IDLE) !== 0;
     // Stroke polylines stay pickable after selection paint-raise clears CANVAS_IDLE
     // (host promote). Fill shapes still require idle ink.
     if (
@@ -284,11 +284,8 @@ export function hitTestSceneAtPoint(opts: HitTestSceneAtPointOpts): string | nul
     ) {
       return id;
     }
-    // Stroke SoA miss → Path2D below. Custom-path idle without strokeSoa must
-    // not use fat AABB (L-hole). Solid fills fall through to AABB when SoA is stale.
-    if (isSoaIdle && !strokeSoa && String(node.attrs?.path || '').trim()) {
-      continue;
-    }
+    // Stroke SoA miss → Path2D / geo / AABB below. Do not skip fallthrough for
+    // idle slots that merely carry a path attr — atlas/rich fills need Path2D.
     const box = getNodeBox(id);
     if (!box) {
       continue;
@@ -308,6 +305,42 @@ export function hitTestSceneAtPoint(opts: HitTestSceneAtPointOpts): string | nul
     if (hit) {
       return id;
     }
+  }
+  return null;
+}
+
+export type SceneStackHitKind = 'node' | 'frame';
+
+/** Ideal hit result: first precise stack entry under the pointer. */
+export type SceneStackHit = { kind: SceneStackHitKind; id: string };
+
+/**
+ * Unified stack walk (ideal contract): candidates already sorted top→bottom by
+ * permanent stackOrder. Frame keys are `frame:id`; first plate AABB or node ink
+ * hit wins.
+ */
+export function hitTestUnifiedStackAtPoint(
+  opts: HitTestSceneAtPointOpts
+): SceneStackHit | null {
+  const { document: doc, order, x, y } = opts;
+  for (const raw of order) {
+    const key = String(raw || '');
+    if (!key) continue;
+    const parsed = parseStackKey(key);
+    if (parsed?.kind === 'frame') {
+      const frame = (Array.isArray(doc.frames) ? doc.frames : []).find(
+        (f) => String(f?.id || '') === parsed.id
+      );
+      if (!frame || frame.locked || !isArtboardVisibleInDocument(frame)) continue;
+      const live = getLiveArtboardFrameGeometry(parsed.id);
+      const box = frameSceneBounds(doc, frame, live);
+      if (pointInSceneBox(x, y, box)) {
+        return { kind: 'frame', id: parsed.id };
+      }
+      continue;
+    }
+    const nodeHit = hitTestSceneAtPoint({ ...opts, order: [key] });
+    if (nodeHit) return { kind: 'node', id: nodeHit };
   }
   return null;
 }
@@ -369,10 +402,27 @@ export function frameIdAtPoint(
   return null;
 }
 
+function effectiveNodeStackZ(doc: SceneDocument, nodeId: string): number {
+  if (selectionPaintRaises(nodeId)) {
+    return selectionPaintZIndex(doc, 'node', nodeId, true);
+  }
+  return stackZIndex(doc, 'node', nodeId);
+}
+
+function effectiveFrameStackZ(
+  doc: SceneDocument,
+  frameId: string,
+  raiseFrameIds?: ReadonlySet<string> | null
+): number {
+  if (raiseFrameIds?.has(frameId) || selectionPaintRaisesFrame(frameId)) {
+    return selectionPaintZIndex(doc, 'frame', frameId, true);
+  }
+  return stackZIndex(doc, 'frame', frameId);
+}
+
 /**
- * True when a higher artboard plate covers (x,y) above this node in stackOrder.
- * Prevents world / lower-frame content from stealing clicks through an
- * overlapping 动画工作台 / artboard that paints on top.
+ * True when a higher artboard plate covers (x,y) above this node in **permanent**
+ * stackOrder (selection paint raise is paint-only — ideal hit contract).
  */
 export function isOccludedByHigherArtboard(
   doc: SceneDocument,
@@ -396,6 +446,125 @@ export function isOccludedByHigherArtboard(
     if (pointInSceneBox(x, y, box)) return true;
   }
   return false;
+}
+
+export type SceneOccluderBox = {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+};
+
+/**
+ * Higher opaque artboard plates that cover this node in stackOrder.
+ * Used for hit-testing and skipping fully covered SoA ink under plates.
+ */
+export function listHigherArtboardOccluderBoxes(
+  doc: SceneDocument | null | undefined,
+  node: SceneNode | SceneNodeInput | null | undefined,
+  opts?: { raiseFrameIds?: Iterable<string> | null }
+): SceneOccluderBox[] {
+  if (!doc || !node) return [];
+  const nodeId = String(node.id || '').trim();
+  if (!nodeId) return [];
+  // Bound children paint above their own plate only — still occlude under
+  // any later / selection-raised artboard (same rule as hit testing).
+  const ownerId = String(node.attrs?.frameId || '').trim();
+  const nodeZ = effectiveNodeStackZ(doc, nodeId);
+  if (nodeZ <= 0) return [];
+  let raiseFrameIds: ReadonlySet<string> | null = null;
+  if (opts?.raiseFrameIds) {
+    const next = new Set<string>();
+    for (const id of opts.raiseFrameIds) {
+      const s = String(id || '').trim();
+      if (s) next.add(s);
+    }
+    raiseFrameIds = next.size ? next : null;
+  }
+  const out: SceneOccluderBox[] = [];
+  for (const frame of doc.frames || []) {
+    const fid = String(frame?.id || '');
+    if (!fid || frame.locked || !isArtboardVisibleInDocument(frame)) continue;
+    if (ownerId && ownerId === fid) continue;
+    if (effectiveFrameStackZ(doc, fid, raiseFrameIds) <= nodeZ) continue;
+    const live = getLiveArtboardFrameGeometry(fid);
+    const box = frameSceneBounds(doc, frame, live);
+    const left = Number(box.left) || 0;
+    const top = Number(box.top) || 0;
+    const width = Math.max(1, Number(box.width) || 1);
+    const height = Math.max(1, Number(box.height) || 1);
+    out.push({ left, top, right: left + width, bottom: top + height });
+  }
+  return out;
+}
+
+export function intersectSceneOccluderBoxes(
+  a: SceneOccluderBox,
+  b: SceneOccluderBox
+): SceneOccluderBox | null {
+  const left = Math.max(a.left, b.left);
+  const top = Math.max(a.top, b.top);
+  const right = Math.min(a.right, b.right);
+  const bottom = Math.min(a.bottom, b.bottom);
+  if (right <= left || bottom <= top) return null;
+  return { left, top, right, bottom };
+}
+
+/** Subject minus one hole → up to four residual rects. */
+function subtractOneOccluderBox(a: SceneOccluderBox, hole: SceneOccluderBox): SceneOccluderBox[] {
+  const hit = intersectSceneOccluderBoxes(a, hole);
+  if (!hit) return [a];
+  const out: SceneOccluderBox[] = [];
+  if (a.top < hit.top) {
+    out.push({ left: a.left, top: a.top, right: a.right, bottom: hit.top });
+  }
+  if (hit.bottom < a.bottom) {
+    out.push({ left: a.left, top: hit.bottom, right: a.right, bottom: a.bottom });
+  }
+  if (a.left < hit.left) {
+    out.push({ left: a.left, top: hit.top, right: hit.left, bottom: hit.bottom });
+  }
+  if (hit.right < a.right) {
+    out.push({ left: hit.right, top: hit.top, right: a.right, bottom: hit.bottom });
+  }
+  return out.filter((r) => r.right > r.left && r.bottom > r.top);
+}
+
+/** Clip subject to the complement of opaque higher artboards (paint/hit parity). */
+export function subtractHigherArtboardOccluders(
+  subject: SceneOccluderBox,
+  holes: readonly SceneOccluderBox[]
+): SceneOccluderBox[] {
+  if (!holes.length) return [subject];
+  let parts = [subject];
+  for (const hole of holes) {
+    const next: SceneOccluderBox[] = [];
+    for (const part of parts) next.push(...subtractOneOccluderBox(part, hole));
+    parts = next;
+    if (!parts.length) break;
+  }
+  return parts;
+}
+
+/** True when the node's AABB lies fully under a higher artboard plate. */
+export function isNodeAabbFullyOccludedByHigherArtboard(
+  doc: SceneDocument | null | undefined,
+  node: SceneNode | SceneNodeInput | null | undefined,
+  box?: { left?: number; top?: number; x?: number; y?: number; width?: number; height?: number }
+): boolean {
+  const holes = listHigherArtboardOccluderBoxes(doc, node);
+  if (!holes.length || !node) return false;
+  const left = Number(box?.left ?? box?.x ?? node.x) || 0;
+  const top = Number(box?.top ?? box?.y ?? node.y) || 0;
+  const width = Math.max(1, Number(box?.width ?? node.width) || 1);
+  const height = Math.max(1, Number(box?.height ?? node.height) || 1);
+  const subject: SceneOccluderBox = {
+    left,
+    top,
+    right: left + width,
+    bottom: top + height,
+  };
+  return subtractHigherArtboardOccluders(subject, holes).length === 0;
 }
 
 /**

--- a/apps/web/src/components/rcb/scene/document/sceneStackPainter.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneStackPainter.ts
@@ -1,0 +1,47 @@
+/**
+ * Unified paint-order contract: visual stacking is `stackOrder` only.
+ *
+ * Physical surfaces may differ (SoA/WebGL ink vs SVG hosts), but anything that
+ * participates in cross-type occlusion (artboard plates, DOM hosts, world nodes
+ * above plates) shares one SVG mount ordered by `data-z` = stack z. SoA ink sits
+ * under that mount and only paints nodes that do not need to interleave with
+ * plates (world nodes below all frames). Selection raise is temporary max+1.
+ *
+ * Do not add per-key CSS z bands or type-specific "always on top" hacks.
+ */
+import type { SceneDocument } from '@/components/rcb/sceneNode';
+import {
+  maxDocumentStackZ,
+  selectionPaintZIndex,
+  stackZIndex,
+} from '@/components/rcb/scene/document/sceneDocument';
+import { syncSharedMountPaintOrder } from '@/components/rcb/shapes/shapeHostRegistry';
+
+/** Stack z for paint (`data-z`), including temporary selection raise. */
+export function stackPaintZ(
+  doc: SceneDocument | null | undefined,
+  kind: 'frame' | 'node',
+  id: string,
+  raised = false
+): number {
+  return selectionPaintZIndex(doc, kind, id, raised);
+}
+
+/** Persistent max stack depth (no selection raise). */
+export function stackPaintMaxZ(doc: SceneDocument | null | undefined): number {
+  return maxDocumentStackZ(doc);
+}
+
+/** Natural stack z without selection raise. */
+export function stackPaintNaturalZ(
+  doc: SceneDocument | null | undefined,
+  kind: 'frame' | 'node',
+  id: string
+): number {
+  return stackZIndex(doc, kind, id);
+}
+
+/** Re-sort the shared plate+host mount by `data-z` / stackOrder. */
+export function syncStackPaintOrder(mount?: SVGGElement | null): void {
+  syncSharedMountPaintOrder(mount);
+}

--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -207,7 +207,6 @@ import {
   frameIsEmpty,
   isPointOnFrameEdge,
   resolveFramePlateDragMode,
-  resolveFramePlateTarget,
 } from '@/components/rcb/frames/framePlatePointer';
 
 function sceneBoxClose(
@@ -960,19 +959,24 @@ function SelectionFeature({
         applyHover(null);
         return;
       }
-      const nodeHit = hitTestRef.current(p.x, p.y, {
+      const rawHit = hitTestRef.current(p.x, p.y, {
         clientX: e.clientX,
         clientY: e.clientY,
       });
-      if (nodeHit) {
-        const hitNode = documentRef.current?.deltaSetLike?.[nodeHit];
+      const frameFromHit = rawHit ? parseFrameSelId(rawHit) : null;
+      if (frameFromHit) {
+        applyHover(frameSelId(frameFromHit));
+        return;
+      }
+      if (rawHit) {
+        const hitNode = documentRef.current?.deltaSetLike?.[rawHit];
         // Preview-only workbench ink must not get hover path silhouettes.
         if (isAnimationWorkbenchPreviewChild(documentRef.current, hitNode)) {
           const fid = String(hitNode?.attrs?.frameId || '').trim();
           applyHover(fid ? frameSelId(fid) : null);
           return;
         }
-        applyHover(nodeHit);
+        applyHover(rawHit);
         return;
       }
       // Empty artboard / frame chrome: still measure select?hover spacing.
@@ -1397,16 +1401,20 @@ function SelectionFeature({
         liveOriginsNow?.some((o) => parseFrameSelId(o.nodeId))
       );
 
-      // Hit-test scene nodes (selection chrome is non-blocking so empty clicks pass through).
-      const frameAtPoint = hitTestFrame?.(p.x, p.y) ?? null;
-      let hitId = hitTest(p.x, p.y, { clientX: e.clientX, clientY: e.clientY });
+      // Ideal hit: QT → permanent stackOrder → first node ink or plate AABB.
+      // Frame hits are encoded as __frame__:id (frameSelId).
+      let hitRaw = hitTest(p.x, p.y, { clientX: e.clientX, clientY: e.clientY });
+      const frameFromHit = hitRaw ? parseFrameSelId(hitRaw) : null;
+      let hitId = frameFromHit ? null : hitRaw;
+      const frameAtPoint = frameFromHit ?? hitTestFrame?.(p.x, p.y) ?? null;
       const selectedIds = liveOriginsNow?.map((o) => o.nodeId) ?? [];
       // Bbox fallback only outside artboard interior — frame plate owns its blank area.
       if (!hitId && !frameAtPoint && selectedIds.some((id) => parseFrameSelId(id))) {
         hitId = fallbackVisibleNodeHit(sceneDoc, p, listNodeIds(), getNodeBox, lottiePlayheadSec);
       }
       const plateFrameId = hitId ? frameForFullBleedPlate(sceneDoc, hitId) : null;
-      const framePlateId = resolveFramePlateTarget(sceneDoc, p, hitId, hitTestFrame);
+      // Unified walk already returns the plate when it wins — no secondary resolve.
+      const framePlateId = frameFromHit;
       const hitExtras = {
         hitId,
         frameAtPoint,
@@ -2114,10 +2122,12 @@ function SelectionFeature({
             : null;
         // Re-pick on up: thin pen/line hits can miss on down (stale spatial /
         // promote race) then succeed a frame later — same point, no drag.
-        const nodeHit =
+        const rawUpHit =
           !platePick && screenDistSq < DRAG_DISTANCE_SQUARED
             ? hitTest(p.x, p.y, { clientX, clientY })
             : null;
+        const frameFromUp = rawUpHit ? parseFrameSelId(rawUpHit) : null;
+        const nodeHit = frameFromUp ? null : rawUpHit;
         if (pin) {
           handlePinnedImageToolBlankClick(pin);
         } else if (nodeHit) {
@@ -2134,8 +2144,8 @@ function SelectionFeature({
           setLiveOrigins(live.origins);
           setLiveUnion(live.union);
           setLiveAngle(live.angle);
-        } else if (frameHit) {
-          onSelectFrame?.(frameHit, { chrome: 'soft' });
+        } else if (frameFromUp || frameHit) {
+          onSelectFrame?.(frameFromUp || frameHit, { chrome: 'soft' });
           setLiveOrigins([]);
           setLiveUnion(null);
           setLiveAngle(0);
@@ -2455,7 +2465,7 @@ function SelectionFeature({
         const ids = liveOriginsRef.current?.map((o) => o.nodeId) || [];
         if (ids.length === 1) hit = ids[0];
       }
-      if (!hit) return;
+      if (!hit || parseFrameSelId(hit)) return;
       const node = sceneDoc?.deltaSetLike?.[hit];
       if (node?.key === 'text') {
         e.preventDefault();

--- a/apps/web/src/components/rcb/shapes/RcbShapeHost.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapeHost.tsx
@@ -5,6 +5,7 @@ import { rcbCameraCssZoom } from '@/components/rcb/core/math';
 import {
   syncFrameContentClip,
 } from '@/components/rcb/frames/frameContentClip';
+import { syncStackPaintOrder } from '@/components/rcb/scene/document/sceneStackPainter';
 import {
   createSvgBoard,
   nodeToSvgElement,
@@ -24,7 +25,6 @@ import {
   setShapeHostRevealOverflow,
   subscribeShapeHost,
   subscribeShapeHosts,
-  syncSharedMountPaintOrder,
   unregisterShapeHost,
   updateShapeHostElement,
 } from '@/components/rcb/shapes/shapeHostRegistry';
@@ -366,7 +366,7 @@ function RcbShapeHost({
     if (!layer) return;
     layer.setAttribute('data-z', String(paintZIndex));
     if (!mount || layer.parentNode !== mount) return;
-    syncSharedMountPaintOrder(mount);
+    syncStackPaintOrder(mount);
   }, [paintZIndex, paintToken, worldEpoch]);
 
   return (

--- a/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
@@ -21,10 +21,12 @@ import {
   uniqueStringIds,
   worldNodeStacksAboveAnyFrame,
 } from '@/components/rcb/scene/document/sceneDocument';
+import { syncStackPaintOrder } from '@/components/rcb/scene/document/sceneStackPainter';
 import {
   findClippingFrameForNode,
   setFrameClipRevealOverflowIds,
   setSelectionPaintRaiseIds,
+  setSelectionPaintRaiseFrameIds,
 } from '@/components/rcb/frames/frameContentClip';
 import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import type { SceneDocument, SceneNodeInput } from '@/components/rcb/sceneNode';
@@ -338,7 +340,7 @@ export function syncSoaBufferFromDocumentNow(
   return true;
 }
 
-/** HTML/SVG hosts only when canvas cannot own the pixels (effects / live HTML media). */
+/** HTML/SVG hosts when canvas ink cannot occupy the correct stackOrder slot. */
 export function nodeNeedsDomShapeHost(
   node: SceneNodeInput | null | undefined,
   forceFull = false
@@ -346,6 +348,9 @@ export function nodeNeedsDomShapeHost(
   if (forceFull) return true;
   if (!node) return true;
   if (isImageProcessRunning(node)) return true;
+  // Plates share the stack SVG above SoA ink — bound children must host so
+  // their data-z can sit above the owner plate.
+  if (String(node.attrs?.frameId || '').trim()) return true;
   const key = String(node.key || '');
   // Static text —canvas ink; caret —TextInlineEditor overlay.
   // Static image —paintCanvasMediaInk; SoftGlow process still forceFull above.
@@ -402,6 +407,8 @@ type Props = {
   revealOverflowIds?: readonly string[];
   /** Single-select temporary paint raise (max+1). Empty for multi-select. */
   paintRaiseIds?: readonly string[];
+  /** Single-selected artboard id — temporary front over world ink under the plate. */
+  paintRaiseFrameIds?: readonly string[];
   /** Must stay as full SVG hosts (SoftGlow / inline editors —selection stays on canvas ink). */
   forceFullIds?: readonly string[];
   /** Shared scene index from SvgCanvas —drives viewport visible set. */
@@ -449,7 +456,9 @@ function trimCanvasInkIds(opts: {
 }
 
 /**
- * Split in-viewport ids: DOM hosts vs SoA/canvas ink (one surface for vectors).
+ * Split in-viewport ids: DOM hosts vs SoA/canvas ink.
+ * Hosts share one mount with artboard plates (`data-z` = stackOrder).
+ * SoA only for world nodes that sit under every artboard plate.
  */
 export function pickFullAndCanvasIds(opts: {
   document: SceneDocument;
@@ -463,6 +472,8 @@ export function pickFullAndCanvasIds(opts: {
   holdHostIds?: ReadonlySet<string>;
   /** Single-select paint raise — must share the plate mount (SoA is under plates). */
   paintRaiseIds?: ReadonlySet<string> | readonly string[];
+  /** Kept for API compat; plate raise is data-z on the shared mount. */
+  paintRaiseFrameIds?: ReadonlySet<string> | readonly string[];
   zoom: number;
   maxCanvasInk?: number;
 }): { fullIds: string[]; canvasIds: string[] } {
@@ -513,6 +524,7 @@ function RcbShapesLayer({
   keepVisibleIds = EMPTY_KEEP,
   revealOverflowIds = EMPTY_KEEP,
   paintRaiseIds = EMPTY_KEEP,
+  paintRaiseFrameIds = EMPTY_KEEP,
   forceFullIds = EMPTY_FORCE_FULL,
   spatialIndex = null,
 }: Props) {
@@ -584,6 +596,10 @@ function RcbShapesLayer({
   const paintRaiseSet = useMemo(
     () => new Set(paintRaiseIds.filter(Boolean)),
     [paintRaiseIds]
+  );
+  const paintRaiseFrameSet = useMemo(
+    () => new Set(paintRaiseFrameIds.filter(Boolean)),
+    [paintRaiseFrameIds]
   );
   const forceFullSet = useMemo(
     () => new Set(forceFullIds.filter(Boolean)),
@@ -666,6 +682,7 @@ function RcbShapesLayer({
         forceFullSet,
         holdHostIds,
         paintRaiseIds: paintRaiseSet,
+        paintRaiseFrameIds: paintRaiseFrameSet,
         zoom: cullCam.zoom || 1,
       }),
     [
@@ -674,6 +691,7 @@ function RcbShapesLayer({
       forceFullSet,
       holdHostIds,
       paintRaiseSet,
+      paintRaiseFrameSet,
       cullCam.zoom,
       workbenchTimelineToken,
     ]
@@ -814,6 +832,7 @@ function RcbShapesLayer({
     if (!document) {
       setFrameClipRevealOverflowIds(null);
       setSelectionPaintRaiseIds(null);
+      setSelectionPaintRaiseFrameIds(null);
       revealKeyRef.current = '';
       revealIdsRef.current = [];
       raiseIdsRef.current = [];
@@ -832,7 +851,8 @@ function RcbShapesLayer({
       if (node && shouldRevealShapeOverflow(true, node)) revealIds.push(id);
     }
     const raiseIds = [...paintRaiseSet];
-    const revealKey = `${revealIds.slice().sort().join('\0')}|${raiseIds.slice().sort().join('\0')}`;
+    const raiseFrameIds = [...paintRaiseFrameSet];
+    const revealKey = `${revealIds.slice().sort().join('\0')}|${raiseIds.slice().sort().join('\0')}|${raiseFrameIds.slice().sort().join('\0')}`;
     const revealChanged = revealKey !== revealKeyRef.current;
     const prevRevealIds = revealIdsRef.current;
     const prevRaiseIds = raiseIdsRef.current;
@@ -841,6 +861,9 @@ function RcbShapesLayer({
     raiseIdsRef.current = raiseIds;
     setFrameClipRevealOverflowIds(revealIds);
     setSelectionPaintRaiseIds(raiseIds);
+    setSelectionPaintRaiseFrameIds(raiseFrameIds);
+    // Plates + hosts share one mount — re-sort by data-z after selection raise.
+    syncStackPaintOrder();
 
     if (aiMutationLock > 0) return;
     if (!canvasIds.length) {
@@ -954,12 +977,14 @@ function RcbShapesLayer({
     revealSet,
     forceFullSet,
     paintRaiseSet,
+    paintRaiseFrameSet,
   ]);
 
   useEffect(() => {
     return () => {
       setFrameClipRevealOverflowIds(null);
       setSelectionPaintRaiseIds(null);
+      setSelectionPaintRaiseFrameIds(null);
       clearSceneCanvasIdlePaint();
     };
   }, []);

--- a/apps/web/src/components/rcb/shapes/shapeHostRegistry.ts
+++ b/apps/web/src/components/rcb/shapes/shapeHostRegistry.ts
@@ -160,7 +160,11 @@ export function clearShapeHosts() {
 
 /** One screen-surface SVG — shape layers share the canonical camera matrix. */
 let sceneWorldRoot: SVGSVGElement | null = null;
-/** Frame body plates mount below SoA canvas ink (separate SVG root). */
+/**
+ * Artboard plates + DOM hosts share `sceneShapesMount`, ordered by `data-z`
+ * (`stackOrder`). SoA/WebGL ink sits under that SVG; nodes that must interleave
+ * with plates paint as hosts on this mount.
+ */
 let sceneFramesRoot: SVGSVGElement | null = null;
 let sceneShapesMount: SVGGElement | null = null;
 let sceneFramesMount: SVGGElement | null = null;
@@ -175,13 +179,15 @@ export function setSceneWorldRoot(
   drawPreviewMount: SVGGElement | null = null,
   smartGuidesMount: SVGGElement | null = null,
   selectionChromeMount: SVGGElement | null = null,
-  framesRoot: SVGSVGElement | null = null,
-  framesMount: SVGGElement | null = null
+  /** @deprecated Plates share the shapes SVG; ignored when null — aliased to root/mount. */
+  _framesRoot: SVGSVGElement | null = null,
+  _framesMount: SVGGElement | null = null
 ) {
   sceneWorldRoot = root;
   sceneShapesMount = shapesMount;
-  sceneFramesRoot = framesRoot;
-  sceneFramesMount = framesMount;
+  // Unified stack: plates + hosts on one mount (stackOrder / data-z).
+  sceneFramesRoot = root;
+  sceneFramesMount = shapesMount;
   sceneDrawPreviewMount = drawPreviewMount;
   sceneSmartGuidesMount = smartGuidesMount;
   sceneSelectionChromeMount = selectionChromeMount;
@@ -193,22 +199,23 @@ export function getSceneWorldRoot() {
   return sceneWorldRoot;
 }
 
+/** Same SVG as the scene world root — plates share the host surface. */
 export function getSceneFramesRoot() {
-  return sceneFramesRoot;
+  return sceneFramesRoot ?? sceneWorldRoot;
 }
 
 export function getSceneShapesMount() {
   return sceneShapesMount;
 }
 
+/** Same mount as shapes — plates interleave with hosts by data-z. */
 export function getSceneFramesMount() {
-  return sceneFramesMount;
+  return sceneFramesMount ?? sceneShapesMount;
 }
 
 /**
  * Sort mount children by data-z (`stackOrder`).
- * Frames use the frames mount (below SoA ink); node hosts use the shapes mount
- * (above ink). Call with the mount that owns the layers being reordered.
+ * Artboard plates and node hosts share this mount so stackOrder is physical.
  */
 export function syncSharedMountPaintOrder(mount?: SVGGElement | null) {
   const root = mount ?? sceneShapesMount;

--- a/docs/adr/0027-canvas-layered-runtime.md
+++ b/docs/adr/0027-canvas-layered-runtime.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-08-15
-- **Updated:** 2026-09-03 — Seven layers; WebGL-only ink + atlas outline stamps; Worker-only bake; no SoA/WebGL/atlas env kill-switches; text/media stay DOM until WebGL owns them; DOF one resolved backend
+- **Updated:** 2026-09-04 — Unified `stackOrder` paint + ideal hit (one QT for nodes + `frame:id`; permanent stackOrder top-first; `__frame__:id` plate hits; selection paint raise paint-only)
 - **Supersedes (partial):** [ADR 0002](./0002-canvas-rcb-runtime.md) runtime paint/hit coupling — RCB ownership stays; SVG is no longer the editor runtime fact layer.
 
 ## Context
@@ -21,8 +21,8 @@ Treat the editor runtime as four facts (**this is the product architecture — d
 
 1. **`SceneDocument`** — unique document source of truth (store / collab patches write here).
 2. **`CameraTransform`** — single pan/zoom matrix; only `worldToScreen` / `stageLocalToWorld` / `screenDeltaToWorldDelta` on hot paths. No DOM “correction” of coordinates during gestures.
-3. **Layered render** — **WebGL2 instanced SoA ink** (only product ink path); DOM hosts only for text / media FO / SoftGlow / editors / heavy paths; **grid** stays on a separate Canvas2D surface (not an ink fallback); selection, guides, and drawing previews share the camera surface; screen UI stays in the HTML overlay. SoftGlow/editors use `RenderDemotionScheduler` (`ACTIVE_SVG` → `CANDIDATE` → `DEPLOYED_SOA`); selection does **not** promote basic shapes onto SVG. There is **no** Canvas2D idle-ink / pan-blit / bake-blit dual path.
-4. **Independent hit** — root pointer capture → chrome hit → spatial index coarse → precise geometry. `sceneToSvg` stays an **export** path, not the live paint core.
+3. **Layered render** — **WebGL2 instanced SoA ink** (only product ink path) sits under one **stack SVG** where artboard plates and DOM hosts interleave by `stackOrder` (`data-z`). DOM hosts only when ink cannot occupy the correct stack slot (above plates, FO media, SoftGlow, editors, lottie/group, heavy paths). **Grid** stays on a separate Canvas2D surface. Selection, guides, and drawing previews share the camera surface; screen UI stays in the HTML overlay. SoftGlow/editors use `RenderDemotionScheduler` (`ACTIVE_SVG` → `CANDIDATE` → `DEPLOYED_SOA`); selection does **not** promote basic shapes onto SVG. There is **no** Canvas2D idle-ink / pan-blit / bake-blit dual path. Do **not** reintroduce per-type CSS z bands or host-occlusion / plate-cutout paint hacks.
+4. **Independent hit** — root pointer capture → chrome hit → **one** `SceneSpatialRuntime` QT (`searchPoint`, nodes + `frame:id` plates) → permanent `stackOrder` top-first → first precise geometry or plate AABB (`hitTestUnifiedStackAtPoint`). Frame picks return `__frame__:id`. SoA `buf.quadtree` is paint/cull only. `sceneToSvg` stays an **export** path, not the live paint core.
 
 SVG is not the editor runtime fact layer. Fact layer = `SceneDocument` + `CameraTransform` + `SceneSpatialRuntime`. SoA (`SceneRenderBuffer` + `SoaQuadtree`) is a **derived** paint/pick cache and must not write back into SceneDocument. Demotion host-release uses one shared wake over `lastActive` timestamps; TransformPreview uses dirty AABB + live filter + threshold rebuild (not per-frame QT upsert).
 
@@ -54,7 +54,7 @@ Do not sell micro-caches or effects as parallel “optimization schemes.” Prod
 |-------|--------|------|
 | 1 | Done (core) | CameraTransform API; ink and selection chrome share the same SVG root and camera `<g>`; geometry-first chrome hit; shared spatial; union AABB chrome. |
 | 2 | Done (core) | `SceneRenderer` (`svg` hosts + `canvas2d` grid); canvas-capable vectors on idle ink (`canIdlePaintOnCanvas` + rounded/poly Path2D). |
-| 3 | Done (default-on) | **SoA** `SceneRenderBuffer` always on in product (Vitest override only); WebGL vector ink + atlas (incl. stroked rect/ellipse); path samples; **text / image / video / audio** stay DOM hosts until WebGL stamps them; selected video/audio keep one FO each; AI lock → one flush; shared spatial from SoA; dirty AABB; **quadtree** idle cull; demotion + freeSlots / bulk sync. Lottie / SoftGlow / pen editors / heavy paths stay DOM hosts. |
+| 3 | Done (default-on) | **SoA** `SceneRenderBuffer` always on in product (Vitest override only); WebGL vector ink + atlas (paths/boolean/outlined, static **text / image / video / audio / gradient / poly / donut-arc** stamps); selected video/audio keep one FO each; AI lock → one flush; shared spatial from SoA; dirty AABB; **quadtree** idle cull; demotion + freeSlots / bulk sync. **Unified stack:** plates + hosts on one SVG mount by `stackOrder`. Lottie / SoftGlow / pen editors / heavy paths / puppet-warp stay DOM hosts. |
 | 4 | Done (default-on) | WebGL2 instancing + atlas — **only** product ink path. Viewport bake ≥800 eligible idle+basic → **Worker only**; incomplete maps keep live instances; camera gesture skips bake. |
 | 5 | Opt-in **effect** (not density roadmap) | **GPU realtime depth-of-field** (`VITE_GPU_DOF=1`): one resolved backend (webgpu *or* webgl2), no create-time cross-fallback. Skips CPU tile bake while active. UI: Effects → Scene depth of field. |
 

--- a/docs/canvas-architecture.md
+++ b/docs/canvas-architecture.md
@@ -10,13 +10,13 @@ RCB is zuoge’s infinite vector canvas. This note is for people changing paint,
 | Camera / pan-zoom | Infinite world (`zoom` ~0.05–100); **CameraTransform** is the sole world↔screen API | `rcb/canvas/RcbCanvas.tsx`, `rcb/core/math.ts`, `rcb/camera/transform.ts` |
 | SceneRenderer | Paint/hit backend (`svg` DOM hosts + `canvas2d` grid + SoA vector ink) | `rcb/render/sceneRenderer.ts` |
 | Product canvas | Tools, media overlays, store writes; hit via SceneRenderer | `editor/canvas/SvgCanvas.tsx` |
-| Shape paint | SoA canvas ink for vectors; DOM hosts for text / media FO / SoftGlow / editors | `rcb/shapes/RcbShapesLayer.tsx`, `RcbShapeHost.tsx` |
+| Shape paint | SoA/WebGL ink under shared stack SVG; plates + DOM hosts interleaved by `stackOrder` | `rcb/shapes/RcbShapesLayer.tsx`, `RcbShapeHost.tsx`, `scene/document/sceneStackPainter.ts` |
 | SoA buffer + demotion | Derived paint/pick cache (`SceneRenderBuffer`); never writes back to SceneDocument | `rcb/render/sceneRenderBuffer.ts`, `renderDemotionScheduler.ts` |
 | Pixel grid + canvas ink | Grid `[data-rcb-scene-canvas]`; vector ink `[data-rcb-idle-ink-canvas]` | `RcbCanvas` + `createCanvasSceneRenderer` |
 | Selection chrome | Shared scene SVG camera group for AABB, path silhouette, shape knobs, guides, and drawing previews; HTML overlay only for screen UI/hit seats | `rcb/selection/SelectionChrome.tsx`, `HostPathChrome.tsx`, chrome overlays |
 | Transform gestures | `pointermove` → RAF-coalesced live preview into `TransformPreview` + transitional SVG DOM; `pointerup` commits SceneDocument and clears preview | `core/transformPreview.ts`, `SelectionFeature` coalescer, `canvasSession.onGeometryPreview/Commit` |
 | Frame clip (live) | Artboard move: preview plate geom (+ live artboard map) → re-seat bound hosts via `nodeLeftTop` → `syncFrameContentClip` (no child TransformPreview under frameLocal). SoA QT uses the same mid-gesture dirty + liveAabb rescue as TransformPreview so plate-bound ink is not culled with stale AABBs | `EditorStageWorld`, `canvasSession.onGeometryPreview`, `prepareSoaQuadtreeForQuery` |
-| Pointer hit | Overlay seats → chrome **geometry** → shared `SceneSpatialRuntime` → Path2D/AABB (SVG DOM off by default) | `pickSelectionInkAtClient`, `hitTestWithSpatialIndex`, `setSharedSceneSpatialRuntime` |
+| Pointer hit | Overlay seats → chrome **geometry** → one `SceneSpatialRuntime` QT (nodes + `frame:id`) → permanent `stackOrder` top-first → precise Path2D/AABB/plate | `hitTestWithSpatialIndex`, `hitTestUnifiedStackAtPoint`, `setSharedSceneSpatialRuntime` |
 | Document model | Types + Zod | `rcb/sceneNode.ts`, `packages/scene-schema` |
 | Mutations | normalize / stack / CRUD | `rcb/scene/document/sceneDocument.ts` |
 | Live state | `document`, selection, tools | `store/modules/editor.ts` |
@@ -26,7 +26,7 @@ RCB is zuoge’s infinite vector canvas. This note is for people changing paint,
 
 **Fact layer (ADR 0027):** `SceneDocument` + `CameraTransform` + `SceneSpatialRuntime`. SVG/`sceneToSvg` is export + transitional live paint — not the interaction substrate. SoA buffers are a **derived** paint/pick cache only.
 
-**Normative constraints (hit / camera):** [ADR 0027](./adr/0027-canvas-layered-runtime.md) — one CameraTransform, one hit pipeline, visual = hit = lattice.
+**Normative constraints (hit / camera):** [ADR 0027](./adr/0027-canvas-layered-runtime.md) — one CameraTransform, one hit pipeline (QT → permanent stackOrder → precise), visual = hit = lattice. SoA QT is paint/cull only.
 
 ## Document shape
 
@@ -48,7 +48,9 @@ There is **no hard max node count** on the document. Capacity is governed by pai
 
 At ≥ `PIXEL_GRID_MIN_ZOOM` (~800%), `RcbCanvas` paints the lattice on a screen-space `[data-rcb-scene-canvas]` via `createCanvasSceneRenderer` / `drawSceneGrid` (camera baked into ctx; axes stay on `gℤ` — same as `snapCoordToGrid` / pen tips; do **not** device-shift axes off the snap lattice). SVG no longer carries the grid `<path>`.
 
-**Single vector ink:** canvas-capable nodes (`canIdlePaintOnCanvas`) publish through `setSceneCanvasIdlePaint` and paint on the SoA ink canvas (above frame plates, below DOM hosts, frame-clipped). Selection does **not** promote basic shapes to SVG. DOM hosts stay for lottie/audio, path editors, heavy paths, **backdrop-blur**, SoftGlow via `forceFullSet`, and the **active** video decoder (≤1 HTML `<video>` FO). Object blur + inner-shadow bake on canvas idle (`paintLocalInkWithObjectEffects`). Non-normal **blendMode** idles via underlay + `globalCompositeOperation` (`paintLocalInkWithBlend`). Static **image** and idle **video** paint on canvas (`paintCanvasMediaInk` / poster). Static **text** paints on canvas ink (`paintCanvasTextInk`: fillText first, then Latin fontkit / CJK canvas-trace outline Path2D when ready); caret edit uses `TextInlineEditor` (`RcbOverlayPortal`) with `hiddenNodeId` — not a ShapeHost / text foreignObject. Donut / arc ellipses idle via rich canvas (`paintEllipseVariantNative` + evenodd), not SoA basic fill. SoftGlow process chrome lives on shape hosts (`attrs.processStatus`). strokeAlign inside/outside paints on canvas ink (SoA basic or rich idle).
+**Unified stack paint:** one SVG mount holds artboard plates + DOM hosts, ordered by `stackOrder` (`data-z` via `syncStackPaintOrder`). SoA/WebGL ink sits **under** that mount and only paints world nodes that do not need to interleave above plates. Nodes stacked above any plate promote to DOM hosts. Do not reintroduce per-type CSS z bands, host-occlusion clips, or plate cutouts.
+
+**Idle ink surface:** canvas-capable nodes (`canIdlePaintOnCanvas`) publish through `setSceneCanvasIdlePaint` and paint on `[data-rcb-idle-ink-canvas]` (WebGL atlas stamps for paths/boolean, static text/image/video/audio, gradients, poly/star, donut/arc). Selection does **not** promote basic shapes to SVG. DOM hosts stay for **lottie/group**, path editors, heavy paths, **backdrop-blur**, SoftGlow via `forceFullSet`, puppet-warp images, and the **active** video/audio decoder (≤1 FO each). Object blur + inner-shadow bake on canvas idle (`paintLocalInkWithObjectEffects`). Non-normal **blendMode** idles via underlay + `globalCompositeOperation` (`paintLocalInkWithBlend`). SoftGlow process chrome lives on shape hosts (`attrs.processStatus`). strokeAlign inside/outside paints on canvas ink (SoA basic or rich idle).
 
 ### SoA buffer + promote / demote
 
@@ -64,9 +66,9 @@ At ≥ `PIXEL_GRID_MIN_ZOOM` (~800%), `RcbCanvas` paints the lattice on a screen
 
 **Sync:** full rebuild uses `skipQuad` then one `quadtree.replaceAll` (avoid O(n²) expand-rebuild). Incremental patches ≥8 ids use bulk insert / QT upsert. TransformPreview **and** live artboard plate mark QT dirty + live-AABB filter on query (**no mid-gesture rebuild** — that froze multi-drags); restamp once when previews / live plate clear. Modest rotate pad (~64).
 
-### DOM hosts (text / media / editors)
+### DOM hosts (FO media / SoftGlow / editors / stack promotion)
 
-Text, image/video foreignObjects, SoftGlow, and live editors mount as **per-node SVG/DOM hosts** (`RcbShapeHost`), ordered by `stackOrder`. Hosts, media `foreignObject`s, drawing previews, guides, and selection chrome all share one stage-sized SVG and one camera `<g>`. The CSS world layer and live host `left/top/viewBox` camera cancellation path were removed; do not restore either one.
+Idle text / image / video poster / audio plate / gradient / poly paint as ink. DOM hosts (`RcbShapeHost`) remain for FO media, SoftGlow, live editors, lottie/group, and any world node whose `stackOrder` sits above an artboard plate. Hosts and plates share one stack SVG mount ordered by `stackOrder`. Drawing previews, guides, and selection chrome share the camera surface. The CSS world layer and live host `left/top/viewBox` camera cancellation path were removed; do not restore either one.
 
 #### Direct size edits and host notifications
 
@@ -143,7 +145,7 @@ Implemented in `RcbShapesLayer.tsx` (current constants):
 
 Spatial: `SceneSpatialRuntime` / `RcbSpatialIndex` are **quadtree-backed** (`SoaQuadtree`). The constructor `cellSize` argument is only a leaf-capacity hint (SvgCanvas still passes 256). Large-scene helpers also use `SCENE_SPATIAL_LARGE_THRESHOLD` (48) in `spatialIndex.ts`. Idle SoA paint/hit additionally uses `buf.quadtree`.
 
-**Rule of thumb:** document can hold thousands of light shapes (stress benches exercise 1k–10k); vectors paint on one SoA canvas ink surface; DOM hosts are for text/media/editors only. Off-screen nodes are culled (not mounted).
+**Rule of thumb:** document can hold thousands of light shapes (stress benches exercise 1k–10k); vectors + static media idle on one SoA/WebGL ink surface under the stack SVG; DOM hosts are for FO media / SoftGlow / editors / stack promotion above plates. Off-screen nodes are culled (not mounted).
 
 ## History / agent (related caps)
 
@@ -175,9 +177,10 @@ Runtime uniforms: `focalDepth`, `aperture`, `maxCoCPx`, `downsample`. Tunable in
 
 ```
 apps/web/src/components/rcb/
-  canvas/RcbCanvas.tsx                # stage layers: grid → frames → ink → hosts → chrome
+  canvas/RcbCanvas.tsx                # stage: grid → SoA ink → stack SVG (plates+hosts) → chrome
   shapes/RcbShapesLayer.tsx           # cull + DOM hosts vs SoA canvas ink + demotion wiring
-  shapes/shapeHostRegistry.ts         # host registry + draw / guides / selection mounts
+  shapes/shapeHostRegistry.ts         # host registry + shared stack mount paint order
+  scene/document/sceneStackPainter.ts # stackOrder → data-z contract
   render/sceneRenderBuffer.ts         # SoA typed arrays, paint, QT sync
   render/renderDemotionScheduler.ts   # ACTIVE_SVG / CANDIDATE / DEPLOYED_SOA
   render/soaBakeLayer.ts              # tile bake + element↔tile maps


### PR DESCRIPTION
## Summary
- Unify plate + DOM host paint on one SVG mount ordered by permanent `stackOrder`; WebGL ink stays under that mount
- Expand atlas idle coverage (boolean/image/video/text/audio/rich fills/poly/star/donut)
- Ideal hit: single QT over nodes + frame plates; top `stackOrder` wins; no plate post-pass

## Test plan
- [ ] Cross-type layer order (rect / boolean / image / video / artboard) matches permanent z
- [ ] Click through overlapping stacks picks top ink or frame plate consistently
- [ ] Idle atlas types still paint; selected/playing video-audio FO hosts still work
- [ ] Unit tests: unifiedStackOrderPaint, higherArtboardPaintOcclusion, sceneRenderer

Made with [Cursor](https://cursor.com)