### PR TITLE
fix(web): select artboards on marquee intersection

### DIFF
--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -145,6 +145,7 @@ import {
   marqueeHitPadScene,
   MARQUEE_MIN_HIT_SCREEN_PX,
   framesHittingMarquee,
+  resolveMarqueeFrameHits,
   resolveInspectPrimaryId,
   isHostInjectedSelection,
   frameForFullBleedPlate,
@@ -2192,9 +2193,16 @@ function SelectionFeature({
         const rawHits = candidates.filter((id) =>
           nodeHitsMarquee(sceneDoc, id, box, getNodeBox, toScene, zoom)
         );
-        const frameHits = framesHittingMarquee(sceneDoc, box).map((f) => f.id);
-        // Full-bleed plate: keep when artboard brushed, or other non-plate content hit.
-        const contentHits = filterMarqueeContentHits(sceneDoc, rawHits, new Set(frameHits), box);
+        // Intersecting plates for content filter; commit uses crossing when the
+        // brush only hits boards, enclosure when content is also selected.
+        const intersectingFrameIds = framesHittingMarquee(sceneDoc, box).map((f) => f.id);
+        const contentHits = filterMarqueeContentHits(
+          sceneDoc,
+          rawHits,
+          new Set(intersectingFrameIds),
+          box
+        );
+        const frameHits = resolveMarqueeFrameHits(sceneDoc, box, contentHits.length);
         commitMarqueeSelection({
           contentHits,
           frameHits,

--- a/apps/web/src/components/rcb/selection/__tests__/postSplitCanvasRegression.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/postSplitCanvasRegression.test.ts
@@ -12,6 +12,7 @@ import {
   computeMovedUnion,
   computeResizedUnion,
   framesHittingMarquee,
+  resolveMarqueeFrameHits,
   filterMarqueeContentHits,
   commitMarqueeSelection,
   normalizeBox,
@@ -300,8 +301,21 @@ describe('selectionLogic marquee helpers', () => {
     const hits = framesHittingMarquee(doc, { left: 0, top: 0, width: 120, height: 120 });
     expect(hits.map((h) => h.id)).toEqual(['f1']);
 
+    // Crossing select: partial overlap still hits the artboard.
     const partialHits = framesHittingMarquee(doc, { left: 0, top: 0, width: 80, height: 80 });
-    expect(partialHits).toEqual([]);
+    expect(partialHits.map((h) => h.id)).toEqual(['f1']);
+    // Empty brush → commit crossing frames.
+    expect(resolveMarqueeFrameHits(doc, { left: 0, top: 0, width: 80, height: 80 }, 0)).toEqual([
+      'f1',
+    ]);
+    // Content also hit → only fully enclosed plates join the selection.
+    expect(resolveMarqueeFrameHits(doc, { left: 0, top: 0, width: 80, height: 80 }, 1)).toEqual([]);
+    expect(resolveMarqueeFrameHits(doc, { left: 0, top: 0, width: 120, height: 120 }, 1)).toEqual([
+      'f1',
+    ]);
+
+    const missHits = framesHittingMarquee(doc, { left: 150, top: 150, width: 20, height: 20 });
+    expect(missHits).toEqual([]);
 
     const filtered = filterMarqueeContentHits(doc, ['n1', 'n2', 'n3', 'n4'], new Set(['f1']));
     expect(filtered).toContain('n1');

--- a/apps/web/src/components/rcb/selection/selectionLogic.ts
+++ b/apps/web/src/components/rcb/selection/selectionLogic.ts
@@ -389,9 +389,29 @@ export function ensureMinScreenHitBox(box: SceneBox, zoom: number): SceneBox {
   };
 }
 
+/** True when the marquee completely contains the artboard plate. */
+export function frameFullyEnclosedByMarquee(
+  frame: { x?: unknown; y?: unknown; width?: unknown; height?: unknown },
+  marquee: SceneBox
+): boolean {
+  const fb: SceneBox = {
+    left: Number(frame.x) || 0,
+    top: Number(frame.y) || 0,
+    width: Math.max(1, Number(frame.width) || 1),
+    height: Math.max(1, Number(frame.height) || 1),
+  };
+  return (
+    marquee.left <= fb.left &&
+    marquee.top <= fb.top &&
+    marquee.left + marquee.width >= fb.left + fb.width &&
+    marquee.top + marquee.height >= fb.top + fb.height
+  );
+}
+
 /**
- * Return frames fully enclosed by the marquee. A frame is not a normal content
- * node: merely crossing its plate must not select it while selecting children.
+ * Return frames that intersect the marquee (crossing select).
+ * Same rule as scene nodes — requiring full enclosure made artboard / 动画
+ * boards unselectable until the brush swallowed the whole plate.
  */
 export function framesHittingMarquee(doc: SceneDocument, marquee: SceneBox): Array<{ id: string; area: number }> {
   const frames = Array.isArray(doc?.frames) ? doc.frames : [];
@@ -404,16 +424,32 @@ export function framesHittingMarquee(doc: SceneDocument, marquee: SceneBox): Arr
       width: Math.max(1, Number(f.width) || 1),
       height: Math.max(1, Number(f.height) || 1),
     };
-    const contains =
-      marquee.left <= fb.left &&
-      marquee.top <= fb.top &&
-      marquee.left + marquee.width >= fb.left + fb.width &&
-      marquee.top + marquee.height >= fb.top + fb.height;
-    if (!contains) continue;
+    if (!boxesIntersect(marquee, fb)) continue;
     out.push({ id: String(f.id), area: fb.width * fb.height });
   }
   out.sort((a, b) => b.area - a.area);
   return out;
+}
+
+/**
+ * Frames to commit from a marquee: crossing when the brush only hits plates;
+ * fully enclosed plates only when scene content is also hit (so grazing a
+ * child does not also select its parent artboard).
+ */
+export function resolveMarqueeFrameHits(
+  doc: SceneDocument,
+  marquee: SceneBox,
+  contentHitCount: number
+): string[] {
+  const intersecting = framesHittingMarquee(doc, marquee);
+  if (contentHitCount <= 0) return intersecting.map((h) => h.id);
+  const frames = Array.isArray(doc?.frames) ? doc.frames : [];
+  return intersecting
+    .filter((h) => {
+      const frame = frames.find((f) => String(f?.id) === h.id);
+      return frame ? frameFullyEnclosedByMarquee(frame, marquee) : false;
+    })
+    .map((h) => h.id);
 }
 
 /** Synthetic selection id so frames share the same union chrome / transform path as nodes. */
@@ -1098,7 +1134,7 @@ export function commitMarqueeSelection(opts: {
   const uniqueFrameHits = [...new Set(frameHits.filter(Boolean))];
   const selectedContent = contentHits.length ? contentHits : rawHits;
 
-  // Multiple fully enclosed artboards — select as units; canvas-root nodes in
+  // Multiple intersecting artboards — select as units; canvas-root nodes in
   // the same brush (outside those frames) can still join the selection.
   if (uniqueFrameHits.length > 1) {
     if (onSelectMixed) {
@@ -1117,7 +1153,7 @@ export function commitMarqueeSelection(opts: {
     }
   }
 
-  // A single fully enclosed artboard is selected only when no scene content
+  // A single intersecting artboard is selected only when no scene content
   // was hit. If content is present, the user is selecting that content.
   if (uniqueFrameHits.length === 1 && contentHits.length === 0) {
     if (onSelectFrame) onSelectFrame(uniqueFrameHits[0]);


### PR DESCRIPTION
## Summary
- Artboard / 动画 plates now use **crossing** marquee select (partial overlap is enough) when the brush only hits empty plates.
- When scene content is also hit, plates still need full enclosure so grazing a child does not co-select its parent board.

## Test plan
- [x] `vitest` `postSplitCanvasRegression.test.ts` (33 passed)
- [ ] Drag a partial marquee over empty artboards / 动画 — both should select
- [ ] Partial marquee over a shape inside a board — shape only, not the parent plate