### PR TITLE
fix(web): keep empty generators on DOM hosts when deselected

### DIFF
--- a/apps/web/src/components/rcb/render/__tests__/sceneRenderer.test.ts
+++ b/apps/web/src/components/rcb/render/__tests__/sceneRenderer.test.ts
@@ -1355,7 +1355,13 @@ describe('Canvas idle path / text / shape paint', () => {
         key: 'audio',
         attrs: { src: '', audioGenerator: true },
       } as SceneNodeInput)
-    ).toBe(true);
+    ).toBe(false);
+    expect(
+      canIdlePaintOnCanvas({
+        key: 'image',
+        attrs: { src: '', imageGenerator: true },
+      } as SceneNodeInput)
+    ).toBe(false);
     expect(
       canIdlePaintOnCanvas({
         key: 'audio',

--- a/apps/web/src/components/rcb/render/sceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/sceneRenderer.ts
@@ -17,7 +17,7 @@ import {
   radiiFromAttrs,
 } from '@/components/rcb/scene/document/sceneRadii';
 import { getShapeHost } from '@/components/rcb/shapes/shapeHostRegistry';
-import { isImageProcessRunning } from '@/components/rcb/scene/document/nodeCapabilities';
+import { isGeneratorNode, isImageProcessRunning } from '@/components/rcb/scene/document/nodeCapabilities';
 import { PROCESS_PLATE_STROKE } from '@/components/rcb/process/processGlow';
 import { paintProcessPlateCanvas } from '@/components/rcb/process/processPlateSvg';
 import {
@@ -950,6 +950,9 @@ function isTransparentCssColor(c: string): boolean {
 export function canIdlePaintOnCanvas(node: SceneNodeInput | null | undefined): boolean {
   if (!node) return false;
   if (isImageProcessRunning(node)) return false;
+  // Empty image/video generators have no src — WebGL atlas bake returns null and
+  // the plate vanishes until paint-raise. Keep them on SVG hosts (--gen-empty).
+  if (isGeneratorNode(node)) return false;
   const key = String(node.key || '');
   if (key === 'lottie' || key === 'group') {
     return false;

--- a/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
@@ -354,6 +354,7 @@ export function nodeNeedsDomShapeHost(
   if (String(node.attrs?.frameId || '').trim()) return true;
   const key = String(node.key || '');
   // Static text —canvas ink; caret —TextInlineEditor overlay.
+  // Image/video/audio/lottie *generators* stay DOM (--gen-empty plate; no atlas src).
   // Static image —paintCanvasMediaInk; SoftGlow process still forceFull above.
   // Video/audio idle —canvas poster/plate; selected decoder is forceFull (FO + HTML).
   if (key === 'lottie' || key === 'group') return true;

--- a/apps/web/src/components/rcb/shapes/__tests__/canvasIdleHostBudget.test.ts
+++ b/apps/web/src/components/rcb/shapes/__tests__/canvasIdleHostBudget.test.ts
@@ -191,6 +191,48 @@ describe('pickFullAndCanvasIds (single ink path)', () => {
     expect(retinaSmall.fullIds).toEqual(['small']);
   });
 
+  it('keeps idle image/video/audio generators as DOM hosts (empty plate has no atlas src)', () => {
+    const imgGen = {
+      id: 'ig',
+      key: 'image',
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 200,
+      attrs: { src: '', imageGenerator: true },
+    };
+    const vidGen = {
+      id: 'vg',
+      key: 'video',
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 200,
+      attrs: { src: '', videoGenerator: true },
+    };
+    const audGen = {
+      id: 'ag',
+      key: 'audio',
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 80,
+      attrs: { audioGenerator: true },
+    };
+    const doc = makeDoc({ ig: imgGen, vg: vidGen, ag: audGen, i0: imageNode('i0') });
+    const { fullIds, canvasIds } = pickFullAndCanvasIds({
+      document: doc,
+      visibleIds: ['ig', 'vg', 'ag', 'i0'],
+      zoom: 1,
+      dpr: 1,
+    });
+    expect(fullIds.sort()).toEqual(['ag', 'ig', 'vg']);
+    expect(canvasIds).toEqual(['i0']);
+    expect(canIdlePaintOnCanvas(imgGen as any)).toBe(false);
+    expect(canIdlePaintOnCanvas(vidGen as any)).toBe(false);
+    expect(canIdlePaintOnCanvas(audGen as any)).toBe(false);
+  });
+
   it('forceFullSet keeps a canvas-ink node as a DOM host', () => {
     const nodes: Record<string, any> = {};
     for (let i = 0; i < 40; i += 1) nodes[`n${i}`] = rect(`n${i}`);
@@ -432,7 +474,7 @@ describe('canIdlePaintOnCanvas', () => {
         height: 80,
         attrs: { audioGenerator: true },
       } as never)
-    ).toBe(true);
+    ).toBe(false);
     expect(
       canIdlePaintOnCanvas({
         id: 'l0',


### PR DESCRIPTION
## Summary
- Empty generators were not deleted on blank click — they demoted to WebGL idle ink, `bakeMediaInkForAtlas` returned null (no src), so nothing was stamped.
- Keep generator nodes as permanent DOM hosts so `--gen-empty` stays visible when deselected.

## Test plan
- [x] vitest canIdlePaintOnCanvas / generator host budget
- [ ] Add 图像生成器 → click blank → plate still visible