### PR TITLE
fix(web): multi artboard/animation marquee needs one control box

### DIFF
--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -715,9 +715,12 @@ function SelectionFeature({
     // Derive ids from keys so a new array reference does not recreate origins
     // every render (that caused Maximum update depth loops).
     const ids = idsKey ? idsKey.split('|').filter(Boolean) : [];
-    // Soft frame focus uses plate edge highlight only — never feed frames into control chrome.
+    // Soft frame focus uses plate edge highlight only — never feed a *single*
+    // soft frame into control chrome. Multi-frame selection always needs the
+    // union box (marquee), even if chrome mode briefly lags soft.
     const fids =
-      frameChromeMode === 'full' && frameIdsKey
+      (frameChromeMode === 'full' || (frameIdsKey && frameIdsKey.includes('|'))) &&
+      frameIdsKey
         ? frameIdsKey.split('|').filter(Boolean)
         : [];
     const nodeOrigins = ids

--- a/apps/web/src/components/rcb/selection/__tests__/multiFrameSelectionChrome.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/multiFrameSelectionChrome.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  editorReducers,
+  reduceEditor,
+  createTemplate,
+} from '@/store/modules/editor';
+import { createEmptyDocument } from '@/components/rcb/scene/document/sceneDocument';
+import { buildShapeOutlines } from '@/components/rcb/selection/selectionLogic';
+
+function seedWithTwoAnimationBoards() {
+  let state = reduceEditor(undefined, () => {});
+  state = reduceEditor(state, editorReducers.createTemplate, {
+    name: 'multi-frame-chrome',
+    document: createEmptyDocument({ emptyWorld: true }),
+    emptyWorld: true,
+    source: 'scratch',
+  });
+  const doc = {
+    ...state.document!,
+    frames: [
+      {
+        id: 'a1',
+        kind: 'animation',
+        name: '动画',
+        x: 0,
+        y: 0,
+        width: 413,
+        height: 413,
+        backgroundColor: '#fff',
+      },
+      {
+        id: 'a2',
+        kind: 'animation',
+        name: '动画',
+        x: 500,
+        y: 0,
+        width: 413,
+        height: 413,
+        backgroundColor: '#fff',
+      },
+    ],
+    stackOrder: ['frame:a1', 'frame:a2'],
+  };
+  state = reduceEditor(state, editorReducers.setDocumentFromCanvas, doc as any);
+  return state;
+}
+
+describe('multi artboard/animation selection chrome', () => {
+  it('setMixedSelection (marquee) uses full chrome for multi frames', () => {
+    let state = seedWithTwoAnimationBoards();
+    state = reduceEditor(state, editorReducers.setMixedSelection, {
+      nodeIds: [],
+      frameIds: ['a1', 'a2'],
+    });
+    expect(state.selectedFrameIds).toEqual(['a1', 'a2']);
+    expect(state.frameChromeMode).toBe('full');
+  });
+
+  it('buildShapeOutlines emits one union box for multi frames', () => {
+    const state = seedWithTwoAnimationBoards();
+    const outlines = buildShapeOutlines({
+      enabled: true,
+      suppressChrome: false,
+      readOnly: false,
+      document: state.document!,
+      selectedNodeIds: [],
+      selectedFrameIds: ['a1', 'a2'],
+      hoverNodeId: null,
+      inspectDev: false,
+      transforming: false,
+      inspectPrimaryId: null,
+      inspectPairNodeId: null,
+      singleId: null,
+      chromeAngle: 0,
+      selectedIsImageGen: false,
+      selectedIsVideoGen: false,
+      liveOrigins: null,
+      getNodeBox: () => null,
+    });
+    const union = outlines.find((o) => o.id === '__rcb_frame_union__');
+    expect(union).toBeTruthy();
+    expect(union!.unionChrome).toBe(true);
+    expect(union!.withHandles).toBe(true);
+    expect(outlines.filter((o) => String(o.id).startsWith('__frame__:')).length).toBe(0);
+  });
+});

--- a/apps/web/src/store/modules/editor.ts
+++ b/apps/web/src/store/modules/editor.ts
@@ -1645,8 +1645,15 @@ export const editorReducers = {
       state.selectedNodeIds = Array.from(new Set(nodeIds));
       state.selectedNodeId = state.selectedNodeIds[0] || null;
       state.selectedFrameIds = frameIds;
-      // Marquee / interior work stays soft — title / layer panel set full explicitly.
-      state.frameChromeMode = 'soft';
+      // Multi artboard / 动画 units need full chrome (one union control box).
+      // Soft is for single occupied-plate interior focus — marquee multi must not
+      // stay soft or each plate only gets an edge highlight with no shared handles.
+      if (frameIds.length > 1 && state.selectedNodeIds.length === 0) {
+        state.frameChromeMode = 'full';
+      } else {
+        // Marquee / interior work stays soft — title / layer panel set full explicitly.
+        state.frameChromeMode = 'soft';
+      }
       if (nodeIds.length) pauseLottieIfPlaying(state);
       if (shouldClearImageToolPanelOnSelect(state.imageToolPanel, nodeIds[0] || null)) {
         state.imageToolPanel = null;


### PR DESCRIPTION
## Summary
- Marquee of 2+ artboards/动画 used `setMixedSelection` which forced soft chrome → per-plate edge highlight only, no shared handles.
- Frames-only multi-select now uses full chrome; SelectionFeature also includes multi frame ids in control origins.

## Test plan
- [x] vitest multiFrameSelectionChrome
- [ ] Manual: marquee two 动画 boards → one blue union box with handles

Made with [Cursor](https://cursor.com)