### PR TITLE
chore(web): drop unused public/rcb-wasm leftovers

### DIFF
--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -2,47 +2,6 @@
 
 declare module 'virtual:svg-icons-register';
 
-/** Static wasm-bindgen glue served from public/rcb-wasm (see build-wasm.mjs). */
-declare module '/rcb-wasm/rcb_wasm_geom.js' {
-  export default function init(opts?: {
-    module_or_path?: RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
-  }): Promise<unknown>;
-  export function densify_path_d(d: string, flatness: number): Float32Array;
-  export function tessellate_fill(xy: Float32Array): Float32Array;
-  export function tessellate_fill_with_holes(
-    outer: Float32Array,
-    holesFlat: Float32Array,
-    holeCounts: Uint32Array
-  ): Float32Array;
-  export function tessellate_stroke(
-    xy: Float32Array,
-    width: number,
-    closed: boolean,
-    align: string,
-    linejoin?: string,
-    miterLimit?: number
-  ): Float32Array;
-  export function tessellate_batch_fill(xyAll: Float32Array, counts: Uint32Array): Float32Array;
-  export function boolean_polygons(op: number, packed: Float32Array): Float32Array;
-  export function offset_polyline(
-    xy: Float32Array,
-    width: number,
-    closed: boolean,
-    join: number,
-    cap: number,
-    miterLimit: number,
-    roundApprox: number
-  ): Float32Array;
-  export function simplify_rdp(xy: Float32Array, epsilon: number): Float32Array;
-  export function simplify_rdp_closed(xy: Float32Array, epsilon: number): Float32Array;
-  export function trace_rgba_contours(
-    rgba: Uint8Array,
-    width: number,
-    height: number,
-    alphaThreshold: number
-  ): Float32Array;
-}
-
 declare const __GOOGLE_CLIENT_ID__: string;
 declare const __DOCS_URL__: string;
 declare const __DESKTOP_MODE__: string;


### PR DESCRIPTION
## Summary
- Delete unused `public/rcb-wasm` leftovers (local-only; was gitignored)
- Remove stale `/rcb-wasm/rcb_wasm_geom.js` module declare and ignore rules

## Test plan
- [ ] Web builds / typechecks without vite-env.d.ts geom declare