### PR TITLE
fix(web): layer video icon HiOutlineVideoCamera

### DIFF
--- a/apps/web/src/components/editor/panels/LayerPanel.tsx
+++ b/apps/web/src/components/editor/panels/LayerPanel.tsx
@@ -32,6 +32,7 @@ import {
   HiOutlineMinus,
   HiOutlinePhoto,
   HiOutlineStop,
+  HiOutlineVideoCamera,
 } from 'react-icons/hi2';
 import { TbArrowUpRight, TbCircle, TbStar, TbTriangle } from 'react-icons/tb';
 import Tooltip from '@/components/base/tooltip';


### PR DESCRIPTION
## Summary
- #254 dropped `LuFilm` import but left a usage; switch the regular video layer glyph to `HiOutlineVideoCamera`.

## Test plan
- [ ] Layer panel video rows show camera icon; generators still show RiVideoAiLine


Made with [Cursor](https://cursor.com)