### PR TITLE
fix(web): move multi artboard selection together and trim mixed toolbar

### DIFF
--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -716,14 +716,18 @@ function SelectionFeature({
     // Derive ids from keys so a new array reference does not recreate origins
     // every render (that caused Maximum update depth loops).
     const ids = idsKey ? idsKey.split('|').filter(Boolean) : [];
-    // Soft frame focus uses plate edge highlight only — never feed a *single*
-    // soft frame into control chrome. Multi-frame selection always needs the
-    // union box (marquee), even if chrome mode briefly lags soft.
-    const fids =
-      (frameChromeMode === 'full' || (frameIdsKey && frameIdsKey.includes('|'))) &&
-      frameIdsKey
-        ? frameIdsKey.split('|').filter(Boolean)
-        : [];
+    // Soft single-frame focus: plate edge only — no control chrome.
+    // Multi-frame or mixed (nodes + frames) always need frames in the union
+    // so drag/move can seed every `__frame__:` origin together.
+    const fids = (() => {
+      if (!frameIdsKey) return [];
+      const list = frameIdsKey.split('|').filter(Boolean);
+      if (!list.length) return [];
+      if (list.length > 1) return list;
+      if (idsKey) return list; // mixed selection
+      if (frameChromeMode === 'full') return list;
+      return [];
+    })();
     const nodeOrigins = ids
       .map((id) => {
         const box = getNodeBox(id);
@@ -1434,6 +1438,22 @@ function SelectionFeature({
         e.preventDefault();
         e.stopPropagation();
 
+        // Member of an existing multi / mixed selection: move the whole union.
+        // Calling onSelectFrame → setActiveFrameId would collapse to one plate.
+        const selectionTotal = storeFrameIds.length + storeNodeIds.length;
+        if (
+          !readOnly &&
+          !e.shiftKey &&
+          storeFrameIds.includes(frameId) &&
+          selectionTotal > 1 &&
+          (liveOriginsNow?.length ?? 0) > 0
+        ) {
+          if (beginMoveSelection()) {
+            clickLog('multi-selection-plate-move', { ...hitExtras, frameId });
+            return;
+          }
+        }
+
         const mode = resolveFramePlateDragMode(sceneDoc, frameId, {
           readOnly,
           canMove: Boolean(onFrameMoveRef.current),
@@ -1703,21 +1723,31 @@ function SelectionFeature({
           return;
         }
       }
+      // Multi-frame / mixed / nodes-only: unified mode:'move' (geom path already
+      // applies `__frame__:` patches). Single empty plate uses frame_move above.
       if (
         !readOnly &&
-        !selectionHasFrame &&
         pointInLiveUnion &&
-        (liveOriginsNow?.length ?? 0) > 0
+        (liveOriginsNow?.length ?? 0) > 0 &&
+        !(frameOnlySelection && liveOriginsNow!.length === 1)
       ) {
         const liveNodeIds = liveOriginsNow
           .map((o) => o.nodeId)
           .filter((id) => !parseFrameSelId(id));
+        const liveFrameIds = liveOriginsNow
+          .map((o) => parseFrameSelId(o.nodeId))
+          .filter((id): id is string => Boolean(id));
         // Store drives chrome/toolbar. liveOrigins can stay hot after a missed
         // pointerup while store is empty — move without onSelect = no chrome.
+        // Never onSelect(nodes-only) when frames are in the live union — that
+        // would drop artboards from the selection mid-gesture.
         const storeCoversLive =
-          liveNodeIds.length > 0 &&
-          liveNodeIds.every((id) => storeNodeIds.includes(id));
-        const resyncedStore = !storeCoversLive && liveNodeIds.length > 0;
+          (liveNodeIds.length === 0 ||
+            liveNodeIds.every((id) => storeNodeIds.includes(id))) &&
+          (liveFrameIds.length === 0 ||
+            liveFrameIds.every((id) => storeFrameIds.includes(id)));
+        const resyncedStore =
+          !storeCoversLive && liveNodeIds.length > 0 && liveFrameIds.length === 0;
         if (resyncedStore) {
           onSelect(expandSelectionWithGroups(sceneDoc, liveNodeIds));
         }
@@ -1728,6 +1758,7 @@ function SelectionFeature({
             dragMode: 'move',
             calledOnSelect: resyncedStore,
             liveNodeIds,
+            liveFrameIds,
           });
           return;
         }

--- a/apps/web/src/components/rcb/selection/__tests__/multiFrameSelectionChrome.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/multiFrameSelectionChrome.test.ts
@@ -56,6 +56,35 @@ describe('multi artboard/animation selection chrome', () => {
     expect(state.frameChromeMode).toBe('full');
   });
 
+  it('setMixedSelection uses full chrome for frames + scene nodes', () => {
+    let state = seedWithTwoAnimationBoards();
+    const doc = {
+      ...state.document!,
+      deltaSetLike: {
+        ...(state.document!.deltaSetLike || {}),
+        n1: {
+          id: 'n1',
+          key: 'rect',
+          x: 100,
+          y: 400,
+          width: 40,
+          height: 40,
+          attrs: {},
+          children: [],
+        },
+      },
+      stackOrder: [...(state.document!.stackOrder || []), 'n1'],
+    };
+    state = reduceEditor(state, editorReducers.setDocumentFromCanvas, doc as any);
+    state = reduceEditor(state, editorReducers.setMixedSelection, {
+      nodeIds: ['n1'],
+      frameIds: ['a1', 'a2'],
+    });
+    expect(state.selectedNodeIds).toEqual(['n1']);
+    expect(state.selectedFrameIds).toEqual(['a1', 'a2']);
+    expect(state.frameChromeMode).toBe('full');
+  });
+
   it('buildShapeOutlines emits one union box for multi frames', () => {
     const state = seedWithTwoAnimationBoards();
     const outlines = buildShapeOutlines({

--- a/apps/web/src/components/rcb/selection/chrome/MultiSelectionToolbar.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/MultiSelectionToolbar.tsx
@@ -369,15 +369,20 @@ function MultiSelectionToolbar({
   box,
   angle = 0,
   edgePadScene = 0,
-}: Props): ReactNode {  const { t } = useTranslation();
+}: Props): ReactNode {
+  const { t } = useTranslation();
   const [distributeOpen, setDistributeOpen] = useState(false);
   const [booleanOpen, setBooleanOpen] = useState(false);
   const [ratioOpen, setRatioOpen] = useState(false);
 
-  /** Explicit nodes — content inside co-selected artboards. */
+  /** Artboards co-selected: do not expand plate children into style ops. */
+  const selectionHasFrames = (frameIds?.length ?? 0) > 0;
   const opNodeIds = useMemo(
-    () => resolveSelectionNodeIds(document, nodeIds, frameIds),
-    [document, nodeIds, frameIds]
+    () =>
+      selectionHasFrames
+        ? (nodeIds || []).filter(Boolean)
+        : resolveSelectionNodeIds(document, nodeIds, frameIds),
+    [document, nodeIds, frameIds, selectionHasFrames]
   );
 
   const boxes = useMemo(() => readBoxes(document, opNodeIds), [document, opNodeIds]);
@@ -416,9 +421,12 @@ function MultiSelectionToolbar({
   const allGenerators =
     opNodeIds.length > 0 &&
     opNodeIds.every((id) => isGeneratorNode(document?.deltaSetLike?.[id]));
-  const showStyleChrome = !allGenerators && (showFill || showStroke || showCornerRadius);
-  const showGeometryChrome = !allGenerators;
-  const showActionChrome = !allGenerators;
+  // Mixed with artboards / 动画: keep align only — opacity / blend / group are
+  // node-style chrome and do not apply to plates (FrameMultiSelectionToolbar).
+  const showStyleChrome =
+    !selectionHasFrames && !allGenerators && (showFill || showStroke || showCornerRadius);
+  const showGeometryChrome = !selectionHasFrames && !allGenerators;
+  const showActionChrome = !selectionHasFrames && !allGenerators;
 
   const activeRatioId = useMemo(
     () => matchAspectPresetKey(box.width, box.height, ELEMENT_ASPECT_PRESETS),

--- a/apps/web/src/store/modules/editor.ts
+++ b/apps/web/src/store/modules/editor.ts
@@ -1645,10 +1645,13 @@ export const editorReducers = {
       state.selectedNodeIds = Array.from(new Set(nodeIds));
       state.selectedNodeId = state.selectedNodeIds[0] || null;
       state.selectedFrameIds = frameIds;
-      // Multi artboard / 动画 units need full chrome (one union control box).
-      // Soft is for single occupied-plate interior focus — marquee multi must not
-      // stay soft or each plate only gets an edge highlight with no shared handles.
-      if (frameIds.length > 1 && state.selectedNodeIds.length === 0) {
+      // Multi artboard / 动画, or mixed frames+nodes: one union control box so
+      // drag moves every member together. Soft is only for single occupied-plate
+      // interior focus (no handles).
+      if (
+        frameIds.length > 1 ||
+        (frameIds.length >= 1 && state.selectedNodeIds.length >= 1)
+      ) {
         state.frameChromeMode = 'full';
       } else {
         // Marquee / interior work stays soft — title / layer panel set full explicitly.


### PR DESCRIPTION
## Summary
- Multi artboard / 动画 (and mixed with scene nodes) now drag as one unit via unified `mode:move` — plate clicks no longer collapse the selection.
- Mixed selection toolbar no longer shows node-only chrome (opacity / blend / create group).

## Test plan
- [x] `vitest` multiFrameSelectionChrome.test.ts
- [ ] Marquee two empty artboards → drag union → both move
- [ ] Marquee artboards + free shape → drag → all move; toolbar has no 不透明度