### PR TITLE
fix(web): artboard WebGL ink, plate selection raise, text outline

### DIFF
--- a/apps/web/src/components/rcb/core/geometry/__tests__/baseline.test.ts
+++ b/apps/web/src/components/rcb/core/geometry/__tests__/baseline.test.ts
@@ -150,12 +150,14 @@ describe('getShapeBaseline', () => {
     expect(lineBaselinePath(80, 24)).toBe('M 0 12 L 80 12');
   });
 
-  it('arrow shaft reaches tip and V shares tip', () => {
+  it('arrow shaft stops at head base; only V meets the tip', () => {
     const d = arrowBaselinePath(100, 24);
     expect(d).toContain('M 0 12');
-    expect(d).toContain('L 100 12');
-    // Shaft + V both meet tip (preview geometry).
-    expect(d.match(/L 100 12/g)?.length).toBeGreaterThanOrEqual(2);
+    // Default ARROW_HEAD=14 → shaft ends at 86, tip at 100.
+    expect(d).toContain('L 86 12');
+    expect(d).not.toMatch(/M 0 12 L 100 12/);
+    // V still shares the tip once.
+    expect(d.match(/L 100 12/g)?.length).toBe(1);
   });
 
   it('circle uses ellipse baseline', () => {

--- a/apps/web/src/components/rcb/core/geometry/baseline.ts
+++ b/apps/web/src/components/rcb/core/geometry/baseline.ts
@@ -46,15 +46,18 @@ function resolveShapeType(node: SceneNodeInput): string {
   return String(node?.attrs?.shapeType || (key === 'shape' ? 'rect' : ''));
 }
 
-/** Open arrow: shaft to tip + V through tip (same geometry as draw preview). */
+/** Open arrow: shaft stops at head base; V alone forms the tip (no tip double-stroke). */
 export function arrowBaselinePath(width: number, height: number, head = ARROW_HEAD): string {
   const w = Math.max(1, width);
   const mid = Math.max(1, height) / 2;
   const headLen = Math.min(head, w * 0.45);
   const wing = headLen * 0.55;
+  // Shaft must not share the tip vertex — thick stroke caps + V miter stacked there
+  // made the tip look crooked (one wing edge longer than the other).
+  const shaftEnd = Math.max(0, w - headLen);
   return new PathBuilder()
     .moveTo(0, mid)
-    .lineTo(w, mid)
+    .lineTo(shaftEnd, mid)
     .moveTo(w - headLen, mid - wing)
     .lineTo(w, mid)
     .lineTo(w - headLen, mid + wing)

--- a/apps/web/src/components/rcb/docs/CANVAS.md
+++ b/apps/web/src/components/rcb/docs/CANVAS.md
@@ -86,7 +86,8 @@ rcb/
 │
 ├── frames/                  # 画板 / 动画工作台
 │   ├── HtmlArtboardFrame.tsx
-│   ├── artboardInkSurface.ts  # 板内 Canvas2D 墨水
+│   ├── artboardInkSurface.ts  # 板内 FO 墨水（共享 WebGL→blit；2D 回退）
+│   ├── artboardWebglInk.ts    # 共享 WebGL2 + onlyFrameId
 │   ├── frameContentClip.ts    # clipContent + selection raise 注册表
 │   └── frameNodeBinding.ts / FrameDraw|MoveFeature …
 │
@@ -117,7 +118,7 @@ rcb/
 | 表面 | 解决什么 | 放大时 |
 |------|----------|--------|
 | **WebGL / Canvas2D SoA** | 上千节点时的吞吐 | 位图/atlas 有分辨率上限 → 糊 |
-| **画板 FO Canvas** | 板内子节点跟板一起裁剪、少占世界层 | 有 `ARTBOARD_INK_MAX_SCALE` 上限 → 再放大糊 |
+| **画板 FO Canvas** | 板内子节点跟板一起裁剪、少占世界层 | `MAX_EDGE` 防 OOM；产品路径为共享 WebGL→FO |
 | **SVG / DOM host** | 矢量边、Lucide 图标、需压住画板、编辑器 | CSS zoom 下仍清晰 |
 | **HTML FO media** | video/audio/滚动文字原生能力 | 清晰取决于资源本身 |
 
@@ -224,10 +225,11 @@ rcb/
 |-----|------|
 | `createSceneRenderer` / `createWebglSceneRenderer` | 世界墨水 |
 | `canIdlePaintOnCanvas` | 能否走 SoA/idle 位图路径 |
-| `pickFullAndCanvasIds` | 拆 `fullIds`(host) / `canvasIds`(SoA) |
+| `pickFullAndCanvasIds` | 拆 `fullIds`(host) / `canvasIds`(SoA)；板内 raise/reveal → host |
 | `idleMediaNeedsSharpHost` 等 | 放大后是否必须升 host |
 | `applySoaHostInkFlags` | host 占用时关掉 SoA 槽，防双画 |
-| `paintArtboardInkSurface`（frames） | 板内墨水 |
+| `paintArtboardInkSurface`（frames） | 板内墨水；reveal id **不进** FO collect |
+| `artboardWebglInk` / `onlyFrameId` | 共享 WebGL→FO；同样跳过 reveal |
 | `syncStackPaintOrder` | 按 `data-z` 排共享 SVG |
 
 **目标 API（建议新增，薄封装）：**
@@ -269,15 +271,16 @@ function paintFrame(doc, camera, dirty): void  // 内部再分发三条后端
 
 | 类型 | 默认 idle | 何时 DomHost |
 |------|-----------|--------------|
-| rect / ellipse / line（基础） | SoaWorld / SoaArtboard | 需盖住画板、描边 atlas 糊、SoftGlow |
-| path / poly / star / pencil | atlas / rich idle | 糊、抬升、盖板、过重 path |
-| text | atlas / 2D idle | 高 zoom 糊；滚动字 FO |
+| rect / ellipse / line（基础） | SoaWorld / SoaArtboard | 板内选中/reveal、需盖住画板、描边 atlas 糊、SoftGlow |
+| path / poly / star / pencil | atlas / rich idle | 糊、抬升、盖板、过重 path、**板内选中/reveal** |
+| text | outline mesh | 编辑态 FO；无 text atlas |
 | image / video / audio | atlas stamp | 屏边 > atlas、空生成器、CORS、过程中、解码编辑 |
 | 空生成器（图/视/音/Lottie） | **禁止 SoA** | **永远 DomHost**（图标清晰 + 可压板） |
 | lottie / group | 禁止 SoA | 永远 DomHost |
 | backdrop-blur / puppet-warp | 禁止 SoA | DomHost |
 
-板绑定（`attrs.frameId`）：idle SoA → **SoaArtboard**，不进世界 WebGL。
+板绑定（`attrs.frameId`）：idle SoA → **SoaArtboard**，不进世界 WebGL。  
+选中 / overflow reveal：FO 停画该 id → **升 SVG host（max+1）**；禁止 FO+世界各画一半。
 
 ---
 
@@ -333,7 +336,7 @@ function paintFrame(doc, camera, dirty): void  // 内部再分发三条后端
 2. **选中才看见？** 多半是 selection paint raise；idle 应用 `nodePaintZIndex`，不是只靠 raise。  
 3. **放大糊？** atlas / 板 ink 上限；该升 DomHost 还是提高 stamp 分辨率。  
 4. **点不着？** hit 遮挡 vs paint 是否一致（`isOccludedByHigherArtboard`）。  
-5. **弹一下 / 层级跳？** 抬升时生成器是否升到 host；SoA 画在 SVG 下无法靠 max+1 盖住 sibling host。  
+5. **弹一下 / 层级跳？** 抬升时生成器 **与板内绑定形** 是否升到 host；SoA 画在 SVG 下无法靠 max+1 盖住板面 / sibling host。板内拖出若仍见鬼影：FO 是否仍在 paint reveal。  
 6. **TDZ / 循环依赖？** 不要从 `sceneDocument` 拉 editor chrome；常量放叶子模块。
 
 ---

--- a/apps/web/src/components/rcb/docs/CANVAS_GUIDE.md
+++ b/apps/web/src/components/rcb/docs/CANVAS_GUIDE.md
@@ -305,11 +305,13 @@ ARTBOARD_INK_MAX_SCALE                     // 导出
 artboardInkScale(zoom, dpr)
 artboardInkBackingInsufficient(zoom, dpr)  // ★
 registerArtboardInkSurface / paintArtboardInkSurface
+→ artboardWebglInk（共享 WebGL + onlyFrameId）→ FO blit；失败时 Canvas2D
 // ★ 新建：artboardInkTiles — 可见分块全分辨率
 
 // Host 拆分（义务）
 pickFullAndCanvasIds(opts) → { fullIds, canvasIds }
-// 调整后：fullIds 不含「因放大糊」；仅义务 + stack-over-plate 等
+// fullIds: 义务 + stack-over-plate + 选中生成器 + **板内 raise/reveal**
+// （世界基础形 raise 仍 SoA；板内必须 host，因世界 GL 在板下）
 nodeNeedsDomShapeHost(node, force?)
 ```
 

--- a/apps/web/src/components/rcb/docs/HOW_IT_WORKS.md
+++ b/apps/web/src/components/rcb/docs/HOW_IT_WORKS.md
@@ -30,7 +30,7 @@ SceneDocument（真相：节点 JSON + stackOrder）
 4. Selection chrome SVG  
 
 所以：**世界 SoA 墨水盖不住楼上的画板板面**。  
-但 **绑进画板内的节点不是靠升 SVG host 去「压板」**——见下一节。
+板内 **idle** 不靠升 SVG 压板（跟板 FO 同层）；**选中/reveal** 必须升 SVG host — 见 §0.1 / §4.4。
 
 ---
 
@@ -43,7 +43,7 @@ SceneDocument（真相：节点 JSON + stackOrder）
 └─ g[data-rcb-frame-plate]     ← data-z = 这块板的 stack z
      ├─ rect 填充（板白底）      ← SVG
      ├─ foreignObject
-     │    └─ <canvas>           ← 板内 idle 矩形/图/字画在这里（SoA → Canvas2D）
+     │    └─ <canvas>           ← 板内 idle 矩形/图/字画在这里（SoA → 共享 WebGL→FO）
      └─ rect 描边（板边框）      ← SVG
 ```
 
@@ -51,18 +51,19 @@ SceneDocument（真相：节点 JSON + stackOrder）
 
 | 问题 | 答案 |
 |------|------|
-| 板内矩形是 SVG 画的吗？ | **不是。** 是板 FO 里的 **Canvas2D**（`paintArtboardInkSurface` → `paintSoaIdleSlot`） |
+| 板内矩形是 SVG 画的吗？ | **不是。** 是板 FO 里的 canvas（`paintArtboardInkSurface` → 共享 WebGL SoA/mesh，失败时才 Canvas2D） |
 | SVG 在板里干什么？ | 只提供 **板壳**（底、边、FO 容器、`data-z`、可选 clip） |
 | 为啥看起来在板「上面」？ | 同一 `g` 里 FO/canvas 叠在 fill rect **之后**，跟板一个层级一起排 |
-| 还要升 DomHost 吗？ | 普通板内 idle **不用**。只有 lottie/空生成器/编辑态等义务才挂 host |
-| 世界 WebGL 画板内节点吗？ | **不画**（`skipFrameBound`），避免画在板下面又画一遍 |
+| 还要升 DomHost 吗？ | **idle 普通板内形不用。** 选中 / overflow reveal 时必须升 SVG host（世界 WebGL 在板下，靠 SoA raise 盖不住板） |
+| 世界 WebGL 画板内节点吗？ | **idle 不画**（`skipFrameBound`）。reveal 瞬间若 SoA 未清 idle，可能短暂世界层 fallback；正式路径是 host |
 
 **对比：**
 
 ```
 世界未绑板矩形 → 世界墨水 canvas（WebGL）→ 物理上在所有 SVG 板之下
-板内矩形       → 板自己的 FO canvas     → 跟着板的 data-z 走，看起来就在板里
-世界要盖住某板 → 才需要升 SVG host（和板比 data-z）
+板内矩形（idle） → 板自己的 FO canvas     → 跟着板的 data-z 走，看起来就在板里
+板内矩形（选中） → 升 SVG host（max+1）   → 压住板面；FO 停画防鬼影
+世界要盖住某板   → 才需要升 SVG host（和板比 data-z）
 ```
 
 ---
@@ -102,7 +103,7 @@ SceneDocument（真相：节点 JSON + stackOrder）
 | `VISIBLE` | 在场景里 |
 | `CANVAS_IDLE` | 允许走 SoA/WebGL/板内 canvas（挂了 DomHost 会清掉，防双画） |
 | `BASIC_GEOM` | 开线段（线/箭头/笔路径）→ WebGL **实例化**画 |
-| `ATLAS_STAMP` | 闭合形 / 富填充 / 文字图 → 先烤成小图打进 **atlas** 再贴 |
+| `ATLAS_STAMP` | 媒体等烤图贴 atlas（形状/文字不走这条） |
 | `DIRTY` | 要重烤 / 重上传 |
 | `FREE` | 槽位空了可回收 |
 
@@ -128,6 +129,7 @@ SoA.ids[slot] = id     = 同一个节点在缓冲里的下标
 if 义务必须 Dom（lottie / group / SoftGlow / 空生成器 / …）
    或 世界节点 stack 高于某块画板（盖不住板除非升 SVG）
    或 选中的生成器（raise 要靠 data-z）
+   或 板内绑定 +（选中 paintRaise | overflow reveal）（同上：世界墨水在板下）
    或 放大后 atlas 会糊（*NeedsSharpHost → 升 SVG）   ← 现状有；改造方案要改成 restamp
 → fullIds → SVG DomHost
 
@@ -175,16 +177,20 @@ attrs.frameId = 某板
   → 世界 WebGL 跳过（skipFrameBound）
   → HtmlArtboardFrame 的 foreignObject canvas
   → paintArtboardInkSurface
-  → paintSoaIdleSlot（Canvas2D，板坐标裁剪）
+  → artboardWebglInk（共享 WebGL2 + onlyFrameId 收集 + mesh）
+  → blit 到 FO canvas（板坐标；WebGL 不可用时才 paintSoaIdleSlot）
 ```
 
-板的白底和描边是 **SVG**；板内图形是 **板里那张 canvas**。  
-这张 canvas 有 `ARTBOARD_INK_MAX_SCALE=8`：再放大会糊（现状）。
+板的白底和描边是 **SVG**；板内图形是 **板里那张 canvas**（WebGL ink on FO）。  
+Backing 仍随 `zoom×dpr` 变；`ARTBOARD_INK_MAX_EDGE` 防 OOM，不再靠 8× 永久发虚。
 
 ### 4.4 选中普通矩形
 
-- **仍走 SoA/WebGL**（不升 SVG）  
-- 选中 raise：在 WebGL 排序里临时 `maxZ+1`，**不改** `stackOrder`  
+- **世界 unbound：** 仍走 SoA/WebGL（不升 SVG）；选中 raise 只在墨水排序里临时 `maxZ+1`
+- **板内绑定（`frameId`）：** 必须升 **SVG host**，`data-z = max+1`，并 `revealOverflow` 清 clip  
+  - FO / `onlyFrameId` **跳过** `frameClipRevealsOverflow`（否则板内留下 clip 鬼影，外面世界层再画一半）  
+  - `applySoaHostInkFlags` 清掉 `CANVAS_IDLE`，防 FO+世界+host 三路双画  
+  - 世界 WebGL 在板 SVG **下面**，只靠 SoA raise **盖不住**白底板
 - 手柄在 chrome 层，不是内容墨水
 
 ### 4.5 要「盖在画板上面」的世界矩形
@@ -201,7 +207,7 @@ attrs.frameId = 某板
 | 矩形/椭圆/多边形/星/三角 | atlas 烤图 + stroke pad |
 | 线/箭头 | BASIC_GEOM → WebGL 开线段或 atlas 笔触 |
 | 铅笔 | 富路径 atlas（不是 BASIC 中心线） |
-| 文字 | SoA TEXT → 烤字进 atlas → 贴图（编辑时另说） |
+| 文字 | SoA TEXT → **字形 outline fill mesh**（无 text atlas；编辑时 FO） |
 | 图片 | idle：atlas；CORS/过程/特殊 → DomHost |
 | 视频 | idle 可 atlas；真正播常用 FO `<video>` |
 | 空生成器 | **强制 SVG host**（图标清晰 + 可压板） |
@@ -341,6 +347,6 @@ idle 资格    → render/sceneRenderer.ts → canIdlePaintOnCanvas
 | 放大糊 | 升 SVG / 或糊着 | atlas restamp + 画板 tile |
 | DomHost | 锐利 + 义务混用 | **仅义务** |
 | 矩形简单 | WebGL 实例（已较锐） | 保持 |
-| 板内 | 单张 canvas 有 8× 帽 | 可见 tile 全分辨率 |
+| 板内 | 共享 WebGL→FO；`MAX_EDGE` 帽 | 可见 tile 全分辨率（显存优化） |
 
 写新功能：先按 **本章现状** 接线；锐利相关新逻辑按 **改造方案** 走 restamp，不要再加第四种 `*NeedsSharpHost`。

--- a/apps/web/src/components/rcb/frames/HtmlArtboardFrame.tsx
+++ b/apps/web/src/components/rcb/frames/HtmlArtboardFrame.tsx
@@ -51,8 +51,8 @@ import {
 /**
  * Clear plate stroke only when SelectionChrome owns the outline.
  * - Sole full-chrome plate: SelectionChrome paints **this** plate's box.
- * - Bound child selected: child SelectionChrome must not share a #3388ff edge
- *   with the soft-focus plate stroke (same blue reads as “selection under frame”).
+ * - Bound child selected: keep the idle gray hairline (plate silhouette); blue
+ *   soft-focus is suppressed separately via {@link framePlateShowsHighlightEdge}.
  * Multi-frame full chrome uses a union outline — members must keep their edges.
  */
 export function framePlateClearsIdleStroke(opts: {
@@ -62,8 +62,7 @@ export function framePlateClearsIdleStroke(opts: {
   /** True when a selected scene node is bound to this plate. */
   boundChildSelected?: boolean;
 }): boolean {
-  const { chromeMode, selectedFrameIds, frameId, boundChildSelected = false } = opts;
-  if (boundChildSelected) return true;
+  const { chromeMode, selectedFrameIds, frameId } = opts;
   return (
     chromeMode === 'full' &&
     selectedFrameIds.length === 1 &&

--- a/apps/web/src/components/rcb/frames/__tests__/artboardInkSurface.test.ts
+++ b/apps/web/src/components/rcb/frames/__tests__/artboardInkSurface.test.ts
@@ -19,19 +19,23 @@ import {
   registerArtboardInkSurface,
   soaSlotIsFrameBound,
 } from '@/components/rcb/frames/artboardInkSurface';
+import * as artboardWebglInk from '@/components/rcb/frames/artboardWebglInk';
 import { setFrameClipRevealOverflowIds } from '@/components/rcb/frames/frameContentClip';
 
 describe('artboardInkScale', () => {
-  it('tracks zoom×dpr up to MAX_SCALE', () => {
+  it('tracks zoom×dpr up to MAX_SCALE (edge OOM guard is separate)', () => {
     expect(artboardInkScale(1, 1)).toBe(1);
     expect(artboardInkScale(2, 1)).toBe(2);
-    expect(artboardInkScale(4, 2)).toBe(ARTBOARD_INK_MAX_SCALE);
-    expect(artboardInkScale(20, 1)).toBe(ARTBOARD_INK_MAX_SCALE);
+    expect(artboardInkScale(4, 2)).toBe(8);
+    expect(artboardInkScale(ARTBOARD_INK_MAX_SCALE + 10, 1)).toBe(ARTBOARD_INK_MAX_SCALE);
     expect(artboardInkBackingInsufficient(2, 1)).toBe(false);
     expect(artboardInkBackingInsufficient(ARTBOARD_INK_MAX_SCALE + 1, 1)).toBe(true);
   });
 
   it('restamps FO canvas at zoom×dpr so camera scale does not mush ink', () => {
+    vi.spyOn(artboardWebglInk, 'artboardWebglInkAvailable').mockReturnValue(false);
+    vi.spyOn(artboardWebglInk, 'paintArtboardWebglInk').mockReturnValue(false);
+
     const canvas = document.createElement('canvas');
     const ops: string[] = [];
     const fakeCtx = {
@@ -45,6 +49,7 @@ describe('artboardInkScale', () => {
       clip: () => undefined,
       translate: () => undefined,
       strokeRect: () => ops.push('strokeRect'),
+      drawImage: () => ops.push('drawImage'),
       globalAlpha: 1,
       fillStyle: '',
       strokeStyle: '',
@@ -83,7 +88,9 @@ describe('artboardInkScale', () => {
     expect(ops).not.toContain('fillRect');
     expect(ops).not.toContain('strokeRect');
     expect(ARTBOARD_INK_MAX_EDGE).toBeGreaterThan(1024);
+    expect(ARTBOARD_INK_MAX_SCALE).toBeGreaterThan(8);
     unreg();
+    vi.restoreAllMocks();
   });
 });
 
@@ -169,7 +176,125 @@ describe('artboard small-canvas SoA partition', () => {
     expect(kindsWithAtlas.length).toBeLessThanOrEqual(1);
   });
 
-  it('selection reveal paints frame-bound overflow on world ink', () => {
+  it('onlyFrameId collects plate-bound idle and omits other plates / world', () => {
+    let doc = createEmptyDocument({ width: 800, height: 600, emptyWorld: true });
+    doc.frames = [
+      {
+        id: 'board-a',
+        name: 'A',
+        backgroundColor: '#fff',
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 200,
+      },
+      {
+        id: 'board-b',
+        name: 'B',
+        backgroundColor: '#fff',
+        x: 300,
+        y: 0,
+        width: 200,
+        height: 200,
+      },
+    ];
+    doc = addNodeToDocument(doc, 'world', {
+      id: 'world',
+      key: 'shape',
+      x: 500,
+      y: 400,
+      width: 20,
+      height: 20,
+      attrs: { shapeType: 'rect', fill: '#f00', 'stroke-enabled': false },
+      children: [],
+    });
+    doc = addNodeToDocument(doc, 'on-a', {
+      id: 'on-a',
+      key: 'shape',
+      x: 10,
+      y: 10,
+      width: 20,
+      height: 20,
+      attrs: {
+        shapeType: 'rect',
+        fill: '#0f0',
+        'stroke-enabled': false,
+        frameId: 'board-a',
+      },
+      children: [],
+    });
+    doc = addNodeToDocument(doc, 'on-b', {
+      id: 'on-b',
+      key: 'shape',
+      x: 310,
+      y: 10,
+      width: 20,
+      height: 20,
+      attrs: {
+        shapeType: 'rect',
+        fill: '#00f',
+        'stroke-enabled': false,
+        frameId: 'board-b',
+      },
+      children: [],
+    });
+    const buf = createSceneRenderBuffer();
+    syncSceneRenderBufferFromDocument(buf, doc);
+    for (let i = 0; i < buf.count; i += 1) {
+      buf.flags[i] = (buf.flags[i] | SOA_FLAG_CANVAS_IDLE) >>> 0;
+    }
+
+    const atlas = createSoaWebglAtlas(512, 128);
+    if (!atlas) return;
+    const kinds: number[] = [];
+    const meshPos: number[] = [];
+    const meshCol: number[] = [];
+    const meshClip: number[] = [];
+    collectSoaWebglInstances(
+      buf,
+      { left: 0, top: 0, width: 200, height: 200 },
+      [],
+      [],
+      kinds,
+      [],
+      [],
+      {
+        document: doc,
+        onlyFrameId: 'board-a',
+        atlas,
+        meshPos,
+        meshCol,
+        meshClip,
+      }
+    );
+    // Only board-a content; world + board-b omitted. Mesh and/or kind instance OK.
+    expect(kinds.length + meshPos.length).toBeGreaterThan(0);
+
+    const kindsWorld: number[] = [];
+    const meshWorld: number[] = [];
+    collectSoaWebglInstances(
+      buf,
+      { x: 0, y: 0, width: 800, height: 600 },
+      [],
+      [],
+      kindsWorld,
+      [],
+      [],
+      {
+        document: doc,
+        skipFrameBound: true,
+        atlas,
+        meshPos: meshWorld,
+        meshCol: [],
+        meshClip: [],
+      }
+    );
+    // World still skips plate-bound (on-a / on-b).
+    const worldOnly = kindsWorld.length + meshWorld.length;
+    expect(worldOnly).toBeGreaterThan(0);
+  });
+
+  it('selection reveal skips FO collect; world paints only while SoA idle remains', () => {
     let doc = createEmptyDocument({ width: 800, height: 600, emptyWorld: true });
     doc.frames = [
       {
@@ -229,6 +354,28 @@ describe('artboard small-canvas SoA partition', () => {
       if (clips.length >= 4) {
         expect(clips[0]).toBeLessThan(-1e7);
       }
+
+      const plateKinds: number[] = [];
+      const plateMesh: number[] = [];
+      collectSoaWebglInstances(
+        buf,
+        { left: 0, top: 0, width: 200, height: 200 },
+        [],
+        [],
+        plateKinds,
+        [],
+        [],
+        {
+          document: doc,
+          onlyFrameId: 'board',
+          atlas,
+          meshPos: plateMesh,
+          meshCol: [],
+          meshClip: [],
+        }
+      );
+      // Revealed overflow must not paint on the FO collect (raised host / world).
+      expect(plateKinds.length + plateMesh.length).toBe(0);
     } finally {
       setFrameClipRevealOverflowIds(null);
     }

--- a/apps/web/src/components/rcb/frames/__tests__/multiFramePlateStroke.test.ts
+++ b/apps/web/src/components/rcb/frames/__tests__/multiFramePlateStroke.test.ts
@@ -53,7 +53,7 @@ describe('multi-frame plate stroke', () => {
     ).toBe(true);
   });
 
-  it('clears plate edge when a bound child owns SelectionChrome', () => {
+  it('clears plate blue soft edge when a bound child owns SelectionChrome (keeps idle hairline)', () => {
     expect(
       framePlateClearsIdleStroke({
         chromeMode: 'soft',
@@ -61,7 +61,7 @@ describe('multi-frame plate stroke', () => {
         frameId: 'a',
         boundChildSelected: true,
       })
-    ).toBe(true);
+    ).toBe(false);
     expect(
       framePlateShowsHighlightEdge({
         chromeMode: 'soft',

--- a/apps/web/src/components/rcb/frames/artboardInkSurface.ts
+++ b/apps/web/src/components/rcb/frames/artboardInkSurface.ts
@@ -1,11 +1,23 @@
 /**
- * Per-artboard ink surface — bound SoA idle nodes on a FO canvas.
- * Plate fill + edge stay on SVG (HtmlArtboardFrame); painting them here too
- * double-layers and bleeds past selection chrome under camera scale.
+ * Per-artboard ink surface — bound SoA idle on a FO canvas via shared WebGL
+ * (same mesh path as world). Plate fill + edge stay on SVG (HtmlArtboardFrame);
+ * painting them here too double-layers and bleeds past selection chrome.
  *
  * Backing tracks zoom: FO sits under SVG `scale(zoom)`, so scene×dpr alone mush.
+ * Soft 8× soft-upscale path removed; MAX_EDGE still caps OOM.
  */
+import { nodeOwnerFrameId } from '@/components/rcb/frames/frameNodeBinding';
+import { frameClipRevealsOverflow } from '@/components/rcb/frames/frameContentClip';
+import { getNodeTransformPreview } from '@/components/rcb/core/transformPreview';
+import { readDevicePixelRatio } from '@/components/rcb/core/dpr';
+import { buildNodeStackZMap } from '@/components/rcb/scene/document/sceneDocument';
+import type { SceneDocument, SceneNodeInput } from '@/components/rcb/sceneNode';
 import type { ArtboardFrame } from '@/components/rcb/frames/types';
+import {
+  artboardWebglInkAvailable,
+  paintArtboardWebglInk,
+  releaseArtboardWebglTarget,
+} from '@/components/rcb/frames/artboardWebglInk';
 import {
   getSharedSceneRenderBuffer,
   paintSoaIdleSlot,
@@ -15,15 +27,12 @@ import {
   setSoaPaintDocument,
   type SceneRenderBuffer,
 } from '@/components/rcb/render/sceneRenderBuffer';
-import { buildNodeStackZMap } from '@/components/rcb/scene/document/sceneDocument';
-import type { SceneDocument, SceneNodeInput } from '@/components/rcb/sceneNode';
-import { getNodeTransformPreview } from '@/components/rcb/core/transformPreview';
-import { readDevicePixelRatio } from '@/components/rcb/core/dpr';
-import { nodeOwnerFrameId } from '@/components/rcb/frames/frameNodeBinding';
-import { frameClipRevealsOverflow } from '@/components/rcb/frames/frameContentClip';
 
-/** Cap on zoom×dpr for a single full-plate ink bitmap (tiles take over past this). */
-export const ARTBOARD_INK_MAX_SCALE = 8;
+/**
+ * Soft cap on zoom×dpr for a single full-plate ink bitmap.
+ * Raised so MAX_EDGE is the practical OOM guard (no permanent mush at 8×).
+ */
+export const ARTBOARD_INK_MAX_SCALE = 64;
 /** Longest backing edge (px) so huge plates at high zoom do not OOM. */
 export const ARTBOARD_INK_MAX_EDGE = 4096;
 
@@ -69,7 +78,7 @@ export function artboardInkBackingInsufficient(zoom: number, dpr = 1): boolean {
 /**
  * Size the FO canvas so CSS scene size × camera zoom maps ~1:1 to device pixels
  * (up to {@link ARTBOARD_INK_MAX_SCALE} / {@link ARTBOARD_INK_MAX_EDGE}).
- * Returns the effective scene→backing scale for `setTransform`.
+ * Returns the effective scene→backing scale for paint transforms.
  */
 function resizeInkCanvas(
   canvas: HTMLCanvasElement,
@@ -108,7 +117,9 @@ function collectBoundIdleIndices(
     if (!(flags & SOA_FLAG_VISIBLE) || !(flags & SOA_FLAG_CANVAS_IDLE)) continue;
     const id = buf.ids[i];
     if (!id) continue;
-    // Selected / editing: paint on world ink without plate clip (match chrome).
+    // Selected / editing: paint on raised SVG host / world ink (not FO).
+    // Dual FO+world paint left a clipped ghost in the plate while the live
+    // drag drew outside — and world WebGL cannot cover the plate fill.
     if (frameClipRevealsOverflow(id)) continue;
     const node = doc.deltaSetLike?.[id] as SceneNodeInput | undefined;
     if (!node || nodeOwnerFrameId(node) !== frameId) continue;
@@ -116,9 +127,38 @@ function collectBoundIdleIndices(
     indices.push(i);
   }
   if (indices.length <= 1) return indices;
-  const zMap = buildNodeStackZMap(doc);
+  const zMap = buildNodeStackZMap(
+    doc,
+    indices.map((i) => buf.ids[i] || '').filter(Boolean)
+  );
   indices.sort((a, b) => (zMap.get(buf.ids[a] || '') ?? 0) - (zMap.get(buf.ids[b] || '') ?? 0));
   return indices;
+}
+
+/** Canvas2D survival path when shared artboard WebGL is unavailable. */
+function paintArtboardInkSurface2d(entry: SurfaceEntry, frame: ArtboardInkPaintFrame, effective: number): void {
+  const w = Math.max(1, Number(frame.width) || 1);
+  const h = Math.max(1, Number(frame.height) || 1);
+  const ctx = entry.canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.setTransform(effective, 0, 0, effective, 0, 0);
+  ctx.clearRect(0, 0, w, h);
+
+  const doc = entry.getDocument();
+  if (!doc) return;
+  setSoaPaintDocument(doc);
+  const buf = getSharedSceneRenderBuffer();
+  const fx = Number(frame.x) || 0;
+  const fy = Number(frame.y) || 0;
+  const indices = collectBoundIdleIndices(buf, doc, String(frame.id));
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(0, 0, w, h);
+  ctx.clip();
+  ctx.translate(-fx, -fy);
+  const view = { left: fx, top: fy, right: fx + w, bottom: fy + h };
+  for (const i of indices) paintSoaIdleSlot(ctx, buf, i, view, doc);
+  ctx.restore();
 }
 
 /** Register a display canvas for continuous artboard ink. */
@@ -143,7 +183,10 @@ export function registerArtboardInkSurface(
   surfaces.set(id, full);
   scheduleArtboardInkPaint(id);
   return () => {
-    if (surfaces.get(id) === full) surfaces.delete(id);
+    if (surfaces.get(id) === full) {
+      surfaces.delete(id);
+      releaseArtboardWebglTarget(id);
+    }
   };
 }
 
@@ -185,29 +228,29 @@ export function paintArtboardInkSurface(entry: SurfaceEntry): void {
   const scale = artboardInkScale(entry.zoom, dpr);
   const effective = resizeInkCanvas(entry.canvas, w, h, scale);
 
-  const ctx = entry.canvas.getContext('2d');
-  if (!ctx) return;
-  ctx.setTransform(effective, 0, 0, effective, 0, 0);
-  // Transparent — SVG `data-rcb-artboard-fill` / edge own the plate. Painting
-  // fill+stroke here too double-layers and bleeds ~1px past selection chrome.
-  ctx.clearRect(0, 0, w, h);
-
   const doc = entry.getDocument();
-  if (doc) {
-    setSoaPaintDocument(doc);
-    const buf = getSharedSceneRenderBuffer();
-    const fx = Number(frame.x) || 0;
-    const fy = Number(frame.y) || 0;
-    const indices = collectBoundIdleIndices(buf, doc, String(frame.id));
-    ctx.save();
-    ctx.beginPath();
-    ctx.rect(0, 0, w, h);
-    ctx.clip();
-    ctx.translate(-fx, -fy);
-    const view = { left: fx, top: fy, right: fx + w, bottom: fy + h };
-    for (const i of indices) paintSoaIdleSlot(ctx, buf, i, view, doc);
-    ctx.restore();
+  if (
+    doc &&
+    artboardWebglInkAvailable() &&
+    paintArtboardWebglInk({
+      targetCanvas: entry.canvas,
+      frameId: String(frame.id),
+      frame: {
+        x: Number(frame.x) || 0,
+        y: Number(frame.y) || 0,
+        width: w,
+        height: h,
+      },
+      document: doc,
+      effectiveScale: effective,
+      dpr,
+    })
+  ) {
+    return;
   }
+
+  // Transparent clear + optional 2D idle — SVG fill/edge own the plate.
+  paintArtboardInkSurface2d(entry, frame, effective);
 }
 
 /** True when a SoA slot belongs to an artboard (painted on ArtboardLayer, not world ink). */

--- a/apps/web/src/components/rcb/frames/artboardWebglInk.ts
+++ b/apps/web/src/components/rcb/frames/artboardWebglInk.ts
@@ -1,0 +1,437 @@
+/**
+ * Shared WebGL2 painter for artboard FO ink (ADR 0027).
+ * One GL context → draw plate-bound SoA/mesh → blit to each FO canvas (2D).
+ * Keeps stackOrder / FO interleave; does not merge plate ink into world GL.
+ */
+import {
+  getSharedSceneRenderBuffer,
+  isSoaCanvasShapesEnabled,
+  setSoaPaintDocument,
+} from '@/components/rcb/render/sceneRenderBuffer';
+import {
+  ensureSharedSoaWebglAtlas,
+  recreateSharedSoaWebglAtlas,
+} from '@/components/rcb/render/webglInstanceAtlas';
+import {
+  collectSoaWebglInstances,
+  compileSoaWebglShader,
+  linkSoaWebglProgram,
+  SOA_WEBGL_INK_FS,
+  SOA_WEBGL_INK_VS,
+  SOA_WEBGL_MESH_FS,
+  SOA_WEBGL_MESH_VS,
+  SOA_WEBGL_NO_CLIP,
+  SOA_WEBGL_UNIT_QUAD,
+  soaWebglInkShadersOk,
+} from '@/components/rcb/render/webglSceneRenderer';
+import type { SceneDocument } from '@/components/rcb/sceneNode';
+
+type ArtboardGlResources = {
+  canvas: HTMLCanvasElement;
+  gl: WebGL2RenderingContext;
+  prog: WebGLProgram;
+  meshProg: WebGLProgram | null;
+  vao: WebGLVertexArrayObject;
+  meshVao: WebGLVertexArrayObject | null;
+  cornerBuf: WebGLBuffer;
+  rectBuf: WebGLBuffer;
+  colorBuf: WebGLBuffer;
+  kindBuf: WebGLBuffer;
+  angleBuf: WebGLBuffer;
+  uvBuf: WebGLBuffer;
+  clipBuf: WebGLBuffer;
+  meshPosBuf: WebGLBuffer | null;
+  meshColBuf: WebGLBuffer | null;
+  meshClipBuf: WebGLBuffer | null;
+  atlasTex: WebGLTexture;
+  instanceCap: number;
+  atlasUploadedRevision: number;
+  atlasBufferRevision: number;
+  scratchRect: Float32Array;
+  scratchColor: Float32Array;
+  scratchKind: Float32Array;
+  scratchAngle: Float32Array;
+  scratchUv: Float32Array;
+  scratchClip: Float32Array;
+};
+
+let shared: ArtboardGlResources | null = null;
+let sharedFailed = false;
+
+function copyToScratch(src: ArrayLike<number>, prev: Float32Array): Float32Array {
+  const n = src.length;
+  const out = prev.length >= n ? prev : new Float32Array(Math.max(n, prev.length * 2 || 64));
+  out.set(src, 0);
+  return out;
+}
+
+function ensureInstanceCapacity(res: ArtboardGlResources, n: number) {
+  if (n <= res.instanceCap) return;
+  const gl = res.gl;
+  res.instanceCap = Math.max(1024, n * 2);
+  gl.bindBuffer(gl.ARRAY_BUFFER, res.rectBuf);
+  gl.bufferData(gl.ARRAY_BUFFER, res.instanceCap * 4 * 4, gl.DYNAMIC_DRAW);
+  gl.bindBuffer(gl.ARRAY_BUFFER, res.colorBuf);
+  gl.bufferData(gl.ARRAY_BUFFER, res.instanceCap * 4 * 4, gl.DYNAMIC_DRAW);
+  gl.bindBuffer(gl.ARRAY_BUFFER, res.kindBuf);
+  gl.bufferData(gl.ARRAY_BUFFER, res.instanceCap * 4, gl.DYNAMIC_DRAW);
+  gl.bindBuffer(gl.ARRAY_BUFFER, res.angleBuf);
+  gl.bufferData(gl.ARRAY_BUFFER, res.instanceCap * 4, gl.DYNAMIC_DRAW);
+  gl.bindBuffer(gl.ARRAY_BUFFER, res.uvBuf);
+  gl.bufferData(gl.ARRAY_BUFFER, res.instanceCap * 4 * 4, gl.DYNAMIC_DRAW);
+  gl.bindBuffer(gl.ARRAY_BUFFER, res.clipBuf);
+  gl.bufferData(gl.ARRAY_BUFFER, res.instanceCap * 4 * 4, gl.DYNAMIC_DRAW);
+}
+
+function createSharedArtboardGl(): ArtboardGlResources | null {
+  if (typeof document === 'undefined') return null;
+  if (!isSoaCanvasShapesEnabled() || !soaWebglInkShadersOk()) return null;
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = 1;
+  const gl = canvas.getContext('webgl2', {
+    alpha: true,
+    premultipliedAlpha: true,
+    antialias: true,
+    preserveDrawingBuffer: true,
+  });
+  if (!gl) return null;
+
+  const vs = compileSoaWebglShader(gl, gl.VERTEX_SHADER, SOA_WEBGL_INK_VS);
+  const fs = compileSoaWebglShader(gl, gl.FRAGMENT_SHADER, SOA_WEBGL_INK_FS);
+  const prog = vs && fs ? linkSoaWebglProgram(gl, vs, fs) : null;
+  const meshVs = compileSoaWebglShader(gl, gl.VERTEX_SHADER, SOA_WEBGL_MESH_VS);
+  const meshFs = compileSoaWebglShader(gl, gl.FRAGMENT_SHADER, SOA_WEBGL_MESH_FS);
+  const meshProg = meshVs && meshFs ? linkSoaWebglProgram(gl, meshVs, meshFs) : null;
+  if (!prog) return null;
+
+  const vao = gl.createVertexArray();
+  const meshVao = gl.createVertexArray();
+  const cornerBuf = gl.createBuffer();
+  const rectBuf = gl.createBuffer();
+  const colorBuf = gl.createBuffer();
+  const kindBuf = gl.createBuffer();
+  const angleBuf = gl.createBuffer();
+  const uvBuf = gl.createBuffer();
+  const clipBuf = gl.createBuffer();
+  const meshPosBuf = gl.createBuffer();
+  const meshColBuf = gl.createBuffer();
+  const meshClipBuf = gl.createBuffer();
+  const atlasTex = gl.createTexture();
+  if (
+    !vao ||
+    !cornerBuf ||
+    !rectBuf ||
+    !colorBuf ||
+    !kindBuf ||
+    !angleBuf ||
+    !uvBuf ||
+    !clipBuf ||
+    !atlasTex
+  ) {
+    return null;
+  }
+
+  gl.bindVertexArray(vao);
+  gl.bindBuffer(gl.ARRAY_BUFFER, cornerBuf);
+  gl.bufferData(gl.ARRAY_BUFFER, SOA_WEBGL_UNIT_QUAD, gl.STATIC_DRAW);
+  gl.enableVertexAttribArray(0);
+  gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+  gl.vertexAttribDivisor(0, 0);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, rectBuf);
+  gl.enableVertexAttribArray(1);
+  gl.vertexAttribPointer(1, 4, gl.FLOAT, false, 0, 0);
+  gl.vertexAttribDivisor(1, 1);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, colorBuf);
+  gl.enableVertexAttribArray(2);
+  gl.vertexAttribPointer(2, 4, gl.FLOAT, false, 0, 0);
+  gl.vertexAttribDivisor(2, 1);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, kindBuf);
+  gl.enableVertexAttribArray(3);
+  gl.vertexAttribPointer(3, 1, gl.FLOAT, false, 0, 0);
+  gl.vertexAttribDivisor(3, 1);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, angleBuf);
+  gl.enableVertexAttribArray(4);
+  gl.vertexAttribPointer(4, 1, gl.FLOAT, false, 0, 0);
+  gl.vertexAttribDivisor(4, 1);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, uvBuf);
+  gl.enableVertexAttribArray(5);
+  gl.vertexAttribPointer(5, 4, gl.FLOAT, false, 0, 0);
+  gl.vertexAttribDivisor(5, 1);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, clipBuf);
+  gl.enableVertexAttribArray(6);
+  gl.vertexAttribPointer(6, 4, gl.FLOAT, false, 0, 0);
+  gl.vertexAttribDivisor(6, 1);
+  gl.bindVertexArray(null);
+
+  if (meshProg && meshVao && meshPosBuf && meshColBuf && meshClipBuf) {
+    gl.bindVertexArray(meshVao);
+    gl.bindBuffer(gl.ARRAY_BUFFER, meshPosBuf);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, meshColBuf);
+    gl.enableVertexAttribArray(1);
+    gl.vertexAttribPointer(1, 4, gl.FLOAT, false, 0, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, meshClipBuf);
+    gl.enableVertexAttribArray(2);
+    gl.vertexAttribPointer(2, 4, gl.FLOAT, false, 0, 0);
+    gl.bindVertexArray(null);
+  }
+
+  gl.bindTexture(gl.TEXTURE_2D, atlasTex);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  gl.texImage2D(
+    gl.TEXTURE_2D,
+    0,
+    gl.RGBA,
+    1,
+    1,
+    0,
+    gl.RGBA,
+    gl.UNSIGNED_BYTE,
+    new Uint8Array([0, 0, 0, 0])
+  );
+  gl.bindTexture(gl.TEXTURE_2D, null);
+
+  return {
+    canvas,
+    gl,
+    prog,
+    meshProg,
+    vao,
+    meshVao: meshProg ? meshVao : null,
+    cornerBuf,
+    rectBuf,
+    colorBuf,
+    kindBuf,
+    angleBuf,
+    uvBuf,
+    clipBuf,
+    meshPosBuf: meshProg ? meshPosBuf : null,
+    meshColBuf: meshProg ? meshColBuf : null,
+    meshClipBuf: meshProg ? meshClipBuf : null,
+    atlasTex,
+    instanceCap: 0,
+    atlasUploadedRevision: -1,
+    atlasBufferRevision: -1,
+    scratchRect: new Float32Array(0),
+    scratchColor: new Float32Array(0),
+    scratchKind: new Float32Array(0),
+    scratchAngle: new Float32Array(0),
+    scratchUv: new Float32Array(0),
+    scratchClip: new Float32Array(0),
+  };
+}
+
+function getSharedArtboardGl(): ArtboardGlResources | null {
+  if (sharedFailed) return null;
+  if (shared) return shared;
+  shared = createSharedArtboardGl();
+  if (!shared) sharedFailed = true;
+  return shared;
+}
+
+/** True when plate idle can use shared SoA WebGL (same mesh path as world). */
+export function artboardWebglInkAvailable(): boolean {
+  return Boolean(getSharedArtboardGl());
+}
+
+export type PaintArtboardWebglInkArgs = {
+  targetCanvas: HTMLCanvasElement;
+  frameId: string;
+  frame: { x: number; y: number; width: number; height: number };
+  document: SceneDocument;
+  /** Scene→backing scale (after MAX_EDGE clamp). */
+  effectiveScale: number;
+  dpr?: number;
+};
+
+/**
+ * Clear shared GL → collect onlyFrameId → draw with plate-local uniforms →
+ * blit onto the FO display canvas (keeps 2D context on the FO element).
+ */
+export function paintArtboardWebglInk(args: PaintArtboardWebglInkArgs): boolean {
+  const res = getSharedArtboardGl();
+  if (!res) return false;
+
+  const w = Math.max(1, Number(args.frame.width) || 1);
+  const h = Math.max(1, Number(args.frame.height) || 1);
+  const fx = Number(args.frame.x) || 0;
+  const fy = Number(args.frame.y) || 0;
+  const scale = Math.max(1e-6, Number(args.effectiveScale) || 1);
+  const dpr = Math.max(1, Number(args.dpr) || 1);
+  const bw = Math.max(1, args.targetCanvas.width);
+  const bh = Math.max(1, args.targetCanvas.height);
+
+  const gl = res.gl;
+  if (res.canvas.width !== bw || res.canvas.height !== bh) {
+    res.canvas.width = bw;
+    res.canvas.height = bh;
+  }
+
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  gl.viewport(0, 0, bw, bh);
+  gl.clearColor(0, 0, 0, 0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.enable(gl.BLEND);
+  gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+
+  setSoaPaintDocument(args.document);
+  const buf = getSharedSceneRenderBuffer();
+  const atlas = ensureSharedSoaWebglAtlas();
+  if (!atlas) return false;
+
+  if (res.atlasBufferRevision !== buf.revision) {
+    res.atlasBufferRevision = buf.revision;
+    res.atlasUploadedRevision = -1;
+  }
+
+  const rects: number[] = [];
+  const colors: number[] = [];
+  const kinds: number[] = [];
+  const angles: number[] = [];
+  const uvs: number[] = [];
+  const clips: number[] = [];
+  const meshPos: number[] = [];
+  const meshCol: number[] = [];
+  const meshClipArr: number[] = [];
+
+  // Plate-local via pan: screen = world * scale + (-fx,-fy)*scale.
+  // screen is in *backing* px (same as 2D setTransform(scale)); uStage must match
+  // (bw,bh) — using plate CSS (w,h) mis-projects whenever scale ≠ 1 (zoom drift).
+  collectSoaWebglInstances(buf, { left: fx, top: fy, width: w, height: h }, rects, colors, kinds, angles, uvs, {
+    atlas,
+    bufferRevision: buf.revision,
+    clips,
+    document: args.document,
+    zoom: scale,
+    dpr,
+    onlyFrameId: args.frameId,
+    meshPos,
+    meshCol,
+    meshClip: meshClipArr,
+  });
+
+  const count = kinds.length;
+  const meshVertCount = Math.floor(meshPos.length / 2);
+  const panX = -fx * scale;
+  const panY = -fy * scale;
+  const stageW = bw;
+  const stageH = bh;
+
+  if (count > 0) {
+    ensureInstanceCapacity(res, count);
+    res.scratchRect = copyToScratch(rects, res.scratchRect);
+    res.scratchColor = copyToScratch(colors, res.scratchColor);
+    res.scratchKind = copyToScratch(kinds, res.scratchKind);
+    res.scratchAngle = copyToScratch(angles, res.scratchAngle);
+    res.scratchUv = copyToScratch(uvs, res.scratchUv);
+    gl.bindBuffer(gl.ARRAY_BUFFER, res.rectBuf);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, res.scratchRect.subarray(0, rects.length));
+    gl.bindBuffer(gl.ARRAY_BUFFER, res.colorBuf);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, res.scratchColor.subarray(0, colors.length));
+    gl.bindBuffer(gl.ARRAY_BUFFER, res.kindBuf);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, res.scratchKind.subarray(0, kinds.length));
+    gl.bindBuffer(gl.ARRAY_BUFFER, res.angleBuf);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, res.scratchAngle.subarray(0, angles.length));
+    gl.bindBuffer(gl.ARRAY_BUFFER, res.uvBuf);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, res.scratchUv.subarray(0, uvs.length));
+    const clipFill =
+      clips.length === count * 4
+        ? clips
+        : Array.from({ length: count * 4 }, (_, i) => SOA_WEBGL_NO_CLIP[i % 4]);
+    res.scratchClip = copyToScratch(clipFill, res.scratchClip);
+    gl.bindBuffer(gl.ARRAY_BUFFER, res.clipBuf);
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, res.scratchClip.subarray(0, count * 4));
+
+    if (atlas.revision !== res.atlasUploadedRevision) {
+      gl.bindTexture(gl.TEXTURE_2D, res.atlasTex);
+      gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 1);
+      try {
+        gl.texImage2D(
+          gl.TEXTURE_2D,
+          0,
+          gl.RGBA,
+          gl.RGBA,
+          gl.UNSIGNED_BYTE,
+          atlas.canvas as TexImageSource
+        );
+        res.atlasUploadedRevision = atlas.revision;
+      } catch {
+        recreateSharedSoaWebglAtlas();
+        res.atlasUploadedRevision = -1;
+      }
+    }
+
+    gl.useProgram(res.prog);
+    gl.uniform2f(gl.getUniformLocation(res.prog, 'uPan'), panX, panY);
+    gl.uniform1f(gl.getUniformLocation(res.prog, 'uZoom'), scale);
+    gl.uniform2f(gl.getUniformLocation(res.prog, 'uStage'), stageW, stageH);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, res.atlasTex);
+    gl.uniform1i(gl.getUniformLocation(res.prog, 'uAtlas'), 0);
+    gl.bindVertexArray(res.vao);
+    gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, count);
+    gl.bindVertexArray(null);
+  }
+
+  if (
+    meshVertCount >= 3 &&
+    res.meshProg &&
+    res.meshVao &&
+    res.meshPosBuf &&
+    res.meshColBuf &&
+    res.meshClipBuf
+  ) {
+    gl.useProgram(res.meshProg);
+    gl.uniform2f(gl.getUniformLocation(res.meshProg, 'uPan'), panX, panY);
+    gl.uniform1f(gl.getUniformLocation(res.meshProg, 'uZoom'), scale);
+    gl.uniform2f(gl.getUniformLocation(res.meshProg, 'uStage'), stageW, stageH);
+    gl.bindVertexArray(res.meshVao);
+    gl.bindBuffer(gl.ARRAY_BUFFER, res.meshPosBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(meshPos), gl.DYNAMIC_DRAW);
+    gl.bindBuffer(gl.ARRAY_BUFFER, res.meshColBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(meshCol), gl.DYNAMIC_DRAW);
+    gl.bindBuffer(gl.ARRAY_BUFFER, res.meshClipBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(meshClipArr), gl.DYNAMIC_DRAW);
+    gl.drawArrays(gl.TRIANGLES, 0, meshVertCount);
+    gl.bindVertexArray(null);
+  }
+
+  const ctx = args.targetCanvas.getContext('2d');
+  if (!ctx) return false;
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.clearRect(0, 0, bw, bh);
+  // Empty plate: clear only (SVG owns fill/edge).
+  if (count > 0 || meshVertCount >= 3) {
+    ctx.drawImage(res.canvas, 0, 0, bw, bh, 0, 0, bw, bh);
+  }
+  return true;
+}
+
+/**
+ * Drop per-plate GPU scratch when a FO unregisters.
+ * Shared GL stays alive (cheap while no plates; recreates on next paint).
+ */
+export function releaseArtboardWebglTarget(_frameId: string): void {
+  // Present path blits via a shared scratch canvas (no per-plate FBO yet).
+  // Hook kept so unregister can grow into FBO release without API churn.
+}
+
+/** Test-only: reset shared GL so probes can re-init. */
+export function resetArtboardWebglInkForTests(): void {
+  if (shared) {
+    shared.gl.getExtension('WEBGL_lose_context')?.loseContext();
+  }
+  shared = null;
+  sharedFailed = false;
+}

--- a/apps/web/src/components/rcb/frames/types.ts
+++ b/apps/web/src/components/rcb/frames/types.ts
@@ -27,7 +27,7 @@ export function framePlateStrokeSceneWidth(zoom: number): number {
  * transform — same miter closed-path recipe as stroked SoA rects (not strokeRect AA).
  *
  * Prefer {@link applyArtboardPlateEdgeStroke} for live plate chrome: artboard ink
- * canvas backing is capped (`ARTBOARD_INK_MAX_SCALE`), so canvas hairlines vanish
+ * canvas backing is edge-capped (`ARTBOARD_INK_MAX_EDGE`), so canvas hairlines vanish
  * when zoomed in past that cap.
  */
 export function strokeCanvasPlateHairline(

--- a/apps/web/src/components/rcb/render/__tests__/sceneRenderer.test.ts
+++ b/apps/web/src/components/rcb/render/__tests__/sceneRenderer.test.ts
@@ -29,7 +29,6 @@ import {
   canvasCompositeFromBlendMode,
   paintCanvasMediaInk,
   bakeShapeInkForAtlas,
-  bakeTextInkForAtlas,
   isSoaAtlasBakeEligible,
   bakeMediaInkForAtlas,
   paintGeneratorEmptyInk,
@@ -708,23 +707,14 @@ describe('Canvas idle path / text / shape paint', () => {
     expect(bakeShapeInkForAtlas(sharp, 80, 80, 1)).toBeNull();
   });
 
-  it('bakeTextInkForAtlas paints glyphs onto an offscreen canvas', () => {
-    const ops: string[] = [];
-    const ctx = mockCtx(ops);
-    (ctx as { fillText?: (...a: unknown[]) => void }).fillText = () => ops.push('fillText');
-    withStubbedCanvas2d(ctx, () => {
-      const node = {
-        id: 't1',
-        key: 'text',
-        width: 120,
-        height: 40,
-        attrs: { text: 'Hello', fontSize: 16 },
-      } as SceneNodeInput;
-      const baked = bakeTextInkForAtlas(node, 120, 40, 1);
-      expect(baked).not.toBeNull();
-      expect(Number((baked as HTMLCanvasElement).width || 0)).toBeGreaterThan(0);
-      expect(ops).toContain('fillText');
-    });
+  it('idle text uses outline mesh path (bakeTextInkForAtlas removed)', () => {
+    expect(typeof bakeShapeInkForAtlas).toBe('function');
+    expect(bakeShapeInkForAtlas(
+      { id: 't1', key: 'text', width: 120, height: 40, attrs: { text: 'Hello' } } as SceneNodeInput,
+      120,
+      40,
+      1
+    )).toBeNull();
   });
 
   it('paintSoaIdleSlot draws text glyphs', () => {

--- a/apps/web/src/components/rcb/render/__tests__/soaRoundedIdle.test.ts
+++ b/apps/web/src/components/rcb/render/__tests__/soaRoundedIdle.test.ts
@@ -371,7 +371,7 @@ describe('SoA basic geom vs rounded / poly', () => {
       // Rich fills idle via Canvas2D Path2D (CANVAS_IDLE), not BASIC_GEOM / ATLAS_STAMP.
       expect(buf.flags[i!] & SOA_FLAG_CANVAS_IDLE, id).toBeTruthy();
     }
-    // Static image/text: atlas-stamp idle (CANVAS_IDLE) without BASIC_GEOM.
+    // Static image: atlas-stamp idle. Text: outline mesh. Both CANVAS_IDLE without BASIC_GEOM.
     expect(isSoaBasicGeomSufficient(doc.deltaSetLike.img)).toBe(false);
     const imgIdx = buf.indexById.get('img')!;
     expect(buf.flags[imgIdx] & SOA_FLAG_BASIC_GEOM).toBeFalsy();

--- a/apps/web/src/components/rcb/render/sceneRenderBuffer.ts
+++ b/apps/web/src/components/rcb/render/sceneRenderBuffer.ts
@@ -41,7 +41,9 @@ import {
   starInnerRatioFromAttrs,
 } from '@/components/rcb/scene/document/sceneShapes';
 import { invalidateShapeMesh } from '@/components/rcb/render/vector/meshCache';
+import { invalidateTextOutlineMesh } from '@/components/rcb/render/vector/textOutlineMesh';
 import { pencilSilhouettePathD } from '@/components/rcb/render/vector/contour';
+import { parseNodeTextStyle } from '@/components/rcb/scene/document/sceneText';
 import { getSoaTextInkPainter } from '@/components/rcb/render/soaTextInkPainter';
 import { getShapeBaseline } from '@/components/rcb/core/geometry/baseline';
 import type { SceneDocument, SceneNodeInput } from '@/components/rcb/sceneNode';
@@ -90,7 +92,7 @@ export const SOA_KIND_LINE = 2;
 export const SOA_KIND_PATH = 3;
 export const SOA_KIND_IMAGE = 4;
 export const SOA_KIND_POLY = 5;
-/** Static text — Canvas/DOM vector glyphs (never atlas stamp). */
+/** Static text — WebGL glyph outline mesh (never atlas stamp). */
 export const SOA_KIND_TEXT = 6;
 export const SOA_KIND_OTHER = 15;
 /** Fallback line/path width when attrs omit border-width (matches prior Canvas/WebGL default). */
@@ -126,7 +128,7 @@ function shapeTypeToken(node: SceneNodeInput): string {
 export function isSoaCanvasEligible(node: SceneNodeInput | null | undefined): boolean {
   if (!node) return false;
   const key = String(node.key || '');
-  // Lottie/group stay DOM. Static image/video/audio/text can atlas-stamp.
+  // Lottie/group stay DOM. Static image/video/audio may atlas-stamp; text is outline mesh.
   if (key === 'lottie' || key === 'group') return false;
   if (key === 'text' || key === 'image' || key === 'video' || key === 'audio') return true;
   const t = shapeTypeToken(node);
@@ -644,6 +646,10 @@ function shapeKindOf(node: SceneNodeInput): number {
 
 function fillColorOf(node: SceneNodeInput): number {
   const attrs = node.attrs || {};
+  if (shapeKindOf(node) === SOA_KIND_TEXT) {
+    const style = parseNodeTextStyle(attrs);
+    return packCssColor(style.fill ?? attrs.fill ?? attrs['fill-color'], 0xff333333);
+  }
   return packCssColor(attrs['fill-color'], 0xffc0c0c0);
 }
 
@@ -706,8 +712,8 @@ function writeSlot(
   let flags = SOA_FLAG_DIRTY;
   if (!isNodeOverlayHidden(document, node)) flags |= SOA_FLAG_VISIBLE;
   if (node.attrs?.locked) flags |= SOA_FLAG_LOCKED;
-  // BASIC_GEOM → SoA vector ink (WebGL mesh / Canvas2D Path2D). Media/text
-  // keep CANVAS_IDLE without BASIC for texture / glyph paths.
+  // BASIC_GEOM → SoA vector ink (WebGL mesh / Canvas2D Path2D). Media keeps
+  // CANVAS_IDLE without BASIC (GPU texture). Text is outline mesh (still no BASIC).
   if (isSoaBasicGeomSufficient(node)) {
     flags |= SOA_FLAG_BASIC_GEOM | SOA_FLAG_CANVAS_IDLE;
   } else if (kind === SOA_KIND_IMAGE || kind === SOA_KIND_TEXT) {
@@ -731,6 +737,7 @@ function writeSlot(
   // Geometry wrote — drop vector caches so next paint rebuilds fill/stroke meshes.
   invalidateShapeMesh(id);
   invalidateNodePath2D(id);
+  if (kind === SOA_KIND_TEXT) invalidateTextOutlineMesh(id);
   if (!opts?.skipQuad) syncQuadSlot(buf, index);
 }
 
@@ -2735,6 +2742,7 @@ export function upsertSoaGeom(
   buf.flags[index] = (buf.flags[index] | SOA_FLAG_DIRTY) >>> 0;
   invalidateShapeMesh(id);
   invalidateNodePath2D(id);
+  if (buf.kinds[index] === SOA_KIND_TEXT) invalidateTextOutlineMesh(id);
   syncQuadSlot(buf, index);
   return index;
 }

--- a/apps/web/src/components/rcb/render/sceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/sceneRenderer.ts
@@ -2796,7 +2796,7 @@ export function bakeAudioInkForAtlas(
 }
 
 /**
- * Shape / text atlas bake — retired (vector dual-backend). Always null.
+ * @deprecated Shape atlas bake retired. Always null.
  */
 export function bakeShapeInkForAtlas(
   _node: SceneNodeInput,
@@ -2807,65 +2807,6 @@ export function bakeShapeInkForAtlas(
   return null;
 }
 
-/**
- * Bake idle text glyphs for WebGL atlas stamp (same ink as Canvas2D idle).
- * Zoom-scaled bake so glyphs stay sharp when zoomed in.
- */
-export function bakeTextInkForAtlas(
-  node: SceneNodeInput,
-  width: number,
-  height: number,
-  zoom = 1
-): HTMLCanvasElement | OffscreenCanvas | null {
-  if (String(node.key || '') !== 'text') return null;
-  const w = Math.max(1, Math.round(width));
-  const h = Math.max(1, Math.round(height));
-  const z = Math.max(0.05, Number(zoom) || 1);
-  const scale = atlasBakePixelScale(w, h, z);
-  const bw = Math.max(1, Math.round(w * scale));
-  const bh = Math.max(1, Math.round(h * scale));
-  let canvas: HTMLCanvasElement | OffscreenCanvas;
-  if (typeof OffscreenCanvas !== 'undefined') {
-    canvas = new OffscreenCanvas(bw, bh);
-  } else if (typeof document !== 'undefined') {
-    const c = document.createElement('canvas');
-    c.width = bw;
-    c.height = bh;
-    canvas = c;
-  } else {
-    return null;
-  }
-  const ctx = canvas.getContext('2d') as
-    | CanvasRenderingContext2D
-    | OffscreenCanvasRenderingContext2D
-    | null;
-  if (!ctx) return null;
-  ctx.setTransform(scale, 0, 0, scale, 0, 0);
-  const opacity = Math.min(1, Math.max(0.05, Number(node.attrs?.opacity) || 1));
-  const fontPx = Math.max(1, Number(node.attrs?.fontSize) || 14);
-  const screenFont = fontPx * z;
-  if (screenFont < 7) {
-    const c2 = ctx as CanvasRenderingContext2D;
-    c2.save();
-    c2.globalAlpha = opacity;
-    paintTextProxyLines(c2, {
-      node,
-      width: w,
-      height: h,
-      fill: resolveNodeProxyFill(node),
-      opacity,
-    });
-    c2.restore();
-  } else {
-    paintCanvasTextInk(ctx as CanvasRenderingContext2D, {
-      node,
-      width: w,
-      height: h,
-      opacity,
-    });
-  }
-  return canvas;
-}
 export function clipCanvasIdleToOwningFrame(
   ctx: CanvasRenderingContext2D,
   document: SceneDocument | null | undefined,

--- a/apps/web/src/components/rcb/render/vector/__tests__/textOutlineMesh.test.ts
+++ b/apps/web/src/components/rcb/render/vector/__tests__/textOutlineMesh.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  createEmptyDocument,
+  addNodeToDocument,
+} from '@/components/rcb/scene/document/sceneDocument';
+import {
+  createSceneRenderBuffer,
+  syncSceneRenderBufferFromDocument,
+  SOA_FLAG_CANVAS_IDLE,
+} from '@/components/rcb/render/sceneRenderBuffer';
+import { collectSoaWebglInstances } from '@/components/rcb/render/webglSceneRenderer';
+import { buildCompoundFillMeshes } from '@/components/rcb/render/vector/wasmGeom';
+import { densifyPathDJs } from '@/components/rcb/render/vector/densifyPathDJs';
+import {
+  clearTextOutlineMeshCache,
+  setTextOutlineMeshForTests,
+} from '@/components/rcb/render/vector/textOutlineMesh';
+import { shapeInkForbidsAtlas } from '@/components/rcb/render/vector/inkBackend';
+import type { SceneNodeInput } from '@/components/rcb/sceneNode';
+
+describe('buildCompoundFillMeshes', () => {
+  it('fills outer with hole (donut) without solid counter', () => {
+    // Outer unit square + inner square (hole).
+    const d = 'M 0 0 L 10 0 L 10 10 L 0 10 Z M 3 3 L 7 3 L 7 7 L 3 7 Z';
+    const pts = densifyPathDJs(d);
+    const mesh = buildCompoundFillMeshes(pts, 'evenodd');
+    expect(mesh).not.toBeNull();
+    expect(mesh!.triangleCount).toBeGreaterThanOrEqual(2);
+    expect(mesh!.positions.length).toBeGreaterThanOrEqual(12);
+  });
+
+  it('emits fill for multiple disjoint glyph-like rings', () => {
+    const d = 'M 0 0 L 2 0 L 2 4 L 0 4 Z M 4 0 L 6 0 L 6 4 L 4 4 Z';
+    const mesh = buildCompoundFillMeshes(densifyPathDJs(d), 'nonzero');
+    expect(mesh).not.toBeNull();
+    expect(mesh!.triangleCount).toBeGreaterThanOrEqual(4);
+  });
+});
+
+describe('text outline mesh idle collect', () => {
+  beforeEach(() => {
+    clearTextOutlineMeshCache();
+  });
+
+  it('shapeInkForbidsAtlas includes text', () => {
+    expect(shapeInkForbidsAtlas({ key: 'text', attrs: {} })).toBe(true);
+  });
+
+  it('TEXT collect draws mesh when outline ready (no atlas kind 3)', () => {
+    let doc = createEmptyDocument({ width: 800, height: 600, emptyWorld: true });
+    doc = addNodeToDocument(doc, 't1', {
+      id: 't1',
+      key: 'text',
+      x: 10,
+      y: 10,
+      width: 80,
+      height: 40,
+      attrs: { text: 'A', fontSize: 24, fill: '#111111' },
+      children: [],
+    });
+    const buf = createSceneRenderBuffer();
+    syncSceneRenderBufferFromDocument(buf, doc);
+    for (let i = 0; i < buf.count; i += 1) {
+      buf.flags[i] = (buf.flags[i] | SOA_FLAG_CANVAS_IDLE) >>> 0;
+    }
+    const node = doc.deltaSetLike!.t1 as SceneNodeInput;
+    // After sync (invalidates caches) — inject ready outline mesh.
+    setTextOutlineMeshForTests(
+      't1',
+      node,
+      'M 4 8 L 20 8 L 20 32 L 4 32 Z M 28 8 L 44 8 L 44 32 L 28 32 Z',
+      { width: 80, height: 40 }
+    );
+    const kinds: number[] = [];
+    const meshPos: number[] = [];
+    const meshCol: number[] = [];
+    const meshClip: number[] = [];
+    collectSoaWebglInstances(
+      buf,
+      { x: 0, y: 0, width: 800, height: 600 },
+      [],
+      [],
+      kinds,
+      [],
+      [],
+      { document: doc, meshPos, meshCol, meshClip }
+    );
+    expect(kinds.some((k) => k === 3)).toBe(false);
+    expect(meshPos.length).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/apps/web/src/components/rcb/render/vector/__tests__/vectorInk.test.ts
+++ b/apps/web/src/components/rcb/render/vector/__tests__/vectorInk.test.ts
@@ -231,8 +231,8 @@ describe('vector ink', () => {
     expect(
       shapeInkForbidsAtlas({ key: 'shape', attrs: { shapeType: 'arrow' } })
     ).toBe(true);
-    // Text idle uses atlas bake on WebGL — not forbidden.
-    expect(shapeInkForbidsAtlas({ key: 'text', attrs: {} })).toBe(false);
+    // Text idle is glyph outline mesh — forbids atlas.
+    expect(shapeInkForbidsAtlas({ key: 'text', attrs: {} })).toBe(true);
     expect(shapeInkForbidsAtlas({ key: 'image', attrs: {} })).toBe(false);
     expect(shapeInkForbidsAtlas({ key: 'video', attrs: {} })).toBe(false);
   });
@@ -255,6 +255,49 @@ describe('vector ink', () => {
     expect(mesh).not.toBeNull();
     expect(mesh!.fill).toBeNull();
     expect(mesh!.stroke).not.toBeNull();
+  });
+
+  it('arrow densify keeps NaN break between shaft and V (no zigzag bridge)', () => {
+    const node = {
+      id: 'ar',
+      key: 'shape',
+      width: 100,
+      height: 24,
+      attrs: {
+        shapeType: 'arrow',
+        stroke: '#111',
+        'border-width': 4,
+        'stroke-enabled': true,
+        'fill-enabled': false,
+      },
+    } as SceneNodeInput;
+    const c = contourFromNode(node, { width: 100, height: 24 });
+    expect(c).not.toBeNull();
+    expect(c!.closed).toBe(false);
+    const breaks = c!.points.filter((p) => !Number.isFinite(p.x));
+    expect(breaks.length).toBeGreaterThanOrEqual(1);
+
+    const mesh = getOrBuildShapeMesh('ar', node, { width: 100, height: 24 });
+    expect(mesh?.stroke).not.toBeNull();
+    // Bridged shaft→wing would place verts far off the centerline mid=12.
+    const pos = mesh!.stroke!.positions;
+    let minY = Infinity;
+    let maxY = -Infinity;
+    for (let i = 1; i < pos.length; i += 2) {
+      const y = pos[i]!;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    }
+    // Head wing ±0.55*14 ≈ ±7.7 around mid 12 → roughly [0, 24] plus stroke half-width 2.
+    expect(minY).toBeGreaterThan(-8);
+    expect(maxY).toBeLessThan(32);
+    // Bridged diagonal would also inflate Y span beyond a sane arrow head.
+    expect(maxY - minY).toBeLessThan(40);
+  });
+
+  it('densifyPathDJs inserts NaN between subpaths', () => {
+    const pts = densifyPathDJs('M 0 0 L 10 0 M 20 5 L 30 5');
+    expect(pts.some((p) => !Number.isFinite(p.x))).toBe(true);
   });
 
   it('pencil mesh is filled freehand silhouette (not centerline ribbon)', () => {

--- a/apps/web/src/components/rcb/render/vector/contour.ts
+++ b/apps/web/src/components/rcb/render/vector/contour.ts
@@ -4,7 +4,7 @@
 import { getShapeBaselineD } from '@/components/rcb/core/geometry/baseline';
 import type { SceneNodeInput } from '@/components/rcb/sceneNode';
 import { shapeGeomFingerprint } from '@/components/rcb/render/vector/geomFingerprint';
-import { densifyPathDJs, DENSIFY_DEFAULT_FLATNESS } from '@/components/rcb/render/vector/densifyPathDJs';
+import { densifyPathDJs, DENSIFY_DEFAULT_FLATNESS, splitPolylineContours } from '@/components/rcb/render/vector/densifyPathDJs';
 import { densifyPathDWasm } from '@/components/rcb/render/vector/wasmGeom';
 import {
   ellipseArcPercentFromAttrs,
@@ -31,11 +31,16 @@ export type ShapeContour = {
 
 /** Densify SVG path `d` — prefers WASM when ready, else JS. */
 export function densifyPathD(d: string, flatness = DENSIFY_DEFAULT_FLATNESS): Vec2[] {
+  const src = String(d || '');
+  // Multi-subpath (arrow shaft + V): JS densify inserts NaN breaks. Old WASM
+  // densify concatenated subpaths into one zigzag stroke mesh.
+  const moveCount = (src.match(/[Mm]/g) || []).length;
+  if (moveCount > 1) return densifyPathDJs(d, flatness);
   return densifyPathDWasm(d, flatness);
 }
 
 /** Explicit JS-only densify (tests / golden). */
-export { densifyPathDJs, DENSIFY_DEFAULT_FLATNESS };
+export { densifyPathDJs, DENSIFY_DEFAULT_FLATNESS, splitPolylineContours };
 
 /** Full ellipse / circle ring — peri÷flatness samples (not 4×8 Bézier chords). */
 export function sampleEllipseRing(

--- a/apps/web/src/components/rcb/render/vector/densifyPathDJs.ts
+++ b/apps/web/src/components/rcb/render/vector/densifyPathDJs.ts
@@ -124,6 +124,7 @@ export function densifyPathDJs(d: string, flatness = DENSIFY_DEFAULT_FLATNESS): 
     const C = cmd.toUpperCase();
     let i = 0;
     if (C === 'M') {
+      let subpathStart = true;
       while (i + 1 < args.length) {
         let x = args[i++]!;
         let y = args[i++]!;
@@ -135,6 +136,11 @@ export function densifyPathDJs(d: string, flatness = DENSIFY_DEFAULT_FLATNESS): 
         cy = y;
         startX = x;
         startY = y;
+        // New subpath — keep a NaN break so stroke mesh does not bridge shaft→V (arrows).
+        if (subpathStart && pts.length > 0) {
+          pts.push({ x: Number.NaN, y: Number.NaN });
+        }
+        subpathStart = false;
         push(x, y);
         while (i + 1 < args.length) {
           let x2 = args[i++]!;
@@ -257,4 +263,20 @@ export function densifyPathDJs(d: string, flatness = DENSIFY_DEFAULT_FLATNESS): 
     }
   }
   return pts;
+}
+
+/** Split densified polylines on NaN,NaN subpath breaks (multi-M paths / arrows). */
+export function splitPolylineContours(points: DensifyVec2[]): DensifyVec2[][] {
+  const runs: DensifyVec2[][] = [];
+  let cur: DensifyVec2[] = [];
+  for (const p of points) {
+    if (!Number.isFinite(p.x) || !Number.isFinite(p.y)) {
+      if (cur.length >= 2) runs.push(cur);
+      cur = [];
+      continue;
+    }
+    cur.push(p);
+  }
+  if (cur.length >= 2) runs.push(cur);
+  return runs;
 }

--- a/apps/web/src/components/rcb/render/vector/index.ts
+++ b/apps/web/src/components/rcb/render/vector/index.ts
@@ -24,6 +24,14 @@ export {
   type CachedShapeMesh,
 } from '@/components/rcb/render/vector/meshCache';
 export {
+  ensureTextOutlineMesh,
+  getTextOutlineMesh,
+  invalidateTextOutlineMesh,
+  clearTextOutlineMeshCache,
+  textOutlineGeomFingerprint,
+  type CachedTextOutlineMesh,
+} from '@/components/rcb/render/vector/textOutlineMesh';
+export {
   appendMeshLocal,
   type AppendMeshLocalOpts,
 } from '@/components/rcb/render/vector/appendMesh';
@@ -39,6 +47,7 @@ export {
   tessellateFillWithHolesWasm,
   tessellateBatchFill,
   buildShapeMeshes,
+  buildCompoundFillMeshes,
   booleanPolygonsWasm,
   offsetPolylineWasm,
   simplifyRdpWasm,

--- a/apps/web/src/components/rcb/render/vector/inkBackend.ts
+++ b/apps/web/src/components/rcb/render/vector/inkBackend.ts
@@ -15,15 +15,15 @@ export function toInkBackend(backend: LegacySceneInkBackend | string): InkBacken
 }
 
 /**
- * Shape / path ink must never use atlas or bakeShapeInkForAtlas.
- * Text may atlas-stamp for WebGL idle (glyphs); media uses GPU textures.
+ * Shape / text / path ink must never use atlas bake.
+ * Media (image/video/audio) still uses GPU atlas textures.
  */
 export function isShapeInkKey(key: string, shapeType?: string): boolean {
   const k = String(key || '').toLowerCase();
   const t = String(shapeType || '').toLowerCase();
   if (k === 'image' || k === 'video' || k === 'audio' || k === 'lottie') return false;
-  // Text idle is atlas-stamped (bakeTextInkForAtlas) — not mesh vector.
-  if (k === 'text' || t === 'text') return false;
+  // Text idle is glyph outline mesh — not atlas.
+  if (k === 'text' || t === 'text') return true;
   if (k === 'shape' || k === 'path') return true;
   return (
     t === 'rect' ||

--- a/apps/web/src/components/rcb/render/vector/textOutlineMesh.ts
+++ b/apps/web/src/components/rcb/render/vector/textOutlineMesh.ts
@@ -1,0 +1,161 @@
+/**
+ * Idle text → glyph outline fill mesh (no atlas).
+ * Async outline via buildOutlinePathAsync; paint uses get when ready.
+ */
+import type { SceneNodeInput } from '@/components/rcb/sceneNode';
+import { parseNodeText, parseNodeTextStyle } from '@/components/rcb/scene/document/sceneText';
+import { buildOutlinePathAsync } from '@/components/rcb/scene/paint/outlineToPath';
+import { densifyPathD } from '@/components/rcb/render/vector/contour';
+import { buildCompoundFillMeshes } from '@/components/rcb/render/vector/wasmGeom';
+import type { FillMesh } from '@/components/rcb/render/vector/tessellateFill';
+
+export type CachedTextOutlineMesh = {
+  fp: string;
+  fill: FillMesh | null;
+  fillRule: 'nonzero' | 'evenodd';
+};
+
+const cache = new Map<string, CachedTextOutlineMesh>();
+const inflight = new Map<string, Promise<void>>();
+const TEXT_MESH_MAX = 2048;
+const touchOrder: string[] = [];
+
+function touch(id: string) {
+  const i = touchOrder.indexOf(id);
+  if (i >= 0) touchOrder.splice(i, 1);
+  touchOrder.push(id);
+  while (touchOrder.length > TEXT_MESH_MAX) {
+    const drop = touchOrder.shift();
+    if (drop) cache.delete(drop);
+  }
+}
+
+/** Layout + style fingerprint — must match idle text paint fields. */
+export function textOutlineGeomFingerprint(
+  node: SceneNodeInput,
+  opts?: { width?: number; height?: number }
+): string {
+  const attrs = node.attrs || {};
+  const style = parseNodeTextStyle(attrs);
+  const w = Math.max(1, Number(opts?.width ?? node.width) || 1);
+  const h = Math.max(1, Number(opts?.height ?? node.height) || 1);
+  return [
+    'textOutline:v1',
+    parseNodeText(attrs),
+    w.toFixed(2),
+    h.toFixed(2),
+    String(style.fontSize ?? ''),
+    String(style.fontFamily ?? ''),
+    String(style.fontWeight ?? ''),
+    String(style.fontStyle ?? ''),
+    String(style.textAlign ?? ''),
+    String(style.lineHeight ?? ''),
+    String(style.letterSpacing ?? ''),
+    String(style.fill ?? ''),
+    String(attrs.textFrame ?? ''),
+    String(attrs.verticalAlign ?? ''),
+    String(attrs.angle ?? ''),
+  ].join('|');
+}
+
+export function invalidateTextOutlineMesh(nodeId: string) {
+  const id = String(nodeId || '').trim();
+  if (!id) return;
+  cache.delete(id);
+  inflight.delete(id);
+  const i = touchOrder.indexOf(id);
+  if (i >= 0) touchOrder.splice(i, 1);
+}
+
+export function clearTextOutlineMeshCache() {
+  cache.clear();
+  inflight.clear();
+  touchOrder.length = 0;
+}
+
+export function getTextOutlineMesh(
+  nodeId: string,
+  node: SceneNodeInput,
+  opts?: { width?: number; height?: number }
+): CachedTextOutlineMesh | null {
+  const id = String(nodeId || '').trim();
+  if (!id || !node) return null;
+  const fp = textOutlineGeomFingerprint(node, opts);
+  const hit = cache.get(id);
+  if (hit && hit.fp === fp && hit.fill) {
+    touch(id);
+    return hit;
+  }
+  return null;
+}
+
+/**
+ * Kick async outline→mesh when missing/stale. Completes with idle paint bump.
+ */
+export function ensureTextOutlineMesh(
+  nodeId: string,
+  node: SceneNodeInput,
+  opts?: { width?: number; height?: number }
+): void {
+  const id = String(nodeId || '').trim();
+  if (!id || !node || String(node.key || '') !== 'text') return;
+  const text = parseNodeText(node.attrs || {}).trim();
+  if (!text) return;
+  const fp = textOutlineGeomFingerprint(node, opts);
+  const hit = cache.get(id);
+  if (hit && hit.fp === fp) return;
+  if (inflight.has(id)) return;
+
+  const paintNode: SceneNodeInput = {
+    ...node,
+    id,
+    width: Math.max(1, Number(opts?.width ?? node.width) || 1),
+    height: Math.max(1, Number(opts?.height ?? node.height) || 1),
+  };
+
+  const job = (async () => {
+    try {
+      const outline = await buildOutlinePathAsync(paintNode);
+      const d = String(outline?.pathD || '').trim();
+      if (!d) {
+        cache.set(id, { fp, fill: null, fillRule: 'evenodd' });
+        touch(id);
+        return;
+      }
+      const fillRule = outline?.fillRule === 'nonzero' ? 'nonzero' : 'evenodd';
+      const points = densifyPathD(d);
+      const fill = buildCompoundFillMeshes(points, fillRule);
+      cache.set(id, { fp, fill, fillRule });
+      touch(id);
+      const { bumpSceneCanvasIdlePaint } = await import('@/components/rcb/render/sceneRenderer');
+      bumpSceneCanvasIdlePaint();
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.warn('[textOutlineMesh] build failed', id, err);
+      }
+      cache.set(id, { fp, fill: null, fillRule: 'evenodd' });
+    } finally {
+      inflight.delete(id);
+    }
+  })();
+  inflight.set(id, job);
+}
+
+/** Test helper: inject a ready mesh from path `d`. */
+export function setTextOutlineMeshForTests(
+  nodeId: string,
+  node: SceneNodeInput,
+  pathD: string,
+  opts?: { width?: number; height?: number; fillRule?: 'nonzero' | 'evenodd' }
+): CachedTextOutlineMesh | null {
+  const id = String(nodeId || '').trim();
+  if (!id) return null;
+  const fp = textOutlineGeomFingerprint(node, opts);
+  const fillRule = opts?.fillRule === 'nonzero' ? 'nonzero' : 'evenodd';
+  const fill = buildCompoundFillMeshes(densifyPathD(pathD), fillRule);
+  const entry: CachedTextOutlineMesh = { fp, fill, fillRule };
+  cache.set(id, entry);
+  touch(id);
+  return entry;
+}

--- a/apps/web/src/components/rcb/render/vector/wasm/geomWorker.ts
+++ b/apps/web/src/components/rcb/render/vector/wasm/geomWorker.ts
@@ -50,19 +50,23 @@ let api: WasmApi | null = null;
 
 async function ensureInit(): Promise<void> {
   if (api) return;
-  const mod = await import(
-    /* @vite-ignore */
-    '/rcb-wasm/rcb_wasm_geom.js'
-  );
+  const dynamicImport = new Function('u', 'return import(u)') as (
+    u: string
+  ) => Promise<Record<string, unknown> & { default?: (opts: { module_or_path: string }) => Promise<void> }>;
+  const mod = await dynamicImport('/rcb-wasm/rcb_wasm_geom.js');
   if (typeof mod.default === 'function') {
     await mod.default({ module_or_path: '/rcb-wasm/rcb_wasm_geom_bg.wasm' });
   }
   api = {
-    tessellate_batch_fill: mod.tessellate_batch_fill,
+    tessellate_batch_fill: mod.tessellate_batch_fill as WasmApi['tessellate_batch_fill'],
     trace_rgba_contours:
-      typeof mod.trace_rgba_contours === 'function' ? mod.trace_rgba_contours : undefined,
+      typeof mod.trace_rgba_contours === 'function'
+        ? (mod.trace_rgba_contours as NonNullable<WasmApi['trace_rgba_contours']>)
+        : undefined,
     simplify_rdp_closed:
-      typeof mod.simplify_rdp_closed === 'function' ? mod.simplify_rdp_closed : undefined,
+      typeof mod.simplify_rdp_closed === 'function'
+        ? (mod.simplify_rdp_closed as NonNullable<WasmApi['simplify_rdp_closed']>)
+        : undefined,
   };
 }
 

--- a/apps/web/src/components/rcb/render/vector/wasm/pkg/package.json
+++ b/apps/web/src/components/rcb/render/vector/wasm/pkg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rcb-wasm-geom",
   "type": "module",
-  "description": "RCB vector densify, tessellation, and polygon boolean (WebAssembly)",
+  "description": "RCB vector densify, tessellation, boolean, stroke offset, RDP, contour (WebAssembly)",
   "version": "0.1.0",
   "license": "MIT",
   "files": [

--- a/apps/web/src/components/rcb/render/vector/wasmGeom.ts
+++ b/apps/web/src/components/rcb/render/vector/wasmGeom.ts
@@ -3,7 +3,7 @@
  * Lazy-loads `packages/rcb-wasm-geom`; each export falls back to JS when unavailable.
  */
 import type { Vec2 } from '@/components/rcb/render/vector/contour';
-import { densifyPathDJs, DENSIFY_DEFAULT_FLATNESS } from '@/components/rcb/render/vector/densifyPathDJs';
+import { densifyPathDJs, DENSIFY_DEFAULT_FLATNESS, splitPolylineContours } from '@/components/rcb/render/vector/densifyPathDJs';
 import {
   tessellateFill as tessellateFillJs,
   tessellateFillWithHoles as tessellateFillWithHolesJs,
@@ -158,10 +158,11 @@ function unpackBatch(packed: Float32Array): (FillMesh | null)[] {
 async function loadWasmModule(): Promise<WasmApi | null> {
   try {
     // Served from public/rcb-wasm (copied by build-wasm.mjs) so Vite ships .wasm.
-    const mod = await import(
-      /* @vite-ignore */
-      '/rcb-wasm/rcb_wasm_geom.js'
-    );
+    // Avoid `import('/public/...')` — Vite rejects public JS as bundle imports; runtime fetch via Function.
+    const dynamicImport = new Function('u', 'return import(u)') as (
+      u: string
+    ) => Promise<Record<string, unknown> & { default?: (opts: { module_or_path: string }) => Promise<void> }>;
+    const mod = await dynamicImport('/rcb-wasm/rcb_wasm_geom.js');
     if (typeof mod.default === 'function') {
       await mod.default({ module_or_path: '/rcb-wasm/rcb_wasm_geom_bg.wasm' });
     }
@@ -173,20 +174,31 @@ async function loadWasmModule(): Promise<WasmApi | null> {
       return null;
     }
     return {
-      densify_path_d: mod.densify_path_d,
-      tessellate_fill: mod.tessellate_fill,
-      tessellate_fill_with_holes: mod.tessellate_fill_with_holes,
-      tessellate_stroke: mod.tessellate_stroke,
-      tessellate_batch_fill: mod.tessellate_batch_fill,
+      densify_path_d: mod.densify_path_d as WasmApi['densify_path_d'],
+      tessellate_fill: mod.tessellate_fill as WasmApi['tessellate_fill'],
+      tessellate_fill_with_holes: mod.tessellate_fill_with_holes as WasmApi['tessellate_fill_with_holes'],
+      tessellate_stroke: mod.tessellate_stroke as WasmApi['tessellate_stroke'],
+      tessellate_batch_fill: mod.tessellate_batch_fill as WasmApi['tessellate_batch_fill'],
       boolean_polygons:
-        typeof mod.boolean_polygons === 'function' ? mod.boolean_polygons : undefined,
+        typeof mod.boolean_polygons === 'function'
+          ? (mod.boolean_polygons as NonNullable<WasmApi['boolean_polygons']>)
+          : undefined,
       offset_polyline:
-        typeof mod.offset_polyline === 'function' ? mod.offset_polyline : undefined,
-      simplify_rdp: typeof mod.simplify_rdp === 'function' ? mod.simplify_rdp : undefined,
+        typeof mod.offset_polyline === 'function'
+          ? (mod.offset_polyline as NonNullable<WasmApi['offset_polyline']>)
+          : undefined,
+      simplify_rdp:
+        typeof mod.simplify_rdp === 'function'
+          ? (mod.simplify_rdp as NonNullable<WasmApi['simplify_rdp']>)
+          : undefined,
       simplify_rdp_closed:
-        typeof mod.simplify_rdp_closed === 'function' ? mod.simplify_rdp_closed : undefined,
+        typeof mod.simplify_rdp_closed === 'function'
+          ? (mod.simplify_rdp_closed as NonNullable<WasmApi['simplify_rdp_closed']>)
+          : undefined,
       trace_rgba_contours:
-        typeof mod.trace_rgba_contours === 'function' ? mod.trace_rgba_contours : undefined,
+        typeof mod.trace_rgba_contours === 'function'
+          ? (mod.trace_rgba_contours as NonNullable<WasmApi['trace_rgba_contours']>)
+          : undefined,
     };
   } catch {
     return null;
@@ -327,6 +339,7 @@ function fillMeshFor(
 }
 
 function strokeMeshFor(points: Vec2[], opts: StrokeTessOpts): StrokeMesh | null {
+  if (points.length < 2) return null;
   if (wasmLive()) {
     return meshFromFlat(
       api!.tessellate_stroke(
@@ -340,6 +353,150 @@ function strokeMeshFor(points: Vec2[], opts: StrokeTessOpts): StrokeMesh | null 
     );
   }
   return tessellateStrokeJs(points, opts);
+}
+
+function mergeStrokeMeshes(parts: StrokeMesh[]): StrokeMesh | null {
+  if (!parts.length) return null;
+  if (parts.length === 1) return parts[0]!;
+  let total = 0;
+  for (const p of parts) total += p.positions.length;
+  const positions = new Float32Array(total);
+  let o = 0;
+  let tris = 0;
+  for (const p of parts) {
+    positions.set(p.positions, o);
+    o += p.positions.length;
+    tris += p.triangleCount;
+  }
+  return { positions, triangleCount: tris };
+}
+
+function mergeFillMeshes(parts: FillMesh[]): FillMesh | null {
+  if (!parts.length) return null;
+  if (parts.length === 1) return parts[0]!;
+  let total = 0;
+  for (const p of parts) total += p.positions.length;
+  const positions = new Float32Array(total);
+  let o = 0;
+  let tris = 0;
+  for (const p of parts) {
+    positions.set(p.positions, o);
+    o += p.positions.length;
+    tris += p.triangleCount;
+  }
+  return { positions, triangleCount: tris };
+}
+
+function ringSignedArea(ring: Vec2[]): number {
+  let a = 0;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    a += ring[j]!.x * ring[i]!.y - ring[i]!.x * ring[j]!.y;
+  }
+  return a * 0.5;
+}
+
+function pointInRing(p: Vec2, ring: Vec2[]): boolean {
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const xi = ring[i]!.x;
+    const yi = ring[i]!.y;
+    const xj = ring[j]!.x;
+    const yj = ring[j]!.y;
+    if ((yi > p.y) !== (yj > p.y) && p.x < ((xj - xi) * (p.y - yi)) / (yj - yi + 1e-20) + xi) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+function ringCentroid(ring: Vec2[]): Vec2 {
+  let x = 0;
+  let y = 0;
+  for (const p of ring) {
+    x += p.x;
+    y += p.y;
+  }
+  const n = Math.max(1, ring.length);
+  return { x: x / n, y: y / n };
+}
+
+/**
+ * Multi-subpath fill (text glyphs / compound paths): nest rings → outer+holes
+ * compounds, then tessellate. Works for evenodd canvas traces and nonzero fontkit.
+ */
+export function buildCompoundFillMeshes(
+  points: Vec2[],
+  _fillRule: 'nonzero' | 'evenodd' = 'evenodd'
+): FillMesh | null {
+  const runs = splitPolylineContours(points)
+    .map((r) => {
+      const out = r.filter((p) => Number.isFinite(p.x) && Number.isFinite(p.y));
+      if (out.length < 3) return out;
+      const a = out[0]!;
+      const b = out[out.length - 1]!;
+      if (Math.abs(a.x - b.x) > 1e-5 || Math.abs(a.y - b.y) > 1e-5) out.push({ ...a });
+      return out;
+    })
+    .filter((r) => r.length >= 3);
+  if (!runs.length) return null;
+  if (runs.length === 1) return fillMeshFor(runs[0]!, undefined);
+
+  const indexed = runs.map((ring, i) => ({
+    ring,
+    i,
+    area: Math.abs(ringSignedArea(ring)),
+  }));
+  indexed.sort((a, b) => b.area - a.area);
+
+  const parent = new Array<number>(runs.length).fill(-1);
+  for (let a = 0; a < indexed.length; a += 1) {
+    const child = indexed[a]!;
+    const c = ringCentroid(child.ring);
+    for (let b = a - 1; b >= 0; b -= 1) {
+      const cand = indexed[b]!;
+      if (cand.area <= child.area + 1e-6) continue;
+      if (pointInRing(c, cand.ring)) {
+        parent[child.i] = cand.i;
+        break;
+      }
+    }
+  }
+
+  const depth = new Array<number>(runs.length).fill(0);
+  const depthOf = (i: number): number => {
+    if (parent[i] < 0) return 0;
+    if (depth[i]) return depth[i]!;
+    depth[i] = depthOf(parent[i]!) + 1;
+    return depth[i]!;
+  };
+  for (let i = 0; i < runs.length; i += 1) depthOf(i);
+
+  const compounds: { outer: Vec2[]; holes: Vec2[][] }[] = [];
+  const outerIndex = new Map<number, number>();
+  for (let i = 0; i < runs.length; i += 1) {
+    if (depth[i]! % 2 === 0) {
+      outerIndex.set(i, compounds.length);
+      compounds.push({ outer: runs[i]!, holes: [] });
+    }
+  }
+  for (let i = 0; i < runs.length; i += 1) {
+    if (depth[i]! % 2 === 0) continue;
+    let p = parent[i]!;
+    while (p >= 0 && depth[p]! % 2 !== 0) p = parent[p]!;
+    const ci = p >= 0 ? outerIndex.get(p) : undefined;
+    if (ci == null) {
+      compounds.push({ outer: runs[i]!, holes: [] });
+    } else {
+      compounds[ci]!.holes.push(runs[i]!);
+    }
+  }
+
+  const parts: FillMesh[] = [];
+  for (const c of compounds) {
+    const m = fillMeshFor(c.outer, c.holes.length ? c.holes : undefined);
+    if (m) parts.push(m);
+  }
+  return mergeFillMeshes(parts);
 }
 
 /** Build fill+stroke for one contour (profiles once). */
@@ -361,20 +518,35 @@ export function buildShapeMeshes(
   let tFill = 0;
   let tStroke = 0;
 
-  if (opts.wantFill && opts.closed) {
+  const runs = splitPolylineContours(points);
+  const primary = runs[0] ?? points.filter((p) => Number.isFinite(p.x) && Number.isFinite(p.y));
+
+  if (opts.wantFill && opts.closed && primary.length >= 3) {
     const a = geomNow();
-    fill = fillMeshFor(points, opts.holes);
+    // Fill uses the first contour; holes come from opts (ellipse donut).
+    fill = fillMeshFor(primary, opts.holes);
     tFill = geomNow() - a;
   }
   if (opts.strokeWidth > 0) {
     const a = geomNow();
-    stroke = strokeMeshFor(points, {
+    const strokeOpts: StrokeTessOpts = {
       width: opts.strokeWidth,
       closed: opts.closed,
       align: opts.strokeAlign,
       linejoin: opts.linejoin,
       miterLimit: opts.miterLimit,
-    });
+    };
+    if (runs.length <= 1) {
+      stroke = strokeMeshFor(primary, strokeOpts);
+    } else {
+      // Arrow etc.: stroke each subpath; never bridge across M breaks.
+      const parts: StrokeMesh[] = [];
+      for (const run of runs) {
+        const m = strokeMeshFor(run, { ...strokeOpts, closed: false });
+        if (m) parts.push(m);
+      }
+      stroke = mergeStrokeMeshes(parts);
+    }
     tStroke = geomNow() - a;
   }
 

--- a/apps/web/src/components/rcb/render/webglInstanceAtlas.ts
+++ b/apps/web/src/components/rcb/render/webglInstanceAtlas.ts
@@ -1,10 +1,9 @@
 /**
- * WebGL instance atlas — fixed-cell LRU packer for media / text bake tiles (ADR 0027).
- * Shape ink is vector (mesh / Path2D); never stamped here.
+ * WebGL instance atlas — fixed-cell LRU packer for media bake tiles (ADR 0027).
+ * Shape / text ink is vector (mesh / Path2D); never stamped here.
  */
 import {
   SOA_KIND_IMAGE,
-  SOA_KIND_TEXT,
   type SceneRenderBuffer,
 } from '@/components/rcb/render/sceneRenderBuffer';
 
@@ -290,8 +289,8 @@ export function releaseSoaAtlasPrefix(atlas: SoaWebglAtlas, prefix: string): num
 }
 
 /**
- * Drop stale atlas stamps. Legacy shape keys (`rich:` / `path:` / `round:`)
- * are always released. Media (`img:` / `aud:`) and text (`txt:`) kept while the slot remains.
+ * Drop stale atlas stamps. Legacy shape keys (`rich:` / `path:` / `round:` / `txt:`)
+ * are always released. Media (`img:` / `aud:`) kept while the slot remains.
  */
 export function pruneSoaAtlasForBuffer(atlas: SoaWebglAtlas, buf: SceneRenderBuffer): number {
   const keep = new Set<string>();
@@ -302,8 +301,6 @@ export function pruneSoaAtlasForBuffer(atlas: SoaWebglAtlas, buf: SceneRenderBuf
     if (kind === SOA_KIND_IMAGE) {
       keep.add(`img:${id}`);
       keep.add(`aud:${id}`);
-    } else if (kind === SOA_KIND_TEXT) {
-      keep.add(`txt:${id}`);
     }
   }
   let n = 0;
@@ -311,16 +308,13 @@ export function pruneSoaAtlasForBuffer(atlas: SoaWebglAtlas, buf: SceneRenderBuf
     if (
       key.startsWith('rich:') ||
       key.startsWith('path:') ||
-      key.startsWith('round:')
+      key.startsWith('round:') ||
+      key.startsWith('txt:')
     ) {
       if (releaseSoaAtlasRegion(atlas, key)) n += 1;
       continue;
     }
-    if (
-      !key.startsWith('img:') &&
-      !key.startsWith('aud:') &&
-      !key.startsWith('txt:')
-    ) {
+    if (!key.startsWith('img:') && !key.startsWith('aud:')) {
       continue;
     }
     const kept = [...keep].some((k) => key === k || key.startsWith(`${k}:`));

--- a/apps/web/src/components/rcb/render/webglSceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/webglSceneRenderer.ts
@@ -44,7 +44,6 @@ import {
 import {
   bakeAudioInkForAtlas,
   bakeMediaInkForAtlas,
-  bakeTextInkForAtlas,
   bumpSceneCanvasIdlePaint,
   isFillImageWebglUnsafe,
   hitTestWithSpatialIndex,
@@ -55,6 +54,10 @@ import {
 } from '@/components/rcb/render/sceneRenderer';
 import { getOrBuildShapeMesh } from '@/components/rcb/render/vector/meshCache';
 import { appendMeshLocal } from '@/components/rcb/render/vector/appendMesh';
+import {
+  ensureTextOutlineMesh,
+  getTextOutlineMesh,
+} from '@/components/rcb/render/vector/textOutlineMesh';
 import {
   findClippingFrameForNode,
   frameClipRevealsOverflow,
@@ -76,7 +79,8 @@ import {
 /** Scene-space LTRB when the slot has no clipContent owner (or reveal-overflow). */
 export const SOA_WEBGL_NO_CLIP: [number, number, number, number] = [-1e8, -1e8, 1e8, 1e8];
 
-const VS = `#version 300 es
+/** Instance ink vertex shader (world + artboard FO). */
+export const SOA_WEBGL_INK_VS = `#version 300 es
 precision mediump float;
 uniform vec2 uPan;
 uniform float uZoom;
@@ -118,7 +122,8 @@ void main() {
   vClip = aClip;
 }`;
 
-const FS = `#version 300 es
+/** Instance ink fragment shader (world + artboard FO). */
+export const SOA_WEBGL_INK_FS = `#version 300 es
 precision mediump float;
 uniform sampler2D uAtlas;
 uniform float uZoom;
@@ -157,7 +162,7 @@ void main() {
 }`;
 
 /** World-space triangle mesh program (vector fill/stroke). */
-const MESH_VS = `#version 300 es
+export const SOA_WEBGL_MESH_VS = `#version 300 es
 precision mediump float;
 uniform vec2 uPan;
 uniform float uZoom;
@@ -180,7 +185,7 @@ void main() {
   vClip = aClip;
 }`;
 
-const MESH_FS = `#version 300 es
+export const SOA_WEBGL_MESH_FS = `#version 300 es
 precision mediump float;
 in vec4 vColor;
 in vec2 vWorld;
@@ -193,7 +198,13 @@ void main() {
   outColor = vColor;
 }`;
 
-const UNIT_QUAD = new Float32Array([0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1]);
+const VS = SOA_WEBGL_INK_VS;
+const FS = SOA_WEBGL_INK_FS;
+const MESH_VS = SOA_WEBGL_MESH_VS;
+const MESH_FS = SOA_WEBGL_MESH_FS;
+
+export const SOA_WEBGL_UNIT_QUAD = new Float32Array([0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1]);
+const UNIT_QUAD = SOA_WEBGL_UNIT_QUAD;
 /** Default line thickness in scene units (used when SoA stroke width is unset). */
 export const SOA_WEBGL_LINE_THICKNESS = 2;
 /** Cap segments emitted per path so one dense stroke cannot explode the instance batch. */
@@ -204,7 +215,12 @@ function normalizeGlslSource(src: string): string {
   return src.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 }
 
-function compile(gl: WebGL2RenderingContext, type: number, src: string) {
+/** Compile a GLSL shader (shared by world ink + artboard FO ink). */
+export function compileSoaWebglShader(
+  gl: WebGL2RenderingContext,
+  type: number,
+  src: string
+): WebGLShader | null {
   const sh = gl.createShader(type);
   if (!sh) return null;
   gl.shaderSource(sh, normalizeGlslSource(src));
@@ -224,7 +240,12 @@ function compile(gl: WebGL2RenderingContext, type: number, src: string) {
   return sh;
 }
 
-function link(gl: WebGL2RenderingContext, vs: WebGLShader, fs: WebGLShader) {
+/** Link VS+FS into a program (shared by world ink + artboard FO ink). */
+export function linkSoaWebglProgram(
+  gl: WebGL2RenderingContext,
+  vs: WebGLShader,
+  fs: WebGLShader
+): WebGLProgram | null {
   const prog = gl.createProgram();
   if (!prog) return null;
   gl.attachShader(prog, vs);
@@ -239,6 +260,14 @@ function link(gl: WebGL2RenderingContext, vs: WebGLShader, fs: WebGLShader) {
     return null;
   }
   return prog;
+}
+
+function compile(gl: WebGL2RenderingContext, type: number, src: string) {
+  return compileSoaWebglShader(gl, type, src);
+}
+
+function link(gl: WebGL2RenderingContext, vs: WebGLShader, fs: WebGLShader) {
+  return linkSoaWebglProgram(gl, vs, fs);
 }
 
 let inkShaderProbeOk: boolean | null = null;
@@ -575,8 +604,14 @@ export type CollectSoaWebglOpts = {
   /**
    * World idle ink: skip nodes with attrs.frameId (ArtboardLayer paints them).
    * Default false for tests / bake helpers that collect everything.
+   * Ignored when {@link onlyFrameId} is set.
    */
   skipFrameBound?: boolean;
+  /**
+   * Artboard FO ink: only slots owned by this frame (and not selection-reveal).
+   * World path leaves this unset and uses skipFrameBound instead.
+   */
+  onlyFrameId?: string;
   /** World-space vector fill/stroke triangle XY (flat). */
   meshPos?: number[];
   /** Per-vertex RGBA for meshPos. */
@@ -606,7 +641,8 @@ export function collectSoaWebglInstances(
   const paintDoc = opts?.document ?? getSoaPaintDocument();
   const zoom = Math.max(0.05, Number(opts?.zoom) || 1);
   const dpr = Math.max(1, Number(opts?.dpr) || 1);
-  const skipFrameBound = opts?.skipFrameBound === true;
+  const onlyFrameId = String(opts?.onlyFrameId || '').trim();
+  const skipFrameBound = !onlyFrameId && opts?.skipFrameBound === true;
   const meshPos = opts?.meshPos;
   const meshCol = opts?.meshCol;
   const meshClip = opts?.meshClip;
@@ -623,9 +659,14 @@ export function collectSoaWebglInstances(
     if (!(flags & SOA_FLAG_VISIBLE) || !(flags & SOA_FLAG_CANVAS_IDLE)) continue;
     const idEarly = buf.ids[i];
     if (idEarly && getNodeTransformPreview(idEarly)?.hidden) continue;
-    if (skipFrameBound && paintDoc && idEarly) {
+    if (onlyFrameId && paintDoc && idEarly) {
       const node = paintDoc.deltaSetLike?.[idEarly];
-      // Selection reveal: paint overflow on world ink (FO stays clipped).
+      // Plate FO stays clipped; selection reveal → raised SVG host (max+1).
+      // World ink is only a lag fallback while CANVAS_IDLE has not cleared yet.
+      if (nodeOwnerFrameId(node) !== onlyFrameId || frameClipRevealsOverflow(idEarly)) continue;
+    } else if (skipFrameBound && paintDoc && idEarly) {
+      const node = paintDoc.deltaSetLike?.[idEarly];
+      // Selection reveal: overflow may still be on SoA until host flags flip.
       if (nodeOwnerFrameId(node) && !frameClipRevealsOverflow(idEarly)) continue;
     }
     const kind = buf.kinds[i];
@@ -727,13 +768,7 @@ export function collectSoaWebglInstances(
 
     if (kind === SOA_KIND_TEXT) {
       const node = paintDoc?.deltaSetLike?.[id];
-      if (!node || !atlas) {
-        clearSoaDirtyFlag(buf, i, flags, forceStamp);
-        continue;
-      }
-      const atlasKey = `txt:${id}:z${atlasZoomBucket(zoom)}`;
-      const baked = bakeTextInkForAtlas(node, w, h, zoom);
-      if (!baked) {
+      if (!node) {
         clearSoaDirtyFlag(buf, i, flags, forceStamp);
         continue;
       }
@@ -741,33 +776,44 @@ export function collectSoaWebglInstances(
       const liveAngle = Number.isFinite(preview?.angle)
         ? Number(preview!.angle)
         : Number(node.attrs?.angle) || 0;
-      const angleRad = (liveAngle * Math.PI) / 180;
-      const region = stampImageToAtlas(
-        atlas,
-        atlasKey,
-        baked as CanvasImageSource,
-        { left: x, top: y, width: w, height: h },
-        { force: forceStamp }
-      );
-      if (region) {
-        for (const activeClip of paintClips) {
-          pushAtlasRegionInstance(
-            atlas,
-            region,
-            rects,
-            colors,
-            kinds,
-            angles,
-            uvs,
-            angleRad,
-            0,
-            0
-          );
-          if (depthOut) depthOut.push(slotDepth);
-          pushInstanceClip(clips, activeClip);
+      const paintNode =
+        Number.isFinite(preview?.angle) &&
+        Math.abs(liveAngle - (Number(node.attrs?.angle) || 0)) > 1e-4
+          ? { ...node, attrs: { ...(node.attrs || {}), angle: liveAngle } }
+          : node;
+      ensureTextOutlineMesh(id, paintNode, { width: w, height: h });
+      const textMesh = getTextOutlineMesh(id, paintNode, { width: w, height: h });
+      if (textMesh?.fill && meshPos && meshCol && meshClip) {
+        const opacity = Math.min(1, Math.max(0, Number(paintNode.attrs?.opacity) || 1));
+        const fillRgba: [number, number, number, number] = [
+          rgba[0],
+          rgba[1],
+          rgba[2],
+          rgba[3] * opacity,
+        ];
+        if (fillRgba[3] > 0.01) {
+          const rotOpts = {
+            angleDeg: liveAngle,
+            pivotW: w,
+            pivotH: h,
+          };
+          for (const activeClip of paintClips) {
+            appendMeshLocal(
+              textMesh.fill.positions,
+              x,
+              y,
+              fillRgba,
+              activeClip,
+              meshPos,
+              meshCol,
+              meshClip,
+              rotOpts
+            );
+          }
         }
         if (forceStamp) buf.flags[i] = (flags & ~SOA_FLAG_DIRTY) >>> 0;
       }
+      // No text atlas — wait for outline mesh (ensure already kicked).
       continue;
     }
 

--- a/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
@@ -479,10 +479,17 @@ export function pickFullAndCanvasIds(opts: {
   holdHostIds?: ReadonlySet<string>;
   /**
    * Single-select temporary raise (within-ink z + hit).
-   * Basic shapes stay on SoA; generators promote to SVG so max+1 data-z can cover siblings.
+   * World basics stay on SoA; generators + plate-bound promote to SVG so max+1
+   * data-z can cover sibling hosts / artboard plates (world WebGL sits under SVG).
    */
   paintRaiseIds?: ReadonlySet<string> | readonly string[];
   paintRaiseFrameIds?: ReadonlySet<string> | readonly string[];
+  /**
+   * Selection / SoftGlow overflow reveal. Plate-bound ids must leave FO ink
+   * (see artboardInkSurface) — promote to SVG host even when paint-raise is
+   * empty (multi-select), otherwise overflow only paints under the plate.
+   */
+  revealOverflowIds?: ReadonlySet<string> | readonly string[];
   zoom: number;
   /** Device pixel ratio for idle media sharpness (defaults to window.devicePixelRatio). */
   dpr?: number;
@@ -507,18 +514,28 @@ export function pickFullAndCanvasIds(opts: {
           ? raiseIds.has(id)
           : (raiseIds as readonly string[]).includes(id))
     );
-    const raiseHost = isPaintRaised && isGeneratorNode(node);
-    // Plate-bound siblings must share ArtboardLayer ink. Zoom-based SVG promote
-    // splits some onto data-z hosts while others stay on the plate canvas →
-    // apparent layer-order flips when the camera zooms.
+    const revealIds = opts.revealOverflowIds;
+    const isRevealed = Boolean(
+      revealIds &&
+        (revealIds instanceof Set
+          ? revealIds.has(id)
+          : (revealIds as readonly string[]).includes(id))
+    );
+    // Plate-bound siblings must share ArtboardLayer ink when idle. Zoom-based
+    // SVG promote splits some onto data-z hosts while others stay on the plate
+    // canvas → apparent layer-order flips when the camera zooms.
     const plateBound = Boolean(nodeOwnerFrameId(node));
+    // Selection raise / overflow reveal: plate-bound basics must leave SoA/FO —
+    // world WebGL sits under plates, so raise-within-ink cannot cover the
+    // artboard. Promote to SVG host at max+1 data-z (same as generators).
+    const raiseHost =
+      (isPaintRaised && isGeneratorNode(node)) ||
+      (plateBound && (isPaintRaised || isRevealed));
     const forceHost =
       forceFullSet.has(id) ||
       Boolean(holdHostIds?.has(id)) ||
       raiseHost ||
-      // Basic shapes keep SoA under raise (chrome/z only). Generators must
-      // leave SoA so max+1 data-z can cover sibling SVG hosts — otherwise ink
-      // stays under the stack SVG and drag chrome looks like it "bounces".
+      // World nodes stacked above any plate still need hosts on the shared mount.
       worldNodeStacksAboveAnyFrame(document, id) ||
       // Shape/text sharpness promote retired — media may still leave SoA for crisp hosts.
       (!plateBound && idleMediaNeedsSharpHost(node, zoom, dpr));
@@ -710,6 +727,7 @@ function RcbShapesLayer({
         holdHostIds,
         paintRaiseIds: paintRaiseSet,
         paintRaiseFrameIds: paintRaiseFrameSet,
+        revealOverflowIds: revealSet,
         zoom: cullCam.zoom || 1,
       }),
     [
@@ -719,6 +737,7 @@ function RcbShapesLayer({
       holdHostIds,
       paintRaiseSet,
       paintRaiseFrameSet,
+      revealSet,
       cullCam.zoom,
       workbenchTimelineToken,
     ]
@@ -1042,7 +1061,13 @@ function RcbShapesLayer({
             key={id}
             nodeId={id}
             document={document}
-            zIndex={nodePaintZIndex(document, id, paintRaiseSet.has(id))}
+            zIndex={nodePaintZIndex(
+              document,
+              id,
+              // Plate-bound reveal must share max+1 with single-select raise —
+              // otherwise the host mounts at natural z under / inside the plate.
+              paintRaiseSet.has(id) || revealSet.has(id)
+            )}
             reloadToken={hostReloadTokenFor(id)}
             frameClipToken={frameClipToken}
             forceHidden={isNodeOverlayHidden(document, node, hiddenNodeId === id)}

--- a/apps/web/src/components/rcb/shapes/__tests__/canvasIdleHostBudget.test.ts
+++ b/apps/web/src/components/rcb/shapes/__tests__/canvasIdleHostBudget.test.ts
@@ -250,7 +250,7 @@ describe('pickFullAndCanvasIds (single ink path)', () => {
     expect(canvasIds.length).toBe(39);
   });
 
-  it('paintRaiseIds only force-host generators (basic shapes stay SoA under raise)', () => {
+  it('paintRaiseIds only force-host generators (world basics stay SoA under raise)', () => {
     const doc = makeDoc({ n0: rect('n0'), n1: rect('n1') });
     const { fullIds, canvasIds } = pickFullAndCanvasIds({
       document: doc,
@@ -260,6 +260,40 @@ describe('pickFullAndCanvasIds (single ink path)', () => {
     });
     expect(fullIds).toEqual([]);
     expect(canvasIds.sort()).toEqual(['n0', 'n1']);
+  });
+
+  it('plate-bound paint raise / reveal leaves FO SoA for max+1 SVG host', () => {
+    const bound = {
+      ...rect('bound'),
+      attrs: { ...rect('bound').attrs, frameId: 'board' },
+    };
+    const idle = {
+      ...rect('idle'),
+      attrs: { ...rect('idle').attrs, frameId: 'board' },
+    };
+    const doc = makeDoc({ bound, idle });
+    doc.frames = [
+      { id: 'board', name: 'A', backgroundColor: '#fff', x: 0, y: 0, width: 200, height: 200 },
+    ];
+
+    const raised = pickFullAndCanvasIds({
+      document: doc,
+      visibleIds: ['bound', 'idle'],
+      paintRaiseIds: ['bound'],
+      zoom: 1,
+    });
+    expect(raised.fullIds).toEqual(['bound']);
+    expect(raised.canvasIds).toEqual(['idle']);
+
+    // Multi-select: paint-raise empty, but overflow reveal still must host-raise.
+    const revealed = pickFullAndCanvasIds({
+      document: doc,
+      visibleIds: ['bound', 'idle'],
+      revealOverflowIds: ['bound'],
+      zoom: 1,
+    });
+    expect(revealed.fullIds).toEqual(['bound']);
+    expect(revealed.canvasIds).toEqual(['idle']);
   });
 
   it('world node above an artboard leaves SoA for shared data-z stacking', () => {

--- a/docs/adr/0027-canvas-layered-runtime.md
+++ b/docs/adr/0027-canvas-layered-runtime.md
@@ -2,7 +2,7 @@
 
 - **Status:** Accepted
 - **Date:** 2026-08-15
-- **Updated:** 2026-09-04 — Artboard = small canvas (per-plate ArtboardLayer ink + FO by `stackOrder`); world WebGL unbound-only (`skipFrameBound`). Earlier: unified `stackOrder` paint + ideal hit.
+- **Updated:** 2026-09-06 — Plate-bound selection/reveal promotes to SVG host at max+1 (`pickFullAndCanvasIds`); FO/`onlyFrameId` skips `frameClipRevealsOverflow` (no clipped ghost + under-plate dual paint). 2026-09-05 — ArtboardLayer ink = shared WebGL2 SoA/mesh blit onto per-plate FO canvas (`onlyFrameId`); FO stackOrder unchanged. 2026-09-04 — Artboard = small canvas (per-plate ArtboardLayer ink + FO by `stackOrder`); world WebGL unbound-only (`skipFrameBound`). Earlier: unified `stackOrder` paint + ideal hit.
 - **Supersedes (partial):** [ADR 0002](./0002-canvas-rcb-runtime.md) runtime paint/hit coupling — RCB ownership stays; SVG is no longer the editor runtime fact layer.
 
 ## Context
@@ -28,10 +28,10 @@ Treat the editor runtime as four facts (**this is the product architecture — d
    ```
 
    - **World WebGL2** instanced SoA ink on `[data-rcb-idle-ink-canvas]` paints **unbound** idle nodes only (`collectSoaWebglInstances` + `skipFrameBound`). World tile bake (`soaBakeLayer`) likewise skips plate-bound slots.
-   - **ArtboardLayer** (per `document.frames[]`): plate fill + bound idle SoA ink on a small canvas inside the stack SVG layer (`data-rcb-frame-layer` + `data-z` via `artboardInkSurface` / `HtmlArtboardFrame`). FO/editor hosts for that plate are siblings on the same mount, ordered by `stackOrder`, so a selected video can sit between two artboards.
-   - **DOM hosts** only for FO media, SoftGlow, editors, lottie/group, heavy paths, and unbound nodes stacked above any plate. Bound idle vectors/media posters use ArtboardLayer ink — never SVG hosts for ownership alone.
+   - **ArtboardLayer** (per `document.frames[]`): plate fill on SVG; **bound idle SoA ink via shared WebGL2** (`artboardWebglInk` / `collectSoaWebglInstances` + `onlyFrameId`) blit onto the per-plate FO canvas (`artboardInkSurface` / `HtmlArtboardFrame`). Same mesh path as world ink; FO/editor hosts for that plate stay siblings on the stack mount ordered by `stackOrder`, so a selected video can sit between two artboards.
+   - **DOM hosts** for FO media, SoftGlow, editors, lottie/group, heavy paths, unbound nodes stacked above any plate, **and plate-bound nodes while selected / overflow-revealed** (max+1 `data-z` — world WebGL cannot cover plate fill). Bound **idle** vectors/media posters use ArtboardLayer ink — never SVG hosts for ownership alone. FO/`onlyFrameId` collect **skips** `frameClipRevealsOverflow` so reveal does not leave a clipped ghost on the plate.
    - **Grid** stays on a separate Canvas2D surface. Selection, guides, and drawing previews share the camera surface; screen UI stays in the HTML overlay.
-   - SoftGlow/editors use `RenderDemotionScheduler` (`ACTIVE_SVG` → `CANDIDATE` → `DEPLOYED_SOA`); selection does **not** promote basic shapes onto SVG.
+   - SoftGlow/editors use `RenderDemotionScheduler` (`ACTIVE_SVG` → `CANDIDATE` → `DEPLOYED_SOA`); selection does **not** promote **world** basic shapes onto SVG (within-ink raise only). **Plate-bound** basics **do** promote on raise/reveal.
    - **Forbidden:** per-type CSS z bands, host-occlusion / plate-cutout paint hacks, global “bound idle → SVG host”, or “transparent plate + draw bound ink on world WebGL” (breaks FO between plates).
 
 4. **Independent hit** — root pointer capture → chrome hit → **one** `SceneSpatialRuntime` QT (`searchPoint`, nodes + `frame:id` plates) → permanent `stackOrder` top-first → first precise geometry or plate AABB (`hitTestUnifiedStackAtPoint`). Frame picks return `__frame__:id`. SoA `buf.quadtree` is paint/cull only. `sceneToSvg` stays an **export** path, not the live paint core.
@@ -46,7 +46,7 @@ Do not sell micro-caches or effects as parallel “optimization schemes.” Prod
 |---|--------|------|
 | 1 | SoA `SceneRenderBuffer` | Typed-array paint/pick cache |
 | 2 | Demotion + host viewport cull | DOM budget; who stays SVG vs SoA |
-| 3 | World WebGL2 + ArtboardLayer ink | Unbound idle on world GL; plate-bound idle on per-artboard small canvas |
+| 3 | World WebGL2 + ArtboardLayer ink | Unbound idle on world GL; plate-bound idle = shared GL → FO canvas |
 | 4 | Viewport tile bake + Worker | Second wall when world idle+basic ≥ ~800; live fill until tiles ready |
 | 5 | Select raise keep-bake + overpaint | Select must not disable bake |
 | 6 | Dirty AABB + SoA QT + incremental sync | Avoid O(N) wipe/rebuild |
@@ -54,7 +54,7 @@ Do not sell micro-caches or effects as parallel “optimization schemes.” Prod
 
 **Embedded (not separate products):** path densify, AI mutation lock, TransformPreview live filter.
 
-**Ink surfaces:** Canvas2D paints the **pixel grid**, Vitest helpers, and **ArtboardLayer** per-plate ink (required so FO hosts interleave by `stackOrder`). World unbound idle ink is WebGL. Soft canvas2d world-ink fallback is survival-only when WebGL2 cannot compile — not the product main path.
+**Ink surfaces:** Canvas2D paints the **pixel grid** and Vitest / WebGL-failure survival paths. **ArtboardLayer** product ink is **WebGL on the FO canvas** (shared context + blit; required so FO hosts interleave by `stackOrder`). World unbound idle ink is WebGL. Soft canvas2d world-ink / artboard-ink fallback is survival-only when WebGL2 cannot compile — not the product main path.
 
 **Do not merge:** `SceneSpatialRuntime` (all-node hit) vs `buf.quadtree` (idle paint/pick) — intentional dual track.
 
@@ -99,7 +99,7 @@ Do not sell micro-caches or effects as parallel “optimization schemes.” Prod
 - Contributors must not add new world-layer control SVG that mirrors host `viewBox`.
 - Do not reintroduce dual attr keys (`fill` vs `fill-color`, frame `kind: 'lottie'`, `lottieFrameHost`, axios-shaped error probes).
 - Do not add a second async bake scheduler alongside Worker (no idle/main-thread bake dual path).
-- Shared GL + multi-FBO for ArtboardLayer is a future density option; current per-plate canvas keeps FO interleave correct.
+- Shared GL for ArtboardLayer is **in use** (scratch canvas + blit to FO); per-plate FBO tiling remains a future density option. Do not merge plate ink into the world WebGL framebuffer (breaks FO between plates).
 
 ## Alternatives considered
 
@@ -116,6 +116,7 @@ Do not sell micro-caches or effects as parallel “optimization schemes.” Prod
 - `apps/web/src/components/rcb/canvas/RcbCanvas.tsx`
 - `apps/web/src/components/rcb/frames/HtmlArtboardFrame.tsx`
 - `apps/web/src/components/rcb/frames/artboardInkSurface.ts`
+- `apps/web/src/components/rcb/frames/artboardWebglInk.ts`
 - `apps/web/src/components/rcb/render/sceneRenderer.ts`
 - `apps/web/src/components/rcb/render/sceneRenderBuffer.ts`
 - `apps/web/src/components/rcb/render/renderDemotionScheduler.ts`

--- a/packages/rcb-wasm-geom/src/lib.rs
+++ b/packages/rcb-wasm-geom/src/lib.rs
@@ -647,6 +647,7 @@ fn densify_path_inner(d: &str, flatness: f32) -> Vec<f32> {
         let mut ai = 0usize;
         match c {
             'M' => {
+                let subpath_start = true;
                 while ai + 1 < args.len() {
                     let mut x = args[ai];
                     let mut y = args[ai + 1];
@@ -659,6 +660,12 @@ fn densify_path_inner(d: &str, flatness: f32) -> Vec<f32> {
                     cy = y;
                     start_x = x;
                     start_y = y;
+                    // NaN break between subpaths (arrow shaft + V must not bridge).
+                    if subpath_start && !pts.is_empty() {
+                        pts.push(f32::NAN);
+                        pts.push(f32::NAN);
+                    }
+                    subpath_start = false;
                     push(&mut pts, x, y);
                     while ai + 1 < args.len() {
                         let mut x2 = args[ai];


### PR DESCRIPTION
## Summary
- Ship RCB geom WASM via `public/rcb-wasm` for production (nginx + Vite env).
- Paint artboard-bound idle ink with shared WebGL2 blit onto per-plate FO (same mesh path as world); raise `ARTBOARD_INK_MAX_SCALE`.
- Selected / overflow-revealed plate-bound shapes promote to SVG hosts at max+1; FO / `onlyFrameId` skip reveal so drag-out no longer leaves a clipped ghost or under-plate dual paint.
- Text idle uses outline fill meshes (no text atlas); multi-subpath densify keeps arrow shaft/wing separate.
- Docs: HOW_IT_WORKS / CANVAS / ADR 0027 updated for plate raise + FO WebGL.

## Test plan
- [ ] Drag a basic shape from inside a Frame past the plate edge: no clipped ghost inside the plate; full shape above the white plate
- [ ] Select plate-bound shape: ink lifts above artboard (max+1 host); deselect returns to FO idle
- [ ] Multi-select plate-bound shapes spanning plate edge: overflow visible, no FO+world half-draw
- [ ] Zoom artboard: FO ink stays sharp up to MAX_EDGE; world unbound ink unchanged
- [ ] Arrow with head: idle stroke matches preview (no shaft→wing bridge)
- [ ] Text idle: outline mesh appears (brief blank until ready OK); edit still FO/DOM
- [ ] Production: `/rcb-wasm/*.wasm` loads (not missing 404 after deploy)

Made with [Cursor](https://cursor.com)