### PR TITLE
fix(web): restore multi-select tidy, line dock, and empty-gen paste

### DIFF
--- a/apps/web/src/components/rcb/canvas/kitBridge.ts
+++ b/apps/web/src/components/rcb/canvas/kitBridge.ts
@@ -1599,9 +1599,8 @@ function flushMappedGeometry(scene: WasmScene) {
       const kitWeight = Math.round(Number(kn.geometry.Text.font_weight) || 400);
       const kitItalic = Boolean(kn.geometry.Text.italic);
       const kitLetter = Number(kn.geometry.Text.letter_spacing) || 0;
-      const prevWeight = isTextBold(prevStyle)
-        ? Math.round(Number(prevStyle.fontWeight) >= 600 ? Number(prevStyle.fontWeight) : 700)
-        : Math.round(Number(prevStyle.fontWeight) || 400) || 400;
+      let prevWeight = Math.round(Number(prevStyle.fontWeight) || 400) || 400;
+      if (isTextBold(prevStyle) && prevWeight < 600) prevWeight = 700;
       const textChanged =
         content !== prevPlain ||
         Math.abs(fontSize - prevStyle.fontSize) > 0.01 ||
@@ -3028,12 +3027,10 @@ async function fetchImageBytes(
  * syncKitSelectionFromStore is not no-op'd by suppressDepth.
  */
 function resyncKitSelectionIfStoreSelected(rcbId: string) {
-  if (!attached) return;
-  if (rcbToKit.get(rcbId) == null) return;
-  const ed = store.getState().editor;
-  const selected = (ed.selectedNodeIds || []).map(String);
-  if (!selected.includes(String(rcbId))) return;
   const handle = attached;
+  const id = String(rcbId);
+  if (!handle || rcbToKit.get(rcbId) == null) return;
+  if (!(store.getState().editor.selectedNodeIds || []).map(String).includes(id)) return;
   const run = () => {
     if (!attached || attached !== handle) return;
     if (suppressDepth > 0) {
@@ -3042,8 +3039,7 @@ function resyncKitSelectionIfStoreSelected(rcbId: string) {
     }
     if (rcbToKit.get(rcbId) == null) return;
     const live = store.getState().editor;
-    const selected = (live.selectedNodeIds || []).map(String);
-    if (!selected.includes(String(rcbId))) return;
+    if (!(live.selectedNodeIds || []).map(String).includes(id)) return;
     syncKitSelectionFromStore(
       handle,
       live.selectedNodeIds || [],
@@ -4921,7 +4917,10 @@ export function isDomHostOnlyRcbNode(node: SceneNodeInput | null | undefined): b
 }
 
 /**
- * Kit owns clipboard when selection has no DomHost-only ids (lottie/group).
+ * Kit owns clipboard when selection has no DomHost-only ids and no empty
+ * generator plates. Empty gens stay Kit-mapped for paint/hit, but generator
+ * flags live only in RCB attrs — Kit duplicate → kitNodeToCreated(rect) drops
+ * them and the center Lucide glyph never paints.
  * Empty node selection still lets Kit handle artboard / engine clipboard.
  */
 export function selectionUsesKitClipboard(
@@ -4930,7 +4929,10 @@ export function selectionUsesKitClipboard(
 ): boolean {
   const ids = (nodeIds || []).map((id) => String(id || '').trim()).filter(Boolean);
   if (!ids.length) return true;
-  return !ids.some((id) => isDomHostOnlyRcbNode(document?.deltaSetLike?.[id]));
+  return !ids.some((id) => {
+    const node = document?.deltaSetLike?.[id];
+    return isEmptyGeneratorPlate(node) || isDomHostOnlyRcbNode(node);
+  });
 }
 
 /** Mirror Kit Group parents into SceneDocument attrs.groupId (product chrome). */

--- a/apps/web/src/components/rcb/selection/SelectionFeature.tsx
+++ b/apps/web/src/components/rcb/selection/SelectionFeature.tsx
@@ -303,7 +303,8 @@ function SelectionFeature({
           {...selectionToolbarDock(toolbarChromeBox!, {
             angle: toolbarChromeAngle,
             edgePadScene: edgePad,
-            lineChrome,
+            // Kit dock AABB is already a world corner AABB — skip lineChrome remap.
+            lineChrome: Boolean(lineChrome && !kitDockAabb),
             node: toolbarNode!,
           })}
           valueBox={toolbarValueBox(chromeGeomBox, toolbarNode)}

--- a/apps/web/src/components/rcb/selection/__tests__/selectionToolbarDock.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/selectionToolbarDock.test.ts
@@ -21,4 +21,16 @@ describe('selectionToolbarDock', () => {
       edgePadScene: 0,
     });
   });
+
+  it('zeros angle after lineChrome endpoint AABB remap', () => {
+    const lineBox = { left: 0, top: 0, width: 100, height: 24 };
+    const dock = selectionToolbarDock(lineBox, {
+      angle: 45,
+      lineChrome: true,
+      node: { attrs: { angle: 45, shapeType: 'line' } },
+    });
+    expect(dock.angle).toBe(0);
+    expect(dock.box).not.toBeNull();
+    expect(dock.box!.height).toBeGreaterThan(1);
+  });
 });

--- a/apps/web/src/components/rcb/selection/__tests__/toolbarBoxForSelection.test.ts
+++ b/apps/web/src/components/rcb/selection/__tests__/toolbarBoxForSelection.test.ts
@@ -37,4 +37,14 @@ describe('toolbarBoxForSelection — line/arrow outer AABB', () => {
     const box = { left: 10, top: 20, width: 80, height: 60 };
     expect(toolbarBoxForSelection(box, { lineChrome: false })).toEqual(box);
   });
+
+  it('does not collapse a Kit world AABB with attrs.angle (mid-box bug)', () => {
+    // Diagonal line's oriented control-box corner AABB — already outer bounds.
+    const world = { left: 0, top: 0, width: 700, height: 700 };
+    const dock = toolbarBoxForSelection(world, {
+      lineChrome: true,
+      node: { attrs: { angle: 45, shapeType: 'line' }, height: 2, width: 992 },
+    });
+    expect(dock).toEqual(world);
+  });
 });

--- a/apps/web/src/components/rcb/selection/chrome/SelectionContextToolbar.tsx
+++ b/apps/web/src/components/rcb/selection/chrome/SelectionContextToolbar.tsx
@@ -441,7 +441,8 @@ function SelectionContextToolbar(props: Props): ReactNode {
   // Timeline host under 动画工作——select frame instead; no node chrome.
   if (isAnimationFrameHostNode(node, document)) return null;
 
-  const placementAngle = angleProp ?? (Number(node?.attrs?.angle) || 0);
+  // Dock passes 0 for Kit world AABB; fall back to node angle otherwise.
+  const placementAngle = Number(angleProp ?? node?.attrs?.angle) || 0;
   const genBox = { x: box.left, y: box.top, width: box.width, height: box.height };
 
   // 动画工作台内子元素：对齐 / 人偶 / 属性（含嵌套 LOT；点 LOT 页签才进内部编辑）。

--- a/apps/web/src/components/rcb/selection/selectionLogic.ts
+++ b/apps/web/src/components/rcb/selection/selectionLogic.ts
@@ -165,15 +165,25 @@ export function frameForFullBleedPlate(doc: SceneDocument, nodeId: string): stri
  * Line/arrow nodes use a tall hit AABB (`STROKE_HIT` ≈ 24). Docking the
  * floating toolbar to that slab's top puts it half a hit-height above the shaft
  * — huge on screen at high zoom. Prefer the shaft's axis-aligned outer bounds
- * (endpoint AABB) so the pill clears both knobs instead of sitting on mid-shaft
- * and covering the higher endpoint on diagonal strokes.
+ * (endpoint AABB). Skip remap when `box` is already a world corner-AABB
+ * (Kit selection frame): treating that width as shaft length + `attrs.angle`
+ * collapses the dock to mid-box.
  */
+/** Above STROKE_HIT≈24: both axes large ⇒ already a Kit/world corner AABB. */
+const LINE_HIT_AABB_MAX_SHORT_AXIS = 40;
+
 export function toolbarBoxForSelection(
   box: SceneBox | null | undefined,
   opts: { lineChrome: boolean; node?: any }
 ): SceneBox | null {
   if (!box) return null;
   if (!opts.lineChrome) return box;
+  if (
+    box.width > LINE_HIT_AABB_MAX_SHORT_AXIS &&
+    box.height > LINE_HIT_AABB_MAX_SHORT_AXIS
+  ) {
+    return box;
+  }
   const angle = Number(opts.node?.attrs?.angle) || 0;
   const ep = strokeEndpointsFromBox(box, angle);
   const minX = Math.min(ep.x0, ep.x1);
@@ -206,9 +216,10 @@ export function selectionToolbarDock(
   const edgePadScene = Math.max(0, Number(opts?.edgePadScene) || 0);
   if (!chromeUnion) return { box: null, angle, edgePadScene };
   if (!opts?.lineChrome) return { box: chromeUnion, angle, edgePadScene };
+  // Endpoint AABB is axis-aligned — do not re-orient in SelectionToolbarShell.
   return {
     box: toolbarBoxForSelection(chromeUnion, { lineChrome: true, node: opts.node }),
-    angle,
+    angle: 0,
     edgePadScene,
   };
 }

--- a/apps/web/src/store/modules/editor.ts
+++ b/apps/web/src/store/modules/editor.ts
@@ -1540,6 +1540,9 @@ export const editorReducers = {
           if (!item?.patch) return true;
           return isTransientNodePatch(item.patch) || patchSkipsHostRemount(item.patch);
         });
+      // Align / distribute / tidy are RCB chrome writes — clear the sticky
+      // Kit→doc flag so KitCanvasHost pushes geometry back into Kit ink.
+      state.lastPatchFromKitCanvas = false;
       if (!skipHistory) persistActivePrecompSession(state);
       syncLibraryOnEdit(state);
       // Bake only frames whose signature actually changed (not every focus tick).

--- a/vendor/vector-editor-ref/packages/editor/src/boolean_ops.ts
+++ b/vendor/vector-editor-ref/packages/editor/src/boolean_ops.ts
@@ -94,11 +94,10 @@ export function computeBooleanSubpaths(
     // fill. Exclude (XOR) may still report EvenOdd — honour that for holes.
     let fillRule = 0;
     try {
-        if (op === 'exclude' && result.getFillType() === ck.FillType.EvenOdd) {
-            fillRule = 1;
-        }
+        fillRule =
+            op === 'exclude' && result.getFillType() === ck.FillType.EvenOdd ? 1 : 0;
     } catch {
-        fillRule = 0;
+        /* keep Winding */
     }
     result.delete();
     // subpaths may be empty (e.g. intersect of disjoint shapes). That's a real
@@ -371,6 +370,18 @@ function isCollocatedHandle(
     return Math.hypot(hx - ax, hy - ay) < eps;
 }
 
+/** Degenerate cubics on polygon edges are a PathOps footgun — emit a line. */
+function appendCubicOrLine(path: Path, from: PathPoint, to: PathPoint) {
+    if (
+        isCollocatedHandle(from.cp2[0], from.cp2[1], from.x, from.y) &&
+        isCollocatedHandle(to.cp1[0], to.cp1[1], to.x, to.y)
+    ) {
+        path.lineTo(to.x, to.y);
+    } else {
+        path.cubicTo(from.cp2[0], from.cp2[1], to.cp1[0], to.cp1[1], to.x, to.y);
+    }
+}
+
 /** Append engine subpaths (cubic beziers via cp1/cp2) onto a CanvasKit path. */
 export function appendSubpathsToPath(path: Path, subpaths: Subpath[]) {
     for (const sp of subpaths) {
@@ -378,37 +389,10 @@ export function appendSubpathsToPath(path: Path, subpaths: Subpath[]) {
         if (pts.length < 2) continue;
         path.moveTo(pts[0].x, pts[0].y);
         for (let i = 1; i < pts.length; i++) {
-            const prev = pts[i - 1];
-            const p = pts[i];
-            // Degenerate cubics on polygon edges are a PathOps footgun at
-            // curve/line junctions — emit a real line when handles collapse.
-            if (
-                isCollocatedHandle(prev.cp2[0], prev.cp2[1], prev.x, prev.y) &&
-                isCollocatedHandle(p.cp1[0], p.cp1[1], p.x, p.y)
-            ) {
-                path.lineTo(p.x, p.y);
-            } else {
-                path.cubicTo(prev.cp2[0], prev.cp2[1], p.cp1[0], p.cp1[1], p.x, p.y);
-            }
+            appendCubicOrLine(path, pts[i - 1], pts[i]);
         }
         if (sp.closed) {
-            const last = pts[pts.length - 1];
-            const first = pts[0];
-            if (
-                isCollocatedHandle(last.cp2[0], last.cp2[1], last.x, last.y) &&
-                isCollocatedHandle(first.cp1[0], first.cp1[1], first.x, first.y)
-            ) {
-                path.lineTo(first.x, first.y);
-            } else {
-                path.cubicTo(
-                    last.cp2[0],
-                    last.cp2[1],
-                    first.cp1[0],
-                    first.cp1[1],
-                    first.x,
-                    first.y,
-                );
-            }
+            appendCubicOrLine(path, pts[pts.length - 1], pts[0]);
             path.close();
         }
     }

--- a/vendor/vector-editor-ref/packages/editor/src/input.ts
+++ b/vendor/vector-editor-ref/packages/editor/src/input.ts
@@ -2000,12 +2000,7 @@ export class InputManager {
             lineHeight: geo.Text.line_height || 1.2,
             color,
             textDecoration: decoCss || 'none',
-            textAlign:
-                geo.Text.text_align === 1
-                    ? 'center'
-                    : geo.Text.text_align === 2
-                      ? 'right'
-                      : 'left',
+            textAlign: (['left', 'center', 'right'] as const)[geo.Text.text_align] || 'left',
             value: originalContent,
             layoutWidth: layoutW != null ? layoutW * scaleX : undefined,
             boxTopEm: fontSize > 0 ? Math.max(0.1, -local.y / fontSize) : 1,
@@ -2416,7 +2411,7 @@ export class InputManager {
             maxX = Math.max(maxX, Number(b[2]));
             maxY = Math.max(maxY, Number(b[3]));
         }
-        if (!(minX < maxX && minY < maxY)) return;
+        if (!(Number.isFinite(minX) && minX < maxX && minY < maxY)) return;
         const dx = this.currentPos.x - minX;
         const dy = this.currentPos.y - minY;
         if (Math.abs(dx) < 1e-9 && Math.abs(dy) < 1e-9) return;
@@ -2480,7 +2475,7 @@ export class InputManager {
             for (const id of live) {
                 const newId = this.scene.duplicateNode(id);
                 // duplicate_node builds in a +20,+20 offset; take it back off for
-                // in-place, or before pointer snap (movePasteToPointer uses bounds).
+                // in-place. Pointer paste leaves it — movePasteToPointer snaps by bounds.
                 if (inPlace) eng.move_node(newId, -20, -20);
                 // Every clone is born at the ROOT wearing the local transform it
                 // had inside its parent, so a copy of a shape in a group scaled

--- a/vendor/vector-editor-ref/packages/editor/src/renderer.ts
+++ b/vendor/vector-editor-ref/packages/editor/src/renderer.ts
@@ -4755,13 +4755,11 @@ export class Renderer {
                 op.selHandleFill.setAntiAlias(false);
                 op.selOutline.setAntiAlias(false);
 
-                const z = Math.max(0.05, this.zoom);
-                const snapX = (v: number) => (Math.round(v * z + this.pan.x) - this.pan.x) / z;
-                const snapY = (v: number) => (Math.round(v * z + this.pan.y) - this.pan.y) / z;
-
-                for (const { x: hx0, y: hy0 } of handlePositions) {
-                    const hx = snapX(hx0);
-                    const hy = snapY(hy0);
+                // Keep handles on the same world points as the control-box /
+                // silhouette stroke. CSS-pixel snap used to drift off those
+                // corners after scale/zoom so opaque white fills punched gaps
+                // in the blue border at every handle.
+                for (const { x: hx, y: hy } of handlePositions) {
                     canvas.save();
                     canvas.rotate(angleDeg, hx, hy);
                     canvas.drawRect(


### PR DESCRIPTION
## Summary
- Clear sticky `lastPatchFromKitCanvas` in `patchDocumentNodes` so align / distribute / tidy push geometry back into Kit.
- Skip lineChrome remap on Kit world AABB so the floating toolbar sits above the shaft, not mid-box.
- Route empty generator plates through RCB clipboard so paste keeps the center glyph.
- Drop selection-handle CSS-pixel snap that punched gaps in the blue border after scale.

## Test plan
- [ ] Multi-select two shapes → Align / Distribute / 自动整理 moves Kit ink
- [ ] Select a diagonal line → toolbar docks above endpoint AABB, not mid-shaft
- [ ] Empty generator plate → Ctrl+V keeps center Lucide icon
- [ ] Scale a shape → selection border stays continuous through handles

Made with [Cursor](https://cursor.com)