### PR TITLE
fix(web): keep artboard borders when multi-frame selected

### DIFF
--- a/apps/web/src/components/editor/page/EditorStageWorld.tsx
+++ b/apps/web/src/components/editor/page/EditorStageWorld.tsx
@@ -94,7 +94,11 @@ import { nodeLeftTop } from '@/components/rcb/scene/paint/sceneToSvg';
 import { rcbCameraCssZoom } from '@/components/rcb/core/math';
 import { clearNodeTransformPreviews } from '@/components/rcb/core/transformPreview';
 import { bindUnownedNodesToFrames } from '@/components/rcb/frames/frameNodeBinding';
-import { clearLiveArtboardFrameGeometry } from '@/components/rcb/frames/HtmlArtboardFrame';
+import {
+  clearLiveArtboardFrameGeometry,
+  framePlateClearsIdleStroke,
+  framePlateShowsHighlightEdge,
+} from '@/components/rcb/frames/HtmlArtboardFrame';
 import {
   isArtboardVisibleInDocument,
   setAnimationWorkbenchGeometryPreview,
@@ -745,17 +749,25 @@ function EditorStageWorld({
               selected={
                 !isDevMode &&
                 !movingFrameIdSet.has(frame.id) &&
-                frameChromeMode === 'full' &&
-                selectedFrameIds.includes(frame.id)
+                framePlateClearsIdleStroke({
+                  chromeMode: frameChromeMode,
+                  selectedFrameIds,
+                  frameId: frame.id,
+                })
               }
               highlighted={
                 !isDevMode &&
                 // While dragging: keep a visible plate edge (no handles). Hiding
                 // both selected + highlighted left only a faint hairline so the
                 // plate looked like it vanished on the light canvas.
-                (movingFrameIdSet.has(frame.id) ||
-                  (frameChromeMode === 'soft' &&
-                    (activeFrameId === frame.id || selectedFrameIds.includes(frame.id))))
+                // Multi full: union chrome does not own per-plate edges — highlight.
+                framePlateShowsHighlightEdge({
+                  chromeMode: frameChromeMode,
+                  selectedFrameIds,
+                  frameId: frame.id,
+                  activeFrameId,
+                  moving: movingFrameIdSet.has(frame.id),
+                })
               }
               layer="body"
               aiGenerating={frameShowsAiOverlay(frame, aiOperationState)}
@@ -860,14 +872,21 @@ function EditorStageWorld({
               selected={
                 !isDevMode &&
                 !movingFrameIdSet.has(frame.id) &&
-                frameChromeMode === 'full' &&
-                selectedFrameIds.includes(frame.id)
+                framePlateClearsIdleStroke({
+                  chromeMode: frameChromeMode,
+                  selectedFrameIds,
+                  frameId: frame.id,
+                })
               }
               highlighted={
                 !isDevMode &&
-                (movingFrameIdSet.has(frame.id) ||
-                  (frameChromeMode === 'soft' &&
-                    (activeFrameId === frame.id || selectedFrameIds.includes(frame.id))))
+                framePlateShowsHighlightEdge({
+                  chromeMode: frameChromeMode,
+                  selectedFrameIds,
+                  frameId: frame.id,
+                  activeFrameId,
+                  moving: movingFrameIdSet.has(frame.id),
+                })
               }
               hideTitle={
                 isDevMode ||

--- a/apps/web/src/components/rcb/frames/HtmlArtboardFrame.tsx
+++ b/apps/web/src/components/rcb/frames/HtmlArtboardFrame.tsx
@@ -37,6 +37,43 @@ import {
   isAnimationArtboardKind,
 } from '@/components/rcb/frames/types';
 
+/**
+ * Clear plate stroke only when SelectionChrome paints **this** plate's box.
+ * Multi-frame full chrome uses a union outline — members must keep their edges.
+ */
+export function framePlateClearsIdleStroke(opts: {
+  chromeMode: 'soft' | 'full';
+  selectedFrameIds: readonly string[];
+  frameId: string;
+}): boolean {
+  const { chromeMode, selectedFrameIds, frameId } = opts;
+  return (
+    chromeMode === 'full' &&
+    selectedFrameIds.length === 1 &&
+    selectedFrameIds[0] === frameId
+  );
+}
+
+/** Soft / multi-member highlight edge when SelectionChrome is not owning the plate. */
+export function framePlateShowsHighlightEdge(opts: {
+  chromeMode: 'soft' | 'full';
+  selectedFrameIds: readonly string[];
+  frameId: string;
+  activeFrameId?: string | null;
+  moving?: boolean;
+}): boolean {
+  const { chromeMode, selectedFrameIds, frameId, activeFrameId = null, moving = false } = opts;
+  if (moving) return true;
+  if (chromeMode === 'soft') {
+    return activeFrameId === frameId || selectedFrameIds.includes(frameId);
+  }
+  return (
+    chromeMode === 'full' &&
+    selectedFrameIds.length > 1 &&
+    selectedFrameIds.includes(frameId)
+  );
+}
+
 type HtmlArtboardFrameProps = {
   frame: ArtboardFrame;
   /** Full chrome selected — plate stroke off (SelectionChrome owns the box). */

--- a/apps/web/src/components/rcb/frames/__tests__/multiFramePlateStroke.test.ts
+++ b/apps/web/src/components/rcb/frames/__tests__/multiFramePlateStroke.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  framePlateClearsIdleStroke,
+  framePlateShowsHighlightEdge,
+} from '../HtmlArtboardFrame';
+
+describe('multi-frame plate stroke', () => {
+  it('clears idle stroke only for the sole full-chrome plate', () => {
+    expect(
+      framePlateClearsIdleStroke({
+        chromeMode: 'full',
+        selectedFrameIds: ['a'],
+        frameId: 'a',
+      })
+    ).toBe(true);
+    expect(
+      framePlateClearsIdleStroke({
+        chromeMode: 'full',
+        selectedFrameIds: ['a', 'b'],
+        frameId: 'a',
+      })
+    ).toBe(false);
+    expect(
+      framePlateClearsIdleStroke({
+        chromeMode: 'soft',
+        selectedFrameIds: ['a'],
+        frameId: 'a',
+      })
+    ).toBe(false);
+  });
+
+  it('highlights multi-full members so plate edges stay under the union box', () => {
+    expect(
+      framePlateShowsHighlightEdge({
+        chromeMode: 'full',
+        selectedFrameIds: ['a', 'b'],
+        frameId: 'a',
+      })
+    ).toBe(true);
+    expect(
+      framePlateShowsHighlightEdge({
+        chromeMode: 'full',
+        selectedFrameIds: ['a'],
+        frameId: 'a',
+      })
+    ).toBe(false);
+    expect(
+      framePlateShowsHighlightEdge({
+        chromeMode: 'soft',
+        selectedFrameIds: ['a'],
+        frameId: 'a',
+      })
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- After marquee-selecting multiple artboards/动画 boards, per-plate borders vanished because `selected` cleared the plate stroke while SelectionChrome only drew the union box.
- Clear plate stroke only for a sole full-chrome plate; multi members keep a highlight edge under the union.

## Test plan
- [ ] Marquee two artboards (incl. 动画) — each keeps a visible border under the blue union
- [ ] Single-select artboard — plate stroke still clears (SelectionChrome owns the box)
- [ ] Soft chrome interior focus still shows blue highlight


Made with [Cursor](https://cursor.com)