### PR TITLE
fix(web): keep frame clip on video/audio decoder hosts

### DIFF
--- a/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
@@ -382,12 +382,20 @@ export function soaBufferMembershipChanged(
  * unclipped selection chrome. Idle (unselected) ink stays clipped.
  * Frame-only selection must NOT reveal child overflow — pass selected node ids
  * (not frame-kept cull ids) into the reveal set.
+ *
+ * Video/audio stay as forceFull DOM hosts for the HTML decoder, but must NOT
+ * clear clipContent — sole-on-board media would otherwise paint past the Frame.
  */
 export function shouldRevealShapeOverflow(
   selectedOrForceFull: boolean,
-  _node: SceneNodeInput | null | undefined
+  node: SceneNodeInput | null | undefined
 ): boolean {
-  return selectedOrForceFull;
+  if (!selectedOrForceFull) return false;
+  const key = String(node?.key || '');
+  if (key === 'video' || key === 'audio') {
+    return isImageProcessRunning(node);
+  }
+  return true;
 }
 
 type Props = {
@@ -1027,8 +1035,8 @@ function RcbShapesLayer({
             reloadToken={hostReloadTokenFor(id)}
             frameClipToken={frameClipToken}
             forceHidden={isNodeOverlayHidden(document, node, hiddenNodeId === id)}
-            // Selected / SoftGlow: drop clipContent so overflow matches chrome.
-            // Frame-selected children use paintRaise mount but stay clipped.
+            // SoftGlow / selected shapes: drop clip so overflow matches chrome.
+            // Video/audio keep clip even when forceFull (decoder host).
             revealOverflow={shouldRevealShapeOverflow(
               revealSet.has(id) || forceFullSet.has(id),
               node

--- a/apps/web/src/components/rcb/shapes/__tests__/processRevealOverflow.test.ts
+++ b/apps/web/src/components/rcb/shapes/__tests__/processRevealOverflow.test.ts
@@ -46,6 +46,35 @@ describe('shouldRevealShapeOverflow', () => {
     ).toBe(false);
   });
 
+  it('keeps frame clip for video/audio even when forceFull / selected', () => {
+    expect(
+      shouldRevealShapeOverflow(true, {
+        id: 'v1',
+        key: 'video',
+        attrs: { frameId: 'f1', src: 'https://example.com/a.mp4' },
+      })
+    ).toBe(false);
+    expect(
+      shouldRevealShapeOverflow(true, {
+        id: 'a1',
+        key: 'audio',
+        attrs: { frameId: 'f1', src: 'https://example.com/a.mp3' },
+      })
+    ).toBe(false);
+    expect(
+      shouldRevealShapeOverflow(true, {
+        id: 'v-glow',
+        key: 'video',
+        attrs: {
+          frameId: 'f1',
+          src: 'https://example.com/a.mp4',
+          processStatus: 'running',
+          processKind: 'removeBg',
+        },
+      })
+    ).toBe(true);
+  });
+
   it('frame-selected children stay clipped (reveal flag false)', () => {
     // Selecting the artboard keeps children mounted (cull / paint-raise) but
     // must not pass selectedOrForceFull=true — only selecting the child does.


### PR DESCRIPTION
## Summary
- Video/audio bound to a Frame stayed unclipped because active decoder `forceFull` cleared `clipContent` via `revealOverflow`.
- Decouple decoder host from overflow reveal so media stay clipped like other frame children.

## Test plan
- [x] vitest processRevealOverflow
- [ ] Drop video + audio into a Frame → overflow outside the plate is clipped