### PR TITLE
fix(web): artboard/animation 副本 no-op from context menu

### DIFF
--- a/apps/web/src/components/editor/canvas/contextMenu/__tests__/nodeTitleContextMenu.test.ts
+++ b/apps/web/src/components/editor/canvas/contextMenu/__tests__/nodeTitleContextMenu.test.ts
@@ -64,4 +64,19 @@ describe('canvas context menu — node titles', () => {
     });
     expect(hit).toEqual({ nodeId: 'circle_1', frameId: null });
   });
+
+  it('treats __frame__: hit ids as artboard plates (not fake node ids)', () => {
+    const hit = resolveContextMenuHit({
+      sceneX: 100,
+      sceneY: 100,
+      target: null,
+      hitTest: () => '__frame__:board_1',
+      clientX: 0,
+      clientY: 0,
+      frames: [{ id: 'board_1', x: 0, y: 0, width: 400, height: 400 }],
+      selectedIds: [],
+      activeFrameId: null,
+    });
+    expect(hit).toEqual({ nodeId: null, frameId: 'board_1' });
+  });
 });

--- a/apps/web/src/components/editor/canvas/contextMenu/useCanvasContextMenu.ts
+++ b/apps/web/src/components/editor/canvas/contextMenu/useCanvasContextMenu.ts
@@ -8,6 +8,7 @@ import {
 
 import { rcbResolveViewportEl, useRcbScreenToScene } from '@/components/rcb';
 import type { ContextMenuState } from '@/components/rcb/selection/chrome/CanvasContextMenu';
+import { parseFrameSelId } from '@/components/rcb/selection/frameSelectionIds';
 import {
   setActiveFrameId,
   setFrameChromeMode,
@@ -209,16 +210,24 @@ export function resolveContextMenuHit(opts: {
   activeFrameId: string | null;
 }): MenuHit {
   const titleFrameId = frameIdFromEventTarget(opts.target);
-  const hitNode =
+  const rawHit =
     opts.hitTest(opts.sceneX, opts.sceneY, {
       clientX: opts.clientX,
       clientY: opts.clientY,
     }) || nodeIdFromEventTarget(opts.target);
 
-  if (hitNode) {
+  // sceneRenderer returns `__frame__:id` for plate hits — same as SelectionFeature.
+  // Treating that string as a node id clears artboard selection and makes
+  // 副本 / copy / cut no-op (no deltaSetLike entry).
+  const frameFromHit = rawHit ? parseFrameSelId(rawHit) : null;
+  if (frameFromHit) {
+    return { nodeId: null, frameId: frameFromHit };
+  }
+
+  if (rawHit) {
     // Soft activeFrameId is highlight context only — never treat it as a
     // frame mutation target when the menu is opened on a scene node.
-    return { nodeId: hitNode, frameId: titleFrameId };
+    return { nodeId: rawHit, frameId: titleFrameId };
   }
   if (titleFrameId) {
     return { nodeId: null, frameId: titleFrameId };
@@ -302,8 +311,21 @@ export function useCanvasContextMenu(args: UseCanvasContextMenuArgs) {
         activeFrameId: activeFrameIdRef.current,
       });
 
+      let menuNodeId = hit.nodeId;
+      let menuFrameId = hit.frameId;
+
       if (hit.nodeId && !selected.includes(hit.nodeId)) {
-        selectNodeOnly(hit.nodeId);
+        const boundFrame = String(
+          documentRef.current?.deltaSetLike?.[hit.nodeId]?.attrs?.frameId || ''
+        ).trim();
+        // Artboard already selected: keep plate as the mutation target so 副本
+        // duplicates the board (not a single child under the pointer).
+        if (boundFrame && selectedFrames.includes(boundFrame)) {
+          menuNodeId = null;
+          menuFrameId = boundFrame;
+        } else {
+          selectNodeOnly(hit.nodeId);
+        }
       } else if (
         !hit.nodeId &&
         hit.frameId &&
@@ -317,8 +339,8 @@ export function useCanvasContextMenu(args: UseCanvasContextMenuArgs) {
         clientY,
         sceneX: p.x,
         sceneY: p.y,
-        nodeId: hit.nodeId,
-        frameId: hit.frameId,
+        nodeId: menuNodeId,
+        frameId: menuFrameId,
       });
     };
 

--- a/apps/web/src/store/modules/editor.ts
+++ b/apps/web/src/store/modules/editor.ts
@@ -1608,10 +1608,13 @@ export const editorReducers = {
           .map((f) => String(f?.id || ''))
           .filter(Boolean)
       );
-      // Solo 动画工作台 host → select parent frame only.
+      // Solo 动画工作台 host / preview child → select parent frame only.
       if (nodeIds.length === 1 && !frameIdsRaw.length) {
         const host = doc.deltaSetLike?.[nodeIds[0]!];
-        if (isAnimationFrameHostNode(host, doc)) {
+        if (
+          isAnimationFrameHostNode(host, doc) ||
+          isAnimationWorkbenchPreviewChild(doc, host)
+        ) {
           const fid = String(host?.attrs?.frameId || '').trim();
           if (fid && valid.has(fid)) {
             const cur =


### PR DESCRIPTION
## Summary
- Context menu treated sceneRenderer `__frame__:id` plate hits as fake node ids, cleared artboard selection, then 副本 snapped nothing.
- Parse frame sel ids (same as SelectionFeature); keep plate selection when right-clicking content inside an already-selected artboard.
- setMixedSelection also promotes workbench preview children to the parent frame.

## Test plan
- [x] vitest nodeTitleContextMenu + sceneClipboardZod
- [ ] Manual: select empty artboard / animation board → right-click 副本 → copy appears to the right
- [ ] Manual: select artboard with children → right-click plate → 副本 duplicates the board

Made with [Cursor](https://cursor.com)