### PR TITLE
fix(web): rename GLSL half var so WebGL2 ink compiles

### DIFF
--- a/apps/web/src/components/rcb/render/webglDepthOfFieldPass.ts
+++ b/apps/web/src/components/rcb/render/webglDepthOfFieldPass.ts
@@ -102,12 +102,12 @@ void main() {
     vec4 r = vec4(vRadii.y, vRadii.z, vRadii.x, vRadii.w);
     float d = sdRoundBox(p, vHalf, r);
     float aa = max(0.5 * fwidth(d), 0.0005);
-    float half = pad + aa * 0.5;
-    float cover = 1.0 - smoothstep(-aa, aa, d - half);
+    float halfW = pad + aa * 0.5;
+    float cover = 1.0 - smoothstep(-aa, aa, d - halfW);
     if (cover < 0.004) discard;
     vec3 rgb = vColor.rgb;
     if (sw > 0.001) {
-      float inFill = 1.0 - smoothstep(-aa, aa, d + half);
+      float inFill = 1.0 - smoothstep(-aa, aa, d + halfW);
       rgb = mix(vStroke.rgb, vColor.rgb, inFill);
     }
     outColor = vec4(rgb, vColor.a * cover);

--- a/apps/web/src/components/rcb/render/webglSceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/webglSceneRenderer.ts
@@ -185,12 +185,12 @@ void main() {
     vec4 r = vec4(vRadii.y, vRadii.z, vRadii.x, vRadii.w);
     float d = sdRoundBox(p, vHalf, r);
     float aa = max(0.5 * fwidth(d), 0.0005);
-    float half = pad + aa * 0.5;
-    float cover = 1.0 - smoothstep(-aa, aa, d - half);
+    float halfW = pad + aa * 0.5;
+    float cover = 1.0 - smoothstep(-aa, aa, d - halfW);
     if (cover < 0.004) discard;
     vec3 rgb = vColor.rgb;
     if (sw > 0.001) {
-      float inFill = 1.0 - smoothstep(-aa, aa, d + half);
+      float inFill = 1.0 - smoothstep(-aa, aa, d + halfW);
       rgb = mix(vStroke.rgb, vColor.rgb, inFill);
     }
     outColor = vec4(rgb, vColor.a * cover);


### PR DESCRIPTION
## Summary
- Stroke AA used a GLSL identifier named `half`, which is reserved in GLSL ES — shader compile failed and the app threw `WebGL2 ink unavailable`.
- Renamed to `halfW` in the main ink shader and DoF pass.

## Test plan
- [ ] Reload canvas — no Uncaught Error: WebGL2 ink unavailable
- [ ] Idle rect strokes still look sharp


Made with [Cursor](https://cursor.com)