### PR TITLE
fix(web): cover video FO while auth resolves; invalidate generator aspect plate

### DIFF
--- a/apps/web/src/components/editor/nodes/VideoNode/VideoHoverPlayback.tsx
+++ b/apps/web/src/components/editor/nodes/VideoNode/VideoHoverPlayback.tsx
@@ -269,10 +269,13 @@ function VideoHoverPlayback({
   /** Frozen still + the mediaTime it was captured at (atlas / demoted fallback). */
   const [freeze, setFreeze] = useState<{ url: string; at: number }>(() => {
     const p = String(poster || '').trim();
-    // blob: posters are revoked across refresh — never seed the freeze <img> with them.
-    if (!p || p.startsWith('blob:')) return { url: '', at: -999 };
+    // Seed FO cover immediately (incl. blob: while durable poster uploads).
+    // Atlas demotion still prefers durable http — see freeze capture path.
+    if (!p) return { url: '', at: -999 };
     return { url: p, at: 0 };
   });
+  /** False until the shared <video> has decoded a frame for the current playSrc. */
+  const [hasDecodedFrame, setHasDecodedFrame] = useState(false);
   const playSrc = usePlayableVideoSrc(src, uploadKey);
   const showUi = !hidden;
   const z = Math.max(0.05, zoom || 1);
@@ -335,9 +338,22 @@ function VideoHoverPlayback({
 
   useEffect(() => {
     const next = String(poster || '').trim();
-    if (!next || next.startsWith('blob:')) return;
-    setFreeze((prev) => (prev.url ? prev : { url: next, at: 0 }));
+    if (!next) return;
+    // Prefer durable http once it lands; keep blob cover until then.
+    setFreeze((prev) => {
+      if (!prev.url || prev.url.startsWith('blob:') || prev.url.startsWith('data:')) {
+        return { url: next, at: 0 };
+      }
+      if (!next.startsWith('blob:') && !next.startsWith('data:') && prev.url !== next) {
+        return { url: next, at: 0 };
+      }
+      return prev;
+    });
   }, [poster]);
+
+  useEffect(() => {
+    setHasDecodedFrame(false);
+  }, [playSrc, nodeId]);
 
   // Bind src once — never via React `src={}`. Re-run when the element mounts.
   useEffect(() => {
@@ -352,13 +368,37 @@ function VideoHoverPlayback({
       /* ignore */
     }
     freezeGenRef.current += 1;
-    // Prefer empty over revoked blob poster — live <video> paints the FO plate.
-    setFreeze({
-      url: posterUrl && !posterUrl.startsWith('blob:') ? posterUrl : '',
-      at: posterUrl && !posterUrl.startsWith('blob:') ? 0 : -999,
-    });
+    setHasDecodedFrame(false);
+    // Keep poster cover until loadeddata — empty freeze + dark video bg = black FO.
+    if (posterUrl) {
+      setFreeze({ url: posterUrl, at: 0 });
+    }
+    try {
+      el.setAttribute('poster', posterUrl || '');
+    } catch {
+      /* optional */
+    }
     el.src = playSrc;
   }, [playSrc, posterUrl, videoEl, nodeId]);
+
+  useEffect(() => {
+    const el = videoEl;
+    if (!el || !playSrc) return;
+    const mark = () => {
+      if (el.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+        setHasDecodedFrame(true);
+      }
+    };
+    mark();
+    el.addEventListener('loadeddata', mark);
+    el.addEventListener('seeked', mark);
+    el.addEventListener('playing', mark);
+    return () => {
+      el.removeEventListener('loadeddata', mark);
+      el.removeEventListener('seeked', mark);
+      el.removeEventListener('playing', mark);
+    };
+  }, [videoEl, playSrc]);
 
   useEffect(() => {
     const el = videoEl;
@@ -517,15 +557,21 @@ function VideoHoverPlayback({
   // Wait for SVG foreignObject mount so we never fall back to a parallel CSS stack.
   if (!svgMount) return null;
 
-  // Still only when this plate does NOT own the live decoder (demoted / no FO).
-  // Owning the decoder: always paint through <video> — pause/scrub seek the element.
+  // Loading cover must hide the dark shared <video> (bg #111827) — it stacks
+  // above the poster <img>. After decode, paused plates paint through <video>.
   const ownsDecoder = sharedVideoOwnerId === String(nodeId) && Boolean(videoEl);
+  const coverUrl = String(freeze.url || posterUrl || '').trim();
   const freezeMatches =
-    Boolean(freeze.url) &&
-    !freeze.url.startsWith('blob:') &&
-    Math.abs(mediaTime - freeze.at) <= 0.12;
-  const showStill = !playing && freezeMatches && !ownsDecoder;
-  const showVideo = ownsDecoder || playing || !showStill;
+    Boolean(coverUrl) && Math.abs(mediaTime - freeze.at) <= 0.12;
+  const loadingCover =
+    Boolean(coverUrl) &&
+    !playing &&
+    ownsDecoder &&
+    (!playSrc || !hasDecodedFrame);
+  const demotedStill =
+    Boolean(coverUrl) && !playing && freezeMatches && !ownsDecoder;
+  const showStill = loadingCover || demotedStill;
+  const showVideo = playing || (ownsDecoder && !loadingCover) || !showStill;
   const barVisible = showUi && !hideChrome && (plateHovered || barHovered || playing);
   // Layout must match FO box (drag-base while CSS-scale resizing), not the visual
   // chrome size — otherwise scrubber/video sit mid-plate during live resize.
@@ -553,9 +599,9 @@ function VideoHoverPlayback({
       data-video-hover-plate=""
       data-video-node-id={nodeId}
     >
-      {showStill ? (
+      {showStill && coverUrl ? (
         <img
-          src={freeze.url}
+          src={coverUrl}
           alt=""
           draggable={false}
           className="pointer-events-none absolute"

--- a/apps/web/src/components/editor/nodes/VideoNode/VideoJsPlayer.tsx
+++ b/apps/web/src/components/editor/nodes/VideoNode/VideoJsPlayer.tsx
@@ -85,6 +85,9 @@ export function usePlayableVideoSrc(src: string, uploadKey?: string | null): str
       return undefined;
     }
 
+    // Clear playable when the logical src changes so a prior http URL does not
+    // flash the wrong clip. VideoHoverPlayback shows poster while auth resolves.
+    // Local blob/data previews may already be revoked on remote finish.
     setPlayable('');
 
     async function resolveBlob() {

--- a/apps/web/src/components/editor/nodes/shared/UploadJobWatcher.tsx
+++ b/apps/web/src/components/editor/nodes/shared/UploadJobWatcher.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/rcb/scene/document/processJobAttrs';
 import { resumeOrWaitUploadJob } from '@/service/uploadJobs';
 import { getHttpErrorMessage } from '@/service/client';
-import { buildUploadFinishAttrs } from '@/utils/canvasUploadFlow';
+import { buildUploadFinishAttrs, ensureDurableVideoFinishAttrs } from '@/utils/canvasUploadFlow';
 import {
   hasActiveNodeUpload,
   isUploadAbortError,
@@ -89,10 +89,15 @@ function UploadJobWatcher() {
         if (cancelled) return;
 
         const finishNode = documentRef.current?.deltaSetLike?.[pendingId] || liveNode;
+        const finishAttrs = await ensureDurableVideoFinishAttrs(
+          buildUploadFinishAttrs(finishNode?.attrs, uploaded),
+          ac.signal
+        );
+        if (cancelled) return;
         finishImageProcess({
             nodeId: pendingId,
             ...(remoteReady ? { src: uploaded.url } : {}),
-            attrs: buildUploadFinishAttrs(finishNode?.attrs, uploaded),
+            attrs: finishAttrs,
           });
       } catch (err: unknown) {
         if (cancelled || isUploadAbortError(err)) return;

--- a/apps/web/src/components/rcb/canvas/kitBridge.ts
+++ b/apps/web/src/components/rcb/canvas/kitBridge.ts
@@ -3141,6 +3141,10 @@ function pushRasterNodeToKit(scene: WasmScene, rcbId: string, node: SceneNodeInp
       if (lastKitStyleJson.get(existing) !== styleJson) {
         scene.setNodeStyleNoHistory(existing, styleJson);
         lastKitStyleJson.set(existing, styleJson);
+      } else {
+        // Wash style is constant; resize alone must still drop the retained
+        // scene picture or the gray plate stays at the pre-aspect size.
+        scene.invalidateCache?.(false);
       }
       return;
     }
@@ -3601,7 +3605,21 @@ export function syncKitGeometryFromDocument(
       // the new box (resize_node only stretches path/rect, not fill coords).
       applyKitNodeStyle(scene, kitId, node);
     }
-    handle.renderer.requestRender();
+    // engine.resize_node does not bump Kit caches. Empty-generator wash style
+    // is unchanged across aspect presets, so applyKitNodeStyle is a no-op and
+    // requestRender alone would replay the old landscape picture under a
+    // portrait selection outline. Drop retained picture + path caches without
+    // onMutate (false); same class of fix as refreshKitArtboardClipPaint.
+    if (typeof scene.invalidateCache === 'function') {
+      scene.invalidateCache(false);
+    } else {
+      try {
+        handle.renderer.invalidateScenePicture?.();
+      } catch {
+        /* optional */
+      }
+      handle.renderer.requestRender();
+    }
   });
 }
 

--- a/apps/web/src/store/modules/editor.ts
+++ b/apps/web/src/store/modules/editor.ts
@@ -320,6 +320,10 @@ const GEOMETRY_ATTR_KEYS = new Set([
   'aspect-original-width',
   'aspect-original-height',
   'shapeType',
+  // Generator ratio presets patch W/H + these attrs together.
+  'videoGenAspect',
+  'imageGenAspect',
+  'lottieGenAspect',
 ]);
 
 /**

--- a/apps/web/src/utils/canvasUploadFlow.ts
+++ b/apps/web/src/utils/canvasUploadFlow.ts
@@ -104,6 +104,16 @@ async function withDurableVideoPosterAttrs(
   return { ...extraAttrs, poster: durable };
 }
 
+/** Ensure video finish attrs carry a durable (non-blob) poster when possible. */
+export async function ensureDurableVideoFinishAttrs(
+  attrs: Record<string, unknown>,
+  signal?: AbortSignal
+): Promise<Record<string, unknown>> {
+  const ac = signal ?? new AbortController().signal;
+  const next = await withDurableVideoPosterAttrs(attrs, ac);
+  return next || attrs;
+}
+
 /** Upload a file for a spawned placeholder node. */
 export async function uploadCanvasPlaceholderFile(opts: {
   nodeId: string;


### PR DESCRIPTION
## Summary
- Show poster and hide the dark shared `<video>` until the auth blob resolves and the first frame decodes (fixes solid-black uploaded videos with a live scrubber).
- Keep durable posters on UploadJobWatcher recovery, matching the main placeholder upload path.
- Invalidate Kit retained scene picture after empty-generator aspect resize so the gray wash matches the selection outline.

## Test plan
- [ ] Upload a short video → plate shows poster/first frame, not black; scrubber still works
- [ ] Empty video generator → switch 16:9 → 9:16 → gray plate matches blue outline
- [ ] Deselect / reselect uploaded video → no black flash on remount

Made with [Cursor](https://cursor.com)