### PR TITLE
fix(web): hide empty selection toolbar pill

### DIFF
--- a/apps/web/src/components/editor/chrome/FloatingToolbar.tsx
+++ b/apps/web/src/components/editor/chrome/FloatingToolbar.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, memo, type HTMLAttributes, type ReactNode } from 'react';
+import { Children, forwardRef, memo, type HTMLAttributes, type ReactNode } from 'react';
 import { cn } from '@/utils/classnames';
 
 type FloatingToolbarProps = HTMLAttributes<HTMLDivElement> & {
@@ -14,6 +14,7 @@ type FloatingToolbarProps = HTMLAttributes<HTMLDivElement> & {
 
 /**
  * Floating editor toolbar chrome — pill ends, or flat when docked to the timeline.
+ * Renders nothing when there are no visible children (avoids an empty white pill).
  */
 export const FloatingToolbar = memo(
   forwardRef<HTMLDivElement, FloatingToolbarProps>(
@@ -24,6 +25,12 @@ export const FloatingToolbar = memo(
       children,
       ...rest
     }, ref) {
+      const content = Children.toArray(children).filter((child) => {
+        if (child == null || child === false || child === true) return false;
+        if (Array.isArray(child) && child.length === 0) return false;
+        return true;
+      });
+      if (!content.length) return null;
       const flat = variant === 'flat';
       return (
         <div
@@ -39,7 +46,7 @@ export const FloatingToolbar = memo(
           )}
           {...rest}
         >
-          {children}
+          {content}
         </div>
       );
     }

--- a/apps/web/src/components/editor/chrome/__tests__/FloatingToolbar.test.tsx
+++ b/apps/web/src/components/editor/chrome/__tests__/FloatingToolbar.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { FloatingToolbar } from '../FloatingToolbar';
+
+describe('FloatingToolbar', () => {
+  it('renders nothing when there are no visible children', () => {
+    const { container } = render(
+      <FloatingToolbar>
+        {null}
+        {false}
+        {[]}
+      </FloatingToolbar>
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the pill when there is content', () => {
+    const { container, getByText } = render(
+      <FloatingToolbar>
+        <button type="button">Align</button>
+      </FloatingToolbar>
+    );
+    expect(container.firstChild).not.toBeNull();
+    expect(getByText('Align')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/editor/page/EditorStageWorld.tsx
+++ b/apps/web/src/components/editor/page/EditorStageWorld.tsx
@@ -698,7 +698,9 @@ function EditorStageWorld({
     canvasApplyLock <= 0 &&
     frameChromeMode === 'full' &&
     selectedFrames.length >= 1 &&
-    selectedNodeIds.length === 0 &&
+    // Multi artboards keep their align/lock bar even if a stray node is also
+    // selected (MultiSelectionToolbar hides node chrome when frames are present).
+    (selectedNodeIds.length === 0 || selectedFrames.length > 1) &&
     Boolean(selectedFrameBox) &&
     !selectedFrames.some((frame) => movingFrameIdSet.has(frame.id)) &&
     !selectionTransforming;

--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -3014,6 +3014,9 @@ function SelectionFeature({
     Boolean(chromeUnion) &&
     !single &&
     selectedNodeIds.length >= 1 &&
+    // Artboard / 动画 multi uses FrameMultiSelectionToolbar; avoid an empty
+    // node-style pill when frame co-selection strips style chrome.
+    selectedFrameIds.length === 0 &&
     !transforming &&
     !hideSelectionToolbars &&
     !isAnimationWorkbenchSelection(document, selectedNodeIds, selectedFrameIds);

--- a/apps/web/src/components/rcb/selection/chrome/MultiSelectionToolbar.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/MultiSelectionToolbar.tsx
@@ -989,17 +989,21 @@ function MultiSelectionToolbar({
     </>
   ) : null;
 
+  const sections = joinToolbarSections([
+    styleItems.length ? <>{styleItems}</> : null,
+    layoutItems.length ? (
+      <div className="flex flex-nowrap items-center gap-0.5">{layoutItems}</div>
+    ) : null,
+    booleanMenu,
+    geometryCluster,
+    actionCluster,
+  ]);
+  // Mixed artboards strip node chrome — do not leave an empty FloatingToolbar pill.
+  if (!sections.length) return null;
+
   return (
     <SelectionToolbarShell box={box} angle={angle} edgePadScene={edgePadScene}>
-      {joinToolbarSections([
-        styleItems.length ? <>{styleItems}</> : null,
-        layoutItems.length ? (
-          <div className="flex flex-nowrap items-center gap-0.5">{layoutItems}</div>
-        ) : null,
-        booleanMenu,
-        geometryCluster,
-        actionCluster,
-      ])}
+      {sections}
     </SelectionToolbarShell>
   );
 }


### PR DESCRIPTION
## Summary
- Empty `FloatingToolbar` no longer renders a blank white pill.
- Mixed multi artboard selection uses `FrameMultiSelectionToolbar` instead of an empty node-style bar.

## Test plan
- [x] vitest FloatingToolbar
- [ ] Marquee multi 动画/画板 — no empty white circle; align/lock bar shows when appropriate