### PR TITLE
fix(web): ship RCB geom wasm via public/rcb-wasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,9 @@ e2e/.*.txt
 # FFmpeg.wasm core (~32MB) — copied locally by apps/web/scripts/copy-ffmpeg-core.mjs
 apps/web/public/ffmpeg/
 
+# RCB geom wasm — copied from src/.../wasm/pkg by apps/web/scripts/build-wasm.mjs
+apps/web/public/rcb-wasm/
+
 # Local infra not published with OSS (keep on disk only)
 infra/langfuse/
 

--- a/apps/web/scripts/build-wasm.mjs
+++ b/apps/web/scripts/build-wasm.mjs
@@ -34,12 +34,41 @@ function writeStub() {
   console.warn('[build-wasm] stub written (wasm-pack unavailable) — JS fallback active');
 }
 
+/** Prefer committed pkg over a stub when Rust tooling is missing (Docker/CI). */
+function hasShippedWasm() {
+  const wasmPath = path.join(outDir, 'rcb_wasm_geom_bg.wasm');
+  const jsPath = path.join(outDir, 'rcb_wasm_geom.js');
+  if (!fs.existsSync(wasmPath) || !fs.existsSync(jsPath)) return false;
+  const kb = fs.statSync(wasmPath).size / 1024;
+  const js = fs.readFileSync(jsPath, 'utf8');
+  return kb > 50 && !js.includes('rcb-wasm-geom not built');
+}
+
+/** Copy glue + .wasm into public/ so Vite ships them as static assets. */
+function syncPublicPkg() {
+  if (!hasShippedWasm()) return;
+  const publicDir = path.join(webRoot, 'public/rcb-wasm');
+  fs.mkdirSync(publicDir, { recursive: true });
+  for (const name of ['rcb_wasm_geom.js', 'rcb_wasm_geom_bg.wasm', 'rcb_wasm_geom.d.ts']) {
+    const src = path.join(outDir, name);
+    if (fs.existsSync(src)) fs.copyFileSync(src, path.join(publicDir, name));
+  }
+  const kb = fs.statSync(path.join(publicDir, 'rcb_wasm_geom_bg.wasm')).size / 1024;
+  console.log(`[build-wasm] synced public/rcb-wasm (${kb.toFixed(1)} KiB)`);
+}
+
 if (!fs.existsSync(path.join(crateDir, 'Cargo.toml'))) {
   console.error('[build-wasm] missing crate', crateDir);
   process.exit(1);
 }
 
 if (!hasCmd('wasm-pack') || !hasCmd('rustc')) {
+  if (hasShippedWasm()) {
+    const kb = fs.statSync(path.join(outDir, 'rcb_wasm_geom_bg.wasm')).size / 1024;
+    console.log(`[build-wasm] keeping shipped pkg (${kb.toFixed(1)} KiB; no wasm-pack)`);
+    syncPublicPkg();
+    process.exit(0);
+  }
   writeStub();
   process.exit(0);
 }
@@ -75,6 +104,11 @@ const r = spawnSync(
 );
 
 if (r.status !== 0) {
+  if (hasShippedWasm()) {
+    console.warn('[build-wasm] wasm-pack failed — keeping shipped pkg');
+    syncPublicPkg();
+    process.exit(0);
+  }
   console.warn('[build-wasm] wasm-pack failed — writing stub');
   writeStub();
   process.exit(0);
@@ -91,6 +125,8 @@ const crateReadme = path.join(crateDir, 'README.md');
 if (fs.existsSync(crateReadme)) {
   fs.copyFileSync(crateReadme, path.join(outDir, 'README.md'));
 }
+
+syncPublicPkg();
 
 // Size budget (~349 KiB with opt-level=z); warn above 600 KiB raw.
 const wasmPath = path.join(outDir, 'rcb_wasm_geom_bg.wasm');

--- a/apps/web/src/components/rcb/render/vector/wasm/geomWorker.ts
+++ b/apps/web/src/components/rcb/render/vector/wasm/geomWorker.ts
@@ -52,9 +52,11 @@ async function ensureInit(): Promise<void> {
   if (api) return;
   const mod = await import(
     /* @vite-ignore */
-    './pkg/rcb_wasm_geom.js'
+    '/rcb-wasm/rcb_wasm_geom.js'
   );
-  if (typeof mod.default === 'function') await mod.default();
+  if (typeof mod.default === 'function') {
+    await mod.default({ module_or_path: '/rcb-wasm/rcb_wasm_geom_bg.wasm' });
+  }
   api = {
     tessellate_batch_fill: mod.tessellate_batch_fill,
     trace_rgba_contours:

--- a/apps/web/src/components/rcb/render/vector/wasmGeom.ts
+++ b/apps/web/src/components/rcb/render/vector/wasmGeom.ts
@@ -157,11 +157,14 @@ function unpackBatch(packed: Float32Array): (FillMesh | null)[] {
 
 async function loadWasmModule(): Promise<WasmApi | null> {
   try {
+    // Served from public/rcb-wasm (copied by build-wasm.mjs) so Vite ships .wasm.
     const mod = await import(
       /* @vite-ignore */
-      '@/components/rcb/render/vector/wasm/pkg/rcb_wasm_geom.js'
+      '/rcb-wasm/rcb_wasm_geom.js'
     );
-    if (typeof mod.default === 'function') await mod.default();
+    if (typeof mod.default === 'function') {
+      await mod.default({ module_or_path: '/rcb-wasm/rcb_wasm_geom_bg.wasm' });
+    }
     if (
       typeof mod.densify_path_d !== 'function' ||
       typeof mod.tessellate_fill !== 'function' ||

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -2,6 +2,47 @@
 
 declare module 'virtual:svg-icons-register';
 
+/** Static wasm-bindgen glue served from public/rcb-wasm (see build-wasm.mjs). */
+declare module '/rcb-wasm/rcb_wasm_geom.js' {
+  export default function init(opts?: {
+    module_or_path?: RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
+  }): Promise<unknown>;
+  export function densify_path_d(d: string, flatness: number): Float32Array;
+  export function tessellate_fill(xy: Float32Array): Float32Array;
+  export function tessellate_fill_with_holes(
+    outer: Float32Array,
+    holesFlat: Float32Array,
+    holeCounts: Uint32Array
+  ): Float32Array;
+  export function tessellate_stroke(
+    xy: Float32Array,
+    width: number,
+    closed: boolean,
+    align: string,
+    linejoin?: string,
+    miterLimit?: number
+  ): Float32Array;
+  export function tessellate_batch_fill(xyAll: Float32Array, counts: Uint32Array): Float32Array;
+  export function boolean_polygons(op: number, packed: Float32Array): Float32Array;
+  export function offset_polyline(
+    xy: Float32Array,
+    width: number,
+    closed: boolean,
+    join: number,
+    cap: number,
+    miterLimit: number,
+    roundApprox: number
+  ): Float32Array;
+  export function simplify_rdp(xy: Float32Array, epsilon: number): Float32Array;
+  export function simplify_rdp_closed(xy: Float32Array, epsilon: number): Float32Array;
+  export function trace_rgba_contours(
+    rgba: Uint8Array,
+    width: number,
+    height: number,
+    alphaThreshold: number
+  ): Float32Array;
+}
+
 declare const __GOOGLE_CLIENT_ID__: string;
 declare const __DOCS_URL__: string;
 declare const __DESKTOP_MODE__: string;

--- a/deploy/nginx/default.conf
+++ b/deploy/nginx/default.conf
@@ -49,4 +49,9 @@ server {
   location / {
     try_files $uri $uri/ /index.html;
   }
+
+  location ~* ^/rcb-wasm/.*\.wasm$ {
+    default_type application/wasm;
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
 }


### PR DESCRIPTION
## Summary
- Keep shipped wasm when Docker has no wasm-pack
- Serve glue+.wasm from /rcb-wasm for production
- Nginx application/wasm MIME

## Test plan
- [x] https://recombyn.com/rcb-wasm/rcb_wasm_geom_bg.wasm 200
- [x] API health + MediaKit for cutout

Made with [Cursor](https://cursor.com)