### PR TITLE
fix(web): keep empty generators on SoA so stackOrder matches rects

### DIFF
--- a/apps/web/src/components/rcb/render/__tests__/webglInstanceAtlas.test.ts
+++ b/apps/web/src/components/rcb/render/__tests__/webglInstanceAtlas.test.ts
@@ -30,6 +30,34 @@ describe('webglInstanceAtlas', () => {
     expect(idleMediaNeedsSharpHost({ key: 'image', width: 80, height: 60 }, 4, 1)).toBe(true);
     expect(idleMediaNeedsSharpHost({ key: 'video', width: 400, height: 300 }, 1, 1)).toBe(true);
     expect(idleMediaNeedsSharpHost({ key: 'shape', width: 400, height: 300 }, 1, 1)).toBe(false);
+    // Empty generators bake a plate glyph — never sharp-host (would break stackOrder).
+    expect(
+      idleMediaNeedsSharpHost(
+        { key: 'image', width: 360, height: 360, attrs: { src: '', imageGenerator: true } },
+        1,
+        1
+      )
+    ).toBe(false);
+    expect(
+      idleMediaNeedsSharpHost(
+        { key: 'video', width: 640, height: 360, attrs: { src: '', videoGenerator: true } },
+        2,
+        2
+      )
+    ).toBe(false);
+    // Filled generator / real media still promote when oversized.
+    expect(
+      idleMediaNeedsSharpHost(
+        {
+          key: 'image',
+          width: 400,
+          height: 400,
+          attrs: { src: 'https://example.com/a.png', imageGenerator: true },
+        },
+        1,
+        1
+      )
+    ).toBe(true);
   });
   it('shelf-packs stamped polylines and returns UVs', () => {
     const atlas = createSoaWebglAtlas(512, 128);

--- a/apps/web/src/components/rcb/render/webglInstanceAtlas.ts
+++ b/apps/web/src/components/rcb/render/webglInstanceAtlas.ts
@@ -35,15 +35,38 @@ export function idleMediaScreenEdgePx(
  * Idle image/video stamps into a fixed atlas cell. When the on-screen edge
  * exceeds that cell, the stamp looks soft until selection paint-raises a
  * full-res SVG host — promote those nodes to DOM hosts while zoomed in.
+ *
+ * Empty generators are excluded: they bake a plate glyph (no bitmap to sharpen),
+ * and DOM promotion would paint above all SoA rects, breaking stackOrder.
  */
 export function idleMediaNeedsSharpHost(
-  node: { key?: unknown; width?: unknown; height?: unknown } | null | undefined,
+  node:
+    | {
+        key?: unknown;
+        width?: unknown;
+        height?: unknown;
+        attrs?: Record<string, unknown> | null;
+      }
+    | null
+    | undefined,
   zoom: number,
   dpr = 1
 ): boolean {
   if (!node) return false;
   const key = String(node.key || '');
   if (key !== 'image' && key !== 'video') return false;
+  const attrs = node.attrs || {};
+  const isImageGen =
+    attrs.imageGenerator === true || String(attrs.imageGenerator || '') === 'true';
+  const isVideoGen =
+    attrs.videoGenerator === true || String(attrs.videoGenerator || '') === 'true';
+  if (isImageGen || isVideoGen) {
+    const src = String(
+      (key === 'video' ? attrs.poster : null) || attrs.src || ''
+    ).trim();
+    // Empty plate — stay on canvas/atlas idle so stackOrder matches rects.
+    if (!src) return false;
+  }
   return idleMediaScreenEdgePx(Number(node.width) || 1, Number(node.height) || 1, zoom, dpr) >
     SOA_ATLAS_INNER;
 }

--- a/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
@@ -511,8 +511,9 @@ export function pickFullAndCanvasIds(opts: {
       Boolean(holdHostIds?.has(id)) ||
       Boolean(paintRaiseSet?.has(id)) ||
       worldNodeStacksAboveAnyFrame(document, id) ||
-      // Atlas cell (~252px) cannot stay sharp for large/zoomed images — same
-      // class of soft-idle bug as rounded-rect SDF before shader fill.
+      // Atlas cell (~252px) cannot stay sharp for large/zoomed bitmaps.
+      // Empty generators are excluded inside idleMediaNeedsSharpHost so they
+      // stay on SoA and honor unified stackOrder vs rect ink.
       idleMediaNeedsSharpHost(node, zoom, dpr);
     if (nodeNeedsDomShapeHost(node, forceHost)) fullIds.push(id);
     else canvasRaw.push(id);

--- a/apps/web/src/components/rcb/shapes/__tests__/canvasIdleHostBudget.test.ts
+++ b/apps/web/src/components/rcb/shapes/__tests__/canvasIdleHostBudget.test.ts
@@ -192,13 +192,15 @@ describe('pickFullAndCanvasIds (single ink path)', () => {
   });
 
   it('keeps idle image/video/audio generators on canvas ink (empty plate atlas bake)', () => {
+    // Default spawn size is 360×360 — must stay under SoA (not sharp-host DOM),
+    // or generators always paint above canvas rects and break stackOrder.
     const imgGen = {
       id: 'ig',
       key: 'image',
       x: 0,
       y: 0,
-      width: 200,
-      height: 200,
+      width: 360,
+      height: 360,
       attrs: { src: '', imageGenerator: true },
     };
     const vidGen = {
@@ -206,8 +208,8 @@ describe('pickFullAndCanvasIds (single ink path)', () => {
       key: 'video',
       x: 0,
       y: 0,
-      width: 200,
-      height: 200,
+      width: 640,
+      height: 360,
       attrs: { src: '', videoGenerator: true },
     };
     const audGen = {


### PR DESCRIPTION
## Summary
- Empty image/video generators were forced to DOM hosts by sharp-host promotion when larger than the atlas cell, so they always drew above SoA rects regardless of `stackOrder`.
- Exclude empty generators from sharp-host; they already bake plate glyphs on the canvas idle path.

## Test plan
- [x] vitest sharp-host + 360px generator host budget
- [ ] Place generator under/over rects — layer order follows stackOrder after deselect