### PR TITLE
fix(web): floor content strokes under zoom so hairlines stay visible

### DIFF
--- a/apps/web/src/components/rcb/render/__tests__/strokeScreenFloor.test.ts
+++ b/apps/web/src/components/rcb/render/__tests__/strokeScreenFloor.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  adaptivePathStrokeMaxSegs,
+  floorContentStrokeSceneWidth,
+} from '../strokeScreenFloor';
+
+describe('floorContentStrokeSceneWidth', () => {
+  it('keeps geometric width when already ≥ 1 CSS px on screen', () => {
+    expect(floorContentStrokeSceneWidth(2, 1)).toBe(2);
+    expect(floorContentStrokeSceneWidth(2, 2)).toBe(2);
+  });
+
+  it('floors so sw * zoom ≥ 1 CSS px when zoomed out', () => {
+    expect(floorContentStrokeSceneWidth(2, 0.25)).toBe(4);
+    expect(floorContentStrokeSceneWidth(1, 0.1)).toBe(10);
+  });
+
+  it('returns 0 for missing stroke', () => {
+    expect(floorContentStrokeSceneWidth(0, 0.2)).toBe(0);
+    expect(floorContentStrokeSceneWidth(-1, 0.2)).toBe(0);
+  });
+});
+
+describe('adaptivePathStrokeMaxSegs', () => {
+  it('keeps full cap near 1× zoom', () => {
+    expect(adaptivePathStrokeMaxSegs(1, 96)).toBe(96);
+    expect(adaptivePathStrokeMaxSegs(0.8, 96)).toBe(96);
+  });
+
+  it('reduces segments when zoomed out', () => {
+    expect(adaptivePathStrokeMaxSegs(0.5, 96)).toBeLessThan(96);
+    expect(adaptivePathStrokeMaxSegs(0.15, 96)).toBeLessThanOrEqual(24);
+  });
+});

--- a/apps/web/src/components/rcb/render/__tests__/webglInstances.test.ts
+++ b/apps/web/src/components/rcb/render/__tests__/webglInstances.test.ts
@@ -404,4 +404,40 @@ describe('collectSoaWebglInstances', () => {
       SOA_WEBGL_NO_CLIP[3],
     ]);
   });
+
+  it('floors kind-4 stroke width at low zoom so hairlines survive', () => {
+    let doc = createEmptyDocument({ width: 800, height: 600, emptyWorld: true });
+    doc = addNodeToDocument(doc, 'r', {
+      id: 'r',
+      key: 'shape',
+      x: 0,
+      y: 0,
+      width: 40,
+      height: 40,
+      attrs: {
+        shapeType: 'rect',
+        fill: '#ff0000',
+        'stroke-enabled': true,
+        'border-width': 2,
+        'border-color': '#000000',
+      },
+      children: [],
+    });
+    const buf = createSceneRenderBuffer();
+    syncSceneRenderBufferFromDocument(buf, doc);
+    buf.flags[0] = (buf.flags[0] | SOA_FLAG_CANVAS_IDLE) >>> 0;
+    const strokes: number[] = [];
+    collectSoaWebglInstances(
+      buf,
+      { x: 0, y: 0, width: 100, height: 100 },
+      [],
+      [],
+      [],
+      [],
+      [],
+      { strokes, zoom: 0.25 }
+    );
+    // aStroke.w = floored scene width (2 → 4 at 0.25 zoom for 1 CSS px floor).
+    expect(strokes[3]).toBe(4);
+  });
 });

--- a/apps/web/src/components/rcb/render/strokeScreenFloor.ts
+++ b/apps/web/src/components/rcb/render/strokeScreenFloor.ts
@@ -1,0 +1,41 @@
+/**
+ * Content strokes are authored in **scene** units. Under CSS/`uZoom` camera scale,
+ * `sw * zoom` can drop below 1 CSS px — WebGL coverage and SVG hairlines vanish
+ * even when every shape stores the same border-width.
+ *
+ * Editor chrome uses a pure screen-constant width (`cssPx / zoom`). Content ink
+ * keeps geometric thickness when zoomed in, and floors to ≥ `minCssPx` on screen
+ * when zoomed out.
+ */
+
+/** Minimum on-screen stroke weight (CSS px) after camera scale. */
+export const CONTENT_STROKE_MIN_CSS_PX = 1;
+
+/**
+ * Scene stroke width so `sw * zoom` stays ≥ `minCssPx` CSS px.
+ * Returns 0 when `sceneWidth` is non-positive (no stroke).
+ */
+export function floorContentStrokeSceneWidth(
+  sceneWidth: number,
+  zoom: number,
+  minCssPx = CONTENT_STROKE_MIN_CSS_PX
+): number {
+  const sw = Math.max(0, Number(sceneWidth) || 0);
+  if (!(sw > 0)) return 0;
+  const z = Math.max(0.05, Number(zoom) || 1);
+  const floor = Math.max(0, Number(minCssPx) || 0) / z;
+  return Math.max(sw, floor);
+}
+
+/**
+ * Cap path segment emission when zoomed out — dense boolean outlines otherwise
+ * explode the instance batch while screen coverage is already a hairline.
+ */
+export function adaptivePathStrokeMaxSegs(zoom: number, cap = 96): number {
+  const z = Math.max(0.05, Number(zoom) || 1);
+  const hard = Math.max(8, Math.floor(Number(cap) || 96));
+  if (z >= 0.75) return hard;
+  if (z >= 0.4) return Math.max(24, Math.floor(hard * 0.5));
+  if (z >= 0.2) return Math.max(16, Math.floor(hard * 0.33));
+  return Math.max(12, Math.floor(hard * 0.2));
+}

--- a/apps/web/src/components/rcb/render/webglDepthOfFieldPass.ts
+++ b/apps/web/src/components/rcb/render/webglDepthOfFieldPass.ts
@@ -66,6 +66,7 @@ void main() {
 const SCENE_FS = `#version 300 es
 precision mediump float;
 uniform sampler2D uAtlas;
+uniform float uZoom;
 in vec2 vUv;
 in vec2 vAtlasUv;
 in vec4 vColor;
@@ -102,6 +103,8 @@ void main() {
     vec4 r = vec4(vRadii.y, vRadii.z, vRadii.x, vRadii.w);
     float d = sdRoundBox(p, vHalf, r);
     float aa = max(0.5 * fwidth(d), 0.0005);
+    float maxAa = max(pad * 0.85, 0.35 / max(uZoom, 0.05));
+    aa = min(aa, maxAa);
     float halfW = pad + aa * 0.5;
     float cover = 1.0 - smoothstep(-aa, aa, d - halfW);
     if (cover < 0.004) discard;

--- a/apps/web/src/components/rcb/render/webglSceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/webglSceneRenderer.ts
@@ -82,6 +82,10 @@ import {
   createWebglDepthOfFieldPass,
   type WebglDepthOfFieldPass,
 } from '@/components/rcb/render/webglDepthOfFieldPass';
+import {
+  adaptivePathStrokeMaxSegs,
+  floorContentStrokeSceneWidth,
+} from '@/components/rcb/render/strokeScreenFloor';
 
 /** Scene-space LTRB when the slot has no clipContent owner (or reveal-overflow). */
 export const SOA_WEBGL_NO_CLIP: [number, number, number, number] = [-1e8, -1e8, 1e8, 1e8];
@@ -152,6 +156,7 @@ float sdRoundBox(vec2 p, vec2 b, vec4 r) {
 const FS = `#version 300 es
 precision mediump float;
 uniform sampler2D uAtlas;
+uniform float uZoom;
 in vec2 vUv;
 in vec2 vAtlasUv;
 in vec4 vColor;
@@ -178,6 +183,7 @@ void main() {
   // UV spans the padded quad so SDF samples match the expanded vertex size.
   // AA is half-fwidth + half-pixel stroke expand so 1px strokes keep SVG-like
   // optical weight (full fwidth smoothstep alone looks thin/虚 vs selected SVG).
+  // Cap AA vs stroke pad / screen px so zoom-out fwidth cannot erase the ring.
   if (vKind > 3.5) {
     float sw = max(0.0, vStroke.w);
     float pad = sw * 0.5;
@@ -186,6 +192,8 @@ void main() {
     vec4 r = vec4(vRadii.y, vRadii.z, vRadii.x, vRadii.w);
     float d = sdRoundBox(p, vHalf, r);
     float aa = max(0.5 * fwidth(d), 0.0005);
+    float maxAa = max(pad * 0.85, 0.35 / max(uZoom, 0.05));
+    aa = min(aa, maxAa);
     float halfW = pad + aa * 0.5;
     float cover = 1.0 - smoothstep(-aa, aa, d - halfW);
     if (cover < 0.004) discard;
@@ -588,7 +596,8 @@ export function collectSoaWebglInstances(
     if (x + w < vl || y + h < vt || x > vr || y > vb) continue;
     const rgba = argbToRgba(buf.colors[i]);
     const strokeRgba = soaWebglStrokeRgba(buf, i);
-    const lineW = soaStrokeWidth(buf, i);
+    const lineW = floorContentStrokeSceneWidth(soaStrokeWidth(buf, i), zoom);
+    const pathMaxSegs = adaptivePathStrokeMaxSegs(zoom, SOA_WEBGL_PATH_MAX_SEGS);
     const forceStamp = (flags & SOA_FLAG_DIRTY) !== 0;
     const nodeId = buf.ids[i] || '';
     const id = nodeId;
@@ -774,6 +783,7 @@ export function collectSoaWebglInstances(
               clips,
               paintClips,
               strokes,
+              maxSegs: pathMaxSegs,
             });
           }
           if (forceStamp) buf.flags[i] = (flags & ~SOA_FLAG_DIRTY) >>> 0;
@@ -805,6 +815,7 @@ export function collectSoaWebglInstances(
         clips,
         paintClips,
         strokes,
+        maxSegs: pathMaxSegs,
       });
       if (forceStamp) buf.flags[i] = (flags & ~SOA_FLAG_DIRTY) >>> 0;
       continue;
@@ -818,7 +829,7 @@ export function collectSoaWebglInstances(
         let lastFinite = -1;
         let emitted = 0;
         const emitSeg = (a: number, b: number) => {
-          if (emitted >= SOA_WEBGL_PATH_MAX_SEGS) return;
+          if (emitted >= pathMaxSegs) return;
           for (const activeClip of paintClips) {
             pushLineInstance(
               buf.pathXY[a] + odx,
@@ -897,7 +908,7 @@ export function collectSoaWebglInstances(
     }
     const rotRad = (rotDeg * Math.PI) / 180;
 
-    const outlineW = buf.strokeWidths[i] || 0;
+    const outlineW = floorContentStrokeSceneWidth(buf.strokeWidths[i] || 0, zoom);
     const outlineArgb = buf.strokeColors[i] || 0;
     const hasOutline = outlineW > 0 && outlineArgb !== 0;
     const outlineCss = hasOutline ? unpackCssColor(outlineArgb) : '';
@@ -1015,6 +1026,22 @@ export function createWebglSceneRenderer(
   let atlasBufferRevision = -1;
   let dofPass: WebglDepthOfFieldPass | null = null;
   let dofVao: WebGLVertexArrayObject | null = null;
+  /** Scratch typed views — avoid per-frame `new Float32Array(arr)` GC. */
+  let scratchRect = new Float32Array(0);
+  let scratchColor = new Float32Array(0);
+  let scratchKind = new Float32Array(0);
+  let scratchAngle = new Float32Array(0);
+  let scratchUv = new Float32Array(0);
+  let scratchClip = new Float32Array(0);
+  let scratchStroke = new Float32Array(0);
+  let scratchDepth = new Float32Array(0);
+
+  function copyToScratch(src: ArrayLike<number>, prev: Float32Array): Float32Array {
+    const n = src.length;
+    const out = prev.length >= n ? prev : new Float32Array(Math.max(n, prev.length * 2 || 64));
+    out.set(src, 0);
+    return out;
+  }
 
   function ensureDofPass(): WebglDepthOfFieldPass | null {
     if (dofPass) return dofPass;
@@ -1272,35 +1299,43 @@ export function createWebglSceneRenderer(
       }
 
       ensureInstanceCapacity(count);
+      scratchRect = copyToScratch(rects, scratchRect);
+      scratchColor = copyToScratch(colors, scratchColor);
+      scratchKind = copyToScratch(kinds, scratchKind);
+      scratchAngle = copyToScratch(angles, scratchAngle);
+      scratchUv = copyToScratch(uvs, scratchUv);
       gl.bindBuffer(gl.ARRAY_BUFFER, rectBuf);
-      gl.bufferSubData(gl.ARRAY_BUFFER, 0, new Float32Array(rects));
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, scratchRect.subarray(0, rects.length));
       gl.bindBuffer(gl.ARRAY_BUFFER, colorBuf);
-      gl.bufferSubData(gl.ARRAY_BUFFER, 0, new Float32Array(colors));
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, scratchColor.subarray(0, colors.length));
       gl.bindBuffer(gl.ARRAY_BUFFER, kindBuf);
-      gl.bufferSubData(gl.ARRAY_BUFFER, 0, new Float32Array(kinds));
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, scratchKind.subarray(0, kinds.length));
       gl.bindBuffer(gl.ARRAY_BUFFER, angleBuf);
-      gl.bufferSubData(gl.ARRAY_BUFFER, 0, new Float32Array(angles));
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, scratchAngle.subarray(0, angles.length));
       gl.bindBuffer(gl.ARRAY_BUFFER, uvBuf);
-      gl.bufferSubData(gl.ARRAY_BUFFER, 0, new Float32Array(uvs));
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, scratchUv.subarray(0, uvs.length));
       const clipFill =
         clips.length === count * 4
           ? clips
           : Array.from({ length: count * 4 }, (_, i) => SOA_WEBGL_NO_CLIP[i % 4]);
+      scratchClip = copyToScratch(clipFill, scratchClip);
       gl.bindBuffer(gl.ARRAY_BUFFER, clipBuf);
-      gl.bufferSubData(gl.ARRAY_BUFFER, 0, new Float32Array(clipFill));
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, scratchClip.subarray(0, count * 4));
       const strokeFill =
         strokes.length === count * 4
           ? strokes
           : Array.from({ length: count * 4 }, () => 0);
+      scratchStroke = copyToScratch(strokeFill, scratchStroke);
       gl.bindBuffer(gl.ARRAY_BUFFER, strokeBuf);
-      gl.bufferSubData(gl.ARRAY_BUFFER, 0, new Float32Array(strokeFill));
+      gl.bufferSubData(gl.ARRAY_BUFFER, 0, scratchStroke.subarray(0, count * 4));
       if (useDof) {
         const depthFill =
           depths.length === count
             ? depths
             : Array.from({ length: count }, () => 0.5);
+        scratchDepth = copyToScratch(depthFill, scratchDepth);
         gl.bindBuffer(gl.ARRAY_BUFFER, depthBuf);
-        gl.bufferSubData(gl.ARRAY_BUFFER, 0, new Float32Array(depthFill));
+        gl.bufferSubData(gl.ARRAY_BUFFER, 0, scratchDepth.subarray(0, count));
       }
 
       if (atlas.revision !== atlasUploadedRevision) {

--- a/apps/web/src/components/rcb/scene/paint/sceneToSvg.ts
+++ b/apps/web/src/components/rcb/scene/paint/sceneToSvg.ts
@@ -90,6 +90,7 @@ import {
   FRAME_PLATE_STROKE,
   framePlateStrokeSceneWidth,
 } from '@/components/rcb/frames/types';
+import { floorContentStrokeSceneWidth } from '@/components/rcb/render/strokeScreenFloor';
 import { strokeDashForStyle } from '../document/sceneStrokeStyle';
 import type { RcbCamera } from '@/components/rcb/core/types';
 import {
@@ -345,9 +346,11 @@ type ShapeStrokeOpts = {
 
 function strokeOptsFromNode(node: SceneNodeInput, color: string, width: number): ShapeStrokeOpts {
   const dash = strokeDashForStyle(node?.attrs?.strokeStyle);
+  // Editor SVG sits under CSS scale(zoom) — floor like WebGL so hairlines survive zoom-out.
+  const floored = floorContentStrokeSceneWidth(width, getInfiniteSvgPaintZoom());
   return {
     color,
-    width,
+    width: floored > 0 ? floored : width,
     ...(dash ? { dasharray: dash } : {}),
     align: resolveStrokeAlign(node?.attrs),
     linecap: resolveStrokeLinecap(node?.attrs),


### PR DESCRIPTION
## Summary
- Content strokes are scene-space; after zoom-out `sw * zoom` drops below 1 CSS px and WebGL AA / coverage makes them look gone even when every shape stores the same border-width.
- Floor live WebGL (kind 2/4) and editor SVG strokes to ≥1 CSS px on screen; cap SDF AA vs stroke pad; reuse per-frame upload scratch buffers; thin path segment emission when zoomed out.

## Test plan
- [ ] Place several rects with the same border-width; zoom out far — borders should remain a visible hairline (not vanish unevenly).
- [ ] Zoom back in — stroke thickness should return to geometric scene width (not stay screen-fat).
- [ ] Boolean / path outlines at low zoom should stay visible without exploding GPU instance count.
- [ ] `vitest` strokeScreenFloor + webglInstances tests green.