### PR TITLE
fix(web): keep correct video frame after pause on SoA path

### DIFF
--- a/apps/web/src/components/editor/nodes/VideoNode/VideoHoverPlayback.tsx
+++ b/apps/web/src/components/editor/nodes/VideoNode/VideoHoverPlayback.tsx
@@ -17,6 +17,19 @@ import VideoPlaybackBar, {
   type VideoMediaControl,
 } from '@/components/editor/nodes/VideoNode/VideoPlaybackBar';
 import { VideoFullscreenPreview } from '@/components/editor/nodes/VideoNode/VideoFullscreenPreviewButton';
+import { waitForVideoFrame } from '@/components/editor/nodes/VideoNode/waitForVideoFrame';
+import {
+  clearVideoIdlePaintFrame,
+  setVideoIdlePaintFrame,
+} from '@/components/rcb/render/videoIdlePaintFrame';
+import {
+  bumpSceneCanvasIdlePaint,
+  getFillImageReady,
+} from '@/components/rcb/render/sceneRenderer';
+import {
+  getSharedSceneRenderBuffer,
+  markSoaDirtyById,
+} from '@/components/rcb/render/sceneRenderBuffer';
 
 function pointInRect(x: number, y: number, r: DOMRect) {
   return x >= r.left && x <= r.right && y >= r.top && y <= r.bottom;
@@ -344,8 +357,9 @@ function VideoHoverPlayback({
     }
     freezeGenRef.current += 1;
     setFreeze({ url: posterUrl, at: 0 });
+    clearVideoIdlePaintFrame(String(nodeId));
     el.src = playSrc;
-  }, [playSrc, posterUrl, videoEl]);
+  }, [playSrc, posterUrl, videoEl, nodeId]);
 
   useEffect(() => {
     const el = videoEl;
@@ -353,66 +367,70 @@ function VideoHoverPlayback({
     setMedia(videoMediaFromElement(el));
   }, [videoEl]);
 
-  // Capture still after pause / seek — wait for a decoded frame, briefly reveal video if hidden.
+  // Capture still after pause / seek — wait for two decoded frames (first RVFC
+  // can still be the previous bitmap). Keep paused <video> visible until capture
+  // lands so a stale freeze never flashes. Publish still into SoA idle paint.
   useEffect(() => {
     const el = videoRef.current as VideoWithFrameCallback | null;
     if (!el) return;
+    const id = String(nodeId);
 
-    let vfc = 0;
-    let raf = 0;
-
-    const freezeNow = () => {
+    const freezeNow = (opts?: { invalidate?: boolean }) => {
       if (!el.paused && !el.ended) return;
-      const wrap = videoWrapRef.current;
-      const prevVis = wrap?.style.visibility;
-      // Hidden videos often won't decode the seeked frame — reveal for capture.
-      // Never punch through a layer-hidden plate (child visibility:visible wins
-      // over parent visibility:hidden in CSS).
-      if (wrap && showUiRef.current) wrap.style.visibility = 'visible';
-
+      if (opts?.invalidate) {
+        // Drop time-matched still so scrubber stays on live paused pixels.
+        setFreeze({ url: '', at: -999 });
+      }
       const gen = ++freezeGenRef.current;
-      const finish = () => {
-        if (gen !== freezeGenRef.current) return;
-        const shot = captureFrameFromVideoEl(el);
-        if (shot) {
+      void (async () => {
+        const wrap = videoWrapRef.current;
+        const prevVis = wrap?.style.visibility;
+        // Hidden videos often won't decode the seeked frame — reveal for capture.
+        // Never punch through a layer-hidden plate (child visibility:visible wins
+        // over parent visibility:hidden in CSS).
+        if (wrap && showUiRef.current) wrap.style.visibility = 'visible';
+        try {
+          await waitForVideoFrame(el);
+          // Second paint — same race extract-frame already works around.
+          await waitForVideoFrame(el);
+          if (gen !== freezeGenRef.current) return;
+          const shot = captureFrameFromVideoEl(el);
+          if (!shot) return;
           const at = Number(el.currentTime) || 0;
           setMediaTime(at);
           setFreeze({ url: shot, at });
+          setVideoIdlePaintFrame(id, shot, at);
+          getFillImageReady(shot);
+          markSoaDirtyById(getSharedSceneRenderBuffer(), id);
+          bumpSceneCanvasIdlePaint();
+        } finally {
+          if (wrap) {
+            wrap.style.visibility = showUiRef.current ? prevVis ?? '' : 'hidden';
+          }
         }
-        if (wrap) {
-          wrap.style.visibility = showUiRef.current ? prevVis ?? '' : 'hidden';
-        }
-      };
-
-      if (typeof el.requestVideoFrameCallback === 'function') {
-        vfc = el.requestVideoFrameCallback(() => finish());
-      } else {
-        raf = requestAnimationFrame(() => {
-          raf = requestAnimationFrame(finish);
-        });
-      }
+      })();
     };
 
-    el.addEventListener('pause', freezeNow);
-    el.addEventListener('seeked', freezeNow);
-    el.addEventListener('loadeddata', freezeNow);
+    const onPause = () => freezeNow({ invalidate: true });
+    const onSeeked = () => freezeNow();
+    const onLoaded = () => freezeNow();
+    el.addEventListener('pause', onPause);
+    el.addEventListener('seeked', onSeeked);
+    el.addEventListener('loadeddata', onLoaded);
     const syncTime = () => setMediaTime(Number(el.currentTime) || 0);
     el.addEventListener('timeupdate', syncTime);
     el.addEventListener('seeked', syncTime);
     freezeNow();
     syncTime();
     return () => {
-      el.removeEventListener('pause', freezeNow);
-      el.removeEventListener('seeked', freezeNow);
-      el.removeEventListener('loadeddata', freezeNow);
+      el.removeEventListener('pause', onPause);
+      el.removeEventListener('seeked', onSeeked);
+      el.removeEventListener('loadeddata', onLoaded);
       el.removeEventListener('timeupdate', syncTime);
       el.removeEventListener('seeked', syncTime);
-      cancelAnimationFrame(raf);
-      if (vfc && typeof el.cancelVideoFrameCallback === 'function') {
-        el.cancelVideoFrameCallback(vfc);
-      }
+      freezeGenRef.current += 1;
     };
-  }, [playSrc]);
+  }, [playSrc, nodeId]);
 
   useEffect(() => {
     const onMove = (e: PointerEvent) => {

--- a/apps/web/src/components/editor/nodes/VideoNode/VideoToolbarEditTools.tsx
+++ b/apps/web/src/components/editor/nodes/VideoNode/VideoToolbarEditTools.tsx
@@ -19,6 +19,7 @@ import {
   captureFrameFromVideoEl,
   getVideoHoverHost,
 } from '@/components/editor/nodes/VideoNode/VideoHoverPlayback';
+import { waitForVideoFrame } from '@/components/editor/nodes/VideoNode/waitForVideoFrame';
 import {
   failImageProcess,
   finishImageProcess,
@@ -67,34 +68,6 @@ function Tool({
       <span>{label}</span>
     </button>
   );
-}
-
-function waitForVideoFrame(video: HTMLVideoElement): Promise<void> {
-  return new Promise((resolve) => {
-    const v = video as HTMLVideoElement & {
-      requestVideoFrameCallback?: (cb: () => void) => number;
-    };
-    let done = false;
-    const finish = () => {
-      if (done) return;
-      done = true;
-      resolve();
-    };
-    const timer = window.setTimeout(finish, 250);
-    if (typeof v.requestVideoFrameCallback === 'function') {
-      v.requestVideoFrameCallback(() => {
-        window.clearTimeout(timer);
-        finish();
-      });
-      return;
-    }
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        window.clearTimeout(timer);
-        finish();
-      });
-    });
-  });
 }
 
 function seekVideoEl(video: HTMLVideoElement, seconds: number): Promise<void> {
@@ -255,7 +228,8 @@ async function captureExtractDataUrl(opts: {
 }
 
 function ExtractFrameMenu({ nodeId }: { nodeId: string }) {
-  const { t } = useTranslation();  const document = useEditorDocumentOnCommit();
+  const { t } = useTranslation();
+  const document = useEditorDocumentOnCommit();
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const busyRef = useRef(false);

--- a/apps/web/src/components/editor/nodes/VideoNode/waitForVideoFrame.ts
+++ b/apps/web/src/components/editor/nodes/VideoNode/waitForVideoFrame.ts
@@ -1,0 +1,28 @@
+/** Wait until the next decoded video frame is available (RVFC, else double rAF). */
+export function waitForVideoFrame(video: HTMLVideoElement): Promise<void> {
+  return new Promise((resolve) => {
+    const v = video as HTMLVideoElement & {
+      requestVideoFrameCallback?: (cb: () => void) => number;
+    };
+    let done = false;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      resolve();
+    };
+    const timer = window.setTimeout(finish, 250);
+    if (typeof v.requestVideoFrameCallback === 'function') {
+      v.requestVideoFrameCallback(() => {
+        window.clearTimeout(timer);
+        finish();
+      });
+      return;
+    }
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        window.clearTimeout(timer);
+        finish();
+      });
+    });
+  });
+}

--- a/apps/web/src/components/rcb/render/__tests__/videoIdlePaintFrame.test.ts
+++ b/apps/web/src/components/rcb/render/__tests__/videoIdlePaintFrame.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { mediaPaintSrc } from '../sceneRenderer';
+import {
+  clearAllVideoIdlePaintFrames,
+  setVideoIdlePaintFrame,
+} from '../videoIdlePaintFrame';
+
+describe('mediaPaintSrc video idle frame', () => {
+  beforeEach(() => {
+    clearAllVideoIdlePaintFrames();
+  });
+
+  it('prefers runtime pause frame over attrs.poster', () => {
+    setVideoIdlePaintFrame('v1', 'data:image/jpeg;base64,PAUSE', 2.1);
+    expect(
+      mediaPaintSrc(
+        {
+          id: 'v1',
+          key: 'video',
+          attrs: {
+            src: 'https://example.com/a.mp4',
+            poster: 'https://example.com/poster.jpg',
+          },
+        },
+        'v1'
+      )
+    ).toBe('data:image/jpeg;base64,PAUSE');
+  });
+
+  it('falls back to poster when no runtime frame', () => {
+    expect(
+      mediaPaintSrc({
+        id: 'v2',
+        key: 'video',
+        attrs: {
+          src: 'https://example.com/a.mp4',
+          poster: 'https://example.com/poster.jpg',
+        },
+      })
+    ).toBe('https://example.com/poster.jpg');
+  });
+});

--- a/apps/web/src/components/rcb/render/sceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/sceneRenderer.ts
@@ -139,6 +139,7 @@ import {
   resolveGpuDofBackend,
   shouldRunGpuDepthOfField,
 } from '@/components/rcb/render/gpuDepthOfField';
+import { getVideoIdlePaintFrame } from '@/components/rcb/render/videoIdlePaintFrame';
 
 /** Cap centerline samples when stroking a dense pencil/path as canvas ink. */
 export const CANVAS_IDLE_STROKE_MAX_PTS = 64;
@@ -2410,10 +2411,14 @@ function readMediaCropNorm(
   return null;
 }
 
-function mediaPaintSrc(node: SceneNodeInput): string {
+/** Prefer pause-frame still over attrs.poster for video idle ink. */
+export function mediaPaintSrc(node: SceneNodeInput, nodeId?: string): string {
   const key = String(node.key || '');
   const attrs = node.attrs || {};
   if (key === 'video') {
+    const id = String(nodeId || node.id || '').trim();
+    const runtime = id ? getVideoIdlePaintFrame(id) : null;
+    if (runtime) return runtime;
     const poster = String(attrs.poster || '').trim();
     if (poster) return poster;
   }
@@ -2431,12 +2436,13 @@ export function paintCanvasMediaInk(
     width: number;
     height: number;
     opacity?: number;
+    nodeId?: string;
   }
 ): void {
   const w = Math.max(1, opts.width);
   const h = Math.max(1, opts.height);
   const opacity = Math.min(1, Math.max(0.05, opts.opacity ?? 1));
-  const src = mediaPaintSrc(opts.node);
+  const src = mediaPaintSrc(opts.node, opts.nodeId);
   const img = src ? getFillImageReady(src) : null;
   if (!img) {
     const attrs = opts.node.attrs || {};
@@ -2504,10 +2510,12 @@ export function paintCanvasMediaInk(
 export function bakeMediaInkForAtlas(
   node: SceneNodeInput,
   width: number,
-  height: number
+  height: number,
+  nodeId?: string
 ): HTMLCanvasElement | OffscreenCanvas | null {
   if (nodeNeedsPuppetWarp(node)) return null;
-  const src = mediaPaintSrc(node);
+  const id = String(nodeId || node.id || '').trim();
+  const src = mediaPaintSrc(node, id);
   if (src) {
     if (isFillImageWebglUnsafe(src)) return null;
     if (!getFillImageReady(src)) return null;
@@ -2538,6 +2546,7 @@ export function bakeMediaInkForAtlas(
     width: w,
     height: h,
     opacity: 1,
+    nodeId: id || undefined,
   });
   // Never return a tainted bake — stamping it would poison the shared WebGL atlas.
   // Empty plates have no external image; skip the readback gate when there is no src.

--- a/apps/web/src/components/rcb/render/videoIdlePaintFrame.ts
+++ b/apps/web/src/components/rcb/render/videoIdlePaintFrame.ts
@@ -1,0 +1,36 @@
+/**
+ * Runtime pause/scrub still for video idle SoA/atlas paint.
+ * Prefer this over attrs.poster so demotion keeps the paused frame without
+ * rewriting document poster (which flashes under the live decoder).
+ */
+const videoIdlePaintFrames = new Map<string, { url: string; at: number }>();
+
+export function setVideoIdlePaintFrame(nodeId: string, url: string, at: number): void {
+  const id = String(nodeId || '').trim();
+  const next = String(url || '').trim();
+  if (!id || !next) return;
+  videoIdlePaintFrames.set(id, { url: next, at: Number(at) || 0 });
+}
+
+export function getVideoIdlePaintFrame(nodeId: string): string | null {
+  const id = String(nodeId || '').trim();
+  if (!id) return null;
+  const url = String(videoIdlePaintFrames.get(id)?.url || '').trim();
+  return url || null;
+}
+
+export function getVideoIdlePaintFrameAt(nodeId: string): number | null {
+  const id = String(nodeId || '').trim();
+  if (!id) return null;
+  const entry = videoIdlePaintFrames.get(id);
+  return entry ? entry.at : null;
+}
+
+export function clearVideoIdlePaintFrame(nodeId: string): void {
+  videoIdlePaintFrames.delete(String(nodeId || '').trim());
+}
+
+/** Test helper — empty the registry. */
+export function clearAllVideoIdlePaintFrames(): void {
+  videoIdlePaintFrames.clear();
+}

--- a/apps/web/src/components/rcb/render/webglSceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/webglSceneRenderer.ts
@@ -52,6 +52,7 @@ import {
   bumpSceneCanvasIdlePaint,
   isFillImageWebglUnsafe,
   hitTestWithSpatialIndex,
+  mediaPaintSrc,
   type CanvasSceneRendererDeps,
   type SceneRenderRequest,
   type SceneRenderer,
@@ -499,12 +500,10 @@ export function collectSoaWebglInstances(
       const isAudio = String(node.key || '') === 'audio';
       const baked = isAudio
         ? bakeAudioInkForAtlas(node, w, h, zoom)
-        : bakeMediaInkForAtlas(node, w, h);
+        : bakeMediaInkForAtlas(node, w, h, id);
       if (!baked) {
         if (!isAudio) {
-          const src = String(
-            (node.key === 'video' ? node.attrs?.poster : null) || node.attrs?.src || ''
-          ).trim();
+          const src = mediaPaintSrc(node, id);
           // Pending decode → bump. CORS/tainted → stop retrying; host will paint.
           // Empty src should bake a plate — if bake still failed, clear dirty
           // (do not eternal-bump; that burned CPU and never drew).


### PR DESCRIPTION
## Summary
- Pause freeze used a single RVFC and could stamp a stale bitmap while `currentTime` was already correct.
- Idle/atlas bake always used `attrs.poster`, so demotion showed the wrong frame.
- Wait two decoded frames (same as extract-frame), invalidate the old still until capture lands, and feed the pause still into SoA/atlas via a runtime idle-paint registry — without reverting to always-DOM video hosts.

## Test plan
- [ ] Select a video, play to mid-clip, pause — plate still matches scrubber time
- [ ] Deselect after pause — canvas/atlas idle ink keeps the same frame (not upload poster)
- [ ] Scrub then pause — still matches scrubber
- [ ] Extract-frame / play again still works


Made with [Cursor](https://cursor.com)