### PR TITLE
fix(web): workbench mesh paint, plate bind, and pencil commit freeze

### DIFF
--- a/apps/web/src/components/editor/canvas/__tests__/applyNodeFrameBindings.test.ts
+++ b/apps/web/src/components/editor/canvas/__tests__/applyNodeFrameBindings.test.ts
@@ -126,4 +126,26 @@ describe('bindCreatedNodeToFrame final AABB', () => {
       'anim'
     );
   });
+
+  it('binds when finished box overlaps the open animation workbench', async () => {
+    const { bindCreatedNodeToFrame } = await import(
+      '@/components/editor/canvas/canvasSession'
+    );
+    setAnimationWorkbenchTimelineFocus('anim');
+    const doc = makeDoc({
+      ox: 0,
+      oy: 0,
+      frame: { x: 0, y: 0, width: 364, height: 364 },
+      // Overlaps right edge — must become a workbench layer (on plate), not surround.
+      node: { x: 300, y: 40, width: 120, height: 80 },
+    });
+    const next = bindCreatedNodeToFrame(
+      doc,
+      's1',
+      { left: 300, top: 40, width: 120, height: 80 },
+      null
+    );
+    expect(String(next.deltaSetLike?.s1?.attrs?.frameId || '')).toBe('anim');
+    expect(next.deltaSetLike?.s1?.attrs?.animationWorkbenchSurround).toBeUndefined();
+  });
 });

--- a/apps/web/src/components/editor/nodes/AnimationNode/AnimationFrameChildToolbar.tsx
+++ b/apps/web/src/components/editor/nodes/AnimationNode/AnimationFrameChildToolbar.tsx
@@ -91,9 +91,31 @@ import {
   BLEND_MODE_OPTIONS,
   parseBlendMode,
 } from '@/components/rcb/selection/chrome/BlendModeControl';
+import {
+  documentPointToNodeLocal,
+  isFrameLocalCoordSpace,
+} from '@/components/rcb/scene/paint/sceneToSvg';
 import store from '@/store';
 import { cn } from '@/utils/classnames';
 import type { SceneDocument, SceneNode } from '@/components/rcb/sceneNode';
+
+/**
+ * Inspector X/Y are plate-local (0 = frame TL). Node storage under frameLocal
+ * is also plate-local — never write world abs (that double-adds frame origin).
+ */
+export function inspectorLocalToStoredXY(
+  document: SceneDocument | null | undefined,
+  frameId: string | null | undefined,
+  frameX: number,
+  frameY: number,
+  localX: number,
+  localY: number
+): { x: number; y: number } {
+  if (isFrameLocalCoordSpace(document) && String(frameId || '').trim()) {
+    return { x: localX, y: localY };
+  }
+  return { x: frameX + localX, y: frameY + localY };
+}
 
 /** Timeline dock listens — expand the layer so new keyframes are visible. */
 export const LOTTIE_EXPAND_LAYER_EVENT = 'lottie-timeline-expand-layer';
@@ -802,6 +824,8 @@ function AnimationFrameChildToolbar({
   const frameY = Number(frame?.y) || 0;
   const frameW = Math.max(1, Number(frame?.width) || 1);
   const frameH = Math.max(1, Number(frame?.height) || 1);
+  const frameLocal = isFrameLocalCoordSpace(document);
+  // Selection chrome is world; inspector fields are plate-local.
   const localX = geom.left - frameX;
   const localY = geom.top - frameY;
   const w = Math.max(1, geom.width);
@@ -996,7 +1020,21 @@ function AnimationFrameChildToolbar({
   }, [frameId]);
 
   const commitWorldXY = (nextLocalX: number, nextLocalY: number) => {
-    patchAttrs({}, { x: frameX + nextLocalX, y: frameY + nextLocalY });
+    const stored = inspectorLocalToStoredXY(
+      document,
+      frameId,
+      frameX,
+      frameY,
+      nextLocalX,
+      nextLocalY
+    );
+    patchAttrs({}, { x: stored.x, y: stored.y });
+  };
+
+  /** World chrome origin → node storage x/y (frameLocal-aware). */
+  const commitWorldOrigin = (worldLeft: number, worldTop: number) => {
+    const stored = documentPointToNodeLocal(document, node, worldLeft, worldTop);
+    patchAttrs({}, { x: Math.round(stored.x), y: Math.round(stored.y) });
   };
 
   /** Keep visual pose when changing Anchor; write anchorX/Y so canvas R/Sk/Sa pivot. */
@@ -1005,8 +1043,8 @@ function AnimationFrameChildToolbar({
     const { fx: ofx, fy: ofy } = anchorPresetToFrac(prev);
     const { fx, fy } = anchorPresetToFrac(next);
     const angleDeg = rot;
-    let nextX = geom.left;
-    let nextY = geom.top;
+    let nextWorldX = geom.left;
+    let nextWorldY = geom.top;
     if (Math.abs(angleDeg) > 1e-6 && (ofx !== fx || ofy !== fy)) {
       const p0x = w * ofx;
       const p0y = h * ofy;
@@ -1019,16 +1057,17 @@ function AnimationFrameChildToolbar({
       const sin = Math.sin(rad);
       const rx = cos * dx - sin * dy;
       const ry = sin * dx + cos * dy;
-      nextX = geom.left + (dx - rx);
-      nextY = geom.top + (dy - ry);
+      nextWorldX = geom.left + (dx - rx);
+      nextWorldY = geom.top + (dy - ry);
     }
+    const stored = documentPointToNodeLocal(document, node, nextWorldX, nextWorldY);
     patchAttrs(
       {
         anchorPreset: next,
         anchorX: Math.round(fx * 100),
         anchorY: Math.round(fy * 100),
       },
-      { x: Math.round(nextX), y: Math.round(nextY) }
+      { x: Math.round(stored.x), y: Math.round(stored.y) }
     );
   };
 
@@ -1146,15 +1185,15 @@ function AnimationFrameChildToolbar({
   };
 
   const alignToFrame = (mode: (typeof ALIGN_ITEMS)[number]['mode']) => {
-    let nextX = geom.left;
-    let nextY = geom.top;
-    if (mode === 'left') nextX = frameX;
-    if (mode === 'centerX') nextX = frameX + (frameW - w) / 2;
-    if (mode === 'right') nextX = frameX + frameW - w;
-    if (mode === 'top') nextY = frameY;
-    if (mode === 'middle') nextY = frameY + (frameH - h) / 2;
-    if (mode === 'bottom') nextY = frameY + frameH - h;
-    patchAttrs({}, { x: Math.round(nextX), y: Math.round(nextY) });
+    let nextWorldX = geom.left;
+    let nextWorldY = geom.top;
+    if (mode === 'left') nextWorldX = frameX;
+    if (mode === 'centerX') nextWorldX = frameX + (frameW - w) / 2;
+    if (mode === 'right') nextWorldX = frameX + frameW - w;
+    if (mode === 'top') nextWorldY = frameY;
+    if (mode === 'middle') nextWorldY = frameY + (frameH - h) / 2;
+    if (mode === 'bottom') nextWorldY = frameY + frameH - h;
+    commitWorldOrigin(nextWorldX, nextWorldY);
   };
 
   const siblingBoxes = useMemo((): SiblingBox[] => {
@@ -1179,9 +1218,10 @@ function AnimationFrameChildToolbar({
 
   const justifyInFrame = (axis: 'h' | 'v') => {
     if (!canJustify || !frame) return;
+    // Sibling boxes use stored node.x/y — under frameLocal that is plate-local.
     const patches = justifyInFramePatches(siblingBoxes, axis, {
-      x: frameX,
-      y: frameY,
+      x: frameLocal ? 0 : frameX,
+      y: frameLocal ? 0 : frameY,
       w: frameW,
       h: frameH,
     });

--- a/apps/web/src/components/editor/nodes/AnimationNode/AnimationTimelineFocusHost.tsx
+++ b/apps/web/src/components/editor/nodes/AnimationNode/AnimationTimelineFocusHost.tsx
@@ -161,7 +161,9 @@ function AnimationTimelineFocusHost({
     }
     requestIdleCanvasFullRepaint();
     return () => {
-      if (!focusFrameId) setAnimationWorkbenchTimelineFocus(null);
+      // Always clear module focus when leaving an open focus (not only when
+      // the next focusFrameId is already null — that skipped cleanup before).
+      setAnimationWorkbenchTimelineFocus(null);
     };
   }, [focusFrameId]);
 
@@ -179,7 +181,6 @@ function AnimationTimelineFocusHost({
     };
 
     const fit = () => {
-      cancelled = false;
       tries = 0;
       const apply = () => {
         if (cancelled) return;
@@ -215,7 +216,15 @@ function AnimationTimelineFocusHost({
       raf = window.requestAnimationFrame(apply);
     };
 
-    const onFit = () => fit();
+    const onFit = () => {
+      // Ignore late afterPaint FIT that lands after the panel was closed.
+      const nodeId = String(
+        (store.getState() as { editor?: any }).editor?.lottieTimelinePanel?.nodeId || ''
+      ).trim();
+      if (!nodeId) return;
+      cancelled = false;
+      fit();
+    };
     const onRelease = () => {
       cancelled = true;
       if (raf) window.cancelAnimationFrame(raf);

--- a/apps/web/src/components/editor/nodes/AnimationNode/__tests__/animationWorkbenchFocus.test.ts
+++ b/apps/web/src/components/editor/nodes/AnimationNode/__tests__/animationWorkbenchFocus.test.ts
@@ -102,6 +102,27 @@ describe('finalizeNodeForAnimationWorkbenchFocus', () => {
     expect(isHiddenByAnimationWorkbenchFocus(node)).toBe(false);
   });
 
+  it('binds overlapping unbound shape into focused workbench (not surround behind plate)', () => {
+    setAnimationWorkbenchTimelineFocus('af1');
+    const raw = docWithPlateAndNode({
+      frameId: 'af1',
+      node: {
+        id: 'rect1',
+        key: 'shape',
+        x: 450,
+        y: 150,
+        width: 120,
+        height: 80,
+        attrs: {},
+      },
+    });
+    // Plate is 100,100,400×300 — rect overlaps right edge.
+    const next = finalizeNodeForAnimationWorkbenchFocus(raw, 'rect1');
+    const node = next.deltaSetLike.rect1;
+    expect(node.attrs.frameId).toBe('af1');
+    expect(node.attrs[WORKBENCH_SURROUND_ATTR]).toBeUndefined();
+  });
+
   it('hides unowned nodes that were never finalized', () => {
     setAnimationWorkbenchTimelineFocus('af1');
     const node = {

--- a/apps/web/src/components/editor/nodes/AnimationNode/__tests__/inspectorLocalToStoredXY.test.ts
+++ b/apps/web/src/components/editor/nodes/AnimationNode/__tests__/inspectorLocalToStoredXY.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { inspectorLocalToStoredXY } from '../AnimationFrameChildToolbar';
+import type { SceneDocument } from '@/components/rcb/sceneNode';
+
+describe('inspectorLocalToStoredXY', () => {
+  it('keeps plate-local under frameLocal (no double frame origin)', () => {
+    const doc = { coordSpace: 'frameLocal' } as SceneDocument;
+    expect(inspectorLocalToStoredXY(doc, 'f1', 200, 100, 472.5, 247.5)).toEqual({
+      x: 472.5,
+      y: 247.5,
+    });
+  });
+
+  it('writes world abs when not frameLocal', () => {
+    const doc = {} as SceneDocument;
+    expect(inspectorLocalToStoredXY(doc, 'f1', 200, 100, 472.5, 247.5)).toEqual({
+      x: 672.5,
+      y: 347.5,
+    });
+  });
+});

--- a/apps/web/src/components/editor/nodes/AnimationNode/animationWorkbenchFocus.ts
+++ b/apps/web/src/components/editor/nodes/AnimationNode/animationWorkbenchFocus.ts
@@ -2,7 +2,9 @@
  * Timeline focus for 动画工作台:
  * - Surround pasteboard nodes (`animationWorkbenchSurround`) belong to a workbench
  *   but live outside its plate; saved with the project, shown only while that
- *   workbench's timeline is open.
+ *   workbench's timeline is open. Attr is visibility/isolation only — ink uses
+ *   the same SoA mesh path as closed-timeline unbound world (never DomHost via
+ *   stack-above; see worldNodeStacksAboveAnyFrame).
  * - While the timeline is open, unrelated frames/nodes are paint/hit hidden.
  * - Bound children outside the playhead in/out range are visually hidden and
  *   not pickable (same inRange rule as AnimationPlayheadSceneSync).
@@ -418,11 +420,12 @@ export function isInactiveAtAnimationPlayhead(
 }
 
 /**
- * After create/bind: outside the focused plate → mark as workbench surround;
- * inside the plate → clear surround.
+ * After create/bind: intersecting the focused plate → bind as workbench layer
+ * (same membership as a world artboard); fully outside → surround pasteboard.
  */
 export function tagCreatedNodeForWorkbenchSurround<T extends {
   deltaSetLike?: Record<string, any> | null;
+  frames?: any[];
 }>(doc: T, nodeId: string): T {
   const focus = timelineFocusFrameId;
   const id = String(nodeId || '').trim();
@@ -436,18 +439,99 @@ export function tagCreatedNodeForWorkbenchSurround<T extends {
   if (fid === focus) {
     if (!(WORKBENCH_SURROUND_ATTR in attrs)) return doc;
     delete attrs[WORKBENCH_SURROUND_ATTR];
-  } else if (!fid) {
-    if (attrs[WORKBENCH_SURROUND_ATTR] === focus) return doc;
-    attrs[WORKBENCH_SURROUND_ATTR] = focus;
-  } else {
-    return doc;
+    return {
+      ...doc,
+      deltaSetLike: {
+        ...doc.deltaSetLike,
+        [id]: { ...node, attrs },
+      },
+    };
+  }
+
+  if (fid) return doc;
+
+  // Unbound but overlapping the open workbench → bind like a world artboard.
+  // Do not leave as surround: world mesh sits under plate SVG (looks “behind”).
+  const key = String(node.key || '');
+  if (
+    key !== 'video' &&
+    key !== 'audio' &&
+    !isGeneratorPlateAttrs(node.attrs) &&
+    nodeIntersectsFocusedWorkbenchPlate(doc, node, focus)
+  ) {
+    return bindUnboundNodeToFocusedWorkbench(doc, id, focus);
+  }
+
+  if (attrs[WORKBENCH_SURROUND_ATTR] === focus) return doc;
+  attrs[WORKBENCH_SURROUND_ATTR] = focus;
+  return {
+    ...doc,
+    deltaSetLike: {
+      ...doc.deltaSetLike,
+      [id]: { ...node, attrs },
+    },
+  };
+}
+
+/** Document AABB of an unbound node vs focused workbench plate. */
+function nodeIntersectsFocusedWorkbenchPlate(
+  doc: { frames?: any[] | null },
+  node: {
+    x?: unknown;
+    y?: unknown;
+    width?: unknown;
+    height?: unknown;
+  },
+  focus: string
+): boolean {
+  const frames = Array.isArray(doc.frames) ? doc.frames : [];
+  const plate = frames.find((f: any) => String(f?.id) === focus);
+  if (!plate) return false;
+  const left = Number(node.x) || 0;
+  const top = Number(node.y) || 0;
+  const width = Math.max(1, Number(node.width) || 1);
+  const height = Math.max(1, Number(node.height) || 1);
+  const fx = Number(plate.x) || 0;
+  const fy = Number(plate.y) || 0;
+  const fw = Math.max(1, Number(plate.width) || 1);
+  const fh = Math.max(1, Number(plate.height) || 1);
+  return left < fx + fw && left + width > fx && top < fy + fh && top + height > fy;
+}
+
+function bindUnboundNodeToFocusedWorkbench<T extends {
+  deltaSetLike?: Record<string, any> | null;
+  frames?: any[];
+  coordSpace?: unknown;
+}>(doc: T, nodeId: string, focus: string): T {
+  const node = doc.deltaSetLike?.[nodeId];
+  if (!node) return doc;
+  const attrs = { ...(node.attrs || {}) } as Record<string, unknown>;
+  const orders = Object.values(doc.deltaSetLike || {})
+    .filter((item: any) => String(item?.attrs?.frameId || '').trim() === focus)
+    .map((item: any) => Number(item?.attrs?.frameOrder))
+    .filter(Number.isFinite);
+  attrs.frameId = focus;
+  attrs.frameOrder = orders.length ? Math.max(...orders) + 1 : 0;
+  delete attrs[WORKBENCH_SURROUND_ATTR];
+
+  let nextX = Number(node.x) || 0;
+  let nextY = Number(node.y) || 0;
+  // Avoid importing sceneToSvg (cycle via playhead). Mirror frameLocal store.
+  if (String((doc as { coordSpace?: unknown }).coordSpace || '') === 'frameLocal') {
+    const plate = (Array.isArray(doc.frames) ? doc.frames : []).find(
+      (f: any) => String(f?.id) === focus
+    );
+    if (plate) {
+      nextX -= Number(plate.x) || 0;
+      nextY -= Number(plate.y) || 0;
+    }
   }
 
   return {
     ...doc,
     deltaSetLike: {
       ...doc.deltaSetLike,
-      [id]: { ...node, attrs },
+      [nodeId]: { ...node, attrs, x: nextX, y: nextY },
     },
   };
 }
@@ -509,47 +593,6 @@ export function finalizeNodeForAnimationWorkbenchFocus<T extends {
     return tagCreatedNodeForWorkbenchSurround(doc, id);
   }
 
-  const frames = Array.isArray(doc.frames) ? doc.frames : [];
-  const plate = frames.find((f: any) => String(f?.id) === focus);
-  if (!plate) return tagCreatedNodeForWorkbenchSurround(doc, id);
-
-  const left = Number(node.x) || 0;
-  const top = Number(node.y) || 0;
-  const width = Math.max(1, Number(node.width) || 1);
-  const height = Math.max(1, Number(node.height) || 1);
-  const fx = Number(plate.x) || 0;
-  const fy = Number(plate.y) || 0;
-  const fw = Math.max(1, Number(plate.width) || 1);
-  const fh = Math.max(1, Number(plate.height) || 1);
-  const intersects =
-    left < fx + fw && left + width > fx && top < fy + fh && top + height > fy;
-
-  if (!intersects) {
-    return tagCreatedNodeForWorkbenchSurround(doc, id);
-  }
-
-  const attrs = { ...(node.attrs || {}) } as Record<string, unknown>;
-  if (String(attrs.frameId || '').trim() === focus) {
-    delete attrs[WORKBENCH_SURROUND_ATTR];
-    if (!(WORKBENCH_SURROUND_ATTR in (node.attrs || {}))) return doc;
-    return {
-      ...doc,
-      deltaSetLike: { ...doc.deltaSetLike, [id]: { ...node, attrs } },
-    };
-  }
-
-  const orders = Object.values(doc.deltaSetLike || {})
-    .filter((item: any) => String(item?.attrs?.frameId || '').trim() === focus)
-    .map((item: any) => Number(item?.attrs?.frameOrder))
-    .filter(Number.isFinite);
-  attrs.frameId = focus;
-  attrs.frameOrder = orders.length ? Math.max(...orders) + 1 : 0;
-  delete attrs[WORKBENCH_SURROUND_ATTR];
-  return {
-    ...doc,
-    deltaSetLike: {
-      ...doc.deltaSetLike,
-      [id]: { ...node, attrs },
-    },
-  };
+  // Intersect → bind; outside → surround. Shared with tagCreatedNodeForWorkbenchSurround.
+  return tagCreatedNodeForWorkbenchSurround(doc, id);
 }

--- a/apps/web/src/components/editor/nodes/ImageNode/ImageProcessOverlay.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/ImageProcessOverlay.tsx
@@ -1,12 +1,34 @@
-import { type ReactNode, memo } from 'react';
+import { useSyncExternalStore, type ReactNode, memo } from 'react';
 import type { SceneNodeInput } from '@/components/rcb/sceneNode';
 import { ProcessGlowShell } from '@/components/rcb/process/ProcessGlowShell';
 import { liveShapeGeomBox } from '@/components/rcb/selection/HostPathChrome';
+import {
+  hasNodeTransformPreviews,
+  subscribeTransformPreview,
+} from '@/components/rcb/core/transformPreview';
+import {
+  hasLiveArtboardFrameGeometry,
+  subscribeLiveArtboardFrameGeometry,
+} from '@/components/rcb/frames/HtmlArtboardFrame';
+
+function subscribeProcessPillHide(listener: () => void): () => void {
+  const a = subscribeTransformPreview(listener);
+  const b = subscribeLiveArtboardFrameGeometry(listener);
+  return () => {
+    a();
+    b();
+  };
+}
+
+function processPillShouldHide(): boolean {
+  return hasNodeTransformPreviews() || hasLiveArtboardFrameGeometry();
+}
 
 /**
  * Status pill for a node whose `attrs.processStatus === 'running'`.
  * Gradient is SVG-native on the process plate; the label docks on the overlay
  * like selection titles / toolbars (screen-constant gap, never FO-clipped).
+ * Hidden while drag/resize or plate move — same as titles / toolbars.
  */
 export function NodeProcessGlow({
   nodeId,
@@ -17,6 +39,13 @@ export function NodeProcessGlow({
   /** Kept for call-site compat; label no longer portals into the SVG host. */
   paintHost?: SVGElement | null;
 }): ReactNode {
+  const hide = useSyncExternalStore(
+    subscribeProcessPillHide,
+    processPillShouldHide,
+    () => false
+  );
+  if (hide) return null;
+
   const w = Math.max(1, Number(node.width) || 1);
   const h = Math.max(1, Number(node.height) || 1);
   const geom = liveShapeGeomBox(nodeId) || {

--- a/apps/web/src/components/editor/nodes/ImageNode/toolPanels/OpacityToolPanel.tsx
+++ b/apps/web/src/components/editor/nodes/ImageNode/toolPanels/OpacityToolPanel.tsx
@@ -29,14 +29,15 @@ function OpacityToolPanel({
         </PanelIconBtn>
       }
     >
-      <div className="flex flex-col items-stretch gap-3 py-3">
+      <div className="flex flex-col items-stretch gap-3 py-1">
         <Slider
           min={0}
           max={100}
           step={1}
           value={safe}
           onChange={onOpacityPctChange}
-          trackHeight={6}
+          /* Thick black pill + white ring thumb — shared opacity chrome. */
+          trackHeight={10}
           thumbWidth={16}
           thumbHeight={16}
         />

--- a/apps/web/src/components/editor/nodes/TextNode/FontFamilyPicker.tsx
+++ b/apps/web/src/components/editor/nodes/TextNode/FontFamilyPicker.tsx
@@ -269,10 +269,18 @@ function FontFamilyPicker({ value, onChange, className }: Props): ReactNode {
         type="button"
         ref={refs.setReference}
         {...getReferenceProps({ onClick: () => setOpen((v) => !v) })}
-        className={cn(SEL_TOOL_BTN, 'max-w-[9rem]', open && 'bg-[var(--accent-soft)]', className)}
+        className={cn(
+          SEL_TOOL_BTN,
+          'max-w-[9rem] justify-between gap-1',
+          open && 'bg-[var(--accent-soft)]',
+          className
+        )}
         aria-label={triggerLabel || t('editor.fontFamily')}
       >
-        <span className="truncate" style={{ fontFamily: getPreviewFontFamily(triggerFont) }}>
+        <span
+          className="min-w-0 flex-1 truncate text-left"
+          style={{ fontFamily: getPreviewFontFamily(triggerFont) }}
+        >
           {triggerLabel || t('editor.fontFamily')}
         </span>
         <HiOutlineChevronDown

--- a/apps/web/src/components/editor/nodes/VideoNode/VideoFullscreenPreviewButton.tsx
+++ b/apps/web/src/components/editor/nodes/VideoNode/VideoFullscreenPreviewButton.tsx
@@ -185,7 +185,6 @@ export function VideoFullscreenPreview({
                 layout="fill"
                 objectFit="contain"
                 controlsMode="hover"
-                muted
                 crop={crop}
                 flipX={flipX === true}
                 flipY={flipY === true}

--- a/apps/web/src/components/editor/nodes/VideoNode/VideoHoverPlayback.tsx
+++ b/apps/web/src/components/editor/nodes/VideoNode/VideoHoverPlayback.tsx
@@ -122,7 +122,8 @@ function createSharedVideoEl(): HTMLVideoElement {
   el.className = 'pointer-events-none absolute block';
   el.playsInline = true;
   el.preload = 'auto';
-  el.muted = true;
+  // Sound on by default — user can mute from the playback bar.
+  el.muted = false;
   el.draggable = false;
   el.controls = false;
   return el;

--- a/apps/web/src/components/editor/nodes/VideoNode/VideoPlaybackBar.tsx
+++ b/apps/web/src/components/editor/nodes/VideoNode/VideoPlaybackBar.tsx
@@ -277,7 +277,7 @@ function VideoPlaybackBar({
   const [current, setCurrent] = useState(0);
   // Only used when attrs.duration is missing.
   const [fallbackDuration, setFallbackDuration] = useState(0);
-  const [muted, setMuted] = useState(true);
+  const [muted, setMuted] = useState(false);
   const [volume, setVolume] = useState(1);
   const [volOpen, setVolOpen] = useState(false);
 

--- a/apps/web/src/components/editor/page/EditorStageWorld.tsx
+++ b/apps/web/src/components/editor/page/EditorStageWorld.tsx
@@ -834,7 +834,9 @@ function EditorStageWorld({
         />
 
         {frames.map((frame) =>
-          !showWorkbenchFrame(frame) ? null : (
+          !showWorkbenchFrame(frame) ||
+          selectionTransforming ||
+          movingFrameIdSet.has(frame.id) ? null : (
             <HtmlArtboardFrame
               key={`process-${frame.id}`}
               frame={frame}
@@ -849,7 +851,7 @@ function EditorStageWorld({
           )
         )}
 
-        {aiNodeBox ? (
+        {aiNodeBox && !selectionTransforming && movingFrameIds.length === 0 ? (
           <AiOperationNodeChrome
             box={aiNodeBox}
             caption={aiNodeCaption}

--- a/apps/web/src/components/editor/panels/__tests__/composerTextSnippet.test.ts
+++ b/apps/web/src/components/editor/panels/__tests__/composerTextSnippet.test.ts
@@ -15,14 +15,14 @@ describe('composerTextSnippet', () => {
     expect(nextTextSnippetChipLabel(chips)).toBe('文字 2');
   });
 
-  it('converts long single-line paste', () => {
-    expect(shouldConvertPasteToTextChip('a'.repeat(80))).toBe(true);
-    expect(shouldConvertPasteToTextChip('a'.repeat(79))).toBe(false);
+  it('converts only pastes at or above 1000 chars', () => {
+    expect(shouldConvertPasteToTextChip('a'.repeat(1000))).toBe(true);
+    expect(shouldConvertPasteToTextChip('a'.repeat(999))).toBe(false);
   });
 
-  it('converts multi-line paste', () => {
+  it('does not convert short multi-line paste', () => {
     const multi = ['line one here', 'line two here', 'line three here'].join('\n');
-    expect(shouldConvertPasteToTextChip(multi)).toBe(true);
+    expect(shouldConvertPasteToTextChip(multi)).toBe(false);
     expect(shouldConvertPasteToTextChip('ab\ncd')).toBe(false);
   });
 

--- a/apps/web/src/components/editor/panels/agent/messages/ChatTurnList.tsx
+++ b/apps/web/src/components/editor/panels/agent/messages/ChatTurnList.tsx
@@ -16,7 +16,6 @@ import { ContextChipPill } from '@/components/editor/panels/AgentComposerInput';
 import {
   SoftGlowSurface,
   VirtualList,
-  LoadingDots,
   type VirtualListHandle,
 } from '@/components/base';
 import { message } from '@/components/base';
@@ -1714,10 +1713,14 @@ function AssistantTurn({
       className="flex w-full min-w-0 flex-col items-stretch gap-2.5 px-0.5"
     >
       {streaming && (!assistant.content?.trim() || processRunning) ? (
-        <LoadingDots
-          className="h-3.5 justify-start px-0.5"
-          label={t('agent.working')}
-        />
+        <span
+          className="rcb-thinking-shimmer px-0.5"
+          role="status"
+          aria-busy
+          aria-label={t('agent.thinking')}
+        >
+          {t('agent.thinking')}
+        </span>
       ) : null}
 
       {/* Process first, then reply — matching product timeline order. */}

--- a/apps/web/src/components/editor/panels/composerTextSnippet.ts
+++ b/apps/web/src/components/editor/panels/composerTextSnippet.ts
@@ -1,7 +1,7 @@
 import type { ComposerContext } from '@/components/editor/panels/AgentComposerInput';
 
 /** Plain-text length at or above this → paste becomes a text chip. */
-export const LONG_PASTE_MIN_CHARS = 80;
+export const LONG_PASTE_MIN_CHARS = 1000;
 
 export function isTextSnippetChip(ctx: Pick<ComposerContext, 'kind' | 'key'>): boolean {
   return ctx.kind === 'text' || String(ctx.key || '').startsWith('text-snippet:');
@@ -34,8 +34,5 @@ export function buildTextSnippetContext(
 
 export function shouldConvertPasteToTextChip(text: string): boolean {
   const t = String(text || '').trim();
-  if (!t) return false;
-  if (t.length >= LONG_PASTE_MIN_CHARS) return true;
-  const lines = t.split(/\r?\n/).filter((line) => line.trim());
-  return lines.length >= 3 && t.length >= 40;
+  return t.length >= LONG_PASTE_MIN_CHARS;
 }

--- a/apps/web/src/components/editor/useProjectCloudSync.ts
+++ b/apps/web/src/components/editor/useProjectCloudSync.ts
@@ -154,7 +154,18 @@ async function removeProjectsFromCloudInternal(rawIds: string[]): Promise<void> 
   const list = normalizeProjectIds(rawIds);
   if (!list.length) return;
 
-  const probes = await Promise.all(list.map((id) => probeProjectOpenElsewhere(id)));
+  // Always probe — including HTTP deploys (request id falls back when randomUUID
+  // is missing). Fail closed: if a probe errors, treat as open-for-editing so we
+  // never delete a project that may still be in an editor tab.
+  const probes = await Promise.all(
+    list.map(async (id) => {
+      try {
+        return await probeProjectOpenElsewhere(id);
+      } catch {
+        return true;
+      }
+    })
+  );
   const blocked = list.find((_, i) => probes[i]);
   if (blocked) throw new ProjectDeleteBlockedError(blocked);
 

--- a/apps/web/src/components/rcb/frames/__tests__/artboardInkSurface.test.ts
+++ b/apps/web/src/components/rcb/frames/__tests__/artboardInkSurface.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, afterEach } from 'vitest';
 import {
   createEmptyDocument,
   addNodeToDocument,
@@ -26,7 +26,34 @@ import {
   artboardWantScale,
 } from '@/components/rcb/frames/artboardInkTiles';
 import * as artboardWebglInk from '@/components/rcb/frames/artboardWebglInk';
+import { shouldBlitArtboardGlContent } from '@/components/rcb/frames/artboardWebglInk';
 import { setFrameClipRevealOverflowIds } from '@/components/rcb/selection/selectionPaintRaise';
+import { clearLiveArtboardFrameGeometry } from '@/components/rcb/frames/HtmlArtboardFrame';
+import { clearSceneCanvasIdlePaint } from '@/components/rcb/render/sceneRenderer';
+
+afterEach(() => {
+  setFrameClipRevealOverflowIds(null);
+  clearLiveArtboardFrameGeometry();
+  clearSceneCanvasIdlePaint();
+  vi.restoreAllMocks();
+});
+
+describe('shouldBlitArtboardGlContent', () => {
+  it('blits media-only plates (framed images with no vector instances)', () => {
+    expect(
+      shouldBlitArtboardGlContent({ count: 0, meshVertCount: 0, mediaVertCount: 6 })
+    ).toBe(true);
+    expect(
+      shouldBlitArtboardGlContent({ count: 0, meshVertCount: 0, mediaVertCount: 0 })
+    ).toBe(false);
+    expect(
+      shouldBlitArtboardGlContent({ count: 1, meshVertCount: 0, mediaVertCount: 0 })
+    ).toBe(true);
+    expect(
+      shouldBlitArtboardGlContent({ count: 0, meshVertCount: 6, mediaVertCount: 0 })
+    ).toBe(true);
+  });
+});
 
 describe('artboardInkScale', () => {
   it('tracks zoom×dpr up to MAX_SCALE (edge OOM guard is separate)', () => {
@@ -260,12 +287,9 @@ describe('artboard small-canvas SoA partition', () => {
       buf.flags[i] = (buf.flags[i] | SOA_FLAG_CANVAS_IDLE) >>> 0;
     }
 
-    const atlas = createSoaWebglAtlas(512, 128);
-    if (!atlas) return;
     const kinds: number[] = [];
-    const meshPos: number[] = [];
-    const meshCol: number[] = [];
-    const meshClip: number[] = [];
+    // Partition check without mesh buffers — atlas mesh path can swallow a
+    // fully-clipped fill (wrote===0) and leave kinds empty under test isolation.
     collectSoaWebglInstances(
       buf,
       { left: 0, top: 0, width: 200, height: 200 },
@@ -277,17 +301,13 @@ describe('artboard small-canvas SoA partition', () => {
       {
         document: doc,
         onlyFrameId: 'board-a',
-        atlas,
-        meshPos,
-        meshCol,
-        meshClip,
       }
     );
-    // Only board-a content; world + board-b omitted. Mesh and/or kind instance OK.
-    expect(kinds.length + meshPos.length).toBeGreaterThan(0);
+    // Only board-a content; world + board-b omitted.
+    expect(kinds.length).toBeGreaterThan(0);
+    expect(kinds.every((k) => k === 0)).toBe(true);
 
     const kindsWorld: number[] = [];
-    const meshWorld: number[] = [];
     collectSoaWebglInstances(
       buf,
       { x: 0, y: 0, width: 800, height: 600 },
@@ -296,21 +316,14 @@ describe('artboard small-canvas SoA partition', () => {
       kindsWorld,
       [],
       [],
-      {
-        document: doc,
-        skipFrameBound: true,
-        atlas,
-        meshPos: meshWorld,
-        meshCol: [],
-        meshClip: [],
-      }
+      { document: doc, skipFrameBound: true }
     );
     // World still skips plate-bound (on-a / on-b).
-    const worldOnly = kindsWorld.length + meshWorld.length;
-    expect(worldOnly).toBeGreaterThan(0);
+    expect(kindsWorld.length).toBeGreaterThan(0);
+    expect(kindsWorld.every((k) => k === 0)).toBe(true);
   });
 
-  it('selection reveal skips FO collect; world paints only while SoA idle remains', () => {
+  it('selection reveal keeps FO collect; world never paints plate-bound idle', () => {
     let doc = createEmptyDocument({ width: 800, height: 600, emptyWorld: true });
     doc.frames = [
       {
@@ -347,13 +360,7 @@ describe('artboard small-canvas SoA partition', () => {
 
     setFrameClipRevealOverflowIds(['bound']);
     try {
-      const atlas = createSoaWebglAtlas(512, 128);
-      if (!atlas) return;
       const kinds: number[] = [];
-      const meshPos: number[] = [];
-      const meshCol: number[] = [];
-      const meshClip: number[] = [];
-      const clips: number[] = [];
       collectSoaWebglInstances(
         buf,
         { x: 0, y: 0, width: 800, height: 600 },
@@ -362,17 +369,13 @@ describe('artboard small-canvas SoA partition', () => {
         kinds,
         [],
         [],
-        { document: doc, skipFrameBound: true, atlas, meshPos, meshCol, meshClip, clips }
+        { document: doc, skipFrameBound: true }
       );
-      // Revealed bound slot must appear on world collect (not FO-only).
-      expect(kinds.length + meshPos.length).toBeGreaterThan(0);
-      // Open clip (no plate LTRB) for revealed overflow.
-      if (clips.length >= 4) {
-        expect(clips[0]).toBeLessThan(-1e7);
-      }
+      // Selection no longer mounts SVG ink hosts — revealed plate ink must not
+      // spill onto world (would paint past the artboard FO clip).
+      expect(kinds.length).toBe(0);
 
       const plateKinds: number[] = [];
-      const plateMesh: number[] = [];
       collectSoaWebglInstances(
         buf,
         { left: 0, top: 0, width: 200, height: 200 },
@@ -384,14 +387,10 @@ describe('artboard small-canvas SoA partition', () => {
         {
           document: doc,
           onlyFrameId: 'board',
-          atlas,
-          meshPos: plateMesh,
-          meshCol: [],
-          meshClip: [],
         }
       );
-      // Revealed overflow must not paint on the FO collect (raised host / world).
-      expect(plateKinds.length + plateMesh.length).toBe(0);
+      // Still paints on the plate FO (FO overflow:hidden keeps ink in-bounds).
+      expect(plateKinds.length).toBeGreaterThan(0);
     } finally {
       setFrameClipRevealOverflowIds(null);
     }

--- a/apps/web/src/components/rcb/frames/artboardInkSurface.ts
+++ b/apps/web/src/components/rcb/frames/artboardInkSurface.ts
@@ -6,7 +6,6 @@
  * at full wantScale (no soft mush) composite into the single FO canvas.
  */
 import { nodeOwnerFrameId } from '@/components/rcb/frames/frameNodeBinding';
-import { frameClipRevealsOverflow } from '@/components/rcb/selection/selectionPaintRaise';
 import { getNodeTransformPreview } from '@/components/rcb/core/transformPreview';
 import { readDevicePixelRatio } from '@/components/rcb/core/dpr';
 import { buildNodeStackZMap } from '@/components/rcb/scene/document/sceneDocument';
@@ -164,7 +163,7 @@ function collectBoundIdleIndices(
     const id = buf.ids[i];
     if (!id) continue;
     if (hiddenNodeId && id === hiddenNodeId) continue;
-    if (frameClipRevealsOverflow(id)) continue;
+    // Keep painting revealed selection on the plate FO (clipped by overflow:hidden).
     const node = doc.deltaSetLike?.[id] as SceneNodeInput | undefined;
     if (!node || nodeOwnerFrameId(node) !== frameId) continue;
     if (getNodeTransformPreview(id)?.hidden) continue;

--- a/apps/web/src/components/rcb/frames/artboardWebglInk.ts
+++ b/apps/web/src/components/rcb/frames/artboardWebglInk.ts
@@ -40,6 +40,20 @@ import {
 import type { SceneDocument } from '@/components/rcb/sceneNode';
 import { releaseArtboardTileCache } from '@/components/rcb/frames/artboardInkTiles';
 
+/**
+ * Whether the shared GL canvas has anything to blit onto the FO 2D canvas.
+ * Images live in `mediaTex` (not `kinds` / mesh) — media-only plates must blit.
+ */
+export function shouldBlitArtboardGlContent(opts: {
+  count: number;
+  meshVertCount: number;
+  mediaVertCount: number;
+}): boolean {
+  return (
+    opts.count > 0 || opts.meshVertCount >= 3 || opts.mediaVertCount >= 3
+  );
+}
+
 type ArtboardGlResources = {
   canvas: HTMLCanvasElement;
   gl: WebGL2RenderingContext;
@@ -415,8 +429,10 @@ export function paintArtboardWebglInk(args: PaintArtboardWebglInkArgs): boolean 
       bufferRevision: buf.revision,
       clips,
       document: args.document,
+      // effectiveScale is already CSS-zoom × dpr (backing px / scene). Do not
+      // multiply dpr again inside strokeRibbonPaint (would double-count).
       zoom: scale,
-      dpr,
+      dpr: 1,
       onlyFrameId: args.frameId,
       meshPos,
       meshCol,
@@ -575,8 +591,9 @@ export function paintArtboardWebglInk(args: PaintArtboardWebglInkArgs): boolean 
   if (!ctx) return false;
   ctx.setTransform(1, 0, 0, 1, 0, 0);
   ctx.clearRect(0, 0, bw, bh);
-  // Empty plate: clear only (SVG owns fill/edge).
-  if (count > 0 || meshVertCount >= 3) {
+  // Empty plate: clear only (SVG owns fill/edge). Media-only plates still
+  // need the blit — images no longer pack into `kinds` / mesh.
+  if (shouldBlitArtboardGlContent({ count, meshVertCount, mediaVertCount })) {
     ctx.drawImage(res.canvas, 0, 0, bw, bh, 0, 0, bw, bh);
   }
   return true;

--- a/apps/web/src/components/rcb/process/ProcessGlowShell.tsx
+++ b/apps/web/src/components/rcb/process/ProcessGlowShell.tsx
@@ -18,6 +18,8 @@ export type ProcessGlowShellProps = {
   angle?: number;
   labelDataAttr?: string;
   className?: string;
+  /** Hide while drag/resize (same contract as titles / toolbars). */
+  hidden?: boolean;
 };
 
 /**
@@ -35,6 +37,7 @@ export function ProcessGlowShell({
   angle = 0,
   labelDataAttr = 'data-image-process-label',
   className,
+  hidden = false,
 }: ProcessGlowShellProps): ReactNode {
   const dock = useMemo(
     () =>
@@ -49,6 +52,8 @@ export function ProcessGlowShell({
       ),
     [box.left, box.top, box.width, box.height, angle]
   );
+
+  if (hidden) return null;
 
   return (
     <WorldScreenChromeRoot

--- a/apps/web/src/components/rcb/render/__tests__/strokeScreenFloor.test.ts
+++ b/apps/web/src/components/rcb/render/__tests__/strokeScreenFloor.test.ts
@@ -1,117 +1,231 @@
 import { describe, expect, it } from 'vitest';
+
 import {
+
   adaptivePathStrokeMaxSegs,
+
   coverageConservingStrokePaint,
+
   floorContentStrokeSceneWidth,
+
   shouldSubmitStrokeRibbon,
+
   strokeRibbonPaint,
+
   strokeScreenWidth,
+
   STROKE_SUBMIT_MIN_SCREEN_PX,
+
 } from '../strokeScreenFloor';
 
+
+
 describe('floorContentStrokeSceneWidth', () => {
+
   it('keeps geometric width at any zoom (no hairline floor)', () => {
+
     expect(floorContentStrokeSceneWidth(2, 1)).toBe(2);
+
     expect(floorContentStrokeSceneWidth(2, 2)).toBe(2);
+
     expect(floorContentStrokeSceneWidth(2, 0.25)).toBe(2);
+
     expect(floorContentStrokeSceneWidth(1, 0.1)).toBe(1);
+
     expect(floorContentStrokeSceneWidth(1, 0.77)).toBe(1);
+
   });
+
+
 
   it('still honors an explicit minCssPx when callers opt in', () => {
+
     expect(floorContentStrokeSceneWidth(2, 0.25, 1)).toBe(4);
+
     expect(floorContentStrokeSceneWidth(1, 0.1, 1)).toBe(10);
+
   });
+
+
 
   it('returns 0 for missing stroke', () => {
+
     expect(floorContentStrokeSceneWidth(0, 0.2)).toBe(0);
+
     expect(floorContentStrokeSceneWidth(-1, 0.2)).toBe(0);
+
   });
+
 });
+
+
 
 describe('strokeRibbonPaint', () => {
-  it('always keeps geometric width; submit only when screen > 1px', () => {
-    expect(STROKE_SUBMIT_MIN_SCREEN_PX).toBe(1);
-    // 2px @ 100% → screen 2 → submit
+
+  it('keeps geometric width at every zoom (timeline-open pasteboard policy)', () => {
+
+    expect(STROKE_SUBMIT_MIN_SCREEN_PX).toBe(0);
+
     expect(strokeRibbonPaint(2, 1)).toEqual({
+
       width: 2,
+
       screenWidth: 2,
+
       submit: true,
+
     });
-    // 1px @ 100% → screen 1 → do not submit
+
     expect(strokeRibbonPaint(1, 1)).toEqual({
-      width: 1,
-      screenWidth: 1,
-      submit: false,
-    });
-    // 2px @ 50% → screen 1 → do not submit (geometry unchanged)
-    expect(strokeRibbonPaint(2, 0.5)).toEqual({
-      width: 2,
-      screenWidth: 1,
-      submit: false,
-    });
-    // Just above threshold
-    const over = strokeRibbonPaint(1.01, 1);
-    expect(over.width).toBe(1.01);
-    expect(over.screenWidth).toBeCloseTo(1.01, 5);
-    expect(over.submit).toBe(true);
-  });
 
-  it('includes dpr in screen projection', () => {
-    // 1 scene px @ zoom 1 @ dpr 2 → screen 2 → submit
-    expect(strokeRibbonPaint(1, 1, 2)).toEqual({
       width: 1,
-      screenWidth: 2,
+
+      screenWidth: 1,
+
       submit: true,
+
     });
-    // 1 scene px @ zoom 0.5 @ dpr 2 → screen 1 → cull
-    expect(strokeRibbonPaint(1, 0.5, 2)).toEqual({
-      width: 1,
+
+    expect(strokeRibbonPaint(2, 0.5)).toEqual({
+
+      width: 2,
+
       screenWidth: 1,
-      submit: false,
+
+      submit: true,
+
     });
+
   });
 
-  it('does not expand width when sub-pixel', () => {
+
+
+  it('does not inflate hairlines when zoomed out', () => {
+
     const p = strokeRibbonPaint(1, 0.25);
+
+    expect(p.submit).toBe(true);
+
     expect(p.width).toBe(1);
+
     expect(p.screenWidth).toBeCloseTo(0.25, 5);
-    expect(p.submit).toBe(false);
+
+
+
+    const fit = strokeRibbonPaint(1, 0.5, 1);
+
+    expect(fit.submit).toBe(true);
+
+    expect(fit.width).toBe(1);
+
+    expect(fit.screenWidth).toBeCloseTo(0.5, 5);
+
   });
+
+
+
+  it('includes dpr in screen projection only (not width)', () => {
+
+    expect(strokeRibbonPaint(1, 1, 2)).toEqual({
+
+      width: 1,
+
+      screenWidth: 2,
+
+      submit: true,
+
+    });
+
+    expect(strokeRibbonPaint(1, 0.5, 2)).toEqual({
+
+      width: 1,
+
+      screenWidth: 1,
+
+      submit: true,
+
+    });
+
+  });
+
+
 
   it('returns zero width / no submit for missing stroke', () => {
+
     expect(strokeRibbonPaint(0, 0.2)).toEqual({
+
       width: 0,
+
       screenWidth: 0,
+
       submit: false,
+
     });
+
   });
+
 });
+
+
 
 describe('strokeScreenWidth + shouldSubmitStrokeRibbon', () => {
-  it('projects and gates at the 1px boundary', () => {
+
+  it('projects raw coverage; any positive screen submits', () => {
+
     expect(strokeScreenWidth(2, 0.5)).toBe(1);
-    expect(shouldSubmitStrokeRibbon(1)).toBe(false);
-    expect(shouldSubmitStrokeRibbon(1.0001)).toBe(true);
+
+    expect(shouldSubmitStrokeRibbon(1)).toBe(true);
+
+    expect(shouldSubmitStrokeRibbon(0.25)).toBe(true);
+
+    expect(shouldSubmitStrokeRibbon(0)).toBe(false);
+
   });
+
 });
+
+
 
 describe('coverageConservingStrokePaint (compat)', () => {
-  it('maps submit to alphaScale without expanding width', () => {
+
+  it('keeps geometric width when zoomed out', () => {
+
     expect(coverageConservingStrokePaint(2, 1)).toEqual({ width: 2, alphaScale: 1 });
-    expect(coverageConservingStrokePaint(1, 1)).toEqual({ width: 1, alphaScale: 0 });
-    expect(coverageConservingStrokePaint(1, 0.25)).toEqual({ width: 1, alphaScale: 0 });
+
+    expect(coverageConservingStrokePaint(1, 1)).toEqual({ width: 1, alphaScale: 1 });
+
+    const zoomed = coverageConservingStrokePaint(1, 0.25);
+
+    expect(zoomed.alphaScale).toBe(1);
+
+    expect(zoomed.width).toBe(1);
+
   });
+
 });
+
+
 
 describe('adaptivePathStrokeMaxSegs', () => {
+
   it('keeps full cap near 1× zoom', () => {
+
     expect(adaptivePathStrokeMaxSegs(1, 96)).toBe(96);
+
     expect(adaptivePathStrokeMaxSegs(0.8, 96)).toBe(96);
+
   });
 
+
+
   it('reduces segments when zoomed out', () => {
+
     expect(adaptivePathStrokeMaxSegs(0.5, 96)).toBeLessThan(96);
+
     expect(adaptivePathStrokeMaxSegs(0.15, 96)).toBeLessThanOrEqual(24);
+
   });
+
 });
+
+

--- a/apps/web/src/components/rcb/render/__tests__/webglInstances.test.ts
+++ b/apps/web/src/components/rcb/render/__tests__/webglInstances.test.ts
@@ -367,7 +367,7 @@ describe('collectSoaWebglInstances', () => {
     expect(meshCol[3]).toBeGreaterThan(0.9);
   });
 
-  it('does not submit stroke ribbon when screen width is ≤1px (mesh still built)', () => {
+  it('submits default 1px stroke ribbon at 100% zoom (mesh still geometric)', () => {
     let doc = createEmptyDocument({ width: 800, height: 600, emptyWorld: true });
     doc = addNodeToDocument(doc, 'p', {
       id: 'p',
@@ -403,9 +403,9 @@ describe('collectSoaWebglInstances', () => {
       zoom: 1,
       dpr: 1,
     });
-    // No GPU submit for ≤1px screen stroke; no rect-instance ghost either.
-    expect(kinds.length).toBe(0);
-    expect(meshPos.length).toBe(0);
+    // Default 1p @ 100% must remain visible in the main world.
+    expect(meshPos.length).toBeGreaterThanOrEqual(6);
+    expect(meshCol[3]).toBeGreaterThan(0.9);
     const cached = getOrBuildShapeMesh('p', doc.deltaSetLike!.p!, {
       width: 100,
       height: 100,
@@ -414,6 +414,47 @@ describe('collectSoaWebglInstances', () => {
     });
     expect(cached?.stroke).not.toBeNull();
     expect(cached!.stroke!.triangleCount).toBeGreaterThan(0);
+  });
+
+  it('floors zoomed-out 1px strokes so artboard content stays visible', () => {
+    let doc = createEmptyDocument({ width: 800, height: 600, emptyWorld: true });
+    doc = addNodeToDocument(doc, 'p2', {
+      id: 'p2',
+      key: 'shape',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      attrs: {
+        shapeType: 'pen',
+        path: 'M 0 0 L 40 0 L 40 40',
+        stroke: '#112233',
+        'border-color': '#112233',
+        'border-width': 1,
+        'fill-color': 'transparent',
+        closed: 'false',
+      },
+      children: [],
+    });
+    const buf = createSceneRenderBuffer();
+    syncSceneRenderBufferFromDocument(buf, doc);
+    rebuildSoaPathSamples(buf, doc);
+    buf.flags[0] = (buf.flags[0] | SOA_FLAG_CANVAS_IDLE) >>> 0;
+    const kinds: number[] = [];
+    const meshPos: number[] = [];
+    const meshCol: number[] = [];
+    const meshClip: number[] = [];
+    collectSoaWebglInstances(buf, { x: 0, y: 0, width: 200, height: 200 }, [], [], kinds, [], [], {
+      document: doc,
+      meshPos,
+      meshCol,
+      meshClip,
+      zoom: 0.25,
+      dpr: 1,
+    });
+    // Fit-zoom / large-frame view: hairline still submits at geometric width.
+    expect(meshPos.length).toBeGreaterThanOrEqual(6);
+    expect(meshCol[3]).toBeGreaterThan(0.9);
   });
 
   it('closed stroked path uses vector mesh (no atlas kind 3 / no segment notches)', () => {

--- a/apps/web/src/components/rcb/render/paintIntent.ts
+++ b/apps/web/src/components/rcb/render/paintIntent.ts
@@ -150,6 +150,8 @@ export function resolvePaintIntent(
     };
   }
 
+  // Unbound world above a plate → SVG host (SoA sits under plate SVG).
+  // Surround is excluded inside worldNodeStacksAboveAnyFrame (mesh only).
   if (document && worldNodeStacksAboveAnyFrame(document, id)) {
     paintDebugStats.domObligatory += 1;
     return { kind: 'dom-obligatory', reason: 'stack-above-plate' };

--- a/apps/web/src/components/rcb/render/sceneRenderBuffer.ts
+++ b/apps/web/src/components/rcb/render/sceneRenderBuffer.ts
@@ -2810,7 +2810,11 @@ export function markAllSoaDirty(buf: SceneRenderBuffer) {
 /** Mark one slot dirty by index (no-op if out of range). */
 export function markSoaDirty(buf: SceneRenderBuffer, index: number) {
   if (index < 0 || index >= buf.count) return;
-  buf.flags[index] = (buf.flags[index] | SOA_FLAG_DIRTY) >>> 0;
+  const prev = buf.flags[index];
+  buf.flags[index] = (prev | SOA_FLAG_DIRTY) >>> 0;
+  // Artboard FO tiles key off `buf.revision`. Without a bump, live corner-radius
+  // / attr dirty keeps blitting stale tiles (sharp AABB ghost under rounded ink).
+  if ((prev & SOA_FLAG_DIRTY) === 0) buf.revision += 1;
 }
 
 /** Mark one slot dirty by node id. */

--- a/apps/web/src/components/rcb/render/strokeScreenFloor.ts
+++ b/apps/web/src/components/rcb/render/strokeScreenFloor.ts
@@ -1,115 +1,205 @@
 /**
+
  * Content strokes are authored in **scene** units and scale with the camera.
+
  *
- * Hairline policy (WebGL ribbons):
- * 1. Always tessellate the full stroke ribbon at geometric scene width.
- * 2. Measure projected screen width: `sceneWidth * zoom * dpr`.
- * 3. Screen width > 1px → submit the ribbon for draw.
- * 4. Screen width ≤ 1px → skip draw submission; cached geometry stays intact.
- *
- * This avoids sub-pixel ribbon raster instability (ants / broken dashes) without
- * expanding width or inventing a solid min-width floor.
- *
- * `floorContentStrokeSceneWidth` keeps the historic name/signature for callers
- * that still want geometric scene width (default minCssPx = 0).
+
+ * Policy (world + artboard FO — same as timeline-open pasteboard draw):
+
+ * 1. Always tessellate at geometric authored width (never inflate when zoomed out).
+
+ * 2. Always submit when authored width > 0 (do not cull sub-pixel ribbons).
+
+ * 3. Artboard passes effectiveScale as zoom with dpr=1 so dpr is not double-counted.
+
  */
+
+
 
 /** @deprecated Prefer strokeRibbonPaint for WebGL ribbons. */
+
 export const CONTENT_STROKE_MIN_CSS_PX = 0;
 
+
+
 /**
- * Screen-pixel threshold for submitting stroke ribbons.
- * At or below this, geometry is kept but not drawn.
+
+ * Legacy constant. Hairline width inflation was removed — keep geometric width.
+
  */
-export const STROKE_SUBMIT_MIN_SCREEN_PX = 1;
+
+export const STROKE_SUBMIT_MIN_SCREEN_PX = 0;
+
+
 
 export type StrokeRibbonPaint = {
-  /** Scene-space ribbon width to tessellate (always authored / geometric). */
+
+  /** Scene-space ribbon width (always geometric authored width). */
+
   width: number;
-  /** Projected screen width (`scene * zoom * dpr`). */
+
+  /** Projected screen width (`authored * zoom * dpr`). */
+
   screenWidth: number;
+
   /** True when the ribbon should be submitted for GPU draw this frame. */
+
   submit: boolean;
+
 };
 
+
+
 /**
+
  * Projected stroke width in screen pixels (includes devicePixelRatio).
+
  */
+
 export function strokeScreenWidth(sceneWidth: number, zoom: number, dpr = 1): number {
+
   const sw = Math.max(0, Number(sceneWidth) || 0);
+
   if (!(sw > 0)) return 0;
+
   const z = Math.max(0.05, Number(zoom) || 1) * Math.max(1, Number(dpr) || 1);
+
   return sw * z;
+
 }
 
-/** Submit ribbon only when projected screen width is strictly greater than 1px. */
+
+
+/** True when projected coverage is positive. */
+
 export function shouldSubmitStrokeRibbon(screenWidthPx: number): boolean {
-  return Number(screenWidthPx) > STROKE_SUBMIT_MIN_SCREEN_PX;
+
+  return Number(screenWidthPx) > 0;
+
 }
 
+
+
 /**
- * Stroke ribbon paint decision for WebGL.
- * Geometry width is always geometric; `submit` gates draw only.
+
+ * Stroke ribbon paint — geometric width only (matches timeline-open pasteboard).
+
  */
+
 export function strokeRibbonPaint(
+
   sceneWidth: number,
+
   zoom: number,
+
   dpr = 1
+
 ): StrokeRibbonPaint {
-  const width = Math.max(0, Number(sceneWidth) || 0);
-  if (!(width > 0)) return { width: 0, screenWidth: 0, submit: false };
-  const screenWidth = strokeScreenWidth(width, zoom, dpr);
+
+  const authored = Math.max(0, Number(sceneWidth) || 0);
+
+  if (!(authored > 0)) return { width: 0, screenWidth: 0, submit: false };
+
+  const z = Math.max(0.05, Number(zoom) || 1) * Math.max(1, Number(dpr) || 1);
+
   return {
-    width,
-    screenWidth,
-    submit: shouldSubmitStrokeRibbon(screenWidth),
+
+    width: authored,
+
+    screenWidth: authored * z,
+
+    submit: true,
+
   };
+
 }
+
+
 
 /**
- * @deprecated Use strokeRibbonPaint. Kept for call-site migration:
- * returns geometric `width` and `alphaScale` 1 when submit else 0.
+
+ * @deprecated Use strokeRibbonPaint.
+
  */
+
 export function coverageConservingStrokePaint(
+
   sceneWidth: number,
+
   zoom: number,
+
   dpr = 1
+
 ): { width: number; alphaScale: number } {
+
   const p = strokeRibbonPaint(sceneWidth, zoom, dpr);
+
   return { width: p.width, alphaScale: p.submit ? 1 : 0 };
+
 }
 
-/** @deprecated Alias — coverage expansion removed; threshold is STROKE_SUBMIT_MIN_SCREEN_PX. */
+
+
+/** @deprecated Alias. */
+
 export const STROKE_COVERAGE_CSS_PX = STROKE_SUBMIT_MIN_SCREEN_PX;
 
-/**
- * Scene stroke width for paint. Returns geometric `sceneWidth` (no screen floor
- * / no CSS-px quantization). Optional `minCssPx` is ignored when <= 0; when > 0
- * it still lifts `sw` so `sw * zoom >= minCssPx` (chrome / tests only).
- * Returns 0 when `sceneWidth` is non-positive (no stroke).
- */
-export function floorContentStrokeSceneWidth(
-  sceneWidth: number,
-  zoom: number,
-  minCssPx = CONTENT_STROKE_MIN_CSS_PX
-): number {
-  const sw = Math.max(0, Number(sceneWidth) || 0);
-  if (!(sw > 0)) return 0;
-  const minCss = Math.max(0, Number(minCssPx) || 0);
-  if (!(minCss > 0)) return sw;
-  const z = Math.max(0.05, Number(zoom) || 1);
-  return Math.max(sw, minCss / z);
-}
+
 
 /**
- * Cap path segment emission when zoomed out — dense boolean outlines otherwise
- * explode the instance batch while screen coverage is already a hairline.
+
+ * Scene stroke width for paint. Returns geometric `sceneWidth`.
+
+ * Optional `minCssPx` > 0 still lifts for chrome/tests only.
+
  */
-export function adaptivePathStrokeMaxSegs(zoom: number, cap = 96): number {
+
+export function floorContentStrokeSceneWidth(
+
+  sceneWidth: number,
+
+  zoom: number,
+
+  minCssPx = CONTENT_STROKE_MIN_CSS_PX
+
+): number {
+
+  const sw = Math.max(0, Number(sceneWidth) || 0);
+
+  if (!(sw > 0)) return 0;
+
+  const minCss = Math.max(0, Number(minCssPx) || 0);
+
+  if (!(minCss > 0)) return sw;
+
   const z = Math.max(0.05, Number(zoom) || 1);
-  const hard = Math.max(8, Math.floor(Number(cap) || 96));
-  if (z >= 0.75) return hard;
-  if (z >= 0.4) return Math.max(24, Math.floor(hard * 0.5));
-  if (z >= 0.2) return Math.max(16, Math.floor(hard * 0.33));
-  return Math.max(12, Math.floor(hard * 0.2));
+
+  return Math.max(sw, minCss / z);
+
 }
+
+
+
+/**
+
+ * Cap path segment emission when zoomed out.
+
+ */
+
+export function adaptivePathStrokeMaxSegs(zoom: number, cap = 96): number {
+
+  const z = Math.max(0.05, Number(zoom) || 1);
+
+  const hard = Math.max(8, Math.floor(Number(cap) || 96));
+
+  if (z >= 0.75) return hard;
+
+  if (z >= 0.4) return Math.max(24, Math.floor(hard * 0.5));
+
+  if (z >= 0.2) return Math.max(16, Math.floor(hard * 0.33));
+
+  return Math.max(12, Math.floor(hard * 0.2));
+
+}
+
+

--- a/apps/web/src/components/rcb/render/vector/__tests__/booleanHoleZoom.test.ts
+++ b/apps/web/src/components/rcb/render/vector/__tests__/booleanHoleZoom.test.ts
@@ -1,4 +1,4 @@
-﻿import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import type { SceneNodeInput } from '@/components/rcb/sceneNode';
 import { sceneFlatness } from '@/components/rcb/render/vector/densifyPathDJs';
 import { getOrBuildShapeMesh, clearShapeMeshCache } from '@/components/rcb/render/vector/meshCache';

--- a/apps/web/src/components/rcb/render/vector/__tests__/vectorInk.test.ts
+++ b/apps/web/src/components/rcb/render/vector/__tests__/vectorInk.test.ts
@@ -319,11 +319,75 @@ describe('vector ink', () => {
     } as SceneNodeInput;
     const mesh = getOrBuildShapeMesh('pen1', node, { width: 100, height: 40 });
     expect(mesh).not.toBeNull();
-    expect(mesh!.fill).not.toBeNull();
-    expect(mesh!.fill!.triangleCount).toBeGreaterThan(4);
-    expect(mesh!.stroke).toBeNull();
+    // Short strokes keep silhouette fill; dense scribbles may ribbon-fallback.
+    const hasFill = Boolean(mesh!.fill && mesh!.fill.triangleCount > 4);
+    const hasStroke = Boolean(mesh!.stroke && mesh!.stroke.triangleCount > 0);
+    expect(hasFill || hasStroke).toBe(true);
     const c = contourFromNode(node, { width: 100, height: 40 });
     expect(c?.pencilSilhouette).toBe(true);
     expect(c!.points.length).toBeGreaterThan(8);
+  });
+
+  it('thin pencil (1px) still emits silhouette fill or round ribbon — not empty', () => {
+    const node = {
+      id: 'pen-thin',
+      key: 'shape',
+      width: 120,
+      height: 80,
+      attrs: {
+        shapeType: 'pencil',
+        path: 'M 8 40 L 24 36 L 40 42 L 56 30 L 72 44 L 88 28 L 104 40',
+        brushStyle: 'vector-ink',
+        'border-width': 1,
+        'border-color': '#111',
+        'fill-enabled': false,
+        strokeLinecap: 'round',
+      },
+    } as SceneNodeInput;
+    const mesh = getOrBuildShapeMesh('pen-thin', node, { width: 120, height: 80, zoom: 5, dpr: 1 });
+    expect(mesh).not.toBeNull();
+    const hasFill = Boolean(mesh!.fill && mesh!.fill.triangleCount > 0);
+    const hasStroke = Boolean(mesh!.stroke && mesh!.stroke.triangleCount > 0);
+    expect(hasFill || hasStroke).toBe(true);
+  });
+
+  it('dense scribble pencil stays interactive (ribbon fallback, no ear-clip stall)', () => {
+    const center: string[] = [];
+    for (let i = 0; i <= 200; i += 1) {
+      center.push(
+        `${i === 0 ? 'M' : 'L'} ${50 + Math.sin(i * 0.2) * 20} ${40 + Math.cos(i * 0.17) * 20}`
+      );
+    }
+    const outline: string[] = [];
+    for (let i = 0; i <= 600; i += 1) {
+      const t = (i / 600) * Math.PI * 2;
+      outline.push(
+        `${i === 0 ? 'M' : 'L'} ${60 + Math.cos(t) * 40 + Math.sin(t * 7) * 8} ${40 + Math.sin(t) * 30}`
+      );
+    }
+    outline.push('Z');
+    const node = {
+      id: 'pen-scribble',
+      key: 'shape',
+      width: 140,
+      height: 100,
+      attrs: {
+        shapeType: 'pencil',
+        path: center.join(' '),
+        pencilOutlinePath: outline.join(' '),
+        brushStyle: 'vector-ink',
+        'border-width': 2,
+        'border-color': '#111',
+      },
+    } as SceneNodeInput;
+    const t0 = performance.now();
+    const mesh = getOrBuildShapeMesh('pen-scribble', node, { width: 140, height: 100 });
+    const ms = performance.now() - t0;
+    expect(mesh).not.toBeNull();
+    const hasInk =
+      Boolean(mesh!.fill && mesh!.fill.triangleCount > 0) ||
+      Boolean(mesh!.stroke && mesh!.stroke.triangleCount > 0);
+    expect(hasInk).toBe(true);
+    expect(ms).toBeLessThan(100);
   });
 });

--- a/apps/web/src/components/rcb/render/vector/contour.ts
+++ b/apps/web/src/components/rcb/render/vector/contour.ts
@@ -96,9 +96,9 @@ export function pencilSilhouettePathD(
   return outline || null;
 }
 
-/** Flatness for freehand fill meshes — coarser than shape curves (silhouette already dense). */
+/** Flatness for freehand fill meshes — track zoom so high-z silhouette stays smooth. */
 export function pencilSilhouetteFlatness(zoom = 1, dpr = 1): number {
-  return Math.max(0.55, sceneFlatness(zoom, dpr) * 2.5);
+  return Math.max(0.08, sceneFlatness(zoom, dpr) * 1.15);
 }
 
 export function contourFromNode(
@@ -124,7 +124,23 @@ export function contourFromNode(
     const outlineD = pencilSilhouettePathD(node, sw);
     if (outlineD) {
       const pencilFlat = pencilSilhouetteFlatness(opts?.zoom ?? 1, opts?.dpr ?? 1);
-      const points = densifyPathD(outlineD, pencilFlat);
+      let points = densifyPathD(outlineD, pencilFlat);
+      // Cap densified silhouette — ear-clip / remesh must stay interactive.
+      const PENCIL_MESH_MAX_RING = 320;
+      if (points.length > PENCIL_MESH_MAX_RING) {
+        const capped: typeof points = [];
+        const last = points.length - 1;
+        const step = last / (PENCIL_MESH_MAX_RING - 1);
+        let prev = -1;
+        for (let i = 0; i < PENCIL_MESH_MAX_RING - 1; i += 1) {
+          const idx = Math.round(i * step);
+          if (idx === prev) continue;
+          capped.push(points[idx]!);
+          prev = idx;
+        }
+        if (prev !== last) capped.push(points[last]!);
+        points = capped;
+      }
       if (points.length >= 3) {
         return { d: outlineD, closed: true, points, geomFp, pencilSilhouette: true };
       }

--- a/apps/web/src/components/rcb/render/vector/meshCache.ts
+++ b/apps/web/src/components/rcb/render/vector/meshCache.ts
@@ -25,6 +25,8 @@ import {
   isRectLikeStrokeSidesShape,
   rectStrokeSideRuns,
 } from '@/components/rcb/render/vector/strokeSides';
+import { parseSimplePathPoints } from '@/components/rcb/tools/pencilBrushes';
+import { tessellateStroke } from '@/components/rcb/render/vector/tessellateStroke';
 
 export type CachedShapeMesh = {
   geomFp: string;
@@ -166,24 +168,49 @@ export function getOrBuildShapeMesh(
     !pencilSil && isRectLikeStrokeSidesShape(shapeType, paintNode.key)
       ? rectStrokeSideRuns(w, h, paintNode.attrs, radiiFromAttrs(paintNode.attrs))
       : null;
-  const { fill, stroke } = buildShapeMeshes(contour.points, {
-    closed: contour.closed,
-    wantFill: pencilSil || (contour.closed && nodeWantsSolidFill(paintNode)),
-    strokeWidth: authoredStroke,
-    strokeAlign: strokeAlignOf(paintNode),
-    linejoin: resolveStrokeLinejoin(paintNode.attrs),
-    linecap: resolveStrokeLinecap(paintNode.attrs),
-    miterLimit: resolveStrokeMiterlimit(paintNode.attrs),
-    holes: holes.length ? holes : undefined,
-    fillRule,
-    arrowHeadFill: false,
-    dasharray,
-    strokeRuns: sideRuns ?? undefined,
-  });
+  // Dense freehand silhouettes self-intersect; skip fill tessellation when the
+  // densified ring is large (ear-clip stalls). Short strokes still get fill.
+  const pencilPreferRibbon = pencilSil && contour.points.length >= 280;
+  const { fill, stroke } = pencilPreferRibbon
+    ? { fill: null, stroke: null }
+    : buildShapeMeshes(contour.points, {
+        closed: contour.closed,
+        wantFill: pencilSil || (contour.closed && nodeWantsSolidFill(paintNode)),
+        strokeWidth: authoredStroke,
+        strokeAlign: strokeAlignOf(paintNode),
+        linejoin: resolveStrokeLinejoin(paintNode.attrs),
+        linecap: resolveStrokeLinecap(paintNode.attrs),
+        miterLimit: resolveStrokeMiterlimit(paintNode.attrs),
+        holes: holes.length ? holes : undefined,
+        fillRule,
+        arrowHeadFill: false,
+        dasharray,
+        strokeRuns: sideRuns ?? undefined,
+      });
+  let fillOut = fill;
+  let strokeOut = stroke;
+  // Self-intersecting freehand rings can fail ear-clip. Prefer a round centerline
+  // ribbon over empty ink (WebGL no longer falls through to butt segment quads).
+  if (pencilSil && !fillOut) {
+    const sw = Math.max(
+      0.5,
+      Number(paintNode.attrs?.['border-width'] ?? paintNode.attrs?.strokeWidth) || 1
+    );
+    const center = parseSimplePathPoints(String(paintNode.attrs?.path || ''));
+    if (center.length >= 2) {
+      strokeOut = tessellateStroke(center, {
+        width: sw,
+        closed: false,
+        align: 'center',
+        linejoin: 'round',
+        linecap: 'round',
+      });
+    }
+  }
   const entry: CachedShapeMesh = {
     geomFp: fp,
-    fill,
-    stroke,
+    fill: fillOut,
+    stroke: strokeOut,
     // Draw gate lives in the renderer (screen width); keep scale at 1.
     strokeAlphaScale: 1,
   };

--- a/apps/web/src/components/rcb/render/vector/tessellateFill.ts
+++ b/apps/web/src/components/rcb/render/vector/tessellateFill.ts
@@ -78,7 +78,8 @@ function fanTris(ring: Vec2[]): number[] {
 function earclipTris(ring: Vec2[], ccw: boolean): number[] {
   const tris: number[] = [];
   const idx = ring.map((_, i) => i);
-  let guard = ring.length * ring.length + 8;
+  // Cap work — n² guard on n≈1k freehand rings stalls the tab for seconds.
+  let guard = Math.min(ring.length * ring.length + 8, 48_000);
   while (idx.length > 3 && guard-- > 0) {
     let clipped = false;
     for (let i = 0; i < idx.length; i += 1) {
@@ -125,7 +126,8 @@ export function tessellateFill(points: Vec2[]): FillMesh | null {
   const a = area(ring);
   if (Math.abs(a) < 1e-10) return null;
   const ccw = a > 0;
-  const tris = ringIsConvex(ring, ccw) ? fanTris(ring) : earclipTris(ring, ccw);
+  if (ringIsConvex(ring, ccw)) return meshFromTris(fanTris(ring));
+  const tris = earclipTris(ring, ccw);
   return meshFromTris(tris);
 }
 

--- a/apps/web/src/components/rcb/render/vector/wasmGeom.ts
+++ b/apps/web/src/components/rcb/render/vector/wasmGeom.ts
@@ -307,7 +307,8 @@ function fillMeshFor(
     try {
       const mesh = meshFromFlat(api!.tessellate_fill(pointsToFlat(points)));
       if (mesh && mesh.triangleCount > 0) return mesh;
-      return mesh;
+      // Empty WASM result — try JS before giving up.
+      return tessellateFillJs(points);
     } catch {
       /* fall through to JS */
     }

--- a/apps/web/src/components/rcb/render/webglSceneRenderer.ts
+++ b/apps/web/src/components/rcb/render/webglSceneRenderer.ts
@@ -28,10 +28,13 @@ import {
 } from '@/components/rcb/render/sceneRenderBuffer';
 import { nodeOwnerFrameId } from '@/components/rcb/frames/frameNodeBinding';
 import { selectionPaintRaises, frameClipRevealsOverflow } from '@/components/rcb/selection/selectionPaintRaise';
+import { getShapeHost } from '@/components/rcb/shapes/shapeHostRegistry';
+import { getLiveShapeParamsPreviewNodeId } from '@/components/rcb/scene/document/sceneShapes';
 import { findClippingFrameForNode } from '@/components/rcb/frames/frameContentClip';
 import {
   buildNodeStackZMap,
   maxDocumentStackZ,
+  worldNodeStacksAboveAnyFrame,
 } from '@/components/rcb/scene/document/sceneDocument';
 import type { SceneDocument, SceneNodeInput } from '@/components/rcb/sceneNode';
 import {
@@ -407,11 +410,12 @@ function pushInstanceClip(
 export function resolveSoaWebglSlotClip(
   buf: SceneRenderBuffer,
   index: number,
-  doc: SceneDocument | null | undefined
+  doc: SceneDocument | null | undefined,
+  opts?: { /** Artboard FO paint — keep plate clip even while selection reveals. */ ignoreReveal?: boolean }
 ): [number, number, number, number] {
   if (!doc) return SOA_WEBGL_NO_CLIP;
   const id = buf.ids[index];
-  if (!id || frameClipRevealsOverflow(id)) return SOA_WEBGL_NO_CLIP;
+  if (!id || (!opts?.ignoreReveal && frameClipRevealsOverflow(id))) return SOA_WEBGL_NO_CLIP;
   const node = doc.deltaSetLike?.[id] as Record<string, unknown> | undefined;
   if (!node) return SOA_WEBGL_NO_CLIP;
   const frame = findClippingFrameForNode(doc, { ...node, id });
@@ -651,7 +655,7 @@ export type CollectSoaWebglOpts = {
   document?: SceneDocument | null;
   /** Camera zoom. */
   zoom?: number;
-  /** Device pixel ratio (media stamps). */
+  /** Device pixel ratio (media stamps / mesh densify). */
   dpr?: number;
   /**
    * World idle ink: skip nodes with attrs.frameId (ArtboardLayer paints them).
@@ -722,15 +726,34 @@ export function collectSoaWebglInstances(
     const idEarly = buf.ids[i];
     if (idEarly && hiddenNodeId && idEarly === hiddenNodeId) continue;
     if (idEarly && getNodeTransformPreview(idEarly)?.hidden) continue;
+    // Stack-above unbound world → SVG host owns ink (surround excluded in helper).
+    if (
+      idEarly &&
+      paintDoc &&
+      worldNodeStacksAboveAnyFrame(paintDoc, idEarly) &&
+      getLiveShapeParamsPreviewNodeId() !== idEarly
+    ) {
+      continue;
+    }
+    // Match Canvas2D: once a host is mounted, never also draw WebGL for it.
+    if (
+      idEarly &&
+      getShapeHost(idEarly)?.el &&
+      getLiveShapeParamsPreviewNodeId() !== idEarly
+    ) {
+      continue;
+    }
     if (onlyFrameId && paintDoc && idEarly) {
       const node = paintDoc.deltaSetLike?.[idEarly];
-      // Plate FO stays clipped; selection reveal → raised SVG host (max+1).
-      // World ink is only a lag fallback while CANVAS_IDLE has not cleared yet.
-      if (nodeOwnerFrameId(node) !== onlyFrameId || frameClipRevealsOverflow(idEarly)) continue;
+      // Stay on plate FO even while selection reveals overflow. Selection no
+      // longer mounts an SVG ink host (CANVAS_IDLE stays), so moving reveal to
+      // world permanently spilled framed pencil/pen past the artboard.
+      // Unclipped blue path chrome still shows outside the plate.
+      if (nodeOwnerFrameId(node) !== onlyFrameId) continue;
     } else if (skipFrameBound && paintDoc && idEarly) {
       const node = paintDoc.deltaSetLike?.[idEarly];
-      // Selection reveal: overflow may still be on SoA until host flags flip.
-      if (nodeOwnerFrameId(node) && !frameClipRevealsOverflow(idEarly)) continue;
+      // Frame-bound idle always belongs on ArtboardLayer — never world.
+      if (nodeOwnerFrameId(node)) continue;
     }
     const kind = buf.kinds[i];
     if (
@@ -769,8 +792,9 @@ export function collectSoaWebglInstances(
     const { x, y, w, h, dx: odx, dy: ody } = resolveSoaPaintBox(buf, i);
     const rgba = argbToRgba(buf.colors[i]);
     const strokeBaseRgba = soaWebglStrokeRgba(buf, i);
-    const strokePaint = strokeRibbonPaint(soaStrokeWidth(buf, i), zoom, dpr);
-    // Geometric scene width for fallback segments; mesh tessellation is also geometric.
+    const authoredStrokeW = soaStrokeWidth(buf, i);
+    const strokePaint = strokeRibbonPaint(authoredStrokeW, zoom, dpr);
+    // Geometric authored width only — same as timeline-open pasteboard draw.
     const lineW = strokePaint.width;
     const submitStroke = strokePaint.submit;
     const strokeRgba: [number, number, number, number] = [
@@ -784,7 +808,9 @@ export function collectSoaWebglInstances(
     const nodeId = buf.ids[i] || '';
     const id = nodeId;
     const slotDepth = depthForId ? depthForId(nodeId) : 0.5;
-    const slotClip = resolveSoaWebglSlotClip(buf, i, paintDoc);
+    const slotClip = resolveSoaWebglSlotClip(buf, i, paintDoc, {
+      ignoreReveal: Boolean(onlyFrameId),
+    });
     const paintClips: Array<[number, number, number, number]> = [
       [slotClip[0], slotClip[1], slotClip[2], slotClip[3]],
     ];
@@ -968,7 +994,6 @@ export function collectSoaWebglInstances(
               );
             }
             // Pencil uses silhouette fill only — skip uniform centerline ribbon.
-            // Screen ≤1px: keep mesh cached, do not submit ribbon (rule 4).
             if (
               mesh.stroke &&
               submitStroke &&
@@ -991,6 +1016,12 @@ export function collectSoaWebglInstances(
             }
           }
           if (wrote > 0) {
+            if (forceStamp) buf.flags[i] = (flags & ~SOA_FLAG_DIRTY) >>> 0;
+            continue;
+          }
+          // Pencil must never fall through to centerline segment quads — that
+          // reads as faceted beads when silhouette fill fails or is clipped.
+          if (isPencil) {
             if (forceStamp) buf.flags[i] = (flags & ~SOA_FLAG_DIRTY) >>> 0;
             continue;
           }

--- a/apps/web/src/components/rcb/scene/document/__tests__/stackCover.test.ts
+++ b/apps/web/src/components/rcb/scene/document/__tests__/stackCover.test.ts
@@ -161,6 +161,25 @@ describe('unified HTML media stack (foreignObject)', () => {
     expect(worldNodeStacksAboveAnyFrame(doc, 'c1')).toBe(false);
   });
 
+  it('workbench surround above a plate is not stack-above (stays SoA mesh)', () => {
+    let doc = createBareDocument();
+    doc.frames = [
+      { id: 'anim', name: 'Animation', backgroundColor: '#fff', x: 0, y: 0, width: 100, height: 100 },
+    ];
+    doc.stackOrder = ['frame:anim'];
+    doc = addNodeToDocument(doc, 's1', {
+      id: 's1',
+      key: 'rect',
+      x: 200,
+      y: 0,
+      width: 20,
+      height: 20,
+      attrs: { animationWorkbenchSurround: 'anim' },
+      children: [],
+    });
+    expect(worldNodeStacksAboveAnyFrame(doc, 's1')).toBe(false);
+  });
+
   it('world node below all frames can stay on SoA', () => {
     let doc = createBareDocument();
     doc = addNodeToDocument(doc, 'under', {

--- a/apps/web/src/components/rcb/scene/document/sceneDocument.ts
+++ b/apps/web/src/components/rcb/scene/document/sceneDocument.ts
@@ -403,6 +403,10 @@ export function nodePaintZIndex(
  * World (unbound) node whose stack z is above at least one artboard plate.
  * Those must paint as SVG hosts on the shared stack mount — SoA ink sits under
  * that SVG, so only hosts can cover 画板 / 动画工作台 plates via data-z.
+ *
+ * Workbench surround (`animationWorkbenchSurround`) is visibility-only: always
+ * false here so pasteboard ink stays SoA mesh (same as closed-timeline world).
+ * Do not reintroduce DomHost promotion for surround.
  */
 export function worldNodeStacksAboveAnyFrame(
   doc: SceneDocument | null | undefined,
@@ -412,6 +416,8 @@ export function worldNodeStacksAboveAnyFrame(
   const node = doc.deltaSetLike?.[nodeId];
   if (!node) return false;
   if (String(node.attrs?.frameId || '').trim()) return false;
+  // Attr string only — avoid importing animationWorkbenchFocus (TDZ cycles).
+  if (String(node.attrs?.animationWorkbenchSurround || '').trim()) return false;
   const nodeZ = stackZIndex(doc, 'node', nodeId);
   if (nodeZ <= 0) return false;
   const order = Array.isArray(doc.stackOrder) ? doc.stackOrder : [];

--- a/apps/web/src/components/rcb/selection/chrome/BlendModeControl.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/BlendModeControl.tsx
@@ -1,23 +1,15 @@
 import { useMemo, useState, type CSSProperties, type ReactNode, memo } from 'react';
-import {
-  autoUpdate,
-  flip,
-  FloatingPortal,
-  offset,
-  shift,
-  useClick,
-  useDismiss,
-  useFloating,
-  useInteractions,
-} from '@floating-ui/react';
 import { useTranslation } from 'react-i18next';
-import { HiOutlineArrowPath, HiOutlineCheck, HiOutlineChevronDown } from 'react-icons/hi2';
+import { HiOutlineCheck, HiOutlineChevronDown } from 'react-icons/hi2';
 import { MdOutlineOpacity } from 'react-icons/md';
 import { Dropdown } from '@/components/base';
 import type { MenuItemType } from '@/components/base/dropdown';
-import { DropdownPanel } from '@/components/base/dropdown/DropdownPanel';
-import Slider from '@/components/base/slider';
-import Tooltip from '@/components/base/tooltip';
+import { useSelector } from '@/store';
+import {
+  closeImageToolPanel,
+  openImageToolPanel,
+  type ImageToolPanelState,
+} from '@/store/modules/editor';
 import { cn } from '@/utils/classnames';
 import { SEL_ICON_BTN_ACTIVE, SEL_TOOL_BTN } from './ToolbarValueSlider';
 
@@ -96,10 +88,6 @@ export function layerOpacityToPct(opacity01: number): number {
   return Math.round(Math.min(1, Math.max(0, opacity01)) * 100);
 }
 
-function clampOpacityPct(n: number): number {
-  return Math.min(100, Math.max(0, Math.round(n)));
-}
-
 /** Mini two-circle preview — monochrome so it matches the rest of the toolbar. */
 export function BlendModeIcon({ mode, className }: { mode: BlendModeId; className?: string }) {
   const cssMode: CSSProperties['mixBlendMode'] =
@@ -125,103 +113,52 @@ export function BlendModeIcon({ mode, className }: { mode: BlendModeId; classNam
   );
 }
 
+/**
+ * Opens the same right-of-node OpacityToolPanel as images (via ImageToolPanelHost).
+ * Multi-select without a single nodeId is not supported here — pass nodeId for side dock.
+ */
 export function OpacityControl({
-  opacity,
-  onOpacityChange,
+  nodeId,
   className,
 }: {
-  opacity?: unknown;
-  onOpacityChange: (opacity01: number) => void;
+  /** Docks OpacityToolPanel to this node's top-right (same as image). */
+  nodeId: string;
   className?: string;
 }) {
   const { t } = useTranslation();
-  const [open, setOpen] = useState(false);
-  const pct = layerOpacityToPct(parseLayerOpacity(opacity, 1));
+  const imageToolPanel = useSelector(
+    (s: any) => s.editor.imageToolPanel as ImageToolPanelState | null
+  );
+  const open =
+    imageToolPanel?.kind === 'opacity' && imageToolPanel?.nodeId === nodeId;
   const opacityLabel = t('editor.imageToolbar.opacity');
-  const applyPct = (nextPct: number) => {
-    onOpacityChange(clampOpacityPct(nextPct) / 100);
-  };
-  const { refs, floatingStyles, context } = useFloating({
-    open,
-    onOpenChange: setOpen,
-    placement: 'bottom-start',
-    strategy: 'fixed',
-    whileElementsMounted: autoUpdate,
-    middleware: [
-      offset(6),
-      flip({
-        padding: 12,
-        fallbackPlacements: ['top-start', 'top-end', 'right-start', 'left-start'],
-      }),
-      shift({ padding: 12 }),
-    ],
-  });
-  const click = useClick(context);
-  const dismiss = useDismiss(context, { outsidePressEvent: 'pointerdown' });
-  const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss]);
 
   return (
     <div className={cn('inline-flex', className)}>
       <button
         type="button"
         aria-label={opacityLabel}
-        aria-expanded={open}
-        ref={refs.setReference}
+        aria-pressed={open}
         className={cn(SEL_TOOL_BTN, open && SEL_ICON_BTN_ACTIVE)}
-        {...getReferenceProps()}
+        onClick={() => {
+          if (open) closeImageToolPanel();
+          else openImageToolPanel({ nodeId, kind: 'opacity' });
+        }}
       >
         <MdOutlineOpacity className="h-4 w-4" />
         <span>{opacityLabel}</span>
       </button>
-      <FloatingPortal>
-        {open ? (
-          <DropdownPanel
-            className="z-[80] w-[240px]"
-            style={floatingStyles}
-            ref={refs.setFloating}
-            {...getFloatingProps()}
-          >
-            <div className="flex h-9 items-center justify-between gap-1 px-3">
-              <span className="min-w-0 truncate text-[13px] font-medium text-[var(--ink)]">
-                {opacityLabel}
-              </span>
-              <Tooltip tip={t('editor.imageToolbar.reset')} placement="top">
-                <button
-                  type="button"
-                  aria-label={t('editor.imageToolbar.reset')}
-                  onClick={() => applyPct(100)}
-                  className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-xl text-[var(--muted)] transition-colors hover:bg-[var(--accent-soft)] hover:text-[var(--ink)]"
-                >
-                  <HiOutlineArrowPath className="h-4 w-4" />
-                </button>
-              </Tooltip>
-            </div>
-            <div className="px-3 pb-3">
-              <Slider
-                min={0}
-                max={100}
-                step={1}
-                value={pct}
-                onChange={applyPct}
-                trackHeight={6}
-                thumbWidth={16}
-                thumbHeight={16}
-              />
-            </div>
-          </DropdownPanel>
-        ) : null}
-      </FloatingPortal>
     </div>
   );
 }
 
 type Props = {
   blendMode?: unknown;
-  opacity?: unknown;
   /** Pass-through is only meaningful for groups/frames. */
   allowPassThrough?: boolean;
   onBlendModeChange: (mode: BlendModeId) => void;
-  onOpacityChange: (opacity01: number) => void;
+  /** Single-node dock for opacity (same as image). */
+  opacityNodeId?: string;
   /** Inserted between blend-mode dropdown and opacity (e.g. corner radius). */
   afterBlendSlot?: ReactNode;
   className?: string;
@@ -229,10 +166,9 @@ type Props = {
 
 function BlendModeControl({
   blendMode,
-  opacity,
   allowPassThrough = false,
   onBlendModeChange,
-  onOpacityChange,
+  opacityNodeId,
   afterBlendSlot,
   className,
 }: Props) {
@@ -302,7 +238,9 @@ function BlendModeControl({
         </button>
       </Dropdown>
       {afterBlendSlot}
-      <OpacityControl opacity={opacity} onOpacityChange={onOpacityChange} />
+      {opacityNodeId ? (
+        <OpacityControl nodeId={opacityNodeId} />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/rcb/selection/chrome/MultiSelectionToolbar.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/MultiSelectionToolbar.tsx
@@ -959,18 +959,13 @@ function MultiSelectionToolbar({
       {sizeField('h', box.height)}
       <BlendModeControl
         blendMode={firstAttrs.blendMode}
-        opacity={firstAttrs.opacity}
+        opacityNodeId={opNodeIds[0]}
         allowPassThrough={opNodeIds.every(
           (id) => document?.deltaSetLike?.[id]?.key === 'frame'
         )}
         onBlendModeChange={(mode) => {
           applyPatches(
             opNodeIds.map((id) => ({ nodeId: id, patch: { attrs: { blendMode: mode } } }))
-          );
-        }}
-        onOpacityChange={(opacity) => {
-          applyPatches(
-            opNodeIds.map((id) => ({ nodeId: id, patch: { attrs: { opacity } } }))
           );
         }}
       />

--- a/apps/web/src/components/rcb/selection/chrome/SelectionContextToolbar.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/SelectionContextToolbar.tsx
@@ -704,12 +704,7 @@ function SelectionContextToolbar(props: Props): ReactNode {
   const showOutline = canOutlineNode(node);
   const imageAspectLocked = resolveImageAspectLocked(node, kind);
   const opacityControl = showLayerChrome ? (
-    <OpacityControl
-      opacity={node?.attrs?.opacity}
-      onOpacityChange={(opacity) =>
-        patchDocumentNode({ nodeId, patch: { attrs: { opacity } } })
-      }
-    />
+    <OpacityControl nodeId={nodeId} />
   ) : null;
   const elementMoreItems: ToolbarMoreItem[] = [];
   if (showOutline) {
@@ -1124,6 +1119,8 @@ function SelectionContextToolbar(props: Props): ReactNode {
                     patchTextStyle({ fontFamily: parsed.family, fontWeight: parsed.weight });
                   }}
                   displayLabel={weightDisplayLabel}
+                  className="max-w-[6.5rem] shrink-0 justify-between"
+                  popupClassName="max-w-[9rem]"
                 />
               ) : null}
               <label className="inline-flex h-8 items-center gap-1 rounded-lg px-1.5 text-[12px] text-[var(--ink)]">

--- a/apps/web/src/components/rcb/selection/chrome/ToolbarMenuSelect.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/ToolbarMenuSelect.tsx
@@ -18,6 +18,8 @@ type Props = {
   className?: string;
   /** Min trigger width */
   minWidth?: string;
+  /** Dropdown panel class (fixed width for weight menus, etc.). */
+  popupClassName?: string;
   /**
    * Combobox mode: type a custom value, chevron still opens the preset list.
    * Used for font size.
@@ -39,6 +41,7 @@ function ToolbarMenuSelect({
   displayLabel,
   className,
   minWidth,
+  popupClassName,
   editable = false,
   inputMin = 1,
   inputMax = 400,
@@ -70,7 +73,7 @@ function ToolbarMenuSelect({
   };
 
   const shellClass = cn(
-    'inline-flex h-8 max-w-[10rem] items-center gap-0.5 rounded-lg px-1.5 text-[12px] text-[var(--ink)] transition-colors hover:bg-[var(--accent-soft)]',
+    'inline-flex h-8 items-center gap-0.5 rounded-lg px-1.5 text-[12px] text-[var(--ink)] transition-colors hover:bg-[var(--accent-soft)]',
     open && 'bg-[var(--accent-soft)]',
     className
   );
@@ -90,7 +93,7 @@ function ToolbarMenuSelect({
         onChange(key);
         setOpen(false);
       }}
-      popupClassName="min-w-[7rem]"
+      popupClassName={cn('!w-[9rem] min-w-[9rem]', popupClassName)}
       floatingClassName="z-[80]"
       referenceClassName="inline-flex"
     >
@@ -149,7 +152,7 @@ function ToolbarMenuSelect({
           className={shellClass}
           style={minWidth ? { minWidth } : undefined}
         >
-          <span className="inline-grid max-w-[8.5rem] items-center">
+          <span className="inline-grid min-w-0 flex-1 items-center">
             <span
               aria-hidden
               className="invisible col-start-1 row-start-1 whitespace-pre truncate px-0.5"

--- a/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
+++ b/apps/web/src/components/rcb/shapes/RcbShapesLayer.tsx
@@ -846,7 +846,13 @@ function RcbShapesLayer({
       flipHostInk(getLiveCornerRadiusPreviewNodeId(), 'canvas');
       const id = getLiveCornerRadiusPreviewNodeId();
       if (id) {
-        markSoaDirtyById(getSharedSceneRenderBuffer(), id);
+        invalidateShapeMesh(id);
+        const buf = getSharedSceneRenderBuffer();
+        markSoaDirtyById(buf, id);
+        const node = document?.deltaSetLike?.[id];
+        const owner = nodeOwnerFrameId(node);
+        // Same as shape-params: FO tiles must restamp or rounded stays under a sharp ghost.
+        if (owner) scheduleArtboardInkPaint(owner);
         bumpSceneCanvasIdlePaint();
       }
     });

--- a/apps/web/src/components/rcb/shapes/__tests__/canvasIdleHostBudget.test.ts
+++ b/apps/web/src/components/rcb/shapes/__tests__/canvasIdleHostBudget.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { setAnimationWorkbenchTimelineFocus } from '@/components/editor/nodes/AnimationNode/animationWorkbenchFocus';
 import { canIdlePaintOnCanvas, canvasIdleIsStrokeOnly, nodeNeedsDomShapeHost, pickFullAndCanvasIds } from '../RcbShapesLayer';
 import { HEAVY_PATH_D_CHARS } from '@/components/rcb/scene/document/sceneShapes';
 import type { SceneDocument } from '@/components/rcb/sceneNode';
@@ -311,6 +312,35 @@ describe('pickFullAndCanvasIds (single ink path)', () => {
     });
     expect(fullIds).toEqual(['n0']);
     expect(canvasIds).toEqual([]);
+  });
+
+  it('workbench surround stays SoA mesh even when stacked above the open plate', () => {
+    // Surround must not DomHost via stack-above — same world mesh as closed timeline.
+    setAnimationWorkbenchTimelineFocus('anim');
+    try {
+      const doc = makeDoc({
+        n0: {
+          ...rect('n0'),
+          attrs: {
+            ...rect('n0').attrs,
+            animationWorkbenchSurround: 'anim',
+          },
+        },
+      });
+      doc.frames = [
+        { id: 'anim', name: 'Animation', backgroundColor: '#fff', x: 0, y: 0, width: 100, height: 100 },
+      ];
+      doc.stackOrder = ['frame:anim', 'node:n0'];
+      const { fullIds, canvasIds } = pickFullAndCanvasIds({
+        document: doc,
+        visibleIds: ['n0'],
+        zoom: 1,
+      });
+      expect(fullIds).toEqual([]);
+      expect(canvasIds).toEqual(['n0']);
+    } finally {
+      setAnimationWorkbenchTimelineFocus(null);
+    }
   });
 
   it('holdHostIds keeps demote-candidate as DOM host', () => {

--- a/apps/web/src/components/rcb/tools/PencilDrawFeature.tsx
+++ b/apps/web/src/components/rcb/tools/PencilDrawFeature.tsx
@@ -7,6 +7,9 @@ import {
   findPencilBrush,
   interpolateStrokeGaps,
   outlinePathFromPoints,
+  downsampleStrokePointsForLive,
+  PENCIL_COMMIT_MAX_PTS,
+  PENCIL_LIVE_MAX_PTS,
   pencilSampleMinStep,
   pencilSimplifyEpsilon,
   polylinePathD,
@@ -36,6 +39,11 @@ import {
   getSceneWorldEpoch,
   subscribeShapeHosts,
 } from '../shapes/shapeHostRegistry';
+import {
+  getSharedSceneRenderBuffer,
+  SOA_FLAG_CANVAS_IDLE,
+  SOA_FLAG_FREE,
+} from '../render/sceneRenderBuffer';
 
 type SceneBox = { left: number; top: number; width: number; height: number };
 
@@ -340,11 +348,16 @@ function PencilDrawFeature({
     }
     const brush = findPencilBrush(brushRef.current);
 
-    const pressures = points.map((p) => p.pressure);
+    // Live: downsample + last:false like perfect-freehand demos. Full pts stay
+    // for commit bake (smoothness / pressure fidelity).
+    const livePts = downsampleStrokePointsForLive(points, PENCIL_LIVE_MAX_PTS);
+    const pressures = livePts.map((p) => p.pressure);
     const hasPressure = pressures.some((p) => typeof p === 'number' && Number.isFinite(p));
-    const d = outlinePathFromPoints(points, widthRef.current, brush.id, {
+    const d = outlinePathFromPoints(livePts, widthRef.current, brush.id, {
       pressureEnabled: true,
       simplify: false,
+      last: false,
+      pathStyle: 'linear',
       pressures: hasPressure
         ? pressures.map((p) => (typeof p === 'number' && Number.isFinite(p) ? p : 0.5))
         : undefined,
@@ -373,19 +386,32 @@ function PencilDrawFeature({
     if (handoffRafRef.current) window.cancelAnimationFrame(handoffRafRef.current);
     let attempts = 0;
     let readyFrames = 0;
+    const soaIdleReady = () => {
+      const buf = getSharedSceneRenderBuffer();
+      for (let i = 0; i < buf.count; i += 1) {
+        if (buf.ids[i] !== nodeId) continue;
+        const flags = buf.flags[i];
+        if (flags & SOA_FLAG_FREE) return false;
+        return (flags & SOA_FLAG_CANVAS_IDLE) !== 0;
+      }
+      return false;
+    };
     const check = () => {
       if (previewEpochRef.current !== epoch) return;
+      // Framed / canvas-idle pencil paints on ArtboardLayer SoA — no SVG host paths.
       const committedEl = getShapeHost(nodeId)?.el;
-      const committedPaintReady = Boolean(
+      const hostPaintReady = Boolean(
         committedEl &&
           (committedEl.querySelector?.('image') ||
             committedEl.querySelector?.(
               'path:not([data-baseline="1"]), rect, circle, ellipse'
             ))
       );
-      if (committedPaintReady) readyFrames += 1;
+      if (hostPaintReady || soaIdleReady()) readyFrames += 1;
       else readyFrames = 0;
-      if (readyFrames >= 2 || attempts >= 120) {
+      // Clear sooner than before — unclipped world SVG preview must not linger
+      // past the plate once SoA ink is up (looks like offset + overflow).
+      if (readyFrames >= 1 || attempts >= 24) {
         handoffRafRef.current = 0;
         clearPreview();
         return;
@@ -573,11 +599,7 @@ function PencilDrawFeature({
           }
         }
       }
-      // Pin the final raw sample into the preview before it hands off to the
-      // committed host. Clearing first caused a visible blank frame on pointerup.
-      if (commit && pts.current.length >= 2) {
-        redrawOverlayRef.current();
-      }
+      // Keep the last live preview — do not re-getStroke on pointerup (sync freeze).
       const points = pts.current;
       pts.current = [];
       lastDrawPointerRef.current = null;
@@ -586,66 +608,82 @@ function PencilDrawFeature({
         clearPreview();
         return;
       }
-      let minX = Infinity;
-      let minY = Infinity;
-      let maxX = -Infinity;
-      let maxY = -Infinity;
-      points.forEach((pt) => {
-        minX = Math.min(minX, pt.x);
-        minY = Math.min(minY, pt.y);
-        maxX = Math.max(maxX, pt.x);
-        maxY = Math.max(maxY, pt.y);
-      });
-      const brush = findPencilBrush(brushRef.current);
-      const pad = brushPad(brush, widthRef.current);
-      const originX = minX - pad;
-      const originY = minY - pad;
-      const local = points.map((pt) => ({
-        x: pt.x - originX,
-        y: pt.y - originY,
-        ...(pt.pressure != null ? { pressure: pt.pressure } : {}),
-      }));
-      const sw = Math.max(0.5, widthRef.current);
-      const pressures = pressureRef.current
-        ? local.map((p) => (p.pressure != null && Number.isFinite(p.pressure) ? p.pressure : 0.5))
-        : undefined;
-      // Bake silhouette once at commit — idle WebGL/Canvas must not re-run getStroke.
-      // Linear M/L/Z (not Q midpoints) so densify/tessellate stay cheap.
-      const pencilOutlinePath = outlinePathFromPoints(local, sw, brushRef.current, {
-        linecap: 'round',
-        pressures,
-        pressureEnabled: pressureRef.current,
-        simplify: false,
-        pathStyle: 'linear',
-      });
-      // Store a light RDP centerline for edits; silhouette is already baked.
-      const size = brushSize(brush, sw);
-      const stored = simplifyPencilCenterline(local, pencilSimplifyEpsilon(size));
-      const d = polylinePathD(stored.length >= 2 ? stored : local);
-      const pathPressure = pressureRef.current
-        ? serializePathPressures(stored.length >= 2 ? stored : local)
-        : undefined;
-      const committedId = onCommit(
-        d,
-        {
-          left: originX,
-          top: originY,
-          width: Math.max(1, maxX - minX + pad * 2),
-          height: Math.max(1, maxY - minY + pad * 2),
-        },
-        {
-          ...(pathPressure ? { pathPressure } : {}),
-          ...(pencilOutlinePath ? { pencilOutlinePath } : {}),
-          brushCategory: brush.category || 'basic',
-          frameId: drawingFrameId.current,
-        }
-      );
+      const epoch = previewEpochRef.current;
+      const frameIdAtCommit = drawingFrameId.current;
       drawingFrameId.current = null;
-      if (committedId) {
-        holdPreviewUntilCommittedPaintRef.current(committedId, previewEpochRef.current);
-      } else {
-        clearPreview();
-      }
+      // Macrotask after pointerup paint — never RDP/getStroke/mesh in the gesture turn.
+      // Dense scribble ear-clip used to freeze for seconds on commit remesh.
+      window.setTimeout(() => {
+        if (previewEpochRef.current !== epoch) {
+          clearPreview();
+          return;
+        }
+        let minX = Infinity;
+        let minY = Infinity;
+        let maxX = -Infinity;
+        let maxY = -Infinity;
+        for (let i = 0; i < points.length; i += 1) {
+          const pt = points[i];
+          minX = Math.min(minX, pt.x);
+          minY = Math.min(minY, pt.y);
+          maxX = Math.max(maxX, pt.x);
+          maxY = Math.max(maxY, pt.y);
+        }
+        const brush = findPencilBrush(brushRef.current);
+        const pad = brushPad(brush, widthRef.current);
+        const originX = minX - pad;
+        const originY = minY - pad;
+        const local = points.map((pt) => ({
+          x: pt.x - originX,
+          y: pt.y - originY,
+          ...(pt.pressure != null ? { pressure: pt.pressure } : {}),
+        }));
+        const sw = Math.max(0.5, widthRef.current);
+        const size = brushSize(brush, sw);
+        // Cap first, then light RDP — never simplify thousands of raw points.
+        const capped = downsampleStrokePointsForLive(local, PENCIL_COMMIT_MAX_PTS);
+        const stored = simplifyPencilCenterline(capped, pencilSimplifyEpsilon(size));
+        const bakePts = stored.length >= 2 ? stored : capped;
+        const pressures = pressureRef.current
+          ? bakePts.map((p) =>
+              p.pressure != null && Number.isFinite(p.pressure) ? p.pressure : 0.5
+            )
+          : undefined;
+        // Linear silhouette densifies cheaply; Q midpoints explode remesh cost.
+        const pencilOutlinePath = outlinePathFromPoints(bakePts, sw, brushRef.current, {
+          linecap: 'round',
+          pressures,
+          pressureEnabled: pressureRef.current,
+          simplify: false,
+          last: true,
+          pathStyle: 'linear',
+        });
+        const d = polylinePathD(bakePts);
+        const pathPressure = pressureRef.current
+          ? serializePathPressures(bakePts)
+          : undefined;
+        const committedId = onCommit(
+          d,
+          {
+            left: originX,
+            top: originY,
+            width: Math.max(1, maxX - minX + pad * 2),
+            height: Math.max(1, maxY - minY + pad * 2),
+          },
+          {
+            ...(pathPressure ? { pathPressure } : {}),
+            ...(pencilOutlinePath ? { pencilOutlinePath } : {}),
+            brushCategory: brush.category || 'basic',
+            frameId: frameIdAtCommit,
+          }
+        );
+        if (previewEpochRef.current !== epoch) return;
+        if (committedId) {
+          holdPreviewUntilCommittedPaintRef.current(committedId, epoch);
+        } else {
+          clearPreview();
+        }
+      }, 0);
     };
 
     const onUp = (e: PointerEvent) => finishStroke(e, true);

--- a/apps/web/src/components/rcb/tools/ShapeDrawFeature.tsx
+++ b/apps/web/src/components/rcb/tools/ShapeDrawFeature.tsx
@@ -357,7 +357,17 @@ function ShapeDrawFeature({
         const y1 = s.y1;
         if (Math.hypot(x1 - x0, y1 - y0) < 3) return;
         const box = normalizeBox(x0, y0, x1, y1);
-        onCreateRef.current(kind, { ...box, x0, y0, x1, y1, frameId: s.frameId });
+        // Prefer plate under the finished stroke mid — drag-into-workbench binds.
+        const midFrame =
+          hitTestFrameRef.current?.((x0 + x1) / 2, (y0 + y1) / 2) || null;
+        onCreateRef.current(kind, {
+          ...box,
+          x0,
+          y0,
+          x1,
+          y1,
+          frameId: midFrame || s.frameId,
+        });
         return;
       }
 
@@ -370,7 +380,13 @@ function ShapeDrawFeature({
         gridSizeRef.current,
         kind
       );
-      onCreateRef.current(kind, { ...geom, frameId: s.frameId });
+      // Final box center — drawing from pasteboard into 动画工作台 still binds.
+      const centerFrame =
+        hitTestFrameRef.current?.(
+          geom.left + geom.width / 2,
+          geom.top + geom.height / 2
+        ) || null;
+      onCreateRef.current(kind, { ...geom, frameId: centerFrame || s.frameId });
     };
 
     hitEl.addEventListener('pointerdown', onDown);

--- a/apps/web/src/components/rcb/tools/__tests__/pencilSmoothness.test.ts
+++ b/apps/web/src/components/rcb/tools/__tests__/pencilSmoothness.test.ts
@@ -3,6 +3,9 @@ import {
   findPencilBrush,
   getPencilBrushPaintRev,
   outlinePathFromPoints,
+  downsampleStrokePointsForLive,
+  PENCIL_COMMIT_MAX_PTS,
+  PENCIL_LIVE_MAX_PTS,
   pencilSampleMinStep,
   pencilSimplifyEpsilon,
   resetPencilBrushOptions,
@@ -15,8 +18,34 @@ describe('pencil stroke smoothness', () => {
   it('sample min step is dense at 1px stroke', () => {
     const brush = findPencilBrush('vector-ink');
     const step = pencilSampleMinStep(1, brush);
-    expect(step).toBeLessThan(0.6);
-    expect(step).toBeGreaterThanOrEqual(0.12);
+    expect(step).toBeLessThan(0.3);
+    expect(step).toBeGreaterThanOrEqual(0.06);
+  });
+
+  it('downsampleStrokePointsForLive caps input and keeps endpoints', () => {
+    const dense: Pt[] = [];
+    for (let i = 0; i <= 500; i += 1) dense.push({ x: i, y: i * 0.1 });
+    const out = downsampleStrokePointsForLive(dense, PENCIL_LIVE_MAX_PTS);
+    expect(out.length).toBeLessThanOrEqual(PENCIL_LIVE_MAX_PTS);
+    expect(out.length).toBeGreaterThan(8);
+    expect(out[0]).toEqual(dense[0]);
+    expect(out[out.length - 1]).toEqual(dense[dense.length - 1]);
+  });
+
+  it('commit bake path caps before RDP (dense scribbles stay cheap)', () => {
+    const dense: Pt[] = [];
+    for (let i = 0; i <= 8000; i += 1) {
+      dense.push({ x: Math.sin(i * 0.05) * 40 + i * 0.02, y: Math.cos(i * 0.07) * 40 });
+    }
+    const t0 = performance.now();
+    const capped = downsampleStrokePointsForLive(dense, PENCIL_COMMIT_MAX_PTS);
+    const simplified = simplifyPencilCenterline(capped, pencilSimplifyEpsilon(4));
+    const ms = performance.now() - t0;
+    expect(capped.length).toBeLessThanOrEqual(PENCIL_COMMIT_MAX_PTS);
+    expect(simplified.length).toBeGreaterThanOrEqual(2);
+    expect(simplified.length).toBeLessThanOrEqual(capped.length);
+    // RDP-on-raw used to multi-second freeze; capped path must stay interactive.
+    expect(ms).toBeLessThan(50);
   });
 
   it('simplifyPencilCenterline drops colinear points and keeps pressure', () => {

--- a/apps/web/src/components/rcb/tools/pencilBrushes.ts
+++ b/apps/web/src/components/rcb/tools/pencilBrushes.ts
@@ -429,6 +429,11 @@ export type PencilStrokeDrawOpts = {
    */
   simplify?: boolean;
   /**
+   * perfect-freehand `last` — false while the pointer is down (cheaper live
+   * outline); true on commit so end caps complete. Defaults to true.
+   */
+  last?: boolean;
+  /**
    * `quad` (default): midpoint Q silhouette for paint.
    * `linear`: M/L/Z polygon — for 轮廓化 path-edit (Q midpoints resist sparsify).
    */
@@ -436,6 +441,36 @@ export type PencilStrokeDrawOpts = {
   /** Override brush streamline (tests / special commit paths). */
   streamline?: number;
 };
+
+/**
+ * Keep live getStroke input bounded — official demos stay fast because pointer
+ * density is natural; our sample step can pack thousands of scene points.
+ * Also used on commit **before** RDP (RDP on raw live samples freezes the tab).
+ */
+export const PENCIL_LIVE_MAX_PTS = 160;
+/** Commit bake input cap after downsample (before getStroke). */
+export const PENCIL_COMMIT_MAX_PTS = 160;
+
+export function downsampleStrokePointsForLive<T extends Pt>(
+  points: T[],
+  maxPoints = PENCIL_LIVE_MAX_PTS
+): T[] {
+  const n = points.length;
+  const cap = Math.max(8, Math.floor(Number(maxPoints) || 160));
+  if (n <= cap) return points;
+  const out: T[] = [];
+  const last = n - 1;
+  const step = last / (cap - 1);
+  let prev = -1;
+  for (let i = 0; i < cap - 1; i += 1) {
+    const idx = Math.round(i * step);
+    if (idx === prev) continue;
+    out.push(points[idx]);
+    prev = idx;
+  }
+  if (prev !== last) out.push(points[last]);
+  return out;
+}
 
 function outlineStrokePoints(pts: Pt[], hasRealPressure: boolean): Pt[] {
   if (hasRealPressure) return pts;
@@ -483,14 +518,23 @@ export function outlinePathFromPoints(
   const outline = getStroke(strokePts, {
     ...options,
     size,
-    thinning: Number(options.thinning ?? 0.5),
+    // Tiny tips + high thinning self-intersect → ear-clip fill fails → was falling
+    // through to centerline segment quads (faceted beads). Cap thinning on thin ink.
+    thinning: (() => {
+      const raw = Number(options.thinning ?? 0.5);
+      if (!(size > 0)) return raw;
+      if (size < 2.5) return Math.min(raw, 0.12);
+      if (size < 4) return Math.min(raw, 0.22);
+      return raw;
+    })(),
     streamline: Number(
       strokeOpts?.streamline != null ? strokeOpts.streamline : (options.streamline ?? 0)
     ),
     simulatePressure: false,
     start,
     end,
-    last: true,
+    // Live preview: last=false (official demo). Commit: last=true for finished caps.
+    last: strokeOpts?.last !== false,
   });
   if (strokeOpts?.pathStyle === 'linear') {
     if (outline.length < 3) return '';
@@ -569,6 +613,7 @@ export function parsePathPressures(raw: unknown, pointCount: number): number[] |
 /**
  * Ramer–Douglas–Peucker on pencil centerlines (MIT-safe in-repo impl).
  * Keeps endpoints and per-point pressure on retained vertices.
+ * Index-based recursion — avoid `slice` copies (pathological on long strokes).
  */
 export function simplifyPencilCenterline(points: Pt[], epsilon: number): Pt[] {
   if (points.length <= 2) return points.map((p) => ({ ...p }));
@@ -585,26 +630,35 @@ export function simplifyPencilCenterline(points: Pt[], epsilon: number): Pt[] {
     return Math.hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy));
   }
 
-  function rdp(pts: Pt[]): Pt[] {
-    if (pts.length <= 2) return pts;
+  const keep = new Uint8Array(points.length);
+  keep[0] = 1;
+  keep[points.length - 1] = 1;
+
+  function rdp(i0: number, i1: number) {
+    if (i1 - i0 <= 1) return;
     let maxDist = 0;
-    let maxIdx = 0;
-    const first = pts[0];
-    const last = pts[pts.length - 1];
-    for (let i = 1; i < pts.length - 1; i += 1) {
-      const d = distToSeg(pts[i], first, last);
+    let maxIdx = i0;
+    const first = points[i0];
+    const last = points[i1];
+    for (let i = i0 + 1; i < i1; i += 1) {
+      const d = distToSeg(points[i], first, last);
       if (d > maxDist) {
         maxDist = d;
         maxIdx = i;
       }
     }
-    if (maxDist <= eps) return [first, last];
-    const left = rdp(pts.slice(0, maxIdx + 1));
-    const right = rdp(pts.slice(maxIdx));
-    return left.slice(0, -1).concat(right);
+    if (maxDist <= eps) return;
+    keep[maxIdx] = 1;
+    rdp(i0, maxIdx);
+    rdp(maxIdx, i1);
   }
 
-  return rdp(points.map((p) => ({ ...p })));
+  rdp(0, points.length - 1);
+  const out: Pt[] = [];
+  for (let i = 0; i < points.length; i += 1) {
+    if (keep[i]) out.push({ ...points[i] });
+  }
+  return out;
 }
 
 /** Scene-space epsilon for freehand bake / commit (~4.5% of tip size, min 0.25). */
@@ -614,8 +668,8 @@ export function pencilSimplifyEpsilon(strokeSize: number): number {
   return Math.max(0.25, s * 0.045);
 }
 
-/** Min scene step between stored samples — scales with ink size, stays dense at high zoom. */
+/** Min scene step between stored samples — denser = smoother freehand at any zoom. */
 export function pencilSampleMinStep(strokeWidth: number, brush?: PencilBrushDef | null): number {
   const size = brush ? brushSize(brush, strokeWidth) : Math.max(1, strokeWidth);
-  return Math.max(0.12, Math.min(0.4, size * 0.1));
+  return Math.max(0.06, Math.min(0.28, size * 0.06));
 }

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -119,8 +119,8 @@ const en = {
     heroCategoryAria: 'Choose what to generate, current: {{category}}',
     heroBrandSubtitle: 'AI design studio',
     /** Home hero slogan. */
-    heroStartTitle: 'Make it, design has never been this simple',
-    heroStartTitleAria: 'Make it, design has never been this simple',
+    heroStartTitle: 'design has never been this simple',
+    heroStartTitleAria: 'design has never been this simple',
     footerCopy: '© {{year}} zuoge',
     footerIcp: '滇ICP备2026017289号',
     heroSuggest: {
@@ -2003,6 +2003,7 @@ const en = {
     clickToEdit: 'Click to edit and resend',
     running: 'Running…',
     working: 'Working…',
+    thinking: 'Thinking',
     workedFor: '{{duration}}',
     workLog: 'Work log',
     expandProcess: 'Expand process',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -117,8 +117,8 @@ const ja = {
     heroCategoryAria: '生成タイプを選択、現在：{{category}}',
     heroBrandSubtitle: 'AIデザインスタジオ',
     /** Home hero slogan. */
-    heroStartTitle: '作ろう、デザインがこんなに簡単だったことはない',
-    heroStartTitleAria: '作ろう、デザインがこんなに簡単だったことはない',
+    heroStartTitle: 'デザインがこんなに簡単だったことはない',
+    heroStartTitleAria: 'デザインがこんなに簡単だったことはない',
     footerCopy: '© {{year}} zuoge',
     footerIcp: '滇ICP备2026017289号',
     heroSuggest: {
@@ -1844,6 +1844,7 @@ const ja = {
     clickToEdit: 'クリックして編集・再送信',
     running: '実行中…',
     working: '処理中…',
+    thinking: '考え中',
     workedFor: '{{duration}}',
     workLog: '作業ログ',
     expandProcess: 'プロセスを展開',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1996,6 +1996,7 @@ const zhCN = {
     clickToEdit: '点击编辑并再次发送',
     running: '执行中…',
     working: '处理中…',
+    thinking: '正在思考',
     workedFor: '{{duration}}',
     workLog: '工作记录',
     expandProcess: '展开过程',

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1836,6 +1836,7 @@ const zhTW = {
     clickToEdit: '點擊編輯並再次傳送',
     running: '執行中…',
     working: '處理中…',
+    thinking: '正在思考',
     workedFor: '{{duration}}',
     workLog: '工作記錄',
     expandProcess: '展開過程',

--- a/apps/web/src/store/modules/editor.ts
+++ b/apps/web/src/store/modules/editor.ts
@@ -263,7 +263,9 @@ const IMAGE_TOOL_SIDE_PANEL_KIND: Record<string, true> = {
 /** Blend / effects dock beside any selected node (not image-only tools). */
 const NODE_LAYER_TOOL_PANEL_KIND: Record<string, true> = {
   effects: true,
-  blendMode: true};
+  blendMode: true,
+  opacity: true,
+};
 
 const IMAGE_TOOL_CROP_SESSION_KIND: Record<string, true> = {
   crop: true,

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -851,6 +851,47 @@ html[data-theme='dark'] .rcb-skeleton-card .rcb-skeleton-bone {
   }
 }
 
+/* Chat: “正在思考” text with horizontal light sweep */
+@keyframes rcb-thinking-shimmer {
+  0% {
+    background-position: 120% 0;
+  }
+  100% {
+    background-position: -120% 0;
+  }
+}
+
+.rcb-thinking-shimmer {
+  display: inline-block;
+  font-size: 13px;
+  line-height: 1.4;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  background-image: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--muted) 88%, transparent) 0%,
+    color-mix(in srgb, var(--muted) 88%, transparent) 36%,
+    color-mix(in srgb, var(--ink) 92%, transparent) 50%,
+    color-mix(in srgb, var(--muted) 88%, transparent) 64%,
+    color-mix(in srgb, var(--muted) 88%, transparent) 100%
+  );
+  background-size: 220% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: rcb-thinking-shimmer 1.6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rcb-thinking-shimmer {
+    animation: none;
+    background-image: none;
+    color: var(--muted);
+    -webkit-text-fill-color: var(--muted);
+  }
+}
+
 /* Global thin scrollbar with track inset */
 * {
   scrollbar-width: thin;

--- a/apps/web/src/utils/__tests__/openProjectSessions.test.ts
+++ b/apps/web/src/utils/__tests__/openProjectSessions.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { probeProjectOpenElsewhere, probeRequestId } from '@/utils/openProjectSessions';
+
+describe('probeRequestId', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('falls back when crypto.randomUUID is missing (insecure HTTP)', () => {
+    vi.stubGlobal('crypto', {
+      getRandomValues: (arr: Uint8Array) => arr,
+    });
+    const id = probeRequestId();
+    expect(id.length).toBeGreaterThan(4);
+  });
+});
+
+describe('probeProjectOpenElsewhere', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('still runs probe when crypto.randomUUID is missing (server HTTP)', async () => {
+    vi.stubGlobal('crypto', {
+      getRandomValues: (arr: Uint8Array) => arr,
+    });
+
+    // No editor peer → times out as not open (probe still executed).
+    await expect(probeProjectOpenElsewhere('proj-1')).resolves.toBe(false);
+  });
+});

--- a/apps/web/src/utils/openProjectSessions.ts
+++ b/apps/web/src/utils/openProjectSessions.ts
@@ -33,38 +33,69 @@ function isEditingReply(msg: unknown, projectId: string, requestId: string): boo
   );
 }
 
+/** Correlation id — works on plain HTTP (non-secure) deploys where randomUUID is missing. */
+export function probeRequestId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
 /** EditorPage: answer delete probes from home / projects list. */
 export function listenForProjectOpenProbes(projectId: string | null | undefined): () => void {
   const id = String(projectId || '').trim();
-  const ch = channelOrNull();
+  let ch: BroadcastChannel | null = null;
+  try {
+    ch = channelOrNull();
+  } catch {
+    return () => {};
+  }
   if (!id || !ch) return () => {};
 
   const onMessage = (event: MessageEvent<CheckMsg>) => {
     const msg = event.data;
     if (!isCheckFor(msg, id)) return;
-    ch.postMessage({ type: 'editing', projectId: id, requestId: msg.requestId });
+    try {
+      ch!.postMessage({ type: 'editing', projectId: id, requestId: msg.requestId });
+    } catch {
+      /* ignore — peer probe will time out / fail closed */
+    }
   };
 
   ch.addEventListener('message', onMessage);
-  return () => ch.removeEventListener('message', onMessage);
+  return () => ch!.removeEventListener('message', onMessage);
 }
 
-/** True when another tab has this project open in the editor. */
+/**
+ * True when another tab has this project open in the editor.
+ * Runs on all deploys (incl. HTTP servers) — only the request id is polyfilled.
+ */
 export function probeProjectOpenElsewhere(projectId: string): Promise<boolean> {
   const id = String(projectId || '').trim();
-  const ch = channelOrNull();
-  if (!id || !ch) return Promise.resolve(false);
+  if (!id) return Promise.resolve(false);
 
-  const requestId = crypto.randomUUID();
+  let ch: BroadcastChannel | null = null;
+  try {
+    ch = channelOrNull();
+  } catch (err) {
+    return Promise.reject(err instanceof Error ? err : new Error('broadcast_channel_unavailable'));
+  }
+  if (!ch) {
+    // SSR / no window — nothing to probe.
+    return Promise.resolve(false);
+  }
 
-  return new Promise((resolve) => {
+  const requestId = probeRequestId();
+
+  return new Promise((resolve, reject) => {
     let settled = false;
+    let timer = 0;
 
     const finish = (open: boolean) => {
       if (settled) return;
       settled = true;
-      ch.removeEventListener('message', onReply);
-      clearTimeout(timer);
+      ch!.removeEventListener('message', onReply);
+      window.clearTimeout(timer);
       resolve(open);
     };
 
@@ -72,8 +103,15 @@ export function probeProjectOpenElsewhere(projectId: string): Promise<boolean> {
       if (isEditingReply(event.data, id, requestId)) finish(true);
     };
 
-    ch.addEventListener('message', onReply);
-    ch.postMessage({ type: 'check', projectId: id, requestId });
-    const timer = window.setTimeout(() => finish(false), PROBE_TIMEOUT_MS);
+    try {
+      ch.addEventListener('message', onReply);
+      ch.postMessage({ type: 'check', projectId: id, requestId });
+    } catch (err) {
+      settled = true;
+      ch.removeEventListener('message', onReply);
+      reject(err instanceof Error ? err : new Error('project_open_probe_failed'));
+      return;
+    }
+    timer = window.setTimeout(() => finish(false), PROBE_TIMEOUT_MS);
   });
 }

--- a/e2e/tests/canvasStressHelpers.ts
+++ b/e2e/tests/canvasStressHelpers.ts
@@ -89,7 +89,7 @@ export async function openBlankEditor(page: Page, namePrefix = 'canvas-product')
     throw new Error('editor behind login');
   }
   await expect(
-    page.getByRole('button', { name: /Image generator|图像生成�?i }).first()
+    page.getByRole('button', { name: /Image generator|图像生成�?i }).first()
   ).toBeVisible({ timeout: 45_000 });
   const stage = page.locator('[data-rcb-canvas="1"], [data-canvas-stage="1"]').first();
   await expect(stage).toBeVisible({ timeout: 45_000 });


### PR DESCRIPTION
## Summary
- Timeline-open surround paint uses the same world WebGL mesh path as closed pasteboard (no DomHost/SVG reintroduction via stack-above).
- Dragging/drawing into an open animation workbench binds the node as a plate layer on top instead of surrounding under the plate.
- Pencil commit no longer freezes: downsample before RDP, defer bake, and cap expensive remesh/tessellation paths.

## Test plan
- [ ] Open timeline: unbound world nodes above/beside plate paint as mesh (not SVG host)
- [ ] Drag existing unbound art into open workbench → appears as top plate layer in timeline
- [ ] Draw shape/pencil into open workbench → binds to plate
- [ ] Pencil scribble then release: UI stays responsive (no multi-second freeze)
- [ ] Hard refresh and re-verify pencil + workbench bind