### PR TITLE
feat(web): artboard = small canvas (bound idle ink layers)

### DIFF
--- a/apps/web/src/components/rcb/canvas/RcbCanvas.tsx
+++ b/apps/web/src/components/rcb/canvas/RcbCanvas.tsx
@@ -42,6 +42,7 @@ import {
   consumeIdleCanvasFullRepaintPending,
   type SceneRenderer,
 } from '../render/sceneRenderer';
+import { soaWebglInkShadersOk } from '../render/webglSceneRenderer';
 import {
   getSharedSceneRenderBuffer,
   isSoaCanvasShapesEnabled,
@@ -587,6 +588,13 @@ function RcbCanvas({
   const [inkBackendKey, setInkBackendKey] = useState(() => resolveIdleInkBackend());
   const inkBackendKeyRef = useRef(inkBackendKey);
   inkBackendKeyRef.current = inkBackendKey;
+  // If WebGL shaders fail, never bind webgl2 onto the stage ink canvas (blocks 2d).
+  // Remount the <canvas> when falling back so a prior failed GL claim is discarded.
+  const inkUsesWebgl =
+    (inkBackendKey === 'webgl' || inkBackendKey === 'webgpu') && soaWebglInkShadersOk();
+  const inkSurfaceKey = `${inkBackendKey}:${inkUsesWebgl ? 'gl' : '2d'}`;
+  const effectiveInkBackend =
+    inkBackendKey === 'webgl' && !inkUsesWebgl ? 'canvas2d' : inkBackendKey;
   useEffect(() => {
     return subscribeGpuDepthOfField(() => {
       setInkBackendKey(resolveIdleInkBackend());
@@ -625,7 +633,7 @@ function RcbCanvas({
       paintGrid: true,
       drawCanvasIdle: false,
     });
-    const inkRenderer = createSceneRenderer(inkBackendKey, {
+    const inkRenderer = createSceneRenderer(effectiveInkBackend, {
       ...sharedDeps,
       canvas: inkCanvas,
       paintGrid: false,
@@ -640,7 +648,7 @@ function RcbCanvas({
       paintRendererRef.current = null;
       inkRendererRef.current = null;
     };
-  }, [inkBackendKey]);
+  }, [effectiveInkBackend, inkSurfaceKey]);
 
   useEffect(() => {
     return subscribeSceneCanvasIdlePaint(() => {
@@ -869,9 +877,11 @@ function RcbCanvas({
                 className="pointer-events-none absolute inset-0 z-0"
               />
               <canvas
+                key={inkSurfaceKey}
                 ref={inkCanvasRef}
                 aria-hidden
                 data-rcb-idle-ink-canvas="1"
+                data-rcb-ink-surface={inkSurfaceKey}
                 data-rcb-canvas-idle-count={String(listSceneCanvasIdlePaintIds().length)}
                 className="pointer-events-none absolute inset-0 z-[1]"
               />

--- a/apps/web/src/components/rcb/frames/HtmlArtboardFrame.tsx
+++ b/apps/web/src/components/rcb/frames/HtmlArtboardFrame.tsx
@@ -36,6 +36,16 @@ import {
   framePlateStrokeSceneWidth,
   isAnimationArtboardKind,
 } from '@/components/rcb/frames/types';
+import {
+  getSceneCanvasIdlePaint,
+  subscribeSceneCanvasIdlePaint,
+} from '@/components/rcb/render/sceneRenderer';
+import { getSoaPaintDocument } from '@/components/rcb/render/sceneRenderBuffer';
+import {
+  registerArtboardInkSurface,
+  scheduleArtboardInkPaint,
+  updateArtboardInkChrome,
+} from '@/components/rcb/frames/artboardInkSurface';
 
 /**
  * Clear plate stroke only when SelectionChrome paints **this** plate's box.
@@ -208,6 +218,14 @@ export function previewArtboardFrameGeometry(
   }
   const plate = el.querySelector<SVGRectElement>('rect[data-baseline="1"]');
   if (plate) setAttrs(plate, { width, height });
+  const fo = el.querySelector<SVGForeignObjectElement>('foreignObject[data-rcb-artboard-ink="1"]');
+  if (fo) setAttrs(fo, { width, height });
+  const inkCanvas = el.querySelector<HTMLCanvasElement>('canvas[data-rcb-artboard-ink-canvas]');
+  if (inkCanvas) {
+    inkCanvas.style.width = `${width}px`;
+    inkCanvas.style.height = `${height}px`;
+  }
+  scheduleArtboardInkPaint(id);
   return true;
 }
 
@@ -219,17 +237,17 @@ function paintFramePlate(
   generating: boolean,
   zoom: number
 ): SVGGElement {
+  const prevPlate = layer.querySelector<SVGGElement>(':scope > g[data-rcb-frame-plate="1"]');
+  const prevHost = prevPlate as PlateInkHost | null;
+  prevHost?.__artboardInkUnregister?.();
   while (layer.firstChild) layer.removeChild(layer.firstChild);
 
   const x = Number(frame.x) || 0;
   const y = Number(frame.y) || 0;
   const w = Math.max(1, Number(frame.width) || 1);
   const h = Math.max(1, Number(frame.height) || 1);
-  const backgroundOpacity = generating
-    ? 1
-    : Math.max(0, Math.min(100, Number(frame.backgroundOpacity ?? 100))) / 100;
 
-  const g = svgEl('g');
+  const g = svgEl('g') as SVGGElement & PlateInkHost;
   append(layer, g);
   setAttrs(g, {
     transform: `translate(${x} ${y})`,
@@ -238,64 +256,100 @@ function paintFramePlate(
     'data-rcb-frame-plate': '1',
   });
   if (generating) setAttrs(g, { 'data-rcb-process-plate': '1' });
-  const anyG = g as unknown as {
-    __sceneLeft?: number;
-    __sceneTop?: number;
-    sceneWidth?: number;
-    sceneHeight?: number;
-  };
-  anyG.__sceneLeft = x;
-  anyG.__sceneTop = y;
-  anyG.sceneWidth = w;
-  anyG.sceneHeight = h;
+  g.__sceneLeft = x;
+  g.__sceneTop = y;
+  g.sceneWidth = w;
+  g.sceneHeight = h;
 
   const root = layer.ownerSVGElement;
-  const clipD = roundedRectPath(w, h, { tl: 0, tr: 0, br: 0, bl: 0 });
-  const stroke = selected
-    ? undefined
-    : {
-        color: highlighted ? FRAME_HIGHLIGHT_STROKE : FRAME_PLATE_STROKE,
-        width: framePlateStrokeSceneWidth(zoom),
-      };
-
   if (generating && root) {
-    appendProcessPlatePaths(g, root, frame.id, clipD, w, h, stroke || undefined);
-  } else {
-    let bg = '#FFFFFF';
-    if (frame.backgroundColor && frame.backgroundColor !== 'transparent') {
-      bg = frame.backgroundColor;
-    }
-    const plate = svgEl('rect', {
-      x: 0,
-      y: 0,
-      width: w,
-      height: h,
-      'data-baseline': '1',
-      'data-radius-body': '1',
-    });
-    append(g, plate);
-    setFill(plate, bg);
-    setAttrs(plate, { 'fill-opacity': backgroundOpacity });
-    plate.removeAttribute('vector-effect');
-    if (selected) {
-      setStroke(plate, 'none');
-      plate.removeAttribute('shape-rendering');
-    } else if (highlighted) {
-      setStroke(plate, {
-        color: FRAME_HIGHLIGHT_STROKE,
-        width: framePlateStrokeSceneWidth(zoom),
-      });
-      setAttrs(plate, { 'shape-rendering': 'crispEdges' });
-    } else {
-      setStroke(plate, {
-        color: FRAME_PLATE_STROKE,
-        width: framePlateStrokeSceneWidth(zoom),
-      });
-      setAttrs(plate, { 'shape-rendering': 'crispEdges' });
-    }
+    const stroke = selected
+      ? undefined
+      : {
+          color: highlighted ? FRAME_HIGHLIGHT_STROKE : FRAME_PLATE_STROKE,
+          width: framePlateStrokeSceneWidth(zoom),
+        };
+    const clipD = roundedRectPath(w, h, { tl: 0, tr: 0, br: 0, bl: 0 });
+    appendProcessPlatePaths(g, root, frame.id, clipD, w, h, stroke);
+    return g;
   }
+
+  mountArtboardInk(g, frame, w, h, selected, highlighted, zoom);
   return g;
 }
+
+type PlateInkHost = {
+  __sceneLeft?: number;
+  __sceneTop?: number;
+  sceneWidth?: number;
+  sceneHeight?: number;
+  __artboardInkCanvas?: HTMLCanvasElement;
+  __artboardInkUnregister?: () => void;
+};
+
+function inkPaintFrameFrom(frame: ArtboardFrame) {
+  const geom = resolvePaintFrameGeometry(frame);
+  return {
+    id: frame.id,
+    x: Number(geom.x) || 0,
+    y: Number(geom.y) || 0,
+    width: Math.max(1, Number(geom.width) || 1),
+    height: Math.max(1, Number(geom.height) || 1),
+    backgroundColor: frame.backgroundColor,
+    backgroundOpacity: frame.backgroundOpacity,
+  };
+}
+
+function mountArtboardInk(
+  g: SVGGElement & PlateInkHost,
+  frame: ArtboardFrame,
+  w: number,
+  h: number,
+  selected: boolean,
+  highlighted: boolean,
+  zoom: number
+): void {
+  const fo = svgEl('foreignObject', {
+    x: 0,
+    y: 0,
+    width: w,
+    height: h,
+    'data-rcb-artboard-ink': '1',
+  }) as SVGForeignObjectElement;
+  append(g, fo);
+
+  const canvas = document.createElement('canvas');
+  canvas.setAttribute('data-rcb-artboard-ink-canvas', frame.id);
+  canvas.style.display = 'block';
+  canvas.style.width = `${w}px`;
+  canvas.style.height = `${h}px`;
+  fo.appendChild(canvas);
+
+  g.__artboardInkCanvas = canvas;
+  g.__artboardInkUnregister = registerArtboardInkSurface({
+    canvas,
+    frameId: frame.id,
+    selected,
+    highlighted,
+    zoom,
+    getFrame: () => inkPaintFrameFrom(frame),
+    getDocument: () => getSceneCanvasIdlePaint()?.document ?? getSoaPaintDocument() ?? null,
+  });
+
+  const plate = svgEl('rect', {
+    x: 0,
+    y: 0,
+    width: w,
+    height: h,
+    'data-baseline': '1',
+    'data-radius-body': '1',
+  });
+  append(g, plate);
+  setFill(plate, 'none');
+  setStroke(plate, 'none');
+  setAttrs(plate, { 'pointer-events': 'none' });
+}
+
 
 function HtmlArtboardFrame({
   frame,
@@ -363,6 +417,8 @@ function HtmlArtboardFrame({
     }
 
     return () => {
+      const plate = sceneLayer.querySelector<SVGGElement>(':scope > g[data-rcb-frame-plate="1"]');
+      (plate as PlateInkHost | null)?.__artboardInkUnregister?.();
       unregisterShapeHost(frame.id);
       try {
         sceneLayer.remove();
@@ -374,6 +430,22 @@ function HtmlArtboardFrame({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [layer, frame.id, worldEpoch]);
 
+  // Idle SoA / document paint → restamp every artboard small-canvas.
+  useEffect(() => {
+    if (layer !== 'body') return undefined;
+    return subscribeSceneCanvasIdlePaint(() => {
+      scheduleArtboardInkPaint(frame.id);
+    });
+  }, [layer, frame.id]);
+
+  // Live plate geometry → restamp ink (bounds already updated in previewArtboardFrameGeometry).
+  useEffect(() => {
+    if (layer !== 'body') return undefined;
+    return subscribeLiveArtboardFrameGeometry(() => {
+      scheduleArtboardInkPaint(frame.id);
+    });
+  }, [layer, frame.id]);
+
   // Selection / zoom hairline: repaint plate in place (do not remount the layer g).
   useLayoutEffect(() => {
     if (layer !== 'body') return;
@@ -384,26 +456,7 @@ function HtmlArtboardFrame({
     // makes bound content look like it is sliding inside the plate.
     const live = getLiveArtboardFrameGeometry(frame.id);
     if (live) {
-      const host = getShapeHost(frame.id)?.el as SVGElement | null | undefined;
-      if (!host) return;
-      const plate = host.querySelector<SVGRectElement>('rect[data-baseline="1"]');
-      if (!plate) return;
-      if (selected) {
-        setStroke(plate, 'none');
-        plate.removeAttribute('shape-rendering');
-      } else if (highlighted) {
-        setStroke(plate, {
-          color: FRAME_HIGHLIGHT_STROKE,
-          width: framePlateStrokeSceneWidth(z),
-        });
-        setAttrs(plate, { 'shape-rendering': 'crispEdges' });
-      } else {
-        setStroke(plate, {
-          color: FRAME_PLATE_STROKE,
-          width: framePlateStrokeSceneWidth(z),
-        });
-        setAttrs(plate, { 'shape-rendering': 'crispEdges' });
-      }
+      updateArtboardInkChrome(frame.id, { selected, highlighted, zoom: z });
       return;
     }
     const paintFrame = { ...frame, ...resolvePaintFrameGeometry(frame) };
@@ -424,6 +477,7 @@ function HtmlArtboardFrame({
     frame.width,
     frame.height,
     frame.backgroundColor,
+    frame.backgroundOpacity,
     frame.clipContent,
   ]);
 

--- a/apps/web/src/components/rcb/frames/__tests__/artboardInkSurface.test.ts
+++ b/apps/web/src/components/rcb/frames/__tests__/artboardInkSurface.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createEmptyDocument,
+  addNodeToDocument,
+} from '@/components/rcb/scene/document/sceneDocument';
+import {
+  createSceneRenderBuffer,
+  syncSceneRenderBufferFromDocument,
+  SOA_FLAG_CANVAS_IDLE,
+} from '@/components/rcb/render/sceneRenderBuffer';
+import { collectSoaWebglInstances } from '@/components/rcb/render/webglSceneRenderer';
+import { soaSlotIsFrameBound } from '@/components/rcb/frames/artboardInkSurface';
+
+describe('artboard small-canvas SoA partition', () => {
+  it('skipFrameBound omits plate-bound idle slots from world collect', () => {
+    let doc = createEmptyDocument({ width: 800, height: 600, emptyWorld: true });
+    doc.frames = [
+      {
+        id: 'board',
+        name: 'A',
+        backgroundColor: '#fff',
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 200,
+      },
+    ];
+    doc = addNodeToDocument(doc, 'world', {
+      id: 'world',
+      key: 'shape',
+      x: 300,
+      y: 0,
+      width: 20,
+      height: 20,
+      attrs: { shapeType: 'rect', fill: '#f00', 'stroke-enabled': false },
+      children: [],
+    });
+    doc = addNodeToDocument(doc, 'bound', {
+      id: 'bound',
+      key: 'shape',
+      x: 10,
+      y: 10,
+      width: 20,
+      height: 20,
+      attrs: {
+        shapeType: 'rect',
+        fill: '#0f0',
+        'stroke-enabled': false,
+        frameId: 'board',
+      },
+      children: [],
+    });
+    const buf = createSceneRenderBuffer();
+    syncSceneRenderBufferFromDocument(buf, doc);
+    for (let i = 0; i < buf.count; i += 1) {
+      buf.flags[i] = (buf.flags[i] | SOA_FLAG_CANVAS_IDLE) >>> 0;
+    }
+    const boundIdx = buf.indexById.get('bound')!;
+    expect(soaSlotIsFrameBound(buf, boundIdx, doc)).toBe(true);
+
+    const kinds: number[] = [];
+    collectSoaWebglInstances(
+      buf,
+      { x: 0, y: 0, width: 800, height: 600 },
+      [],
+      [],
+      kinds,
+      [],
+      [],
+      { document: doc, skipFrameBound: true }
+    );
+    // Only the unbound world rect (kind 0, stroke disabled).
+    expect(kinds).toEqual([0]);
+  });
+});

--- a/apps/web/src/components/rcb/frames/artboardInkSurface.ts
+++ b/apps/web/src/components/rcb/frames/artboardInkSurface.ts
@@ -1,0 +1,211 @@
+/**
+ * Per-artboard ink surface — plate fill + bound SoA idle nodes on a small canvas.
+ * Lives inside the frame's stack SVG layer (data-z) so FO hosts can interleave
+ * with other artboards. World WebGL skips frame-bound slots (see skipFrameBound).
+ */
+import type { ArtboardFrame } from '@/components/rcb/frames/types';
+import {
+  FRAME_HIGHLIGHT_STROKE,
+  FRAME_PLATE_STROKE,
+  framePlateStrokeSceneWidth,
+} from '@/components/rcb/frames/types';
+import {
+  getSharedSceneRenderBuffer,
+  paintSoaIdleSlot,
+  SOA_FLAG_CANVAS_IDLE,
+  SOA_FLAG_FREE,
+  SOA_FLAG_VISIBLE,
+  setSoaPaintDocument,
+  type SceneRenderBuffer,
+} from '@/components/rcb/render/sceneRenderBuffer';
+import { buildNodeStackZMap } from '@/components/rcb/scene/document/sceneDocument';
+import type { SceneDocument, SceneNodeInput } from '@/components/rcb/sceneNode';
+import { getNodeTransformPreview } from '@/components/rcb/core/transformPreview';
+import { readDevicePixelRatio } from '@/components/rcb/core/dpr';
+import { nodeOwnerFrameId } from '@/components/rcb/frames/frameNodeBinding';
+
+export type ArtboardInkPaintFrame = Pick<
+  ArtboardFrame,
+  'id' | 'x' | 'y' | 'width' | 'height'
+> & {
+  backgroundColor?: string;
+  backgroundOpacity?: number;
+};
+
+type SurfaceEntry = {
+  canvas: HTMLCanvasElement;
+  frameId: string;
+  getFrame: () => ArtboardInkPaintFrame;
+  getDocument: () => SceneDocument | null;
+  selected: boolean;
+  highlighted: boolean;
+  zoom: number;
+};
+
+const surfaces = new Map<string, SurfaceEntry>();
+let paintRaf = 0;
+
+function clampZoom(zoom: number | undefined): number {
+  return Math.max(0.05, Number(zoom) || 1);
+}
+
+function plateFillCss(frame: ArtboardInkPaintFrame): { css: string; alpha: number } {
+  const raw = frame.backgroundColor;
+  const css = raw && raw !== 'transparent' ? String(raw) : '#FFFFFF';
+  const alpha = Math.max(0, Math.min(100, Number(frame.backgroundOpacity ?? 100))) / 100;
+  return { css, alpha };
+}
+
+function resizeInkCanvas(canvas: HTMLCanvasElement, w: number, h: number, dpr: number): void {
+  const bw = Math.max(1, Math.round(w * dpr));
+  const bh = Math.max(1, Math.round(h * dpr));
+  if (canvas.width !== bw || canvas.height !== bh) {
+    canvas.width = bw;
+    canvas.height = bh;
+  }
+  canvas.style.width = `${w}px`;
+  canvas.style.height = `${h}px`;
+}
+
+function collectBoundIdleIndices(
+  buf: SceneRenderBuffer,
+  doc: SceneDocument,
+  frameId: string
+): number[] {
+  const indices: number[] = [];
+  for (let i = 0; i < buf.count; i += 1) {
+    const flags = buf.flags[i];
+    if (flags & SOA_FLAG_FREE) continue;
+    if (!(flags & SOA_FLAG_VISIBLE) || !(flags & SOA_FLAG_CANVAS_IDLE)) continue;
+    const id = buf.ids[i];
+    if (!id) continue;
+    const node = doc.deltaSetLike?.[id] as SceneNodeInput | undefined;
+    if (!node || nodeOwnerFrameId(node) !== frameId) continue;
+    if (getNodeTransformPreview(id)?.hidden) continue;
+    indices.push(i);
+  }
+  if (indices.length <= 1) return indices;
+  const zMap = buildNodeStackZMap(doc);
+  indices.sort((a, b) => (zMap.get(buf.ids[a] || '') ?? 0) - (zMap.get(buf.ids[b] || '') ?? 0));
+  return indices;
+}
+
+/** Register a display canvas for continuous artboard ink. */
+export function registerArtboardInkSurface(
+  entry: Omit<SurfaceEntry, 'selected' | 'highlighted' | 'zoom'> & {
+    selected?: boolean;
+    highlighted?: boolean;
+    zoom?: number;
+  }
+): () => void {
+  const id = String(entry.frameId || '').trim();
+  if (!id) return () => undefined;
+  const full: SurfaceEntry = {
+    canvas: entry.canvas,
+    frameId: id,
+    getFrame: entry.getFrame,
+    getDocument: entry.getDocument,
+    selected: Boolean(entry.selected),
+    highlighted: Boolean(entry.highlighted),
+    zoom: clampZoom(entry.zoom),
+  };
+  surfaces.set(id, full);
+  scheduleArtboardInkPaint(id);
+  return () => {
+    if (surfaces.get(id) === full) surfaces.delete(id);
+  };
+}
+
+/** Update plate chrome flags without remounting the foreignObject canvas. */
+export function updateArtboardInkChrome(
+  frameId: string,
+  opts: { selected?: boolean; highlighted?: boolean; zoom?: number }
+): void {
+  const entry = surfaces.get(String(frameId || '').trim());
+  if (!entry) return;
+  if (opts.selected != null) entry.selected = Boolean(opts.selected);
+  if (opts.highlighted != null) entry.highlighted = Boolean(opts.highlighted);
+  if (opts.zoom != null) entry.zoom = clampZoom(opts.zoom);
+  scheduleArtboardInkPaint(frameId);
+}
+
+/**
+ * Repaint one plate sync, or coalesce a full restamp on the next frame.
+ * Calling with an id does not also schedule a global RAF (avoids double paint).
+ */
+export function scheduleArtboardInkPaint(frameId?: string): void {
+  if (frameId) {
+    const one = surfaces.get(String(frameId).trim());
+    if (one) paintArtboardInkSurface(one);
+    return;
+  }
+  if (paintRaf) return;
+  paintRaf = requestAnimationFrame(() => {
+    paintRaf = 0;
+    for (const entry of surfaces.values()) paintArtboardInkSurface(entry);
+  });
+}
+
+export function paintArtboardInkSurface(entry: SurfaceEntry): void {
+  const frame = entry.getFrame();
+  const w = Math.max(1, Number(frame.width) || 1);
+  const h = Math.max(1, Number(frame.height) || 1);
+  const dpr = Math.max(1, readDevicePixelRatio() || 1);
+  resizeInkCanvas(entry.canvas, w, h, dpr);
+
+  const ctx = entry.canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, w, h);
+
+  const { css, alpha } = plateFillCss(frame);
+  ctx.globalAlpha = alpha;
+  ctx.fillStyle = css;
+  ctx.fillRect(0, 0, w, h);
+  ctx.globalAlpha = 1;
+
+  const doc = entry.getDocument();
+  if (doc) {
+    setSoaPaintDocument(doc);
+    const buf = getSharedSceneRenderBuffer();
+    const fx = Number(frame.x) || 0;
+    const fy = Number(frame.y) || 0;
+    const indices = collectBoundIdleIndices(buf, doc, String(frame.id));
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(0, 0, w, h);
+    ctx.clip();
+    ctx.translate(-fx, -fy);
+    const view = { left: fx, top: fy, right: fx + w, bottom: fy + h };
+    for (const i of indices) paintSoaIdleSlot(ctx, buf, i, view, doc);
+    ctx.restore();
+  }
+
+  paintPlateStroke(ctx, w, h, entry);
+}
+
+function paintPlateStroke(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  entry: SurfaceEntry
+): void {
+  if (entry.selected) return;
+  const sw = framePlateStrokeSceneWidth(clampZoom(entry.zoom));
+  ctx.strokeStyle = entry.highlighted ? FRAME_HIGHLIGHT_STROKE : FRAME_PLATE_STROKE;
+  ctx.lineWidth = sw;
+  ctx.strokeRect(sw / 2, sw / 2, Math.max(0, w - sw), Math.max(0, h - sw));
+}
+
+/** True when a SoA slot belongs to an artboard (painted on ArtboardLayer, not world ink). */
+export function soaSlotIsFrameBound(
+  buf: SceneRenderBuffer,
+  index: number,
+  doc: SceneDocument | null | undefined
+): boolean {
+  if (!doc) return false;
+  const id = buf.ids[index];
+  if (!id) return false;
+  const node = doc.deltaSetLike?.[id] as SceneNodeInput | undefined;
+  return Boolean(nodeOwnerFrameId(node));
+}

--- a/apps/web/src/components/rcb/frames/frameNodeBinding.ts
+++ b/apps/web/src/components/rcb/frames/frameNodeBinding.ts
@@ -21,6 +21,13 @@ export function isAvMediaSceneNode(node: { key?: unknown } | null | undefined): 
   return key === 'video' || key === 'audio';
 }
 
+/** Owning artboard id from `attrs.frameId`, or empty when unbound. */
+export function nodeOwnerFrameId(
+  node: { attrs?: { frameId?: unknown } | null } | null | undefined
+): string {
+  return String(node?.attrs?.frameId || '').trim();
+}
+
 /** 动画工作台 rejects AV + generators; nested free Lottie plates become precomp tabs. */
 export function canBindNodeToArtboardFrame(
   frame: ArtboardFrame | null | undefined,

--- a/apps/web/src/components/rcb/render/__tests__/webglInkFallbackCanvas.test.ts
+++ b/apps/web/src/components/rcb/render/__tests__/webglInkFallbackCanvas.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import {
+  resetSoaWebglInkShaderProbeForTests,
+  soaWebglInkShadersOk,
+} from '../webglSceneRenderer';
+import { createSceneRenderer } from '../sceneRenderer';
+import { setSoaCanvasShapesEnabledForTests } from '../sceneRenderBuffer';
+import { createEmptyDocument } from '@/components/rcb/scene/document/sceneDocument';
+
+describe('webgl ink fallback without tainting stage canvas', () => {
+  beforeEach(() => {
+    resetSoaWebglInkShaderProbeForTests();
+    setSoaCanvasShapesEnabledForTests(true);
+  });
+  afterEach(() => {
+    resetSoaWebglInkShaderProbeForTests();
+    setSoaCanvasShapesEnabledForTests(null);
+  });
+
+  it('soaWebglInkShadersOk runs on a probe canvas (does not throw)', () => {
+    // happy-dom / jsdom may lack WebGL2 — either true or false is fine.
+    expect(typeof soaWebglInkShadersOk()).toBe('boolean');
+  });
+
+  it('createSceneRenderer(webgl) yields a working renderer without poisoning 2d', () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 64;
+    canvas.height = 64;
+    const renderer = createSceneRenderer('webgl', {
+      canvas,
+      getDocument: () => createEmptyDocument({ emptyWorld: true }),
+      getZoom: () => 1,
+      listNodeIds: () => [],
+      getNodeBox: () => null,
+      paintGrid: false,
+      drawCanvasIdle: true,
+    });
+    expect(renderer).toBeTruthy();
+    expect(renderer.backend === 'webgl' || renderer.backend === 'canvas2d').toBe(true);
+    // Critical: fallback must not have claimed webgl2 on the stage canvas.
+    if (renderer.backend === 'canvas2d') {
+      expect(canvas.getContext('webgl2')).toBeNull();
+    }
+    renderer.dispose();
+  });
+});

--- a/apps/web/src/components/rcb/render/sceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/sceneRenderer.ts
@@ -133,7 +133,7 @@ import {
   subscribeSoaBakeTileReady,
   unionSoaDirtyAabb,
 } from '@/components/rcb/render/soaBakeLayer';
-import { createWebglSceneRenderer } from '@/components/rcb/render/webglSceneRenderer';
+import { createWebglSceneRenderer, soaWebglInkShadersOk } from '@/components/rcb/render/webglSceneRenderer';
 import { createWebgpuSceneRenderer } from '@/components/rcb/render/webgpuSceneRenderer';
 import {
   resolveGpuDofBackend,
@@ -3069,11 +3069,23 @@ export function createSceneRenderer(
     if (!isSoaCanvasShapesEnabled()) {
       throw new Error('createSceneRenderer(webgl) requires SoA canvas shapes');
     }
+    // Probe on a throwaway canvas first — never bind webgl2 onto the stage ink
+    // canvas unless the ink program links (otherwise Canvas2D fallback is dead).
+    if (!soaWebglInkShadersOk()) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[scene] WebGL2 ink shaders unavailable; using canvas2d idle ink (do not claim webgl2 on stage canvas)'
+        );
+      }
+      ensureSoaBakeTileReadyBridge();
+      return createCanvasSceneRenderer(canvasDeps);
+    }
     const gl = createWebglSceneRenderer(canvasDeps);
     if (!gl) {
       if (import.meta.env.DEV) {
         // eslint-disable-next-line no-console
-        console.warn('[scene] WebGL2 ink unavailable; falling back to canvas2d');
+        console.warn('[scene] WebGL2 ink unavailable after probe; falling back to canvas2d');
       }
       ensureSoaBakeTileReadyBridge();
       return createCanvasSceneRenderer(canvasDeps);

--- a/apps/web/src/components/rcb/render/soaBakeLayer.ts
+++ b/apps/web/src/components/rcb/render/soaBakeLayer.ts
@@ -19,6 +19,7 @@ import {
 } from './sceneRenderBuffer';
 import { getNodeTransformPreview, hasNodeTransformPreviews } from '@/components/rcb/core/transformPreview';
 import type { SceneDocument } from '@/components/rcb/sceneNode';
+import { nodeOwnerFrameId } from '@/components/rcb/frames/frameNodeBinding';
 
 /** Document for plate clip while baking tiles (set by the stage renderer). */
 let bakeClipDocument: SceneDocument | null = null;
@@ -45,6 +46,14 @@ function getBakeReadyListeners(): Set<() => void> {
 
 export function setSoaBakeClipDocument(doc: SceneDocument | null | undefined) {
   bakeClipDocument = doc ?? null;
+}
+
+/** World bake tiles skip plate-bound ink (ArtboardLayer owns those slots). */
+function isBakeFrameBoundSlot(buf: SceneRenderBuffer, i: number): boolean {
+  if (!bakeClipDocument) return false;
+  const id = buf.ids[i];
+  if (!id) return false;
+  return Boolean(nodeOwnerFrameId(bakeClipDocument.deltaSetLike?.[id]));
 }
 
 /** Engage when canvas-idle SoA density is near a full viewport (~800+). */
@@ -120,6 +129,7 @@ export function computeSoaIdleBounds(buf: SceneRenderBuffer): SoaWorldBounds | n
   for (let i = 0; i < buf.count; i += 1) {
     const flags = buf.flags[i];
     if (!(flags & SOA_FLAG_VISIBLE) || !(flags & SOA_FLAG_CANVAS_IDLE)) continue;
+    if (isBakeFrameBoundSlot(buf, i)) continue;
     const kind = buf.kinds[i];
     if (
       kind !== SOA_KIND_RECT &&
@@ -310,6 +320,7 @@ export function countSoaBakeEligibleSlots(buf: SceneRenderBuffer): number {
     if (!(flags & SOA_FLAG_VISIBLE)) continue;
     if (!(flags & SOA_FLAG_CANVAS_IDLE)) continue;
     if (!(flags & SOA_FLAG_BASIC_GEOM)) continue;
+    if (isBakeFrameBoundSlot(buf, i)) continue;
     n += 1;
   }
   return n;
@@ -357,6 +368,7 @@ function paintIdleInto(
   paintSoaBufferBasic(ctx as CanvasRenderingContext2D, buf, bounds, {
     dirtyOnly: false,
     document: bakeClipDocument,
+    skipIndex: (i) => isBakeFrameBoundSlot(buf, i),
   });
 }
 
@@ -506,6 +518,7 @@ function bindElementsForTileBounds(
   for (let i = 0; i < buf.count; i += 1) {
     const flags = buf.flags[i];
     if (!(flags & SOA_FLAG_VISIBLE) || !(flags & SOA_FLAG_CANVAS_IDLE)) continue;
+    if (isBakeFrameBoundSlot(buf, i)) continue;
     const id = buf.ids[i];
     if (!id) continue;
     const o = i * POS_STRIDE;

--- a/apps/web/src/components/rcb/render/webglSceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/webglSceneRenderer.ts
@@ -28,6 +28,7 @@ import {
   type SceneRenderBuffer,
 } from '@/components/rcb/render/sceneRenderBuffer';
 import { getLiveCornerRadiusPreviewRadii } from '@/components/rcb/scene/document/sceneRadii';
+import { nodeOwnerFrameId } from '@/components/rcb/frames/frameNodeBinding';
 import type { SceneDocument, SceneNodeInput } from '@/components/rcb/sceneNode';
 import {
   collectSoaBakeTilesIntoAtlas,
@@ -259,6 +260,57 @@ function link(gl: WebGL2RenderingContext, vs: WebGLShader, fs: WebGLShader) {
     return null;
   }
   return prog;
+}
+
+let inkShaderProbeOk: boolean | null = null;
+
+/**
+ * Compile the product ink program on a throwaway canvas.
+ * Must run BEFORE `getContext('webgl2')` on the stage ink canvas — a failed
+ * compile still binds WebGL2 to that element and blocks Canvas2D fallback
+ * (deselected shapes then vanish; only selection chrome remains).
+ */
+export function soaWebglInkShadersOk(): boolean {
+  if (inkShaderProbeOk != null) return inkShaderProbeOk;
+  if (typeof document === 'undefined') {
+    inkShaderProbeOk = false;
+    return false;
+  }
+  try {
+    const probe = document.createElement('canvas');
+    probe.width = 1;
+    probe.height = 1;
+    const gl = probe.getContext('webgl2', {
+      alpha: true,
+      premultipliedAlpha: true,
+      antialias: false,
+    });
+    if (!gl) {
+      inkShaderProbeOk = false;
+      return false;
+    }
+    const vs = compile(gl, gl.VERTEX_SHADER, VS);
+    const fs = compile(gl, gl.FRAGMENT_SHADER, FS);
+    const prog = vs && fs ? link(gl, vs, fs) : null;
+    inkShaderProbeOk = Boolean(prog);
+    if (prog) gl.deleteProgram(prog);
+    if (vs) gl.deleteShader(vs);
+    if (fs) gl.deleteShader(fs);
+    gl.getExtension('WEBGL_lose_context')?.loseContext();
+    return inkShaderProbeOk;
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.error('[webgl] ink shader probe failed', err);
+    }
+    inkShaderProbeOk = false;
+    return false;
+  }
+}
+
+/** Test-only: clear probe cache after shader source changes. */
+export function resetSoaWebglInkShaderProbeForTests() {
+  inkShaderProbeOk = null;
 }
 
 function argbToRgba(argb: number): [number, number, number, number] {
@@ -565,6 +617,11 @@ export type CollectSoaWebglOpts = {
   document?: SceneDocument | null;
   /** Camera zoom — text atlas greeking threshold. */
   zoom?: number;
+  /**
+   * World idle ink: skip nodes with attrs.frameId (ArtboardLayer paints them).
+   * Default false for tests / bake helpers that collect everything.
+   */
+  skipFrameBound?: boolean;
 };
 
 /**
@@ -588,6 +645,7 @@ export function collectSoaWebglInstances(
   const strokes = opts?.strokes;
   const paintDoc = opts?.document ?? getSoaPaintDocument();
   const zoom = Math.max(0.05, Number(opts?.zoom) || 1);
+  const skipFrameBound = opts?.skipFrameBound === true;
   const vl = view.left ?? view.x ?? 0;
   const vt = view.top ?? view.y ?? 0;
   const vr = vl + view.width;
@@ -597,6 +655,10 @@ export function collectSoaWebglInstances(
     if (!(flags & SOA_FLAG_VISIBLE) || !(flags & SOA_FLAG_CANVAS_IDLE)) continue;
     const idEarly = buf.ids[i];
     if (idEarly && getNodeTransformPreview(idEarly)?.hidden) continue;
+    if (skipFrameBound && paintDoc && idEarly) {
+      const node = paintDoc.deltaSetLike?.[idEarly];
+      if (nodeOwnerFrameId(node)) continue;
+    }
     const kind = buf.kinds[i];
     if (
       kind !== SOA_KIND_RECT &&
@@ -1314,6 +1376,8 @@ export function createWebglSceneRenderer(
           strokes,
           document: req.document,
           zoom: z,
+          // ArtboardLayer owns plate-bound idle ink on per-frame small canvases.
+          skipFrameBound: true,
         });
       }
       const count = kinds.length;

--- a/apps/web/src/components/rcb/render/webgpuSceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/webgpuSceneRenderer.ts
@@ -492,6 +492,7 @@ function drawFrame(gpu: GpuRuntime, canvas: HTMLCanvasElement, req: SceneRenderR
       depthForId: (id) => depthLookup.depthForId(id),
       clips,
       document: req.document,
+      skipFrameBound: true,
     });
   }
 

--- a/apps/web/src/components/rcb/scene/document/__tests__/unifiedStackOrderPaint.test.ts
+++ b/apps/web/src/components/rcb/scene/document/__tests__/unifiedStackOrderPaint.test.ts
@@ -132,7 +132,7 @@ describe('unified stackOrder paint', () => {
     expect(canvasIds).toEqual([]);
   });
 
-  it('frame-bound children always take a DOM host (plate shares stack SVG above ink)', () => {
+  it('frame-bound idle rects stay on ArtboardLayer ink (not DOM hosts)', () => {
     const node = {
       id: 'child',
       key: 'shape',
@@ -140,21 +140,35 @@ describe('unified stackOrder paint', () => {
       y: 0,
       width: 40,
       height: 40,
-      attrs: { shapeType: 'rect', frameId: 'board', 'fill-color': '#abc' },
+      attrs: { shapeType: 'rect', frameId: 'board', 'fill-color': '#abc', 'stroke-enabled': false },
     };
-    expect(nodeNeedsDomShapeHost(node as never)).toBe(true);
+    expect(nodeNeedsDomShapeHost(node as never)).toBe(false);
     let doc = createBareDocument();
     doc.frames = [
       { id: 'board', name: 'A', backgroundColor: '#fff', x: 0, y: 0, width: 100, height: 100 },
     ];
     doc.stackOrder = ['frame:board'];
     doc = addNodeToDocument(doc, 'child', { ...node, children: [] } as never);
-    const { fullIds } = pickFullAndCanvasIds({
+    const { fullIds, canvasIds } = pickFullAndCanvasIds({
       document: doc,
       visibleIds: ['child'],
       zoom: 1,
     });
-    expect(fullIds).toContain('child');
+    expect(fullIds).not.toContain('child');
+    expect(canvasIds).toContain('child');
+  });
+
+  it('frame-bound lottie still takes a DOM host', () => {
+    const node = {
+      id: 'lot',
+      key: 'lottie',
+      x: 0,
+      y: 0,
+      width: 40,
+      height: 40,
+      attrs: { frameId: 'board' },
+    };
+    expect(nodeNeedsDomShapeHost(node as never)).toBe(true);
   });
 
   it('static text idles on ink when below plates; hosts when stacked above', () => {

--- a/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
@@ -349,14 +349,8 @@ export function nodeNeedsDomShapeHost(
   if (forceFull) return true;
   if (!node) return true;
   if (isImageProcessRunning(node)) return true;
-  // Plates share the stack SVG above SoA ink — bound children must host so
-  // their data-z can sit above the owner plate.
-  if (String(node.attrs?.frameId || '').trim()) return true;
+  // Artboard-bound idle vectors use ArtboardLayer ink — not SVG hosts for frameId alone.
   const key = String(node.key || '');
-  // Static text —canvas ink; caret —TextInlineEditor overlay.
-  // Static image —paintCanvasMediaInk / atlas bake (empty gens bake plate glyph).
-  // SoftGlow process still forceFull above.
-  // Video/audio idle —canvas poster/plate; selected decoder is forceFull (FO + HTML).
   if (key === 'lottie' || key === 'group') return true;
   return !canIdlePaintOnCanvas(node);
 }

--- a/apps/web/src/components/rcb/shapes/__tests__/canvasIdleHostBudget.test.ts
+++ b/apps/web/src/components/rcb/shapes/__tests__/canvasIdleHostBudget.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { canIdlePaintOnCanvas, canvasIdleIsStrokeOnly, pickFullAndCanvasIds } from '../RcbShapesLayer';
+import { canIdlePaintOnCanvas, canvasIdleIsStrokeOnly, nodeNeedsDomShapeHost, pickFullAndCanvasIds } from '../RcbShapesLayer';
 import { HEAVY_PATH_D_CHARS } from '@/components/rcb/scene/document/sceneShapes';
 import type { SceneDocument } from '@/components/rcb/sceneNode';
 
@@ -488,6 +488,77 @@ describe('canIdlePaintOnCanvas', () => {
         attrs: {},
       } as never)
     ).toBe(false);
+  });
+
+  it('framed solid rects idle on ArtboardLayer ink (not full SVG hosts)', () => {
+    const nodes: Record<string, any> = {
+      framed: {
+        ...rect('framed'),
+        attrs: { ...(rect('framed').attrs || {}), frameId: 'board', frameOrder: 0 },
+      },
+    };
+    const doc = makeDoc(nodes);
+    doc.frames = [
+      {
+        id: 'board',
+        name: 'A',
+        backgroundColor: '#fff',
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 200,
+      },
+    ] as never;
+    const { fullIds, canvasIds } = pickFullAndCanvasIds({
+      document: doc,
+      visibleIds: ['framed'],
+      zoom: 1,
+    });
+    expect(fullIds).not.toContain('framed');
+    expect(canvasIds).toContain('framed');
+  });
+
+  it('animation workbench: idle vectors stay on ArtboardLayer; lottie stays FO host', () => {
+    const nodes: Record<string, any> = {
+      ink: {
+        ...rect('ink'),
+        attrs: { ...(rect('ink').attrs || {}), frameId: 'lot', frameOrder: 0 },
+      },
+      nest: {
+        id: 'nest',
+        key: 'lottie',
+        x: 10,
+        y: 10,
+        width: 80,
+        height: 80,
+        attrs: { frameId: 'lot', frameOrder: 1, animationData: '{}' },
+      },
+    };
+    const doc = makeDoc(nodes);
+    doc.frames = [
+      {
+        id: 'lot',
+        name: '动画工作台',
+        backgroundColor: '#fff',
+        x: 0,
+        y: 0,
+        width: 364,
+        height: 364,
+        kind: 'animation',
+      },
+    ] as never;
+    doc.stackOrder = ['frame:lot', 'node:ink', 'node:nest'];
+    const { fullIds, canvasIds } = pickFullAndCanvasIds({
+      document: doc,
+      visibleIds: ['ink', 'nest'],
+      zoom: 1,
+    });
+    expect(fullIds).not.toContain('ink');
+    expect(canvasIds).toContain('ink');
+    expect(fullIds).toContain('nest');
+    expect(canvasIds).not.toContain('nest');
+    expect(nodeNeedsDomShapeHost(nodes.nest as never)).toBe(true);
+    expect(nodeNeedsDomShapeHost(nodes.ink as never)).toBe(false);
   });
 
   it('canvasIdleIsStrokeOnly for stroke-only pens', () => {

--- a/docs/adr/0027-canvas-layered-runtime.md
+++ b/docs/adr/0027-canvas-layered-runtime.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-08-15
-- **Updated:** 2026-09-04 — Unified `stackOrder` paint + ideal hit (one QT for nodes + `frame:id`; permanent stackOrder top-first; `__frame__:id` plate hits; selection paint raise paint-only)
+- **Updated:** 2026-09-04 — Artboard = small canvas (per-plate ArtboardLayer ink + FO by `stackOrder`); world WebGL unbound-only (`skipFrameBound`). Earlier: unified `stackOrder` paint + ideal hit.
 - **Supersedes (partial):** [ADR 0002](./0002-canvas-rcb-runtime.md) runtime paint/hit coupling — RCB ownership stays; SVG is no longer the editor runtime fact layer.
 
 ## Context
@@ -21,7 +21,19 @@ Treat the editor runtime as four facts (**this is the product architecture — d
 
 1. **`SceneDocument`** — unique document source of truth (store / collab patches write here).
 2. **`CameraTransform`** — single pan/zoom matrix; only `worldToScreen` / `stageLocalToWorld` / `screenDeltaToWorldDelta` on hot paths. No DOM “correction” of coordinates during gestures.
-3. **Layered render** — **WebGL2 instanced SoA ink** (only product ink path) sits under one **stack SVG** where artboard plates and DOM hosts interleave by `stackOrder` (`data-z`). DOM hosts only when ink cannot occupy the correct stack slot (above plates, FO media, SoftGlow, editors, lottie/group, heavy paths). **Grid** stays on a separate Canvas2D surface. Selection, guides, and drawing previews share the camera surface; screen UI stays in the HTML overlay. SoftGlow/editors use `RenderDemotionScheduler` (`ACTIVE_SVG` → `CANDIDATE` → `DEPLOYED_SOA`); selection does **not** promote basic shapes onto SVG. There is **no** Canvas2D idle-ink / pan-blit / bake-blit dual path. Do **not** reintroduce per-type CSS z bands or host-occlusion / plate-cutout paint hacks.
+3. **Layered render** — paint order is:
+
+   ```text
+   grid (Canvas2D) → world WebGL (unbound idle) → stack by stackOrder (ArtboardLayer ink + FO hosts) → chrome
+   ```
+
+   - **World WebGL2** instanced SoA ink on `[data-rcb-idle-ink-canvas]` paints **unbound** idle nodes only (`collectSoaWebglInstances` + `skipFrameBound`). World tile bake (`soaBakeLayer`) likewise skips plate-bound slots.
+   - **ArtboardLayer** (per `document.frames[]`): plate fill + bound idle SoA ink on a small canvas inside the stack SVG layer (`data-rcb-frame-layer` + `data-z` via `artboardInkSurface` / `HtmlArtboardFrame`). FO/editor hosts for that plate are siblings on the same mount, ordered by `stackOrder`, so a selected video can sit between two artboards.
+   - **DOM hosts** only for FO media, SoftGlow, editors, lottie/group, heavy paths, and unbound nodes stacked above any plate. Bound idle vectors/media posters use ArtboardLayer ink — never SVG hosts for ownership alone.
+   - **Grid** stays on a separate Canvas2D surface. Selection, guides, and drawing previews share the camera surface; screen UI stays in the HTML overlay.
+   - SoftGlow/editors use `RenderDemotionScheduler` (`ACTIVE_SVG` → `CANDIDATE` → `DEPLOYED_SOA`); selection does **not** promote basic shapes onto SVG.
+   - **Forbidden:** per-type CSS z bands, host-occlusion / plate-cutout paint hacks, global “bound idle → SVG host”, or “transparent plate + draw bound ink on world WebGL” (breaks FO between plates).
+
 4. **Independent hit** — root pointer capture → chrome hit → **one** `SceneSpatialRuntime` QT (`searchPoint`, nodes + `frame:id` plates) → permanent `stackOrder` top-first → first precise geometry or plate AABB (`hitTestUnifiedStackAtPoint`). Frame picks return `__frame__:id`. SoA `buf.quadtree` is paint/cull only. `sceneToSvg` stays an **export** path, not the live paint core.
 
 SVG is not the editor runtime fact layer. Fact layer = `SceneDocument` + `CameraTransform` + `SceneSpatialRuntime`. SoA (`SceneRenderBuffer` + `SoaQuadtree`) is a **derived** paint/pick cache and must not write back into SceneDocument. Demotion host-release uses one shared wake over `lastActive` timestamps; TransformPreview uses dirty AABB + live filter + threshold rebuild (not per-frame QT upsert).
@@ -34,15 +46,15 @@ Do not sell micro-caches or effects as parallel “optimization schemes.” Prod
 |---|--------|------|
 | 1 | SoA `SceneRenderBuffer` | Typed-array paint/pick cache |
 | 2 | Demotion + host viewport cull | DOM budget; who stays SVG vs SoA |
-| 3 | WebGL2 instancing + atlas | Only ink backend (no C2D dual path) |
-| 4 | Viewport tile bake + Worker | Second wall when idle+basic ≥ ~800; live fill until tiles ready |
+| 3 | World WebGL2 + ArtboardLayer ink | Unbound idle on world GL; plate-bound idle on per-artboard small canvas |
+| 4 | Viewport tile bake + Worker | Second wall when world idle+basic ≥ ~800; live fill until tiles ready |
 | 5 | Select raise keep-bake + overpaint | Select must not disable bake |
 | 6 | Dirty AABB + SoA QT + incremental sync | Avoid O(N) wipe/rebuild |
 | 7 | Independent hit + camera | Architecture; not an FPS knob |
 
 **Embedded (not separate products):** path densify, AI mutation lock, TransformPreview live filter.
 
-**Not a fallback:** Canvas2D is used for the **pixel grid surface** and Vitest paint helpers only. Product idle ink is WebGL (WebGPU only when DOF effect is on). Missing WebGL2 is a hard error — do not silently downgrade to Canvas2D ink.
+**Ink surfaces:** Canvas2D paints the **pixel grid**, Vitest helpers, and **ArtboardLayer** per-plate ink (required so FO hosts interleave by `stackOrder`). World unbound idle ink is WebGL (WebGPU only when DOF is on). Soft canvas2d world-ink fallback is survival-only when WebGL2 cannot compile — not the product main path.
 
 **Do not merge:** `SceneSpatialRuntime` (all-node hit) vs `buf.quadtree` (idle paint/pick) — intentional dual track.
 
@@ -54,15 +66,16 @@ Do not sell micro-caches or effects as parallel “optimization schemes.” Prod
 |-------|--------|------|
 | 1 | Done (core) | CameraTransform API; ink and selection chrome share the same SVG root and camera `<g>`; geometry-first chrome hit; shared spatial; union AABB chrome. |
 | 2 | Done (core) | `SceneRenderer` (`svg` hosts + `canvas2d` grid); canvas-capable vectors on idle ink (`canIdlePaintOnCanvas` + rounded/poly Path2D). |
-| 3 | Done (default-on) | **SoA** `SceneRenderBuffer` always on in product (Vitest override only); WebGL vector ink + atlas (paths/boolean/outlined, static **text / image / video / audio / gradient / poly / donut-arc** stamps); selected video/audio keep one FO each; AI lock → one flush; shared spatial from SoA; dirty AABB; **quadtree** idle cull; demotion + freeSlots / bulk sync. **Unified stack:** plates + hosts on one SVG mount by `stackOrder`. Lottie / SoftGlow / pen editors / heavy paths / puppet-warp stay DOM hosts. |
-| 4 | Done (default-on) | WebGL2 instancing + atlas — **only** product ink path. Viewport bake ≥800 eligible idle+basic → **Worker only**; incomplete maps keep live instances; camera gesture skips bake. |
+| 3 | Done (default-on) | **SoA** + world WebGL; **ArtboardLayer** per-frame small canvas (plate + bound idle); stack SVG for plates/hosts by `stackOrder`; selected video/audio ≤1 FO; Lottie / SoftGlow / editors / heavy paths stay DOM hosts. |
+| 4 | Done (default-on) | WebGL2 instancing + atlas for **world** idle ink. Viewport bake ≥800 (unbound slots); camera gesture skips bake. |
 | 5 | Opt-in **effect** (not density roadmap) | **GPU realtime depth-of-field** (`VITE_GPU_DOF=1`): one resolved backend (webgpu *or* webgl2), no create-time cross-fallback. Skips CPU tile bake while active. UI: Effects → Scene depth of field. |
+| 6 | Done (core) | Artboard = small canvas contract above; world collect/bake use `skipFrameBound`. |
 
 ### Acceptance targets
 
 - 10k light nodes pan at stable 60 FPS
 - Pointer-move → paint P95 &lt; 16ms; single-point hit P95 &lt; 1ms
-- Non-media DOM node count in the low hundreds
+- Non-media DOM node count in the low hundreds (bound idle vectors must not scale SVG hosts)
 - Zoom 5%–10_000%: element/control geometry transform error = 0
 - Drag does not dispatch full editor store scene updates
 - Export and screen share one `SceneDocument`, without depending on live DOM ink
@@ -77,6 +90,7 @@ Do not sell micro-caches or effects as parallel “optimization schemes.” Prod
 - Host lifecycle notifications can be scoped to an individual node, preventing unrelated title chrome from rerendering during a mount or paint refresh.
 - Can replace paint backend without rewriting selection / tools.
 - Dense idle ink uses QT + optional tile bake; demotion avoids blank frames by preparing SoA ink before releasing DOM hosts.
+- ArtboardLayer lets FO media stack between plates without plate cutouts.
 
 ### Negative / trade-offs
 
@@ -85,20 +99,27 @@ Do not sell micro-caches or effects as parallel “optimization schemes.” Prod
 - Contributors must not add new world-layer control SVG that mirrors host `viewBox`.
 - Do not reintroduce dual attr keys (`fill` vs `fill-color`, frame `kind: 'lottie'`, `lottieFrameHost`, axios-shaped error probes).
 - Do not add a second async bake scheduler alongside Worker (no idle/main-thread bake dual path).
+- Shared GL + multi-FBO for ArtboardLayer is a future density option; current per-plate canvas keeps FO interleave correct.
 
 ## Alternatives considered
 
 1. **Keep SVG runtime, harden viewBox sync** — rejected; complexity grows with zoom and node count.
 2. **Adopt an external whiteboard SDK** — rejected (ADR 0002); product artboards / agents / media stay in-house.
 3. **Jump straight to WebGL** — rejected initially; stabilize camera + hit + chrome first. Phase 4 now defaults WebGL after SoA + hit landed.
+4. **One world WebGL + transparent SVG plates for bound ink** — rejected; FO hosts would always sit above all WebGL, so selected media cannot stack between artboards.
+5. **Bound idle → SVG host so ink sits above its plate** — rejected; host count scales with framed content and defeats SoA density targets.
 
 ## References
 
 - [docs/canvas-architecture.md](../canvas-architecture.md)
 - `apps/web/src/components/rcb/camera/transform.ts`
+- `apps/web/src/components/rcb/canvas/RcbCanvas.tsx`
+- `apps/web/src/components/rcb/frames/HtmlArtboardFrame.tsx`
+- `apps/web/src/components/rcb/frames/artboardInkSurface.ts`
 - `apps/web/src/components/rcb/render/sceneRenderer.ts`
 - `apps/web/src/components/rcb/render/sceneRenderBuffer.ts`
 - `apps/web/src/components/rcb/render/renderDemotionScheduler.ts`
+- `apps/web/src/components/rcb/render/webglSceneRenderer.ts`
 - `apps/web/src/components/rcb/core/soaQuadtree.ts`
 - `apps/web/src/components/rcb/core/spatialIndex.ts`
 - `apps/web/src/components/rcb/render/soaBakeLayer.ts`

--- a/docs/canvas-architecture.md
+++ b/docs/canvas-architecture.md
@@ -8,11 +8,11 @@ RCB is zuoge’s infinite vector canvas. This note is for people changing paint,
 |-------|------|----------------|
 | Stage shell | Camera, frames, product canvas | `editor/page/EditorStageWorld.tsx` |
 | Camera / pan-zoom | Infinite world (`zoom` ~0.05–100); **CameraTransform** is the sole world↔screen API | `rcb/canvas/RcbCanvas.tsx`, `rcb/core/math.ts`, `rcb/camera/transform.ts` |
-| SceneRenderer | Paint/hit backend (`svg` DOM hosts + `canvas2d` grid + SoA vector ink) | `rcb/render/sceneRenderer.ts` |
+| SceneRenderer | Paint/hit backend (`svg` DOM hosts + `canvas2d` grid + world SoA/WebGL + ArtboardLayer) | `rcb/render/sceneRenderer.ts` |
 | Product canvas | Tools, media overlays, store writes; hit via SceneRenderer | `editor/canvas/SvgCanvas.tsx` |
-| Shape paint | SoA/WebGL ink under shared stack SVG; plates + DOM hosts interleaved by `stackOrder` | `rcb/shapes/RcbShapesLayer.tsx`, `RcbShapeHost.tsx`, `scene/document/sceneStackPainter.ts` |
+| Pixel grid + ink | Grid `[data-rcb-scene-canvas]`; world idle `[data-rcb-idle-ink-canvas]`; plate-bound idle via ArtboardLayer | `RcbCanvas` + `createCanvasSceneRenderer` + `artboardInkSurface` |
+| Shape paint | World WebGL (unbound) + ArtboardLayer small-canvas (bound) + FO hosts by `stackOrder` | `rcb/shapes/RcbShapesLayer.tsx`, `RcbShapeHost.tsx`, `frames/HtmlArtboardFrame.tsx`, `frames/artboardInkSurface.ts`, `scene/document/sceneStackPainter.ts` |
 | SoA buffer + demotion | Derived paint/pick cache (`SceneRenderBuffer`); never writes back to SceneDocument | `rcb/render/sceneRenderBuffer.ts`, `renderDemotionScheduler.ts` |
-| Pixel grid + canvas ink | Grid `[data-rcb-scene-canvas]`; vector ink `[data-rcb-idle-ink-canvas]` | `RcbCanvas` + `createCanvasSceneRenderer` |
 | Selection chrome | Shared scene SVG camera group for AABB, path silhouette, shape knobs, guides, and drawing previews; HTML overlay only for screen UI/hit seats | `rcb/selection/SelectionChrome.tsx`, `HostPathChrome.tsx`, chrome overlays |
 | Transform gestures | `pointermove` → RAF-coalesced live preview into `TransformPreview` + transitional SVG DOM; `pointerup` commits SceneDocument and clears preview | `core/transformPreview.ts`, `SelectionFeature` coalescer, `canvasSession.onGeometryPreview/Commit` |
 | Frame clip (live) | Artboard move: preview plate geom (+ live artboard map) → re-seat bound hosts via `nodeLeftTop` → `syncFrameContentClip` (no child TransformPreview under frameLocal). SoA QT uses the same mid-gesture dirty + liveAabb rescue as TransformPreview so plate-bound ink is not culled with stale AABBs | `EditorStageWorld`, `canvasSession.onGeometryPreview`, `prepareSoaQuadtreeForQuery` |
@@ -48,9 +48,15 @@ There is **no hard max node count** on the document. Capacity is governed by pai
 
 At ≥ `PIXEL_GRID_MIN_ZOOM` (~800%), `RcbCanvas` paints the lattice on a screen-space `[data-rcb-scene-canvas]` via `createCanvasSceneRenderer` / `drawSceneGrid` (camera baked into ctx; axes stay on `gℤ` — same as `snapCoordToGrid` / pen tips; do **not** device-shift axes off the snap lattice). SVG no longer carries the grid `<path>`.
 
-**Unified stack paint:** one SVG mount holds artboard plates + DOM hosts, ordered by `stackOrder` (`data-z` via `syncStackPaintOrder`). SoA/WebGL ink sits **under** that mount and only paints world nodes that do not need to interleave above plates. Nodes stacked above any plate promote to DOM hosts. Do not reintroduce per-type CSS z bands, host-occlusion clips, or plate cutouts.
+**Paint stack:**
 
-**Idle ink surface:** canvas-capable nodes (`canIdlePaintOnCanvas`) publish through `setSceneCanvasIdlePaint` and paint on `[data-rcb-idle-ink-canvas]` (WebGL atlas stamps for paths/boolean, static text/image/video/audio, gradients, poly/star, donut/arc). Selection does **not** promote basic shapes to SVG. DOM hosts stay for **lottie/group**, path editors, heavy paths, **backdrop-blur**, SoftGlow via `forceFullSet`, puppet-warp images, and the **active** video/audio decoder (≤1 FO each). Object blur + inner-shadow bake on canvas idle (`paintLocalInkWithObjectEffects`). Non-normal **blendMode** idles via underlay + `globalCompositeOperation` (`paintLocalInkWithBlend`). SoftGlow process chrome lives on shape hosts (`attrs.processStatus`). strokeAlign inside/outside paints on canvas ink (SoA basic or rich idle).
+```text
+grid (Canvas2D) → world WebGL (unbound idle) → stack by stackOrder (ArtboardLayer + FO hosts) → chrome
+```
+
+One SVG mount holds artboard plate layers + DOM hosts, ordered by `stackOrder` (`data-z` via `syncStackPaintOrder`). Each plate layer embeds an **ArtboardLayer** small canvas (plate fill + bound idle SoA ink via `artboardInkSurface`). World SoA/WebGL on `[data-rcb-idle-ink-canvas]` paints unbound idle only (`skipFrameBound`). Unbound nodes stacked above any plate promote to DOM hosts. Do not reintroduce per-type CSS z bands, host-occlusion clips, plate cutouts, or bound-idle→SVG-host paint.
+
+**Idle ink:** canvas-capable nodes (`canIdlePaintOnCanvas`) publish through `setSceneCanvasIdlePaint`. Unbound → world WebGL; bound → owning ArtboardLayer. Selection does **not** promote basic shapes to SVG. DOM hosts stay for **lottie/group**, path editors, heavy paths, **backdrop-blur**, SoftGlow via `forceFullSet`, puppet-warp images, and the **active** video/audio decoder (≤1 FO each) — including when frame-bound (FO sits above the plate canvas via `data-z`). Object blur + inner-shadow bake on canvas idle (`paintLocalInkWithObjectEffects`). Non-normal **blendMode** idles via underlay + `globalCompositeOperation` (`paintLocalInkWithBlend`). SoftGlow process chrome lives on shape hosts (`attrs.processStatus`). strokeAlign inside/outside paints on canvas ink (SoA basic or rich idle).
 
 ### SoA buffer + promote / demote
 
@@ -68,7 +74,7 @@ At ≥ `PIXEL_GRID_MIN_ZOOM` (~800%), `RcbCanvas` paints the lattice on a screen
 
 ### DOM hosts (FO media / SoftGlow / editors / stack promotion)
 
-Idle text / image / video poster / audio plate / gradient / poly paint as ink. DOM hosts (`RcbShapeHost`) remain for FO media, SoftGlow, live editors, lottie/group, and any world node whose `stackOrder` sits above an artboard plate. Hosts and plates share one stack SVG mount ordered by `stackOrder`. Drawing previews, guides, and selection chrome share the camera surface. The CSS world layer and live host `left/top/viewBox` camera cancellation path were removed; do not restore either one.
+Idle text / image / video poster / audio plate / gradient / poly paint as ink (world WebGL or ArtboardLayer). DOM hosts (`RcbShapeHost`) remain for FO media, SoftGlow, live editors, lottie/group, and any unbound world node whose `stackOrder` sits above an artboard plate. Hosts and artboard plate layers share one stack SVG mount ordered by `stackOrder`. Drawing previews, guides, and selection chrome share the camera surface. The CSS world layer and live host `left/top/viewBox` camera cancellation path were removed; do not restore either one.
 
 #### Direct size edits and host notifications
 
@@ -145,7 +151,7 @@ Implemented in `RcbShapesLayer.tsx` (current constants):
 
 Spatial: `SceneSpatialRuntime` / `RcbSpatialIndex` are **quadtree-backed** (`SoaQuadtree`). The constructor `cellSize` argument is only a leaf-capacity hint (SvgCanvas still passes 256). Large-scene helpers also use `SCENE_SPATIAL_LARGE_THRESHOLD` (48) in `spatialIndex.ts`. Idle SoA paint/hit additionally uses `buf.quadtree`.
 
-**Rule of thumb:** document can hold thousands of light shapes (stress benches exercise 1k–10k); vectors + static media idle on one SoA/WebGL ink surface under the stack SVG; DOM hosts are for FO media / SoftGlow / editors / stack promotion above plates. Off-screen nodes are culled (not mounted).
+**Rule of thumb:** document can hold thousands of light shapes (stress benches exercise 1k–10k); unbound vectors idle on world SoA/WebGL; frame-bound idle ink lives on per-artboard small canvases (ArtboardLayer) interleaved with FO hosts by `stackOrder`; DOM hosts are for FO media / SoftGlow / editors / stack promotion above plates. Off-screen nodes are culled (not mounted).
 
 ## History / agent (related caps)
 
@@ -169,7 +175,7 @@ Runtime uniforms: `focalDepth`, `aperture`, `maxCoCPx`, `downsample`. Tunable in
 ## Practical capacity
 
 - **Light vectors:** hundreds → low thousands with cull + SoA canvas ink + QT
-- **Dense scenes:** one ink surface (real paint), not host-overflow dual path
+- **Dense scenes:** world WebGL + per-artboard ArtboardLayer ink (real paint); FO hosts stay exceptional
 - **Many videos / animations / generators:** DOM + decode dominate before node-count alone
 - **Huge path `d`:** hit-test / history pressure (`HEAVY_PATH_D_CHARS`)
 
@@ -177,13 +183,15 @@ Runtime uniforms: `focalDepth`, `aperture`, `maxCoCPx`, `downsample`. Tunable in
 
 ```
 apps/web/src/components/rcb/
-  canvas/RcbCanvas.tsx                # stage: grid → SoA ink → stack SVG (plates+hosts) → chrome
+  canvas/RcbCanvas.tsx                # stage: grid → world SoA ink → stack SVG (plates+hosts) → chrome
+  frames/HtmlArtboardFrame.tsx        # plate layer + ArtboardLayer FO canvas mount
+  frames/artboardInkSurface.ts        # per-frame plate fill + bound idle SoA ink
   shapes/RcbShapesLayer.tsx           # cull + DOM hosts vs SoA canvas ink + demotion wiring
   shapes/shapeHostRegistry.ts         # host registry + shared stack mount paint order
   scene/document/sceneStackPainter.ts # stackOrder → data-z contract
   render/sceneRenderBuffer.ts         # SoA typed arrays, paint, QT sync
   render/renderDemotionScheduler.ts   # ACTIVE_SVG / CANDIDATE / DEPLOYED_SOA
-  render/soaBakeLayer.ts              # tile bake + element↔tile maps
+  render/soaBakeLayer.ts              # world tile bake (skipFrameBound) + element↔tile maps
   render/gpuDepthOfField.ts           # DOF params + stack depth normalization
   render/webglDepthOfFieldPass.ts     # WebGL2 FBO + CoC blur
   render/webgpuSceneRenderer.ts       # WebGPU MRT scene + CoC DOF (async device)


### PR DESCRIPTION
## Summary
- Each artboard paints plate fill + bound idle SoA ink on a per-frame ArtboardLayer small canvas so FO hosts can interleave by `stackOrder`
- World WebGL / bake skip frame-bound slots (`skipFrameBound`); drop `frameId → always SVG host`
- Update ADR 0027 + canvas-architecture to the final paint stack; remove the old under-plate / frameId-host contract

## Test plan
- [x] `vitest` artboardInkSurface / canvasIdleHostBudget / unifiedStackOrderPaint / webglInstances / soaBakeLayer
- [ ] Manual: framed rects idle on plate without SVG hosts; higher artboard still occludes lower content
- [ ] Manual: selected video FO stacks between two overlapping artboards
- [ ] Manual: animation workbench / LOT tab — nested lottie stays FO; plate ink still paints
