### PR TITLE
fix(web): grow smart-guide x marks by 2px

### DIFF
--- a/apps/web/src/components/rcb/selection/chrome/SmartGuidesOverlay.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/SmartGuidesOverlay.tsx
@@ -143,7 +143,7 @@ export default function SmartGuidesOverlay({
   // Keep ≥1 CSS px under camera scale so the guide never drops to a dashed hairline.
   const stroke = Math.max(1 / z, CHROME_STROKE_PX / z);
   const tip = 5 * inv;
-  const markR = Math.max(stroke * 1.25, 2 * inv);
+  const markR = Math.max(stroke * 1.25, 4 * inv);
   const dash = `${5 * inv} ${4 * inv}`;
 
   // Remount when shared world SVG appears / is replaced.


### PR DESCRIPTION
## Summary
- Increase smart-guide × mark radius by 2 CSS px (2 → 4).

## Test plan
- [ ] Drag to snap — × marks look ~2px larger than before


Made with [Cursor](https://cursor.com)