### PR TITLE
fix(api): MCP canvas headless/live-only and Agent tools

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -36,7 +36,7 @@
 
 🤖 **Design Agent** — 同一キャンバス上のストリーミング会話：計画 → Skill → `tool_ops` → 適用。LangGraph カーネル固定；挙動は AgentProfile YAML、段階プロンプト、Skills、ツール登録で設定。
 
-🔌 **MCP キャンバス** — 外部クライアントは内蔵 Agent と同じ `tool_ops` 契約。Live：エディタ起動中にブラウザで apply。Headless：エディタ未起動時は API がドキュメントを patch。
+🔌 **MCP キャンバス** — 外部クライアントは内蔵 Agent と同じ `tool_ops` 契約。Live：エディタ起動中にブラウザで apply。Headless：基本 CRUD/フレームは API がドキュメントを patch。live-only を含む場合はオフライン待ち行列（`queued_offline`、黙って破棄しない）。
 
 🧩 **プラグイン** — Skill パックは `plugins/skills/`、キャンバスプラグインは `plugins/canvas/`。`.recombyn-plugin` にパック可能。
 
@@ -173,8 +173,9 @@ RECOMBYN_TOKEN = "<token>"
 RECOMBYN_PROJECT_ID = "<project-id>"
 ```
 
-**Live** — エディタ起動中、ブラウザで apply。  
-**Headless** — エディタ未起動、API がプロジェクトを patch。
+**Live** — エディタ起動中、ブラウザで apply（`queued_live`）。  
+**Headless** — 未起動時、基本 CRUD/フレームは API が patch（`applied_headless`）。  
+**オフライン待ち** — live-only（boolean など）を含むとエディタ起動まで待ち行列（`queued_offline`）。
 
 詳細：[docs/mcp-canvas.md](docs/mcp-canvas.md)。
 

--- a/README.md
+++ b/README.md
@@ -173,8 +173,9 @@ RECOMBYN_TOKEN = "<token>"
 RECOMBYN_PROJECT_ID = "<project-id>"
 ```
 
-**Live** — editor open; ops apply in the browser.  
-**Headless** — editor closed; API patches the project document.
+**Live** — editor open; ops apply in the browser (`queued_live`).  
+**Headless** — editor closed; basic create/update/delete/frame ops patch the document (`applied_headless`).  
+**Offline queue** — editor closed + live-only ops (boolean/align/…); batch waits until the project is opened (`queued_offline`, never silently dropped).
 
 Details: [docs/mcp-canvas.md](docs/mcp-canvas.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,7 +35,7 @@
 
 🤖 **Design Agent** — 同一张画布上的流式对话：规划 → 挂 Skill → 产出 `tool_ops` → 落笔。LangGraph 内核固定；行为由 AgentProfile YAML、阶段提示词、Skills 与工具注册表配置。
 
-🔌 **MCP 画布** — 外部客户端使用与内置 Agent 相同的 `tool_ops` 合约。Live：编辑器打开时在浏览器 apply；Headless：编辑器关闭时由 API 直接 patch 文档。
+🔌 **MCP 画布** — 外部客户端使用与内置 Agent 相同的 `tool_ops` 合约。Live：编辑器打开时浏览器 apply；Headless：基础 CRUD/画板 API 直接 patch；含 boolean 等 live-only 时离线排队（`queued_offline`，不静默丢弃）。
 
 🧩 **插件** — Skill 包在 `plugins/skills/`，画布插件在 `plugins/canvas/`，可打包为 `.recombyn-plugin`。
 
@@ -172,8 +172,9 @@ RECOMBYN_TOKEN = "<token>"
 RECOMBYN_PROJECT_ID = "<project-id>"
 ```
 
-**Live**：编辑器打开，浏览器实时 apply。  
-**Headless**：编辑器关闭，API 直接 patch 项目文档。
+**Live**：编辑器打开，浏览器实时 apply（`queued_live`）。  
+**Headless**：编辑器关闭时，基础 CRUD/画板由 API patch（`applied_headless`）。  
+**离线排队**：含 boolean/align 等 live-only 时整批排队，打开项目后再 apply（`queued_offline`，不静默丢弃）。
 
 详情：[docs/mcp-canvas.md](docs/mcp-canvas.md)。
 

--- a/apps/api/app/services/llm/mcp_canvas_tools.py
+++ b/apps/api/app/services/llm/mcp_canvas_tools.py
@@ -31,32 +31,131 @@ def mcp_canvas_langchain_tools(*, user_id: str, project_id: str | None = None) -
         except McpCanvasError as exc:
             return json.dumps({"error": str(exc), "code": exc.code}, ensure_ascii=False)
 
+    def _pid(project_id: str | None = None) -> str:
+        return str(project_id or default_pid or "").strip()
+
     class ProjectIdArgs(BaseModel):
         model_config = ConfigDict(extra="forbid")
         project_id: str | None = Field(default=None, description="Recombyn project id")
+
+    class ListNodesArgs(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        project_id: str | None = Field(default=None)
+        limit: int | None = Field(default=120, ge=1, le=200)
 
     class ApplyOpsArgs(BaseModel):
         model_config = ConfigDict(extra="forbid")
         project_id: str | None = Field(default=None)
         ops: list[dict[str, Any]] = Field(description="Canvas tool_ops batch")
 
+    class CreateShapeArgs(BaseModel):
+        model_config = ConfigDict(extra="allow")
+        project_id: str | None = Field(default=None)
+        shapeType: str = Field(default="rect")
+        x: float = 40
+        y: float = 40
+        width: float = 120
+        height: float = 80
+        fill: str | None = None
+        stroke: str | None = None
+        frameId: str | None = None
+
+    class CreateTextArgs(BaseModel):
+        model_config = ConfigDict(extra="allow")
+        project_id: str | None = Field(default=None)
+        text: str = Field(default="Text")
+        x: float = 40
+        y: float = 40
+        width: float = 200
+        fontSize: float | None = None
+        fill: str | None = None
+        frameId: str | None = None
+
+    class UpdateNodeArgs(BaseModel):
+        model_config = ConfigDict(extra="allow")
+        project_id: str | None = Field(default=None)
+        nodeId: str = Field(description="Scene node id")
+
+    class DeleteNodesArgs(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        project_id: str | None = Field(default=None)
+        nodeIds: list[str] = Field(description="Node ids to delete")
+
     tools: list[Any] = [
         StructuredTool.from_function(
             func=lambda project_id=None: _run(
-                "get_scene_summary", {"project_id": project_id or default_pid}
+                "get_scene_summary", {"project_id": _pid(project_id)}
             ),
             name="canvas_get_scene_summary",
             description="Read Recombyn canvas summary for a project (frames, nodes, types).",
             args_schema=ProjectIdArgs,
         ),
         StructuredTool.from_function(
+            func=lambda project_id=None, limit=120: _run(
+                "list_nodes",
+                {"project_id": _pid(project_id), "limit": limit},
+            ),
+            name="canvas_list_nodes",
+            description="List scene nodes on a Recombyn project canvas.",
+            args_schema=ListNodesArgs,
+        ),
+        StructuredTool.from_function(
+            func=lambda project_id=None: _run(
+                "list_frames", {"project_id": _pid(project_id)}
+            ),
+            name="canvas_list_frames",
+            description="List artboard frames on a Recombyn project canvas.",
+            args_schema=ProjectIdArgs,
+        ),
+        StructuredTool.from_function(
             func=lambda project_id=None, ops=None: _run(
                 "apply_tool_ops",
-                {"project_id": project_id or default_pid, "ops": ops or []},
+                {"project_id": _pid(project_id), "ops": ops or []},
             ),
             name="canvas_apply_tool_ops",
-            description="Apply validated canvas tool_ops to a Recombyn project (MCP dispatch).",
+            description=(
+                "Apply validated canvas tool_ops. "
+                "Basic create/update/delete/frame ops apply headless; "
+                "boolean/align/image_process/viewport and similar need a live editor "
+                "(status queued_live or queued_offline)."
+            ),
             args_schema=ApplyOpsArgs,
+        ),
+        StructuredTool.from_function(
+            func=lambda project_id=None, **kwargs: _run(
+                "create_shape",
+                {"project_id": _pid(project_id), **kwargs},
+            ),
+            name="canvas_create_shape",
+            description="Create a shape on the project canvas (headless-capable).",
+            args_schema=CreateShapeArgs,
+        ),
+        StructuredTool.from_function(
+            func=lambda project_id=None, **kwargs: _run(
+                "create_text",
+                {"project_id": _pid(project_id), **kwargs},
+            ),
+            name="canvas_create_text",
+            description="Create a text node on the project canvas (headless-capable).",
+            args_schema=CreateTextArgs,
+        ),
+        StructuredTool.from_function(
+            func=lambda project_id=None, nodeId="", **kwargs: _run(
+                "update_node",
+                {"project_id": _pid(project_id), "nodeId": nodeId, **kwargs},
+            ),
+            name="canvas_update_node",
+            description="Update a scene node (headless-capable).",
+            args_schema=UpdateNodeArgs,
+        ),
+        StructuredTool.from_function(
+            func=lambda project_id=None, nodeIds=None: _run(
+                "delete_nodes",
+                {"project_id": _pid(project_id), "nodeIds": nodeIds or []},
+            ),
+            name="canvas_delete_nodes",
+            description="Delete scene nodes (headless-capable).",
+            args_schema=DeleteNodesArgs,
         ),
     ]
     return tools

--- a/apps/api/app/services/mcp/apply_headless.py
+++ b/apps/api/app/services/mcp/apply_headless.py
@@ -12,7 +12,6 @@ from app.services.design.ops.text_node_attrs import (
     style_from_create_text_args,
     validate_headless_patch,
 )
-from app.services.mcp.tool_registry import is_live_only_tool
 
 _TEXT_UPDATE_KEYS = (
     "text",
@@ -26,17 +25,26 @@ _TEXT_UPDATE_KEYS = (
     "textDecoration",
 )
 
-_TEXT_UPDATE_KEYS = (
-    "text",
-    "fill",
-    "fontSize",
-    "fontWeight",
-    "fontFamily",
-    "fontStyle",
-    "textAlign",
-    "lineHeight",
-    "textDecoration",
+# Ops that `ops_to_document_patch` can apply without a live editor.
+# Everything else in the canvas catalog is live-only (queued for FE apply).
+HEADLESS_OP_NAMES = frozenset(
+    {
+        "create_shape",
+        "create_path",
+        "create_text",
+        "update_node",
+        "delete_nodes",
+        "hide_nodes",
+        "create_frame",
+        "update_frame",
+        "delete_frame",
+        "set_canvas_background",
+    }
 )
+
+
+def is_headless_op(name: str) -> bool:
+    return str(name or "").strip() in HEADLESS_OP_NAMES
 
 
 def _bool_attr(value: Any) -> str:
@@ -568,7 +576,7 @@ def ops_to_document_patch(
         if not isinstance(op, dict):
             continue
         name = str(op.get("name") or "").strip()
-        if is_live_only_tool(name):
+        if not is_headless_op(name):
             continue
         args = op.get("args") if isinstance(op.get("args"), dict) else {}
 

--- a/apps/api/app/services/mcp/dispatch.py
+++ b/apps/api/app/services/mcp/dispatch.py
@@ -69,10 +69,13 @@ def _persist_ops(user_id: str, project_id: str, ops: list[dict[str, Any]]) -> di
     doc = _project_document(row)
     validated = _validate_ops_for_document(doc, ops)
     live = has_live_session(project_id)
-    live_only = [o for o in validated if is_live_only_tool(str(o.get("name") or ""))]
-    headless_candidates = [o for o in validated if not is_live_only_tool(str(o.get("name") or ""))]
+    live_required = [o for o in validated if is_live_only_tool(str(o.get("name") or ""))]
+    headless_ok = [o for o in validated if not is_live_only_tool(str(o.get("name") or ""))]
+    op_summaries = [{"name": o.get("name"), "args": o.get("args")} for o in validated]
+    live_names = [str(o.get("name") or "") for o in live_required]
 
-    if live or live_only:
+    # Open editor: full designTools parity via FE bridge.
+    if live:
         batch_id = publish_pending_ops(project_id, validated)
         return {
             "status": "queued_live",
@@ -80,24 +83,34 @@ def _persist_ops(user_id: str, project_id: str, ops: list[dict[str, Any]]) -> di
             "queued": len(validated),
             "batchId": batch_id,
             "revision": project_revision(row),
-            "liveOnly": [o.get("name") for o in live_only],
-            "ops": [{"name": o.get("name"), "args": o.get("args")} for o in validated],
+            "liveOnly": live_names,
+            "ops": op_summaries,
         }
 
-    patch = ops_to_document_patch(doc, headless_candidates)
+    # No editor: never silently drop live-only ops — queue until the project opens.
+    if live_required:
+        batch_id = publish_pending_ops(project_id, validated)
+        return {
+            "status": "queued_offline",
+            "applied": 0,
+            "queued": len(validated),
+            "batchId": batch_id,
+            "revision": project_revision(row),
+            "message": (
+                "Some ops require a live editor session. "
+                "Open this project in the web editor to apply "
+                f"({', '.join(sorted({n for n in live_names if n})[:8])})."
+            ),
+            "liveOnly": live_names,
+            "ops": op_summaries,
+        }
+
+    patch = ops_to_document_patch(doc, headless_ok)
     if not patch:
-        if live_only:
-            batch_id = publish_pending_ops(project_id, validated)
-            return {
-                "status": "queued_offline",
-                "applied": 0,
-                "queued": len(validated),
-                "batchId": batch_id,
-                "revision": project_revision(row),
-                "message": "Some ops require a live editor session",
-                "ops": [{"name": o.get("name"), "args": o.get("args")} for o in validated],
-            }
-        raise McpCanvasError("ops produced no document changes", code="empty_patch")
+        raise McpCanvasError(
+            "ops produced no document changes (check node ids / args)",
+            code="empty_patch",
+        )
 
     schema_errors = validate_headless_patch(patch)
     if schema_errors:
@@ -128,10 +141,10 @@ def _persist_ops(user_id: str, project_id: str, ops: list[dict[str, Any]]) -> di
     publish_project_revision(project_id, rev)
     return {
         "status": "applied_headless",
-        "applied": len(headless_candidates),
+        "applied": len(headless_ok),
         "queued": 0,
         "revision": rev,
-        "ops": [{"name": o.get("name"), "args": o.get("args")} for o in headless_candidates],
+        "ops": [{"name": o.get("name"), "args": o.get("args")} for o in headless_ok],
     }
 
 

--- a/apps/api/app/services/mcp/tool_registry.py
+++ b/apps/api/app/services/mcp/tool_registry.py
@@ -13,6 +13,7 @@ from app.services.llm.design_tools import (
     _parameters_from_pydantic,
     pydantic_model_from_args_schema,
 )
+from app.services.mcp.apply_headless import HEADLESS_OP_NAMES
 
 _META_READ = frozenset({"get_scene_summary", "list_nodes", "list_frames"})
 _META_BATCH = frozenset({"apply_tool_ops"})
@@ -26,22 +27,36 @@ def _load_canvas_tools_yaml() -> dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
-@lru_cache(maxsize=1)
-def live_only_tool_names() -> frozenset[str]:
+def _yaml_force_live_only() -> frozenset[str]:
     cfg = _load_canvas_tools_yaml()
     raw = cfg.get("live_only")
     if isinstance(raw, list):
         return frozenset(str(x).strip() for x in raw if str(x or "").strip())
-    return frozenset(
-        {
-            "set_viewport",
-            "set_active_tool",
-            "set_grid",
-            "export_canvas",
-            "image_process",
-            "outline_text",
-        }
-    )
+    return frozenset()
+
+
+@lru_cache(maxsize=1)
+def headless_tool_names() -> frozenset[str]:
+    """Ops the API can patch into the project document without an open editor."""
+    return frozenset(HEADLESS_OP_NAMES)
+
+
+@lru_cache(maxsize=1)
+def live_only_tool_names() -> frozenset[str]:
+    """
+    Write ops that must run in a live editor (FE designTools).
+
+    Auto: every exposed canvas op_key minus headless-capable names.
+    Plus any names listed under YAML `live_only` (force list).
+    """
+    names: set[str] = set(_yaml_force_live_only())
+    for row in default_canvas_actions():
+        key = str(row.get("op_key") or "").strip()
+        if key and key not in HEADLESS_OP_NAMES:
+            names.add(key)
+    # Never treat meta tools as live-only writes.
+    names -= _META_READ | _META_BATCH
+    return frozenset(names)
 
 
 def live_session_ttl_sec() -> int:
@@ -62,6 +77,10 @@ def max_ops_per_call() -> int:
 
 def is_live_only_tool(name: str) -> bool:
     return str(name or "").strip() in live_only_tool_names()
+
+
+def is_headless_tool(name: str) -> bool:
+    return str(name or "").strip() in headless_tool_names()
 
 
 def is_canvas_write_tool(name: str) -> bool:
@@ -103,6 +122,13 @@ def exposed_tool_names() -> frozenset[str]:
     return frozenset(names)
 
 
+def clear_mcp_tool_caches() -> None:
+    """Test helper — drop lru caches after YAML / seed changes."""
+    exposed_tool_names.cache_clear()
+    live_only_tool_names.cache_clear()
+    headless_tool_names.cache_clear()
+
+
 def _meta_tool_defs() -> list[dict[str, Any]]:
     return [
         _openai_fn_def(
@@ -137,7 +163,8 @@ def _meta_tool_defs() -> list[dict[str, Any]]:
         ),
         _openai_fn_def(
             "apply_tool_ops",
-            "Apply a batch of canvas tool_ops after server-side validation.",
+            "Apply a batch of canvas tool_ops after server-side validation. "
+            "Basic create/update/delete/frame ops apply headless; others need a live editor.",
             {
                 "type": "object",
                 "properties": {
@@ -185,6 +212,8 @@ def list_mcp_tool_definitions() -> list[dict[str, Any]]:
         hint = str(row.get("model_hint") or row.get("label") or key).strip()
         if is_live_only_tool(key):
             hint = f"[live editor] {hint}"
+        else:
+            hint = f"[headless ok] {hint}"
         model = pydantic_model_from_args_schema(key, row.get("args_schema"))
         params = _parameters_from_pydantic(model)
         props = dict(params.get("properties") or {})

--- a/apps/api/seeds/mcp/canvas_tools.yaml
+++ b/apps/api/seeds/mcp/canvas_tools.yaml
@@ -1,5 +1,11 @@
 # MCP canvas — expose full canvas_actions catalog to external MCP clients.
-# live_only ops require an open editor (queued → FE designTools apply).
+#
+# Headless-capable ops (API document patch, no editor):
+#   create_shape, create_path, create_text, update_node, delete_nodes,
+#   hide_nodes, create_frame, update_frame, delete_frame, set_canvas_background
+# Everything else in the canvas catalog is treated as live_only (queued for FE).
+# `live_only` below is an explicit force-list (union with the auto-derived set).
+
 expose_all_canvas_ops: true
 
 expose:
@@ -10,7 +16,7 @@ expose:
   batch:
     - apply_tool_ops
 
-# UI / async / viewport — validated then queued for live editor apply only.
+# Force live-editor apply (also auto-includes all non-headless catalog ops).
 live_only:
   - set_viewport
   - set_active_tool
@@ -18,6 +24,8 @@ live_only:
   - export_canvas
   - image_process
   - outline_text
+  - boolean_op
+  - align_nodes
 
 allowlist_only: false
 max_ops_per_call: 32

--- a/apps/api/tests/unit_tests/test_mcp_canvas_dispatch.py
+++ b/apps/api/tests/unit_tests/test_mcp_canvas_dispatch.py
@@ -9,6 +9,7 @@ from app.services.mcp.apply_headless import ops_to_document_patch
 from app.services.mcp.dispatch import McpCanvasError, call_mcp_canvas_tool
 from app.services.mcp.scene import scene_frames_from_document, scene_nodes_from_document, summarize_scene
 from app.services.mcp.tool_registry import (
+    clear_mcp_tool_caches,
     exposed_tool_names,
     is_canvas_write_tool,
     is_live_only_tool,
@@ -26,9 +27,9 @@ def _empty_doc() -> dict:
 
 @pytest.fixture(autouse=True)
 def _clear_tool_registry_cache():
-    exposed_tool_names.cache_clear()
+    clear_mcp_tool_caches()
     yield
-    exposed_tool_names.cache_clear()
+    clear_mcp_tool_caches()
 
 
 def test_expose_all_canvas_ops_in_registry():
@@ -45,7 +46,11 @@ def test_expose_all_canvas_ops_in_registry():
 def test_live_only_tools_flagged():
     assert is_live_only_tool("set_viewport")
     assert is_live_only_tool("image_process")
+    assert is_live_only_tool("boolean_op")
+    assert is_live_only_tool("align_nodes")
     assert not is_live_only_tool("create_shape")
+    assert not is_live_only_tool("create_text")
+    assert not is_live_only_tool("update_node")
     assert is_canvas_write_tool("update_node")
     assert not is_canvas_write_tool("get_scene_summary")
 
@@ -189,6 +194,24 @@ def test_ops_to_document_patch_skips_live_only():
     doc = _empty_doc()
     patch = ops_to_document_patch(doc, [{"name": "set_viewport", "args": {"action": "fit"}}])
     assert patch == {}
+    patch2 = ops_to_document_patch(
+        doc,
+        [
+            {"name": "boolean_op", "args": {"op": "unite", "nodeIds": ["a", "b"]}},
+            {
+                "name": "create_shape",
+                "args": {
+                    "shapeType": "rect",
+                    "x": 0,
+                    "y": 0,
+                    "width": 10,
+                    "height": 10,
+                    "fill": "#000",
+                },
+            },
+        ],
+    )
+    assert patch2.get("upsertNodes")
 
 
 def test_summarize_scene_empty():
@@ -290,6 +313,60 @@ def test_call_requires_project_id():
     assert exc.value.code == "bad_request"
 
 
+@patch("app.services.mcp.dispatch.has_live_session", return_value=False)
+@patch("app.services.mcp.dispatch.publish_pending_ops", return_value="batch-off")
+@patch("app.services.mcp.dispatch.load_writable_project")
+def test_call_live_only_op_queues_offline(mock_load, mock_pending, _live):
+    mock_load.return_value = {"id": "p1", "revision": 2, "document": _empty_doc()}
+    out = call_mcp_canvas_tool(
+        user_id="u1",
+        tool="boolean_op",
+        arguments={
+            "project_id": "p1",
+            "op": "unite",
+            "nodeIds": ["n1", "n2"],
+        },
+    )
+    assert out["status"] == "queued_offline"
+    assert out["batchId"] == "batch-off"
+    assert "boolean_op" in (out.get("liveOnly") or [])
+    mock_pending.assert_called_once()
+
+
+@patch("app.services.mcp.dispatch.has_live_session", return_value=False)
+@patch("app.services.mcp.dispatch.publish_pending_ops", return_value="batch-mix")
+@patch("app.services.mcp.dispatch.project_store.patch_project")
+@patch("app.services.mcp.dispatch.load_writable_project")
+def test_mixed_batch_with_live_only_queues_all_offline(
+    mock_load, mock_patch, mock_pending, _live
+):
+    mock_load.return_value = {"id": "p1", "revision": 2, "document": _empty_doc()}
+    out = call_mcp_canvas_tool(
+        user_id="u1",
+        tool="apply_tool_ops",
+        arguments={
+            "project_id": "p1",
+            "ops": [
+                {
+                    "name": "create_shape",
+                    "args": {
+                        "shapeType": "rect",
+                        "x": 0,
+                        "y": 0,
+                        "width": 40,
+                        "height": 40,
+                        "fill": "#000",
+                    },
+                },
+                {"name": "align_nodes", "args": {"nodeIds": ["a", "b"], "align": "left"}},
+            ],
+        },
+    )
+    assert out["status"] == "queued_offline"
+    mock_pending.assert_called_once()
+    mock_patch.assert_not_called()
+
+
 @patch("app.core.config.settings")
 def test_mcp_agent_tools_when_disabled(mock_settings):
     mock_settings.mcp_canvas_enabled = False
@@ -306,4 +383,10 @@ def test_mcp_agent_tools_when_enabled(mock_settings):
     tools = mcp_canvas_langchain_tools(user_id="u1", project_id="p1")
     names = {getattr(t, "name", "") for t in tools}
     assert "canvas_get_scene_summary" in names
+    assert "canvas_list_nodes" in names
+    assert "canvas_list_frames" in names
     assert "canvas_apply_tool_ops" in names
+    assert "canvas_create_shape" in names
+    assert "canvas_create_text" in names
+    assert "canvas_update_node" in names
+    assert "canvas_delete_nodes" in names

--- a/apps/web/src/components/editor/mcp/McpCanvasBridge.tsx
+++ b/apps/web/src/components/editor/mcp/McpCanvasBridge.tsx
@@ -1,7 +1,7 @@
 /**
  * Live editor bridge for MCP canvas control:
- * - heartbeat � server routes ops to live queue (full designTools parity)
- * - pending batches ? applyAgentToolOps (same stagger + canvas lock as Design Agent)
+ * - heartbeat → server routes ops to live queue (full designTools parity)
+ * - pending batches → applyAgentToolOps (same stagger + canvas lock as Design Agent)
  * - revision reload when headless writes land
  */
 import { useCallback, useEffect, useRef } from 'react';

--- a/docs/mcp-canvas.md
+++ b/docs/mcp-canvas.md
@@ -18,10 +18,24 @@ Restart API and web after changing env vars.
 
 | Mode | When | What happens |
 |------|------|----------------|
-| **Live** | Editor open + heartbeat | Ops queue to Redis → `McpCanvasBridge` applies via `designTools` (full op set) |
-| **Headless** | Editor closed | API validates ops and patches the project document directly |
+| **Live** (`queued_live`) | Editor open + heartbeat | Ops queue to Redis → `McpCanvasBridge` applies via `designTools` (full op set) |
+| **Headless** (`applied_headless`) | Editor closed + only headless-capable ops | API validates and patches the project document |
+| **Offline queue** (`queued_offline`) | Editor closed + any live-only op | Entire batch is queued until the project is opened in the web editor — **never silently dropped** |
 
-Complex ops (`boolean_op`, `align_nodes`, `image_process`, …) need **Live** mode. Basic create/update/delete work headless.
+### Headless-capable ops
+
+These apply without an open editor (`apps/api/.../apply_headless.py`):
+
+- `create_shape`, `create_path`, `create_text`
+- `update_node`, `delete_nodes`, `hide_nodes`
+- `create_frame`, `update_frame`, `delete_frame`
+- `set_canvas_background`
+
+### Live-only ops
+
+Everything else in the canvas catalog (e.g. `boolean_op`, `align_nodes`, `image_process`, `set_viewport`, `export_canvas`, …) is **live-only**. Catalog tool descriptions are prefixed with `[live editor]` or `[headless ok]`.
+
+Seed / force list: `apps/api/seeds/mcp/canvas_tools.yaml` (`live_only` ∪ auto-derived non-headless op keys).
 
 ## API
 
@@ -72,9 +86,21 @@ SUPER_ADMIN_TEST_CODE=888888 node scripts/ci-mint-token.mjs
 
 Full catalog: `GET /api/v1/mcp/canvas/tools` or MCP `tools/list` via the stdio bridge.
 
+## Design Agent integration
+
+When `MCP_CANVAS_ENABLED=true`, the LangGraph agent also gets server-side canvas tools (same dispatch):
+
+- `canvas_get_scene_summary`, `canvas_list_nodes`, `canvas_list_frames`
+- `canvas_apply_tool_ops`
+- `canvas_create_shape`, `canvas_create_text`, `canvas_update_node`, `canvas_delete_nodes`
+
+The primary Agent paint path remains SSE `tool_ops` → FE `applyAgentToolOps`. MCP tools are an optional react-mode side channel (useful when the editor is closed or for read-back).
+
 ## Related
 
 - Tool registry seed: `apps/api/seeds/mcp/canvas_tools.yaml`
+- Headless patch: `apps/api/app/services/mcp/apply_headless.py`
+- Dispatch: `apps/api/app/services/mcp/dispatch.py`
 - Stdio bridge: `scripts/mcp/recombyn_canvas_stdio.mjs`
 - FE bridge: `apps/web/src/components/editor/mcp/McpCanvasBridge.tsx`
 - Agent react tools: `apps/api/app/services/llm/mcp_canvas_tools.py`


### PR DESCRIPTION
## Summary
- Auto-derive live-only canvas ops from headless-capable set; offline live-only batches return `queued_offline` (never silent drop)
- Expand Design Agent MCP tools: list nodes/frames + create/update/delete shortcuts
- Docs + unit tests aligned (`docs/mcp-canvas.md`, READMEs)

## Test plan
- [x] `pytest apps/api/tests/unit_tests/test_mcp_canvas_dispatch.py`
- [ ] With MCP enabled: create_shape headless → `applied_headless`
- [ ] boolean_op offline → `queued_offline`; open editor → apply