### PR TITLE
fix(web): keep idle images sharp when atlas cell would downsample

### DIFF
--- a/apps/web/src/components/rcb/index.ts
+++ b/apps/web/src/components/rcb/index.ts
@@ -158,6 +158,9 @@ export {
   isSoaWebglAtlasEnabled,
   SOA_ATLAS_SEG_THRESHOLD,
   SOA_ATLAS_CELL,
+  SOA_ATLAS_INNER,
+  idleMediaNeedsSharpHost,
+  idleMediaScreenEdgePx,
 } from './render/webglInstanceAtlas';
 export {
   subscribeSoaBakeTileReady,

--- a/apps/web/src/components/rcb/render/__tests__/webglInstanceAtlas.test.ts
+++ b/apps/web/src/components/rcb/render/__tests__/webglInstanceAtlas.test.ts
@@ -10,7 +10,10 @@ import {
   pruneSoaAtlasForBuffer,
   atlasRegionToUv,
   SOA_ATLAS_CELL,
+  SOA_ATLAS_INNER,
   SOA_ATLAS_SEG_THRESHOLD,
+  idleMediaNeedsSharpHost,
+  idleMediaScreenEdgePx,
 } from '../webglInstanceAtlas';
 import {
   createSceneRenderBuffer,
@@ -19,6 +22,15 @@ import {
 } from '../sceneRenderBuffer';
 
 describe('webglInstanceAtlas', () => {
+  it('idleMediaNeedsSharpHost when screen edge exceeds atlas inner cell', () => {
+    expect(SOA_ATLAS_INNER).toBe(SOA_ATLAS_CELL - 4);
+    expect(idleMediaScreenEdgePx(80, 60, 1, 1)).toBe(80);
+    expect(idleMediaNeedsSharpHost({ key: 'image', width: 80, height: 60 }, 1, 1)).toBe(false);
+    expect(idleMediaNeedsSharpHost({ key: 'image', width: 400, height: 300 }, 1, 1)).toBe(true);
+    expect(idleMediaNeedsSharpHost({ key: 'image', width: 80, height: 60 }, 4, 1)).toBe(true);
+    expect(idleMediaNeedsSharpHost({ key: 'video', width: 400, height: 300 }, 1, 1)).toBe(true);
+    expect(idleMediaNeedsSharpHost({ key: 'shape', width: 400, height: 300 }, 1, 1)).toBe(false);
+  });
   it('shelf-packs stamped polylines and returns UVs', () => {
     const atlas = createSoaWebglAtlas(512, 128);
     if (!atlas) return;

--- a/apps/web/src/components/rcb/render/webglInstanceAtlas.ts
+++ b/apps/web/src/components/rcb/render/webglInstanceAtlas.ts
@@ -15,8 +15,39 @@ import {
 export const SOA_ATLAS_DEFAULT_SIZE = 2048;
 export const SOA_ATLAS_CELL = 256;
 export const SOA_ATLAS_PAD = 2;
+/** Usable texels per cell after padding — idle media softer than this on screen. */
+export const SOA_ATLAS_INNER = SOA_ATLAS_CELL - SOA_ATLAS_PAD * 2;
 /** Prefer atlas stamp when a path would emit at least this many segments. */
 export const SOA_ATLAS_SEG_THRESHOLD = 12;
+
+/** Longest screen edge (CSS px × dpr) for an idle media stamp. */
+export function idleMediaScreenEdgePx(
+  width: number,
+  height: number,
+  zoom: number,
+  dpr = 1
+): number {
+  const edge = Math.max(Math.max(1, Number(width) || 1), Math.max(1, Number(height) || 1));
+  return edge * Math.max(0.05, Number(zoom) || 1) * Math.max(1, Number(dpr) || 1);
+}
+
+/**
+ * Idle image/video stamps into a fixed atlas cell. When the on-screen edge
+ * exceeds that cell, the stamp looks soft until selection paint-raises a
+ * full-res SVG host — promote those nodes to DOM hosts while zoomed in.
+ */
+export function idleMediaNeedsSharpHost(
+  node: { key?: unknown; width?: unknown; height?: unknown } | null | undefined,
+  zoom: number,
+  dpr = 1
+): boolean {
+  if (!node) return false;
+  const key = String(node.key || '');
+  if (key !== 'image' && key !== 'video') return false;
+  return idleMediaScreenEdgePx(Number(node.width) || 1, Number(node.height) || 1, zoom, dpr) >
+    SOA_ATLAS_INNER;
+}
+
 
 export type SoaAtlasRegion = {
   key: string;

--- a/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
@@ -40,6 +40,7 @@ import {
   requestIdleCanvasFullRepaint,
   setSceneCanvasIdlePaint,
 } from '@/components/rcb/render/sceneRenderer';
+import { idleMediaNeedsSharpHost } from '@/components/rcb/render/webglInstanceAtlas';
 import {
   getLiveCornerRadiusPreviewNodeId,
   subscribeLiveCornerRadiusPreview,
@@ -475,6 +476,8 @@ export function pickFullAndCanvasIds(opts: {
   /** Kept for API compat; plate raise is data-z on the shared mount. */
   paintRaiseFrameIds?: ReadonlySet<string> | readonly string[];
   zoom: number;
+  /** Device pixel ratio for idle media sharpness (defaults to window.devicePixelRatio). */
+  dpr?: number;
   maxCanvasInk?: number;
 }): { fullIds: string[]; canvasIds: string[] } {
   const { document, visibleIds, zoom } = opts;
@@ -486,6 +489,9 @@ export function pickFullAndCanvasIds(opts: {
       : new Set(opts.paintRaiseIds)
     : null;
   const maxCanvasInk = opts.maxCanvasInk ?? MAX_CANVAS_INK_PAINT;
+  const dpr =
+    opts.dpr ??
+    (typeof window !== 'undefined' ? Number(window.devicePixelRatio) || 1 : 1);
   const fullIds: string[] = [];
   const canvasRaw: string[] = [];
   for (const id of visibleIds) {
@@ -495,7 +501,10 @@ export function pickFullAndCanvasIds(opts: {
       forceFullSet.has(id) ||
       Boolean(holdHostIds?.has(id)) ||
       Boolean(paintRaiseSet?.has(id)) ||
-      worldNodeStacksAboveAnyFrame(document, id);
+      worldNodeStacksAboveAnyFrame(document, id) ||
+      // Atlas cell (~252px) cannot stay sharp for large/zoomed images — same
+      // class of soft-idle bug as rounded-rect SDF before shader fill.
+      idleMediaNeedsSharpHost(node, zoom, dpr);
     if (nodeNeedsDomShapeHost(node, forceHost)) fullIds.push(id);
     else canvasRaw.push(id);
   }

--- a/apps/web/src/components/rcb/shapes/__tests__/canvasIdleHostBudget.test.ts
+++ b/apps/web/src/components/rcb/shapes/__tests__/canvasIdleHostBudget.test.ts
@@ -151,9 +151,44 @@ describe('pickFullAndCanvasIds (single ink path)', () => {
       document: doc,
       visibleIds: ['t0', 'p0', 'i0'],
       zoom: 1,
+      dpr: 1,
     });
     expect(fullIds).toEqual([]);
     expect(canvasIds.sort()).toEqual(['i0', 'p0', 't0']);
+  });
+
+  it('promotes large/zoomed idle images to DOM hosts (atlas cell would soft-downsample)', () => {
+    const large = {
+      ...imageNode('big'),
+      width: 400,
+      height: 300,
+    };
+    const doc = makeDoc({ big: large, small: imageNode('small') });
+    const at1x = pickFullAndCanvasIds({
+      document: doc,
+      visibleIds: ['big', 'small'],
+      zoom: 1,
+      dpr: 1,
+    });
+    expect(at1x.fullIds).toEqual(['big']);
+    expect(at1x.canvasIds).toEqual(['small']);
+
+    const zoomedSmall = pickFullAndCanvasIds({
+      document: doc,
+      visibleIds: ['small'],
+      zoom: 4,
+      dpr: 1,
+    });
+    expect(zoomedSmall.fullIds).toEqual(['small']);
+    expect(zoomedSmall.canvasIds).toEqual([]);
+
+    const retinaSmall = pickFullAndCanvasIds({
+      document: doc,
+      visibleIds: ['small'],
+      zoom: 1,
+      dpr: 4,
+    });
+    expect(retinaSmall.fullIds).toEqual(['small']);
   });
 
   it('forceFullSet keeps a canvas-ink node as a DOM host', () => {


### PR DESCRIPTION
## Summary
- Idle world images/videos were soft because SoA atlas cells (~252px) cannot match retina/zoomed screen size; selection looked sharp via paint-raise SVG host.
- Promote oversized/zoomed idle media to DOM hosts so clarity matches the selected state.

## Test plan
- [x] vitest canvasIdleHostBudget + webglInstanceAtlas
- [ ] Deselect a logo/image on retina or zoomed canvas — stays sharp
- [ ] Small icons at 100% 1x still use atlas (no host spam)