### PR TITLE
fix(web): LOT blank after switching back to main scene tab

### DIFF
--- a/apps/web/src/components/editor/nodes/AnimationNode/__tests__/mainSceneLotPreview.test.ts
+++ b/apps/web/src/components/editor/nodes/AnimationNode/__tests__/mainSceneLotPreview.test.ts
@@ -105,18 +105,31 @@ describe('main scene LOT preview data', () => {
     expect(isNodeStructurallyHiddenInDocument(state.document, lot)).toBe(false);
     expect(isMainSceneLotPreviewReady(state.document!, lotId)).toBe(true);
 
+    const lotXBefore = Number(lot.x);
+    const lotYBefore = Number(lot.y);
     state = reduceEditor(state, editorReducers.enterLottiePrecompEdit, {
       hostNodeId: hostId,
       assetId: `lot_${lotId}`,
       selectedLayerInd: 1,
     });
     expect(state.lottiePrecompEdit?.sessionNodeIds?.length).toBeGreaterThan(0);
+    // During LOT tab the workbench shrinks; nested lot must rebase to local 0,0.
+    const lotDuring = state.document!.deltaSetLike[lotId];
+    expect(Number(lotDuring.x)).toBe(0);
+    expect(Number(lotDuring.y)).toBe(0);
+    expect(isNodeStructurallyHiddenInDocument(state.document, lotDuring)).toBe(false);
+
     state = reduceEditor(state, editorReducers.exitLottiePrecompEdit);
     expect(state.lottiePrecompEdit).toBeNull();
+    const lotAfter = state.document!.deltaSetLike[lotId];
+    expect(Number(lotAfter.x)).toBe(lotXBefore);
+    expect(Number(lotAfter.y)).toBe(lotYBefore);
     expect(isMainSceneLotPreviewReady(state.document!, lotId)).toBe(true);
-    expect(
-      isNodeStructurallyHiddenInDocument(state.document, state.document!.deltaSetLike[lotId])
-    ).toBe(false);
+    expect(isNodeStructurallyHiddenInDocument(state.document, lotAfter)).toBe(false);
+    const frameAfter = (state.document!.frames || []).find((f) => String(f?.id) === frameId)!;
+    expect(Number(frameAfter.x)).toBe(480);
+    expect(Number(frameAfter.y)).toBe(320);
+    expect(Number(frameAfter.width)).toBe(418);
   });
 
   it('placeUploadedLottie: 主场景 preview ready before and after LOT tab exit', () => {

--- a/apps/web/src/components/editor/nodes/AnimationNode/animationPrecompSession.ts
+++ b/apps/web/src/components/editor/nodes/AnimationNode/animationPrecompSession.ts
@@ -8,7 +8,7 @@ import {
 } from '@/components/rcb/scene/document/nodeFactories';
 import { removeNodesFromDocument } from '@/components/rcb/scene/document/sceneDocument';
 import type { SceneDocument } from '@/components/rcb/sceneNode';
-import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
+import { nodeLeftTop, isFrameLocalCoordSpace } from '@/components/rcb/scene/paint/sceneToSvg';
 import { materializeRootShapeLayers } from '@/components/editor/nodes/AnimationNode/animationLottieMaterialize';
 import {
   extractPrecompAssetJson,
@@ -36,6 +36,8 @@ export type PrecompSessionBegin = {
   document: SceneDocument;
   frameId: string;
   frameSnapshot: FrameGeomSnapshot;
+  /** Nested LOT plate-local geom before LOT-tab frame shrink (frameLocal). */
+  lotSnapshot: FrameGeomSnapshot | null;
   lotNodeId: string | null;
   sessionNodeIds: string[];
 };
@@ -46,6 +48,7 @@ export type LottiePrecompEditState = {
   selectedLayerInd: number | null;
   frameId?: string;
   frameSnapshot?: FrameGeomSnapshot;
+  lotSnapshot?: FrameGeomSnapshot | null;
   lotNodeId?: string | null;
   sessionNodeIds?: string[];
 };
@@ -364,6 +367,20 @@ export function beginPrecompEditSession(opts: {
     height: Math.max(1, num(prevFrame.height, 1)),
   };
 
+  const lotId = plate.lotNodeId;
+  const frameLocal = isFrameLocalCoordSpace(opts.document);
+  let lotSnapshot: FrameGeomSnapshot | null = null;
+  if (lotId && opts.document.deltaSetLike?.[lotId]) {
+    const lotNode = opts.document.deltaSetLike[lotId];
+    lotSnapshot = {
+      x: num(lotNode.x),
+      y: num(lotNode.y),
+      width: Math.max(1, num(lotNode.width, 1)),
+      height: Math.max(1, num(lotNode.height, 1)),
+    };
+  }
+
+  // Shrink workbench to the nested LOT plate (world).
   frames[frameIdx] = {
     ...prevFrame,
     x: plate.left,
@@ -377,14 +394,24 @@ export function beginPrecompEditSession(opts: {
     frames,
     deltaSetLike: { ...(opts.document.deltaSetLike || {}) },
   };
+  // Host fills the resized plate. frameLocal → local 0,0 (not world plate.left).
   doc = patchNode(doc, hostId, {
-    x: plate.left,
-    y: plate.top,
+    x: frameLocal ? 0 : plate.left,
+    y: frameLocal ? 0 : plate.top,
     width: plate.width,
     height: plate.height,
   });
+  // Rebase nested LOT into the new plate — otherwise frameLocal children keep
+  // their old local x/y and fall outside clipContent (blank 主场景 after tab switch).
+  if (lotId && lotSnapshot) {
+    doc = patchNode(doc, lotId, {
+      x: frameLocal ? 0 : plate.left,
+      y: frameLocal ? 0 : plate.top,
+      width: plate.width,
+      height: plate.height,
+    });
+  }
 
-  const lotId = plate.lotNodeId;
   const sourceAnim = resolveSourceAnim(doc, host.attrs?.animationData, assetId, lotId);
   if (!sourceAnim) return null;
   const materializeAnim = stripAllLayerLinks(sourceAnim);
@@ -397,8 +424,8 @@ export function beginPrecompEditSession(opts: {
     frameId,
     animationData: materializeAnim,
     plate: {
-      x: plate.left,
-      y: plate.top,
+      x: frameLocal ? 0 : plate.left,
+      y: frameLocal ? 0 : plate.top,
       width: plate.width,
       height: plate.height,
     },
@@ -411,6 +438,7 @@ export function beginPrecompEditSession(opts: {
       document: doc,
       frameId,
       frameSnapshot,
+      lotSnapshot,
       lotNodeId: lotId,
       sessionNodeIds: [],
     };
@@ -443,6 +471,7 @@ export function beginPrecompEditSession(opts: {
     document: doc,
     frameId,
     frameSnapshot,
+    lotSnapshot,
     lotNodeId: lotId,
     sessionNodeIds: matured.nodeIds,
   };
@@ -512,6 +541,7 @@ export function endPrecompEditSession(opts: {
   assetId: string;
   frameId: string;
   frameSnapshot: FrameGeomSnapshot;
+  lotSnapshot?: FrameGeomSnapshot | null;
   lotNodeId: string | null;
   sessionNodeIds: string[];
   playheadSec?: number;
@@ -530,6 +560,7 @@ export function endPrecompEditSession(opts: {
   const frameId = String(opts.frameId || '').trim();
   const sessionIds = opts.sessionNodeIds.filter(Boolean);
   const lotId = opts.lotNodeId || linkedLotNodeIdFromAsset(assetId);
+  const frameLocal = isFrameLocalCoordSpace(doc);
 
   doc = writeBackLotOnPrecompExit(doc, hostId, assetId, lotId, sessionIds);
 
@@ -544,7 +575,21 @@ export function endPrecompEditSession(opts: {
     }
     const host = doc.deltaSetLike?.[hostId];
     if (host && isAnimationFrameHostNode(host, doc)) {
-      doc = patchNode(doc, hostId, { ...opts.frameSnapshot });
+      doc = patchNode(
+        doc,
+        hostId,
+        frameLocal
+          ? {
+              x: 0,
+              y: 0,
+              width: opts.frameSnapshot.width,
+              height: opts.frameSnapshot.height,
+            }
+          : { ...opts.frameSnapshot }
+      );
+    }
+    if (lotId && opts.lotSnapshot && doc.deltaSetLike?.[lotId]) {
+      doc = patchNode(doc, lotId, { ...opts.lotSnapshot });
     }
   }
 
@@ -564,6 +609,7 @@ export function endPrecompEditFromState(
     assetId: edit.assetId,
     frameId: edit.frameId,
     frameSnapshot: edit.frameSnapshot,
+    lotSnapshot: edit.lotSnapshot ?? null,
     lotNodeId: edit.lotNodeId ?? null,
     sessionNodeIds: resolvePrecompSessionNodeIds(document, edit),
     playheadSec,

--- a/apps/web/src/store/modules/editor.ts
+++ b/apps/web/src/store/modules/editor.ts
@@ -3568,6 +3568,7 @@ export const editorReducers = {
         selectedLayerInd: layerInd,
         frameId: begun.frameId,
         frameSnapshot: begun.frameSnapshot,
+        lotSnapshot: begun.lotSnapshot,
         lotNodeId: begun.lotNodeId,
         sessionNodeIds: begun.sessionNodeIds};
       setLottiePrecompEditFocus({


### PR DESCRIPTION
## Summary
- Entering the LOT precomp tab shrunk the workbench to the nested plate world AABB while frameLocal host/lot kept old local x/y, so ink fell outside clipContent.
- Snapshot nested LOT geom on enter, rebase host+lot to local 0,0 for the session, restore both on exit to main scene.
- Regression: non-zero frame origin enter LOT tab exit preview ready and not structurally hidden.

## Test plan
- [x] vitest mainSceneLotPreview.test.ts + animationPrecompSession.test.ts
- [ ] Manual: import LOT (non-origin artboard) open LOT tab switch to main scene ink visible inside selection

Made with [Cursor](https://cursor.com)