### PR TITLE
fix(web): repair truncated LayerPanel audioGenerator string

### DIFF
--- a/apps/web/src/components/editor/panels/LayerPanel.tsx
+++ b/apps/web/src/components/editor/panels/LayerPanel.tsx
@@ -904,7 +904,7 @@ function NodeLayerRow({
             t('editor.tools.imageGenerator'),
             t('editor.tools.videoGenerator'),
             t('editor.tools.lottieGenerator'),
-            t('editor.tools.audioGenerator', { defaultValue: '音频生成�? }),
+            t('editor.tools.audioGenerator'),
             t
           )}
         </span>


### PR DESCRIPTION
## Summary
- `LayerPanel` had a corrupted `defaultValue: '音频生成…'` that truncated mid-string and failed Vite oxc parse (`Unterminated string`).
- Drop the broken defaultValue; use `t('editor.tools.audioGenerator')` like the other generator labels (zh-CN/en locales already define the key).

## Test plan
- [ ] `pnpm --filter web dev` loads without oxc parse overlay on LayerPanel.
- [ ] Layer list still shows audio generator label via i18n.