### PR TITLE
fix(web): sync multi-frame chrome after mode:move commit

### DIFF
--- a/apps/web/src/components/editor/canvas/SvgCanvas.tsx
+++ b/apps/web/src/components/editor/canvas/SvgCanvas.tsx
@@ -460,12 +460,16 @@ function SvgCanvas({
   );
   const overlayRoot = useRcbOverlayRoot();
 
-  const clearFrameGeometryPreview = useCallback(() => {
+  const clearFrameGeometryPreview = useCallback((frameIds?: readonly string[]) => {
     const liveDoc = documentRef.current;
     const frames = Array.isArray(liveDoc?.frames) ? liveDoc.frames : [];
-    const previewIds = [...frameGeometryPreviewIdsRef.current];
-    clearLiveArtboardFrameGeometry(previewIds);
-    previewIds.forEach((id) => {
+    // Prefer explicit commit ids — multi-frame mode:move can cancel the last
+    // preview rAF so the tracked preview set is empty while hosts are still stale.
+    const fromArg = (frameIds || []).map(String).filter(Boolean);
+    const fromPreview = [...frameGeometryPreviewIdsRef.current];
+    const ids = [...new Set(fromArg.length ? [...fromArg, ...fromPreview] : fromPreview)];
+    clearLiveArtboardFrameGeometry(ids.length ? ids : undefined);
+    ids.forEach((id) => {
       const frame = frames.find((item: any) => String(item?.id) === id);
       if (frame) previewArtboardFrameGeometry(frame, { recordLive: false });
     });

--- a/apps/web/src/components/editor/canvas/canvasSession.ts
+++ b/apps/web/src/components/editor/canvas/canvasSession.ts
@@ -691,7 +691,7 @@ export type CanvasSessionDeps = {
   measureViewport: () => DOMRect | null;
   getDragWriteCoalescer: () => DragWriteCoalescer;
   previewFrameGeometry: (frames: ArtboardFrameGeometry[]) => void;
-  clearFrameGeometryPreview: () => void;
+  clearFrameGeometryPreview: (frameIds?: readonly string[]) => void;
   publishVideoLiveGeom: (next: Record<string, VideoGeomOverride> | null) => void;
   clearVideoLiveGeom: () => void;
 };
@@ -1225,8 +1225,10 @@ export function createCanvasSession(deps: CanvasSessionDeps): CanvasSession {
     }
     // Same React turn as the store doc — HTML plates must not fall back to
     // stale coords between commit and onTransformingChange(false).
+    // Pass committed frame ids so multi-frame mode:move rebakes every host even
+    // when the last preview coalesce was cancelled (empty preview set).
     deps.clearVideoLiveGeom();
-    deps.clearFrameGeometryPreview();
+    deps.clearFrameGeometryPreview(frames.map((f) => f.id));
     clearNodeTransformPreviews();
     if (frames.length && board) {
       syncOwnedFrameClipsOnBoard(board, next, { zoom: deps.getZoom() });

--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -781,12 +781,12 @@ function SelectionFeature({
     if (dragRef.current) return;
     // After draw/remount, prefer live host geom so picks match HostPathChrome paint
     // (store AABB alone drifts under sticky lattice at high zoom).
+    // Frames: baseOrigins already went through resolveFrameChromeBox (live plate /
+    // host-if-close / document) — do not overwrite with a bare stale host lattice
+    // after multi-frame mode:move.
     const origins = baseOrigins.map((o) => {
       const frameId = parseFrameSelId(o.nodeId);
-      if (frameId) {
-        const live = liveShapeGeomBox(frameId);
-        return live ? { nodeId: o.nodeId, box: live } : o;
-      }
+      if (frameId) return o;
       const live = liveShapeGeomBox(o.nodeId);
       if (!live) return o;
       const node = document?.deltaSetLike?.[o.nodeId];
@@ -824,7 +824,12 @@ function SelectionFeature({
           angle: 0,
           membersKey,
         };
-        nextUnion = !idsKey && origins[0]?.box ? origins[0].box : selectionUnion;
+        // Multi artboard / 动画: always the full selection union — origins[0]
+        // collapsed the blue box onto the first plate after move (chrome drift).
+        nextUnion =
+          !idsKey && origins.length === 1 && origins[0]?.box
+            ? origins[0].box
+            : selectionUnion;
         nextAngle = 0;
       }
     } else {

--- a/apps/web/src/components/rcb/selection/__tests__/animWorkbenchFrameChromeHide.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/animWorkbenchFrameChromeHide.test.ts
@@ -131,5 +131,8 @@ describe('frame chrome while transforming', () => {
     expect(box.left).toBe(120);
     expect(box.top).toBe(80);
     clearLiveArtboardFrameGeometry(['f1']);
+    const after = resolveFrameChromeBox('f1', { x: 50, y: 60, width: 200, height: 200 });
+    expect(after.left).toBe(50);
+    expect(after.top).toBe(60);
   });
 });

--- a/apps/web/src/components/rcb/selection/selectionLogic.ts
+++ b/apps/web/src/components/rcb/selection/selectionLogic.ts
@@ -100,13 +100,18 @@ import { getLiveArtboardFrameGeometry } from '@/components/rcb/frames/HtmlArtboa
 
 export const CORNER_HANDLES = new Set<ResizeHandle>(['nw', 'ne', 'sw', 'se']);
 
-/** Frame chrome box: host paint → live artboard map → document (gesture-safe). */
+/** Frame chrome box: live plate (gesture) → host if it matches document → document. */
 export function resolveFrameChromeBox(
   frameId: string,
   frame: { x?: number; y?: number; width?: number; height?: number }
 ): SceneBox {
-  const liveHost = liveShapeGeomBox(String(frameId));
-  if (liveHost) return liveHost;
+  const docBox: SceneBox = {
+    left: Number(frame.x) || 0,
+    top: Number(frame.y) || 0,
+    width: Math.max(1, Number(frame.width) || 1),
+    height: Math.max(1, Number(frame.height) || 1),
+  };
+  // Gesture preview owns the plate while dragging (store lags behind).
   const livePlate = getLiveArtboardFrameGeometry(String(frameId));
   if (livePlate) {
     return {
@@ -116,12 +121,14 @@ export function resolveFrameChromeBox(
       height: Math.max(1, Number(livePlate.height) || 1),
     };
   }
-  return {
-    left: Number(frame.x) || 0,
-    top: Number(frame.y) || 0,
-    width: Math.max(1, Number(frame.width) || 1),
-    height: Math.max(1, Number(frame.height) || 1),
-  };
+  const liveHost = liveShapeGeomBox(String(frameId));
+  if (liveHost) {
+    // Sticky lattice is sub-pixel. After multi-frame mode:move, hosts can lag
+    // the committed store — prefer document when the host drifted.
+    const drift = Math.hypot(liveHost.left - docBox.left, liveHost.top - docBox.top);
+    if (drift <= 1.5) return liveHost;
+  }
+  return docBox;
 }
 
 export function textResizeModeForHandle(
@@ -2208,14 +2215,15 @@ export function resolveChromeUnion(opts: {
       if (liveUnion) return liveUnion;
     }
   }
-  // Frames: title uses live `__sceneLeft` / sticky transform; chrome must too —
-  // editor store frame.x alone drifts at 10000% so the label looks off the left edge.
+  // Frames: gesture live plate / committed document via resolveFrameChromeBox —
+  // do not prefer bare host lattice (stale after multi-frame mode:move).
   if (opts.selectedNodeIds.length === 0 && opts.selectedFrameIds.length >= 1) {
+    const frames = Array.isArray(opts.document?.frames) ? opts.document.frames : [];
     const lives: SceneBox[] = [];
     for (const id of opts.selectedFrameIds) {
-      const live = liveShapeGeomBox(id);
-      if (!live) break;
-      lives.push(live);
+      const frame = frames.find((f: any) => f && String(f.id) === String(id));
+      if (!frame) break;
+      lives.push(resolveFrameChromeBox(String(id), frame));
     }
     if (lives.length === opts.selectedFrameIds.length) {
       const liveUnion =


### PR DESCRIPTION
## Summary
- After multi 动画/画板 `mode:move`, blue outlines drifted from white plates because hosts were not rebaked when the last preview coalesce was cancelled, and idle sync collapsed the union to the first plate.
- Rebake all committed frame ids on geometry clear; chrome boxes go through `resolveFrameChromeBox` (gesture live → host if close → document).

## Test plan
- [x] vitest animWorkbenchFrameChromeHide + multiFrameSelectionChrome
- [ ] Marquee multi 动画 → drag → release — blue boxes stay on the white plates