### PR TITLE
fix(web): repair LayerPanel invalid UTF-8

### DIFF
--- a/apps/web/src/components/editor/panels/LayerPanel.tsx
+++ b/apps/web/src/components/editor/panels/LayerPanel.tsx
@@ -997,7 +997,7 @@ function LayerStackRowView({
   );
 }
 
-/** Left layers dock â€?history + frames/nodes from unified stackOrder. */
+/** Left layers dock  - history + frames/nodes from unified stackOrder. */
 function LayerPanel({
   onClose,
   onSelectNode,
@@ -1013,8 +1013,8 @@ function LayerPanel({
 } = {}) {
   const { t } = useTranslation();
   const documentCommitted = useEditorDocumentOnCommit();
-  // Paste bumps documentRevision / sceneRevision â€?defer layer-list rebuild so the
-  // canvas SoA paint stays ahead of the dock at 2kâ€?0k nodes.
+  // Paste bumps documentRevision / sceneRevision  - defer layer-list rebuild so the
+  // canvas SoA paint stays ahead of the dock at 2k - 0k nodes.
   // canvas commit is not blocked by dock work while history snaps accumulate.
   const document = useDeferredValue(documentCommitted);
   const selectedNodeId = useSelectedNodeId();
@@ -1170,7 +1170,7 @@ function LayerPanel({
   const onDockResizePointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
     const drag = resizeDragRef.current;
     if (!drag) return;
-    // Right edge: drag right â€?wider
+    // Right edge: drag right  - wider
     setDockWidth(clampLayerDockWidth(drag.startW + (e.clientX - drag.startX)));
   };
 
@@ -1191,7 +1191,7 @@ function LayerPanel({
   };
 
   const historyItems = useMemo(() => {
-    // Newest first â€?length only (never subscribe to full snap docs).
+    // Newest first  - length only (never subscribe to full snap docs).
     if (!historyPastLen) return [];
     return Array.from({ length: historyPastLen }, (_, i) => ({
       id: `h-${historyPastLen - i}`,
@@ -1294,7 +1294,7 @@ function LayerPanel({
         </div>
       ) : null}
 
-      {/* Layer rows â€?top of list = front of stack (virtualized) */}
+      {/* Layer rows  - top of list = front of stack (virtualized) */}
       <VirtualList
         ref={layerListRef}
         items={layerRows}


### PR DESCRIPTION
## Summary
- Replace corrupted em-dash byte sequences in LayerPanel comments so Vite/rolldown can load the module
- Unblocks production `Dockerfile.web` builds on the VPS

## Test plan
- [x] Local file decodes as UTF-8
- [x] VPS web image builds successfully after the fix