### PR TITLE
fix(web): nest uploaded LOT in frameLocal plate space

### DIFF
--- a/apps/web/src/components/editor/nodes/AnimationNode/__tests__/mainSceneLotPreview.test.ts
+++ b/apps/web/src/components/editor/nodes/AnimationNode/__tests__/mainSceneLotPreview.test.ts
@@ -73,6 +73,52 @@ function userLotFixture() {
 }
 
 describe('main scene LOT preview data', () => {
+  it('placeUploadedLottie: frameLocal nest stays inside plate (non-zero frame origin)', () => {
+    const anim = lotFixture();
+    expect(anim).toBeTruthy();
+
+    let state = seedEditor();
+    expect(String(state.document?.coordSpace || '')).toBe('frameLocal');
+    state = reduceEditor(state, editorReducers.placeUploadedLottie, {
+      animationData: anim,
+      name: '测试生成LOT-edited',
+      x: 480,
+      y: 320,
+      width: 418,
+      height: 418,
+    });
+    const frameId = String(state.selectedFrameIds?.[0] || '');
+    const hostId = String(state.lottieTimelinePanel!.nodeId);
+    const lotId = findNestedLot(state, hostId, frameId)!;
+    expect(lotId).toBeTruthy();
+
+    const frame = (state.document!.frames || []).find((f) => String(f?.id) === frameId)!;
+    expect(Number(frame.x)).toBe(480);
+    expect(Number(frame.y)).toBe(320);
+
+    const lot = state.document!.deltaSetLike[lotId];
+    // Plate-local — not world (480+…). World coords get clipped away → blank 主场景.
+    expect(Number(lot.x)).toBeLessThan(Number(frame.width));
+    expect(Number(lot.y)).toBeLessThan(Number(frame.height));
+    expect(Number(lot.x)).toBeGreaterThanOrEqual(0);
+    expect(Number(lot.y)).toBeGreaterThanOrEqual(0);
+    expect(isNodeStructurallyHiddenInDocument(state.document, lot)).toBe(false);
+    expect(isMainSceneLotPreviewReady(state.document!, lotId)).toBe(true);
+
+    state = reduceEditor(state, editorReducers.enterLottiePrecompEdit, {
+      hostNodeId: hostId,
+      assetId: `lot_${lotId}`,
+      selectedLayerInd: 1,
+    });
+    expect(state.lottiePrecompEdit?.sessionNodeIds?.length).toBeGreaterThan(0);
+    state = reduceEditor(state, editorReducers.exitLottiePrecompEdit);
+    expect(state.lottiePrecompEdit).toBeNull();
+    expect(isMainSceneLotPreviewReady(state.document!, lotId)).toBe(true);
+    expect(
+      isNodeStructurallyHiddenInDocument(state.document, state.document!.deltaSetLike[lotId])
+    ).toBe(false);
+  });
+
   it('placeUploadedLottie: 主场景 preview ready before and after LOT tab exit', () => {
     const anim = lotFixture();
     expect(anim).toBeTruthy();

--- a/apps/web/src/store/modules/editor.ts
+++ b/apps/web/src/store/modules/editor.ts
@@ -2711,10 +2711,15 @@ export const editorReducers = {
       const fh = Math.max(1, Number(frame.height) || height);
       const nestW = Math.min(width, fw);
       const nestH = Math.min(height, fh);
+      // frameLocal docs store children in plate-local space (0,0 = frame TL).
+      // World (fx+…) coords leave the lot outside clipContent → no 主场景 preview.
+      const localPlate = String(state.document.coordSpace || '') === 'frameLocal';
+      const nestX = Math.max(0, (fw - nestW) / 2);
+      const nestY = Math.max(0, (fh - nestH) / 2);
       try {
         const { id, node } = createLottieNode({
-          x: fx + Math.max(0, (fw - nestW) / 2),
-          y: fy + Math.max(0, (fh - nestH) / 2),
+          x: localPlate ? nestX : fx + nestX,
+          y: localPlate ? nestY : fy + nestY,
           width: nestW,
           height: nestH,
           name: lotName,
@@ -3847,9 +3852,10 @@ export const editorReducers = {
           height: Math.max(32, Math.round(frame.height)),
           durationSec: Math.max(0.5, Number(frame.durationSec) || 5),
           fps: Math.max(1, Math.round(Number(frame.fps) || 30))});
+        const localPlate = String(state.document?.coordSpace || '') === 'frameLocal';
         const { id, node } = createLottieNode({
-          x: frame.x,
-          y: frame.y,
+          x: localPlate ? 0 : frame.x,
+          y: localPlate ? 0 : frame.y,
           width: frame.width,
           height: frame.height,
           name: ' ',
@@ -3864,8 +3870,8 @@ export const editorReducers = {
           const next = normalizeDocument(state.document);
           const host = next.deltaSetLike?.[id];
           if (host) {
-            host.x = Number(frame.x) || 0;
-            host.y = Number(frame.y) || 0;
+            host.x = localPlate ? 0 : Number(frame.x) || 0;
+            host.y = localPlate ? 0 : Number(frame.y) || 0;
             host.width = Math.max(1, Number(frame.width) || 1);
             host.height = Math.max(1, Number(frame.height) || 1);
             host.attrs = {


### PR DESCRIPTION
## Summary
- `placeUploadedLottie` now places the nested LOT in plate-local coords when `coordSpace === 'frameLocal'`
- Same local geom for newly created animation frame hosts
- Regression: non-zero frame origin keeps 主场景 preview + LOT tab enter/exit

## Test plan
- [ ] Upload `.json`/`.lot`, open 关键帧 — 主场景 shows LOT ink inside the white plate
- [ ] Switch LOT tab → edit shape → back to 主场景 — preview returns; edit persists on re-enter
- [ ] `vitest` `mainSceneLotPreview.test.ts`

Made with [Cursor](https://cursor.com)