### PR TITLE
fix(web): canvas pick must not attach blocked LOT workbench

### DIFF
--- a/apps/web/src/components/editor/canvas/SvgCanvas.tsx
+++ b/apps/web/src/components/editor/canvas/SvgCanvas.tsx
@@ -151,11 +151,13 @@ import SvgPaper from './SvgPaper';
 import { pointerToWorld, type ArtboardRect } from './pointerToWorld';
 import {
   attachPickFilterOpts,
+  canAttachFrameToPick,
   ctxMenuSeedNodeIds,
   filterChatAttachNodeIds,
   frameForFullBleedPlate,
   resolveAttachPickPayload,
 } from './attachPick';
+import { parseFrameSelId } from '@/components/rcb/selection/frameSelectionIds';
 import { ctxMenuTargetHasProcessing, resolveCtxMenuTargets } from './ctxMenuGuards';
 import { buildCanvasContextMenuProps } from './buildCanvasContextMenuProps';
 import { closedPenFillAttrs, pathNodeHasSolidFill } from './penFillAttrs';
@@ -842,21 +844,29 @@ function SvgCanvas({
     }
     const onMove = (e: PointerEvent) => {
       const pt = rcbScreenToScene(camera, stageEl, e.clientX, e.clientY);
-      const id = hitTestRef.current(pt.x, pt.y, {
+      const rawHit = hitTestRef.current(pt.x, pt.y, {
         clientX: e.clientX,
         clientY: e.clientY,
       });
-      if (!id) {
+      const opts = attachPickFilterOpts(canvasAttachPickRef.current);
+      const doc = documentRef.current;
+      const frameFromHit = rawHit ? parseFrameSelId(rawHit) : null;
+      if (frameFromHit) {
+        setCanvasAttachPickBlocked(!canAttachFrameToPick(doc, frameFromHit, opts));
+        return;
+      }
+      if (!rawHit) {
         setCanvasAttachPickBlocked(false);
         return;
       }
-      const doc = documentRef.current;
-      const seed = expandSelectionWithGroups(doc, [id]);
-      const attachable = filterChatAttachNodeIds(
-        doc,
-        seed,
-        attachPickFilterOpts(canvasAttachPickRef.current)
-      );
+      const seed = expandSelectionWithGroups(doc, [rawHit]);
+      const attachable = filterChatAttachNodeIds(doc, seed, opts);
+      // Full-bleed plate → click promotes to frame; mirror that for the cursor.
+      const plate = frameForFullBleedPlate(doc, rawHit);
+      if (plate && attachable.length === 0) {
+        setCanvasAttachPickBlocked(!canAttachFrameToPick(doc, plate.id, opts));
+        return;
+      }
       setCanvasAttachPickBlocked(seed.length > 0 && attachable.length === 0);
     };
     stageEl.addEventListener('pointermove', onMove);
@@ -874,6 +884,11 @@ function SvgCanvas({
           clearCanvasAttachPick();
           return;
         }
+        const filter = attachPickFilterOpts(pick);
+        if (!canAttachFrameToPick(documentRef.current, frameId, filter)) {
+          setCanvasAttachPickBlocked(true);
+          return; // stay in pick mode (matches not-allowed cursor)
+        }
         completeCanvasAttachPick(pick.target, `frame:${frameId}`);
         return;
       }
@@ -887,7 +902,7 @@ function SvgCanvas({
       setActiveFrameId(frameId);
       setFrameChromeMode(chrome);
     },
-    [ completeCanvasAttachPick]
+    [completeCanvasAttachPick]
   );
 
   const onSelectFrames = useCallback(
@@ -897,6 +912,11 @@ function SvgCanvas({
       if (pick?.target) {
         if (!ids.length) {
           clearCanvasAttachPick();
+          return;
+        }
+        const filter = attachPickFilterOpts(pick);
+        if (!canAttachFrameToPick(documentRef.current, ids[0], filter)) {
+          setCanvasAttachPickBlocked(true);
           return;
         }
         completeCanvasAttachPick(pick.target, `frame:${ids[0]}`);
@@ -909,7 +929,7 @@ function SvgCanvas({
       setSelectedNodeIds([]);
       setSelectedFrameIds(ids);
     },
-    [ completeCanvasAttachPick]
+    [completeCanvasAttachPick]
   );
 
   const onSelectMixed = useCallback(
@@ -975,19 +995,19 @@ function SvgCanvas({
           clearCanvasAttachPick();
           return;
         }
+        const filter = attachPickFilterOpts(pick);
         if (ids.length === 1) {
           const plateFrame = frameForFullBleedPlate(doc, ids[0]);
           if (plateFrame) {
+            if (!canAttachFrameToPick(doc, plateFrame.id, filter)) {
+              setCanvasAttachPickBlocked(true);
+              return;
+            }
             completeCanvasAttachPick(pick.target, `frame:${plateFrame.id}`);
             return;
           }
         }
-        const resolved = resolveAttachPickPayload(
-          doc,
-          ids,
-          undefined,
-          attachPickFilterOpts(pick)
-        );
+        const resolved = resolveAttachPickPayload(doc, ids, undefined, filter);
         if (!resolved) {
           clearCanvasAttachPick();
           return;

--- a/apps/web/src/components/editor/canvas/__tests__/attachPick.imagesOnlyFrame.test.ts
+++ b/apps/web/src/components/editor/canvas/__tests__/attachPick.imagesOnlyFrame.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canAttachFrameToPick,
+  resolveAttachPickPayload,
+} from '../attachPick';
+import type { SceneDocument } from '@/components/rcb/sceneNode';
+
+function docLotWorkbench(): SceneDocument {
+  return {
+    frames: [
+      {
+        id: 'af1',
+        kind: 'animation',
+        name: '重测生成LOT-edited',
+        x: 0,
+        y: 0,
+        width: 285,
+        height: 285,
+      },
+    ],
+    deltaSetLike: {
+      ROOT: { id: 'ROOT', children: ['host', 'lot'] },
+      host: {
+        id: 'host',
+        key: 'lottie',
+        width: 285,
+        height: 285,
+        attrs: { frameId: 'af1', animationFrameHost: true },
+      },
+      lot: {
+        id: 'lot',
+        key: 'lottie',
+        width: 285,
+        height: 285,
+        attrs: { frameId: 'af1', animationData: '{"v":"5.7.4","layers":[]}' },
+      },
+    },
+  } as unknown as SceneDocument;
+}
+
+function docArtboardWithImage(): SceneDocument {
+  return {
+    frames: [
+      {
+        id: 'f1',
+        kind: 'artboard',
+        name: 'Board',
+        x: 0,
+        y: 0,
+        width: 400,
+        height: 400,
+      },
+    ],
+    deltaSetLike: {
+      ROOT: { id: 'ROOT', children: ['img'] },
+      img: {
+        id: 'img',
+        key: 'image',
+        width: 200,
+        height: 200,
+        attrs: { frameId: 'f1', src: 'https://example.com/a.png' },
+      },
+    },
+  } as unknown as SceneDocument;
+}
+
+describe('canAttachFrameToPick', () => {
+  it('blocks animation workbench frames for imagesOnly pick', () => {
+    expect(canAttachFrameToPick(docLotWorkbench(), 'af1', { imagesOnly: true })).toBe(
+      false
+    );
+  });
+
+  it('allows animation frames for non-image (chat/media) pick', () => {
+    expect(canAttachFrameToPick(docLotWorkbench(), 'af1')).toBe(true);
+  });
+
+  it('allows artboard frames that contain an attachable image', () => {
+    expect(
+      canAttachFrameToPick(docArtboardWithImage(), 'f1', { imagesOnly: true })
+    ).toBe(true);
+  });
+
+  it('resolveAttachPickPayload: frame fallback stays blocked for LOT + imagesOnly', () => {
+    const resolved = resolveAttachPickPayload(docLotWorkbench(), [], 'af1', {
+      imagesOnly: true,
+    });
+    expect(resolved).toEqual({ payload: '', blockedOnly: true });
+  });
+
+  it('resolveAttachPickPayload: lottie node alone is blockedOnly under imagesOnly', () => {
+    const resolved = resolveAttachPickPayload(docLotWorkbench(), ['lot'], undefined, {
+      imagesOnly: true,
+    });
+    expect(resolved?.blockedOnly).toBe(true);
+  });
+});

--- a/apps/web/src/components/editor/canvas/attachPick.ts
+++ b/apps/web/src/components/editor/canvas/attachPick.ts
@@ -6,6 +6,8 @@ import {
   readNodeGroupId
 } from '@/components/rcb/scene/document/sceneGroups';
 import { frameForFullBleedPlate as frameForFullBleedPlateId } from '@/components/rcb/scene/document/sceneHitBridge';
+import { nodeIdsBoundToFrames } from '@/components/rcb/scene/document/sceneClipboard';
+import { isAnimationArtboardKind } from '@/components/rcb/frames/types';
 import type { SceneDocument } from '@/components/rcb/sceneNode';
 
 /** Near-full-bleed plate covering an artboard — treat click as frame select.
@@ -40,6 +42,31 @@ export function ctxMenuSeedFrameIds(selectedFrameIds: string[], menuFrameId?: st
 }
 
 export type AttachPickOpts = { imagesOnly?: boolean };
+
+/**
+ * Frame attach during canvas pick.
+ * Image-only composers must not swallow animation / empty plates (hover shows
+ * not-allowed, but frame: shortcuts used to attach anyway).
+ */
+export function canAttachFrameToPick(
+  doc: SceneDocument | null | undefined,
+  frameId: string | null | undefined,
+  opts?: AttachPickOpts
+): boolean {
+  const fid = String(frameId || '').trim();
+  if (!fid || !doc) return false;
+  if (!opts?.imagesOnly) return true;
+  const frame = (Array.isArray(doc.frames) ? doc.frames : []).find(
+    (f) => String(f?.id || '') === fid
+  );
+  if (!frame || frame.hidden) return false;
+  // 动画工作台 is LOT ink — never a valid image reference.
+  if (isAnimationArtboardKind(frame.kind)) return false;
+  const bound = nodeIdsBoundToFrames(doc, [fid]);
+  return filterChatAttachNodeIds(doc, bound, opts).some(
+    (id) => doc.deltaSetLike?.[id]?.key === 'image'
+  );
+}
 
 /** Resolve a pick click into an attach payload, or null if empty / only blocked nodes. */
 export function resolveAttachPickPayload(
@@ -77,7 +104,12 @@ export function resolveAttachPickPayload(
   }
   if (seed.length) return { payload: '', blockedOnly: true };
   const fid = String(frameId || '').trim();
-  if (fid) return { payload: `frame:${fid}`, blockedOnly: false };
+  if (fid) {
+    if (!canAttachFrameToPick(doc, fid, opts)) {
+      return { payload: '', blockedOnly: true };
+    }
+    return { payload: `frame:${fid}`, blockedOnly: false };
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Hover over LOT workbench correctly showed not-allowed for imagesOnly pick, but click used `frame:` / full-bleed shortcuts and still filled the composer.
- Add `canAttachFrameToPick` (reject animation plates / empty boards for image pick) and use it in onSelectFrame / plate shortcuts / hover.

## Test plan
- [x] vitest attachPick.imagesOnlyFrame + fullBleed
- [ ] Manual: image generator 从画布选择 → hover LOT shows disabled → click does not add chip

Made with [Cursor](https://cursor.com)