### PR TITLE
chore(web): swap video glyphs to RiVideoAiLine / HiOutlineVideoCamera

### DIFF
--- a/apps/web/src/components/editor/panels/LayerPanel.tsx
+++ b/apps/web/src/components/editor/panels/LayerPanel.tsx
@@ -14,7 +14,6 @@ import {
   LuFrame,
   LuPanelLeft,
   LuPencil,
-  LuFilm,
   LuHexagon,
   LuImagePlus,
   LuLayoutGrid,

--- a/apps/web/src/components/editor/panels/agent/composer/AgentComposerShell.tsx
+++ b/apps/web/src/components/editor/panels/agent/composer/AgentComposerShell.tsx
@@ -23,12 +23,12 @@ import {
   HiOutlinePhoto,
   HiOutlinePlay,
   HiOutlinePlus,
+  HiOutlineVideoCamera,
   HiOutlineXMark,
   HiChevronUp,
   HiChevronDown,
 } from 'react-icons/hi2';
 import { LuFilm, LuInfinity, LuMessageSquare } from 'react-icons/lu';
-import { RiVideoLine } from 'react-icons/ri';
 import { Dropdown, DropdownPanel, DropdownPanelItem } from '@/components/base';
 import { Icon } from '@/components/base/icon';
 import Tooltip from '@/components/base/tooltip';
@@ -745,7 +745,7 @@ function interactionModeIcon(mode: ComposerInteractionMode): ReactNode {
     return <HiOutlineMusicalNote className="h-3.5 w-3.5 shrink-0" strokeWidth={2} />;
   }
   if (mode === 'video') {
-    return <RiVideoLine className="h-3.5 w-3.5 shrink-0" />;
+    return <HiOutlineVideoCamera className="h-3.5 w-3.5 shrink-0" strokeWidth={2} />;
   }
   if (mode === 'image') {
     return <HiOutlinePhoto className="h-3.5 w-3.5 shrink-0" strokeWidth={2} />;
@@ -779,7 +779,7 @@ function buildInteractionModeOptions(
     {
       key: 'video',
       label: t('agent.interactionVideo'),
-      icon: <RiVideoLine className="h-3.5 w-3.5 shrink-0" />,
+      icon: <HiOutlineVideoCamera className="h-3.5 w-3.5 shrink-0" strokeWidth={2} />,
     },
     {
       key: 'audio',

--- a/apps/web/src/components/rcb/selection/chrome/NodeTitleLabel.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/NodeTitleLabel.tsx
@@ -17,6 +17,7 @@ import {
 } from 'react';
 import { LuAudioLines, LuImagePlus, LuType } from 'react-icons/lu';
 import { RiVideoAiLine } from 'react-icons/ri';
+import { HiOutlineVideoCamera } from 'react-icons/hi2';
 import { AnimationOutlineIcon } from '@/components/editor/nodes/AnimationNode/AnimationOutlineIcon';
 import {
   RcbOverlayPortal,
@@ -228,12 +229,7 @@ function TitleIcon({ kind }: { kind: NodeTitleIcon }): ReactNode {
         </SvgTitleIcon>
       );
     case 'video':
-      return (
-        <SvgTitleIcon>
-          <rect x={2} y={5} width={20} height={14} rx={2} {...STROKE_ICON} />
-          <path d="M10 9l5 3-5 3z" {...STROKE_ICON} fill={MUTED} />
-        </SvgTitleIcon>
-      );
+      return <LucideTitleIcon Icon={HiOutlineVideoCamera} />;
     default:
       return (
         <SvgTitleIcon>


### PR DESCRIPTION
## Summary
- Video generator stays `RiVideoAiLine`.
- Node title / layer / chat panel video icons use `HiOutlineVideoCamera`.

## Test plan
- [ ] Video generator title + layer glyph show AI video icon
- [ ] Regular video node title + layer show camera icon
- [ ] Chat interaction mode video option shows camera icon


Made with [Cursor](https://cursor.com)