### PR TITLE
fix(web): LOT tab blank from partial materialize

### DIFF
--- a/apps/web/src/components/editor/nodes/AnimationNode/AnimationNodeOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/AnimationNode/AnimationNodeOverlay.tsx
@@ -337,6 +337,7 @@ function LottiePlateHost({
         assetId?: string;
         lotNodeId?: string | null;
         sessionNodeIds?: string[];
+        sessionHidesLotInk?: boolean;
       }
   );
   const node = document?.deltaSetLike?.[nodeId];
@@ -360,7 +361,7 @@ function LottiePlateHost({
     hidden,
     precompAssetId,
     precompLotId,
-    precompSessionMaterialized: Boolean(precompEdit?.sessionNodeIds?.length),
+    precompSessionMaterialized: Boolean(precompEdit?.sessionHidesLotInk),
   });
   const inkRevision = String(node.attrs?.lottieInkRevision ?? '');
 

--- a/apps/web/src/components/editor/nodes/AnimationNode/AnimationPrecompEditFocusHost.tsx
+++ b/apps/web/src/components/editor/nodes/AnimationNode/AnimationPrecompEditFocusHost.tsx
@@ -142,6 +142,7 @@ function AnimationPrecompEditFocusHost({
         selectedLayerInd: number | null;
         lotNodeId?: string | null;
         sessionNodeIds?: string[];
+        sessionHidesLotInk?: boolean;
         frameId?: string;
       }
   );
@@ -150,7 +151,7 @@ function AnimationPrecompEditFocusHost({
   const assetId = edit?.assetId || '';
   const frameId = edit?.frameId || '';
   const lotNodeId = edit?.lotNodeId ?? linkedLotNodeIdFromAsset(assetId);
-  const sessionMaterialized = Boolean(edit?.sessionNodeIds?.length);
+  const sessionMaterialized = Boolean(edit?.sessionHidesLotInk);
   const pushedRef = useRef(false);
   const fittedKeyRef = useRef('');
   const stageElRef = useRef(stageEl);

--- a/apps/web/src/components/editor/nodes/AnimationNode/__tests__/precompTabDataCompare.test.ts
+++ b/apps/web/src/components/editor/nodes/AnimationNode/__tests__/precompTabDataCompare.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Diagnostic: dump LOT / host / session state across tab enter.
+ * Fails if enter hides lot ink while leaving non-materialized layers behind.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setAnimationWorkbenchTimelineFocus } from '@/components/editor/nodes/AnimationNode/animationWorkbenchFocus';
+import { setLottiePrecompEditFocus } from '@/components/editor/nodes/AnimationNode/animationPrecompEditFocus';
+import { parseLottieAnimationData } from '@/components/rcb/scene/document/nodeFactories';
+import {
+  editorReducers,
+  reduceEditor,
+  createTemplate,
+} from '@/store/modules/editor';
+import { createEmptyDocument } from '@/components/rcb/scene/document/sceneDocument';
+import { extractPrecompAssetJson } from '@/components/editor/nodes/AnimationNode/animationPrecompEditModel';
+import { isMainSceneLotPreviewReady } from '@/components/editor/nodes/AnimationNode/mainSceneLotPreview';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+
+afterEach(() => {
+  setAnimationWorkbenchTimelineFocus(null);
+  setLottiePrecompEditFocus({ active: false });
+});
+
+function seedEditor() {
+  let state = reduceEditor(undefined, () => {});
+  state = reduceEditor(state, editorReducers.createTemplate, {
+    name: 'tab-compare',
+    document: createEmptyDocument({ emptyWorld: true }),
+    emptyWorld: true,
+    source: 'scratch',
+  });
+  return state;
+}
+
+function findNestedLot(state: any, hostId: string, frameId: string) {
+  return Object.keys(state.document!.deltaSetLike || {}).find((id: string) => {
+    const n = state.document!.deltaSetLike[id];
+    return (
+      id !== hostId &&
+      n?.key === 'lottie' &&
+      String(n.attrs?.frameId || '') === frameId &&
+      !n.attrs?.animationFrameHost
+    );
+  });
+}
+
+function layerStats(anim: Record<string, unknown> | null | undefined) {
+  const layers = Array.isArray(anim?.layers) ? (anim!.layers as any[]) : [];
+  let shape = 0;
+  let rectLike = 0;
+  let other = 0;
+  for (const layer of layers) {
+    if (!layer || typeof layer !== 'object') continue;
+    const ty = Number(layer.ty);
+    if (ty === 4) {
+      shape += 1;
+      const shapes = Array.isArray(layer.shapes) ? layer.shapes : [];
+      const hasRect = shapes.some(
+        (s: any) =>
+          s &&
+          (s.ty === 'rc' ||
+            s.ty === 'el' ||
+            (Array.isArray(s.it) &&
+              s.it.some((it: any) => it && (it.ty === 'rc' || it.ty === 'el'))))
+      );
+      if (hasRect) rectLike += 1;
+      else other += 1;
+    } else {
+      other += 1;
+    }
+  }
+  return { total: layers.length, shape, rectLike, other };
+}
+
+function snap(state: any, lotId: string, hostId: string, assetId: string) {
+  const doc = state.document!;
+  const frameId = String(state.selectedFrameIds?.[0] || doc.activeFrameId || '');
+  const frame = (doc.frames || []).find((f: any) => String(f?.id) === frameId);
+  const lot = doc.deltaSetLike[lotId];
+  const host = doc.deltaSetLike[hostId];
+  const lotAnim = parseLottieAnimationData(lot?.attrs?.animationData);
+  const hostAsset = extractPrecompAssetJson(host?.attrs?.animationData, assetId);
+  const hostAssetAnim = hostAsset ? parseLottieAnimationData(hostAsset) : null;
+  const sessionIds = (state.lottiePrecompEdit?.sessionNodeIds || []) as string[];
+  const sessionNodes = sessionIds.map((id) => {
+    const n = doc.deltaSetLike[id];
+    return {
+      id,
+      key: n?.key,
+      x: n?.x,
+      y: n?.y,
+      w: n?.width,
+      h: n?.height,
+      fill: n?.attrs?.['fill-color'],
+      shapeType: n?.attrs?.shapeType,
+      hidden: n?.attrs?.hidden,
+    };
+  });
+  return {
+    frame: frame
+      ? { x: frame.x, y: frame.y, w: frame.width, h: frame.height }
+      : null,
+    host: host
+      ? { x: host.x, y: host.y, w: host.width, h: host.height }
+      : null,
+    lot: lot
+      ? {
+          x: lot.x,
+          y: lot.y,
+          w: lot.width,
+          h: lot.height,
+          hasJson: Boolean(String(lot.attrs?.animationData || '').trim()),
+          jsonLen: String(lot.attrs?.animationData || '').length,
+          layers: layerStats(lotAnim),
+        }
+      : null,
+    hostAssetLayers: layerStats(hostAssetAnim),
+    sessionCount: sessionIds.length,
+    sessionNodes,
+    previewReady: isMainSceneLotPreviewReady(doc, lotId),
+    precompActive: Boolean(state.lottiePrecompEdit),
+  };
+}
+
+describe('precomp tab data compare', () => {
+  const fixtureFiles = readdirSync(FIXTURES).filter((f) => f.endsWith('.json'));
+
+  it.each(fixtureFiles)('fixture %s: enter must not hide ink with partial materialize', (file) => {
+    const anim = parseLottieAnimationData(readFileSync(join(FIXTURES, file), 'utf8'));
+    expect(anim).toBeTruthy();
+    const statsBeforePlace = layerStats(anim!);
+    // Skip tiny fixtures with no layers.
+    if (statsBeforePlace.total === 0) return;
+
+    let state = seedEditor();
+    state = reduceEditor(state, editorReducers.placeUploadedLottie, {
+      animationData: anim,
+      name: file,
+      x: 480,
+      y: 320,
+      width: 418,
+      height: 418,
+    });
+    const frameId = String(state.selectedFrameIds?.[0] || '');
+    const hostId = String(state.lottieTimelinePanel!.nodeId);
+    const lotId = findNestedLot(state, hostId, frameId)!;
+    expect(lotId).toBeTruthy();
+    const assetId = `lot_${lotId}`;
+
+    const before = snap(state, lotId, hostId, assetId);
+    expect(before.lot?.hasJson).toBe(true);
+    expect(before.previewReady).toBe(true);
+
+    state = reduceEditor(state, editorReducers.enterLottiePrecompEdit, {
+      hostNodeId: hostId,
+      assetId,
+      selectedLayerInd: 1,
+    });
+    const during = snap(state, lotId, hostId, assetId);
+
+    // Core invariant: if LOT has non-rect layers, we must not claim a full
+    // session materialize that hides lottie-web ink (blank LOT tab).
+    const nonRect = before.lot!.layers.other;
+    if (nonRect > 0) {
+      expect(state.lottiePrecompEdit?.sessionHidesLotInk ?? false).toBe(false);
+    }
+
+    // Lot JSON must survive enter.
+    expect(during.lot?.hasJson).toBe(true);
+    expect(during.lot!.jsonLen).toBeGreaterThan(10);
+    expect(during.lot!.layers.total).toBe(before.lot!.layers.total);
+
+    state = reduceEditor(state, editorReducers.exitLottiePrecompEdit);
+    const after = snap(state, lotId, hostId, assetId);
+    expect(after.previewReady).toBe(true);
+    expect(after.lot?.hasJson).toBe(true);
+    expect(after.lot!.layers.total).toBe(before.lot!.layers.total);
+    expect(after.frame).toEqual(before.frame);
+  });
+
+  it('simple rect LOT: exit preserves animated position keys', () => {
+    const anim = parseLottieAnimationData(
+      readFileSync(join(FIXTURES, 'retake-lot-edited.json'), 'utf8')
+    );
+    let state = seedEditor();
+    state = reduceEditor(state, editorReducers.placeUploadedLottie, {
+      animationData: anim,
+      name: 'rect',
+      x: 100,
+      y: 100,
+      width: 285,
+      height: 285,
+    });
+    const frameId = String(state.selectedFrameIds?.[0] || '');
+    const hostId = String(state.lottieTimelinePanel!.nodeId);
+    const lotId = findNestedLot(state, hostId, frameId)!;
+    const assetId = `lot_${lotId}`;
+    const before = parseLottieAnimationData(
+      state.document!.deltaSetLike[lotId].attrs!.animationData as string
+    )!;
+    const beforeKeys = (before.layers as any[])[0].ks.p.k.length;
+
+    state = reduceEditor(state, editorReducers.enterLottiePrecompEdit, {
+      hostNodeId: hostId,
+      assetId,
+      selectedLayerInd: 1,
+    });
+    expect(state.lottiePrecompEdit?.sessionHidesLotInk).toBe(true);
+
+    state = reduceEditor(state, editorReducers.exitLottiePrecompEdit);
+    const after = parseLottieAnimationData(
+      state.document!.deltaSetLike[lotId].attrs!.animationData as string
+    )!;
+    expect((after.layers as any[])[0].ks.p.a).toBe(1);
+    expect((after.layers as any[])[0].ks.p.k.length).toBe(beforeKeys);
+  });
+});

--- a/apps/web/src/components/editor/nodes/AnimationNode/animationLottieMaterialize.ts
+++ b/apps/web/src/components/editor/nodes/AnimationNode/animationLottieMaterialize.ts
@@ -102,8 +102,55 @@ function readRectSize(shapes: unknown[]): {
         ellipse: s.ty === 'el',
       };
     }
+    if (Array.isArray(s.it)) {
+      const nested = readRectSize(s.it as unknown[]);
+      if (nested) return nested;
+    }
   }
   return null;
+}
+
+/** Root ty:4 layers that materializeRootShapeLayers can explode. */
+export function countMaterializableRootShapeLayers(animationData: unknown): number {
+  const root = parseLottieAnimationData(animationData);
+  if (!root || !Array.isArray(root.layers)) return 0;
+  let n = 0;
+  for (const raw of root.layers as unknown[]) {
+    const layer = asObj(raw);
+    if (!layer) continue;
+    if (num(layer.ty, -1) !== 4) continue;
+    const shapes = Array.isArray(layer.shapes) ? (layer.shapes as unknown[]) : [];
+    if (readRectSize(shapes)) n += 1;
+  }
+  return n;
+}
+
+/**
+ * True when LOT tab may hide lottie-web ink (session shapes fully replace it).
+ * Partial explode + hide = blank tab (paths / images stay only in the JSON).
+ */
+export function sessionCoversLotInk(
+  animationData: unknown,
+  sessionNodeCount: number
+): boolean {
+  if (sessionNodeCount <= 0) return false;
+  const root = parseLottieAnimationData(animationData);
+  if (!root || !Array.isArray(root.layers)) return false;
+  let materializable = 0;
+  for (const raw of root.layers as unknown[]) {
+    const layer = asObj(raw);
+    if (!layer) continue;
+    const ty = num(layer.ty, -1);
+    if (ty === 4) {
+      const shapes = Array.isArray(layer.shapes) ? (layer.shapes as unknown[]) : [];
+      if (readRectSize(shapes)) materializable += 1;
+      else return false; // path / complex shape — keep ink
+    } else if (ty === 0 || ty === 2 || ty === 1) {
+      // precomp / image / text — keep ink
+      return false;
+    }
+  }
+  return materializable > 0 && sessionNodeCount >= materializable;
 }
 
 export type MaterializeLottieResult = {

--- a/apps/web/src/components/editor/nodes/AnimationNode/animationPrecompSession.ts
+++ b/apps/web/src/components/editor/nodes/AnimationNode/animationPrecompSession.ts
@@ -9,7 +9,7 @@ import {
 import { removeNodesFromDocument } from '@/components/rcb/scene/document/sceneDocument';
 import type { SceneDocument } from '@/components/rcb/sceneNode';
 import { nodeLeftTop, isFrameLocalCoordSpace } from '@/components/rcb/scene/paint/sceneToSvg';
-import { materializeRootShapeLayers } from '@/components/editor/nodes/AnimationNode/animationLottieMaterialize';
+import { materializeRootShapeLayers, sessionCoversLotInk } from '@/components/editor/nodes/AnimationNode/animationLottieMaterialize';
 import {
   extractPrecompAssetJson,
   linkedLotNodeIdFromAsset,
@@ -38,8 +38,12 @@ export type PrecompSessionBegin = {
   frameSnapshot: FrameGeomSnapshot;
   /** Nested LOT plate-local geom before LOT-tab frame shrink (frameLocal). */
   lotSnapshot: FrameGeomSnapshot | null;
+  /** Nested LOT animationData before enter — restore if host write-back would drop ink. */
+  lotAnimationSnapshot: string | null;
   lotNodeId: string | null;
   sessionNodeIds: string[];
+  /** True only when session shapes fully cover materializable layers (safe to hide ink). */
+  sessionHidesLotInk: boolean;
 };
 
 export type LottiePrecompEditState = {
@@ -49,8 +53,10 @@ export type LottiePrecompEditState = {
   frameId?: string;
   frameSnapshot?: FrameGeomSnapshot;
   lotSnapshot?: FrameGeomSnapshot | null;
+  lotAnimationSnapshot?: string | null;
   lotNodeId?: string | null;
   sessionNodeIds?: string[];
+  sessionHidesLotInk?: boolean;
 };
 
 function num(v: unknown, fallback = 0): number {
@@ -283,27 +289,41 @@ function plateForLot(
   };
 }
 
-function writeAssetLayers(
+/**
+ * Stamp `ln` onto existing precomp asset layers by `ind` — keep original shapes/keyframes.
+ * Replacing the whole layer list on enter was dropping path ink and blanking the LOT tab.
+ */
+function stampSessionLinksIntoHostAsset(
   hostAnimationData: unknown,
   assetId: string,
-  maturedLayers: unknown[],
-  maturedW: number,
-  maturedH: number
+  maturedLayers: unknown[]
 ): string | null {
   const root = parseLottieAnimationData(hostAnimationData);
   if (!root || !Array.isArray(root.assets)) return null;
-  const assets = (root.assets as Record<string, unknown>[]).map((a) =>
-    a && typeof a === 'object' ? { ...a } : a
-  );
-  const idx = assets.findIndex((a) => String(a?.id || '') === assetId);
-  if (idx < 0) return null;
-  const prev = assets[idx] as Record<string, unknown>;
-  assets[idx] = {
-    ...prev,
-    w: Math.max(1, Math.round(maturedW)),
-    h: Math.max(1, Math.round(maturedH)),
-    layers: maturedLayers,
-  };
+  const lnByInd = new Map<number, string>();
+  for (const raw of maturedLayers) {
+    if (!raw || typeof raw !== 'object') continue;
+    const layer = raw as Record<string, unknown>;
+    const ln = String(layer.ln || '').trim();
+    const ind = Math.round(num(layer.ind, NaN));
+    if (!ln || !Number.isFinite(ind)) continue;
+    lnByInd.set(ind, ln);
+  }
+  if (!lnByInd.size) return null;
+
+  const assets = (root.assets as Record<string, unknown>[]).map((asset) => {
+    if (!asset || String(asset.id || '') !== assetId) return asset;
+    if (!Array.isArray(asset.layers)) return asset;
+    const layers = (asset.layers as unknown[]).map((raw) => {
+      if (!raw || typeof raw !== 'object') return raw;
+      const layer = { ...(raw as Record<string, unknown>) };
+      const ind = Math.round(num(layer.ind, NaN));
+      const ln = Number.isFinite(ind) ? lnByInd.get(ind) : undefined;
+      if (ln) layer.ln = ln;
+      return layer;
+    });
+    return { ...asset, layers };
+  });
   return serializeLottieAnimationData({ ...root, assets });
 }
 
@@ -370,6 +390,7 @@ export function beginPrecompEditSession(opts: {
   const lotId = plate.lotNodeId;
   const frameLocal = isFrameLocalCoordSpace(opts.document);
   let lotSnapshot: FrameGeomSnapshot | null = null;
+  let lotAnimationSnapshot: string | null = null;
   if (lotId && opts.document.deltaSetLike?.[lotId]) {
     const lotNode = opts.document.deltaSetLike[lotId];
     lotSnapshot = {
@@ -378,6 +399,8 @@ export function beginPrecompEditSession(opts: {
       width: Math.max(1, num(lotNode.width, 1)),
       height: Math.max(1, num(lotNode.height, 1)),
     };
+    const raw = String(lotNode.attrs?.animationData || '').trim();
+    lotAnimationSnapshot = raw || null;
   }
 
   // Shrink workbench to the nested LOT plate (world).
@@ -439,8 +462,10 @@ export function beginPrecompEditSession(opts: {
       frameId,
       frameSnapshot,
       lotSnapshot,
+      lotAnimationSnapshot,
       lotNodeId: lotId,
       sessionNodeIds: [],
+      sessionHidesLotInk: false,
     };
   }
 
@@ -453,16 +478,17 @@ export function beginPrecompEditSession(opts: {
   const maturedLayers = Array.isArray(maturedParsed?.layers)
     ? (maturedParsed!.layers as unknown[])
     : [];
-  const hostJson = writeAssetLayers(
+  // Stamp ln only — never replace asset layers with a re-serialized subset
+  // (that permanently deleted path/image layers and blanked the LOT).
+  const hostJson = stampSessionLinksIntoHostAsset(
     doc.deltaSetLike?.[hostId]?.attrs?.animationData ?? host.attrs?.animationData,
     assetId,
-    maturedLayers,
-    Math.max(1, num(maturedParsed?.w, plate.width)),
-    Math.max(1, num(maturedParsed?.h, plate.height))
+    maturedLayers
   );
   if (hostJson) {
     doc = patchNode(doc, hostId, { attrs: { animationData: hostJson } });
   }
+  const sessionHidesLotInk = sessionCoversLotInk(sourceAnim, matured.nodeIds.length);
   // Keep nested lot in the SVG paint tree (no attrs.hidden). Removing the node
   // from SVG drops the foreignObject mount; after LOT tab exit the 主场景 lottie
   // overlay never reattaches. Ink hide during LOT edit is overlay-only.
@@ -472,8 +498,10 @@ export function beginPrecompEditSession(opts: {
     frameId,
     frameSnapshot,
     lotSnapshot,
+    lotAnimationSnapshot,
     lotNodeId: lotId,
     sessionNodeIds: matured.nodeIds,
+    sessionHidesLotInk,
   };
 }
 
@@ -542,6 +570,7 @@ export function endPrecompEditSession(opts: {
   frameId: string;
   frameSnapshot: FrameGeomSnapshot;
   lotSnapshot?: FrameGeomSnapshot | null;
+  lotAnimationSnapshot?: string | null;
   lotNodeId: string | null;
   sessionNodeIds: string[];
   playheadSec?: number;
@@ -563,6 +592,20 @@ export function endPrecompEditSession(opts: {
   const frameLocal = isFrameLocalCoordSpace(doc);
 
   doc = writeBackLotOnPrecompExit(doc, hostId, assetId, lotId, sessionIds);
+
+  // If write-back lost layers vs enter snapshot, restore the original LOT JSON
+  // then re-apply host-synced transforms only when session fully covered ink.
+  if (lotId && opts.lotAnimationSnapshot && doc.deltaSetLike?.[lotId]) {
+    const snap = parseLottieAnimationData(opts.lotAnimationSnapshot);
+    const now = parseLottieAnimationData(doc.deltaSetLike[lotId].attrs?.animationData);
+    const snapCount = Array.isArray(snap?.layers) ? snap!.layers.length : 0;
+    const nowCount = Array.isArray(now?.layers) ? now!.layers.length : 0;
+    if (snapCount > 0 && nowCount < snapCount) {
+      doc = patchNode(doc, lotId, {
+        attrs: { animationData: opts.lotAnimationSnapshot },
+      });
+    }
+  }
 
   if (sessionIds.length) doc = removeNodesFromDocument(doc, sessionIds);
 
@@ -610,6 +653,7 @@ export function endPrecompEditFromState(
     frameId: edit.frameId,
     frameSnapshot: edit.frameSnapshot,
     lotSnapshot: edit.lotSnapshot ?? null,
+    lotAnimationSnapshot: edit.lotAnimationSnapshot ?? null,
     lotNodeId: edit.lotNodeId ?? null,
     sessionNodeIds: resolvePrecompSessionNodeIds(document, edit),
     playheadSec,

--- a/apps/web/src/store/modules/editor.ts
+++ b/apps/web/src/store/modules/editor.ts
@@ -3540,7 +3540,7 @@ export const editorReducers = {
           setLottiePrecompEditFocus({
             active: true,
             lotNodeId: state.lottiePrecompEdit.lotNodeId ?? null,
-            sessionMaterialized: true});
+            sessionMaterialized: Boolean(state.lottiePrecompEdit.sessionHidesLotInk)});
           bakePrecompSessionDocumentPoses(state);
           requestPlayheadSceneApply({ afterPaint: true });
           return;
@@ -3572,12 +3572,14 @@ export const editorReducers = {
         frameId: begun.frameId,
         frameSnapshot: begun.frameSnapshot,
         lotSnapshot: begun.lotSnapshot,
+        lotAnimationSnapshot: begun.lotAnimationSnapshot,
         lotNodeId: begun.lotNodeId,
-        sessionNodeIds: begun.sessionNodeIds};
+        sessionNodeIds: begun.sessionNodeIds,
+        sessionHidesLotInk: begun.sessionHidesLotInk};
       setLottiePrecompEditFocus({
         active: true,
         lotNodeId: begun.lotNodeId ?? null,
-        sessionMaterialized: begun.sessionNodeIds.length > 0});
+        sessionMaterialized: begun.sessionHidesLotInk});
       state.document.activeFrameId = begun.frameId;
       state.selectedFrameIds = [];
       state.selectedNodeId = null;


### PR DESCRIPTION
## Summary
- Compared before/during/after tab data: enter was rewriting host asset layers and hiding lottie-web whenever any session shape existed.
- Partial explode (paths/images left in JSON only) + hide ink = blank LOT tab.
- Stamp `ln` onto existing layers only; hide ink only when session fully covers materializable rect/ellipse layers; restore LOT JSON if exit write-back drops layers.

## Test plan
- [x] vitest precompTabDataCompare + mainSceneLotPreview + animationPrecompSession + materialize
- [ ] Manual: open complex LOT tab — ink visible; simple rect LOT still editable as shapes; exit 主场景 still shows LOT

Made with [Cursor](https://cursor.com)