### PR TITLE
fix(web): keep frameLocal children local when duplicating artboards

### DIFF
--- a/apps/web/src/components/rcb/scene/document/__tests__/sceneClipboardZod.test.ts
+++ b/apps/web/src/components/rcb/scene/document/__tests__/sceneClipboardZod.test.ts
@@ -279,6 +279,64 @@ describe('scene clipboard Zod', () => {
     expect(out.document.deltaSetLike!['overlap-free']?.attrs?.frameId).toBeFalsy();
   });
 
+  it('frameLocal duplicate keeps bound children plate-local (no double offset)', () => {
+    let doc = createEmptyDocument({ emptyWorld: true });
+    doc = {
+      ...doc,
+      coordSpace: 'frameLocal',
+      frames: [
+        {
+          id: 'frame-src',
+          name: 'Frame',
+          kind: 'artboard',
+          x: 120,
+          y: 80,
+          width: 300,
+          height: 400,
+          backgroundColor: '#fff',
+          clipContent: true,
+        },
+      ],
+      stackOrder: ['frame:frame-src'],
+    };
+    doc = addNodeToDocument(doc, 'child', {
+      id: 'child',
+      key: 'rect',
+      x: 40,
+      y: 50,
+      width: 80,
+      height: 60,
+      attrs: { frameId: 'frame-src', 'fill-color': '#f00' },
+      children: [],
+    } as any);
+    expect(String(doc.coordSpace || '')).toBe('frameLocal');
+
+    const out = pasteClipboardIntoDocument(
+      doc,
+      {
+        frames: [
+          {
+            id: 'frame-src',
+            frame: { ...(doc.frames![0] as object), id: 'frame-src' } as any,
+          },
+        ],
+        nodes: [{ id: 'child', node: doc.deltaSetLike!.child as any }],
+      },
+      { offsetX: 320, offsetY: 0, trusted: true }
+    );
+
+    expect(out.frameIds).toHaveLength(1);
+    expect(out.ids).toHaveLength(1);
+    const newFrame = out.document.frames!.find((f) => f.id === out.frameIds[0])!;
+    const newChild = out.document.deltaSetLike![out.ids[0]]!;
+    expect(Number(newFrame.x)).toBe(120 + 320);
+    expect(Number(newFrame.y)).toBe(80);
+    // Must stay plate-local — applying offsetX again puts ink outside clipContent.
+    expect(Number(newChild.x)).toBe(40);
+    expect(Number(newChild.y)).toBe(50);
+    expect(String(newChild.attrs?.frameId)).toBe(out.frameIds[0]);
+  });
+
   it('clipboardNodesBounds ignores overflowing children of clipped frames', () => {
     const bounds = clipboardNodesBounds({
       frames: [

--- a/apps/web/src/components/rcb/scene/document/sceneClipboard.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneClipboard.ts
@@ -315,37 +315,46 @@ export function pasteClipboardIntoDocument(
 
   const prepared: Array<{ id: string; node: SceneNode }> = [];
   const newIds: string[] = [];
+  const frameLocal = String(next.coordSpace || '') === 'frameLocal';
   (clip.nodes || []).forEach(({ id, node: raw }) => {
     const node = cloneSceneValue(raw);
     const newId = idMap.get(id)!;
     node.id = newId;
-    node.x = (Number(node.x) || 0) + ox;
-    node.y = (Number(node.y) || 0) + oy;
-    const outset = strokeVisualOutset(node);
-    if (outset > 0) {
-      const visual = snapBoxToGrid(
-        {
-          left: node.x - outset,
-          top: node.y - outset,
-          width: Math.max(1, Number(node.width) || 1) + outset * 2,
-          height: Math.max(1, Number(node.height) || 1) + outset * 2,
-        },
-        gridSize
-      );
-      node.x = visual.left + outset;
-      node.y = visual.top + outset;
+    const sourceFrameId = String(node.attrs?.frameId || '').trim();
+    const mappedFrameId = sourceFrameId ? frameIdMap.get(sourceFrameId) : undefined;
+    // Duplicating an artboard: children stay plate-local. Offsetting them again
+    // (on top of moving the frame) pushes ink outside clipContent — empty copies.
+    const keepPlateLocal = Boolean(mappedFrameId) && frameLocal;
+    if (!keepPlateLocal) {
+      node.x = (Number(node.x) || 0) + ox;
+      node.y = (Number(node.y) || 0) + oy;
+      const outset = strokeVisualOutset(node);
+      if (outset > 0) {
+        const visual = snapBoxToGrid(
+          {
+            left: node.x - outset,
+            top: node.y - outset,
+            width: Math.max(1, Number(node.width) || 1) + outset * 2,
+            height: Math.max(1, Number(node.height) || 1) + outset * 2,
+          },
+          gridSize
+        );
+        node.x = visual.left + outset;
+        node.y = visual.top + outset;
+      } else {
+        node.x = snapCoordToGrid(node.x, gridSize);
+        node.y = snapCoordToGrid(node.y, gridSize);
+      }
     } else {
-      node.x = snapCoordToGrid(node.x, gridSize);
-      node.y = snapCoordToGrid(node.y, gridSize);
+      node.x = Number(node.x) || 0;
+      node.y = Number(node.y) || 0;
     }
     const gid = String(node.attrs?.groupId || '').trim();
     if (gid) {
       if (!groupMap.has(gid)) groupMap.set(gid, nanoid(8));
       node.attrs = { ...(node.attrs || {}), groupId: groupMap.get(gid) };
     }
-    const sourceFrameId = String(node.attrs?.frameId || '').trim();
     if (sourceFrameId) {
-      const mappedFrameId = frameIdMap.get(sourceFrameId);
       node.attrs = {
         ...(node.attrs || {}),
         ...(mappedFrameId ? { frameId: mappedFrameId } : { frameId: undefined }),


### PR DESCRIPTION
## Summary
- When pasting/duplicating an artboard with bound children on `frameLocal` docs, children keep plate-local `x/y`; only the frame moves
- Fixes empty-looking 画板 / 动画工作台 copies from right-click 副本 / Ctrl+D

## Test plan
- [ ] Select a 画板 with shapes → 副本 / Ctrl+D → copy appears to the right with content
- [ ] Same for 动画工作台
- [ ] `vitest` `sceneClipboardZod.test.ts`

Made with [Cursor](https://cursor.com)